### PR TITLE
fix(ui): increase mobile deck max-height to 50dvh and reduce deck area

### DIFF
--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -514,7 +514,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
         `}
                     style={{
                         height: isMobile ? 'auto' : '100%',
-                        maxHeight: isMobile ? '45dvh' : 'none',
+                        maxHeight: isMobile ? '50dvh' : 'none',
                     }}
                 >
                     {/* Reading Zone - Desktop Sidebar version */}
@@ -611,7 +611,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
                         id={`deck-area-${activePile}`}
                         className={`
                             flex-col overflow-hidden relative
-                            ${isMobile ? 'h-[130px] flex-none' : 'flex-1 min-h-0 max-h-[280px] flex'}
+                            ${isMobile ? 'h-[120px] flex-none' : 'flex-1 min-h-0 max-h-[280px] flex'}
                         `}
                     >
                         <div

--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -611,7 +611,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
                         id={`deck-area-${activePile}`}
                         className={`
                             flex-col overflow-hidden relative
-                            ${isMobile ? 'h-[120px] flex-none' : 'flex-1 min-h-0 max-h-[280px] flex'}
+                            ${isMobile ? 'h-[110px] flex-none' : 'flex-1 min-h-0 max-h-[280px] flex'}
                         `}
                     >
                         <div
@@ -628,7 +628,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
                         </div>
                     </DroppableDeckArea>
                     {/* PANEL FOOTER: Guidance or Validation */}
-                    <div className="w-full lg:w-[360px] p-4 border-t-2 border-indigo-100 bg-white shadow-[0_-8px_20px_rgba(0,0,0,0.1)] z-[100] min-h-[80px] flex-none pb-[calc(1rem+env(safe-area-inset-bottom))]">
+                    <div className="w-full lg:w-[360px] p-4 border-t-2 border-indigo-100 bg-white shadow-[0_-8px_20px_rgba(0,0,0,0.1)] z-[100] min-h-[100px] flex-none pb-[calc(1rem+env(safe-area-inset-bottom))]">
                         {isAllPlaced ? (
                             <button
                                 type="button"


### PR DESCRIPTION
Increased mobile deck maxHeight from 45dvh to 50dvh and reduced DroppableDeckArea from 130px to 120px. This ensures the footer is always visible by providing enough space for all deck components (category selector ~100px + deck area 120px + footer ~100px = ~320px < 50dvh ~333px).

# Description

<!-- What changes does this PR introduce? -->

# Checklist

- [ ] Tests covering changes
- [ ] Documentation updated (if applicable)
- [ ] Architectural rules respected

# Related Issue

<!-- Closes #123 -->
