### PR TITLE
fix(ui): increase mobile deck max-height to 50dvh and reduce deck area

Increased mobile deck maxHeight from 45dvh to 50dvh and reduced DroppableDeckArea from 130px to 120px. This ensures the footer is always visible by providing enough space for all deck components (category selector ~100px + deck area 120px + footer ~100px = ~320px < 50dvh ~333px).

### DIFF
--- a/frontend/src/components/GridSort.layout.test.tsx
+++ b/frontend/src/components/GridSort.layout.test.tsx
@@ -138,8 +138,8 @@ describe('GridSort Detailed UI Verification', () => {
         // We can checks for the green checkmark class presence on the container
         const emptyStateText = screen.getByText('fine.deck.all_placed');
         const container = emptyStateText.closest('div');
-        // The container has `flex flex-col items-center gap-3`
-        expect(container?.className).toContain('gap-3');
+        // The container has `flex flex-col items-center gap-2`
+        expect(container?.className).toContain('gap-2');
     });
 
     // 4. Layout & Sidebar

--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -514,7 +514,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
         `}
                     style={{
                         height: isMobile ? 'auto' : '100%',
-                        maxHeight: isMobile ? '45dvh' : 'none',
+                        maxHeight: isMobile ? '50dvh' : 'none',
                     }}
                 >
                     {/* Reading Zone - Desktop Sidebar version */}
@@ -611,7 +611,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
                         id={`deck-area-${activePile}`}
                         className={`
                             flex-col overflow-hidden relative
-                            ${isMobile ? 'h-[130px] flex-none' : 'flex-1 min-h-0 max-h-[280px] flex'}
+                            ${isMobile ? 'h-[120px] flex-none' : 'flex-1 min-h-0 max-h-[280px] flex'}
                         `}
                     >
                         <div

--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -514,7 +514,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
         `}
                     style={{
                         height: isMobile ? 'auto' : '100%',
-                        maxHeight: isMobile ? 'none' : 'none', // Removed 33vh restriction
+                        maxHeight: isMobile ? '45dvh' : 'none',
                     }}
                 >
                     {/* Reading Zone - Desktop Sidebar version */}

--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -301,12 +301,12 @@ const GridSort: React.FC<GridSortProps> = React.memo(
                     </div>
                 ))
             ) : (
-                <div className="w-full h-full flex flex-col items-center justify-center text-center text-slate-400 py-8 lg:col-span-2 lg:h-full lg:place-self-center">
-                    <div className="flex flex-col items-center gap-3">
-                        <div className="p-4 bg-green-50 rounded-full border border-green-100 shadow-sm animate-in zoom-in duration-300">
-                            <Check size={32} className="text-green-500" strokeWidth={3} />
+                <div className="w-full h-full flex flex-col items-center justify-center text-center text-slate-400 py-4 lg:col-span-2 lg:h-full lg:place-self-center">
+                    <div className="flex flex-col items-center gap-2">
+                        <div className="p-2 bg-green-50 rounded-full border border-green-100 shadow-sm animate-in zoom-in duration-300">
+                            <Check size={20} className="text-green-500" strokeWidth={2.5} />
                         </div>
-                        <span className="text-sm font-bold text-slate-500 animate-in fade-in slide-in-from-bottom-2 duration-500 delay-100">
+                        <span className="text-xs font-bold text-slate-500 animate-in fade-in slide-in-from-bottom-2 duration-500 delay-100">
                             {t('fine.deck.all_placed')}
                         </span>
                     </div>


### PR DESCRIPTION
# Description

<!-- What changes does this PR introduce? -->

# Checklist

- [ ] Tests covering changes
- [ ] Documentation updated (if applicable)
- [ ] Architectural rules respected

# Related Issue

<!-- Closes #123 -->
