### PR TITLE
fix(ui): set footer height to exactly 110px in fine sort grid

### DIFF
--- a/frontend/src/components/GridSort.mobile-layout.test.tsx
+++ b/frontend/src/components/GridSort.mobile-layout.test.tsx
@@ -120,9 +120,9 @@ describe('GridSort Mobile Layout Refinements', () => {
         // Find the specific instruction text
         const instruction = screen.getByText('fine.workbench.initial_instruction');
 
-        // Traverse up to find the footer container (which we know has min-h-[80px])
+        // Traverse up to find the footer container (which we know has h-[110px])
         // We use closest() with the class we added in the implementation
-        const footer = instruction.closest('.min-h-\\[80px\\]');
+        const footer = instruction.closest('.h-\\[110px\\]');
 
         expect(footer).toBeInTheDocument();
         expect(footer?.className).toContain('flex-none');

--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -628,7 +628,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
                         </div>
                     </DroppableDeckArea>
                     {/* PANEL FOOTER: Guidance or Validation */}
-                    <div className="w-full lg:w-[360px] p-4 border-t-2 border-indigo-100 bg-white shadow-[0_-8px_20px_rgba(0,0,0,0.1)] z-[100] min-h-[80px] flex-none pb-[calc(1rem+env(safe-area-inset-bottom))]">
+                    <div className="w-full lg:w-[360px] p-4 border-t-2 border-indigo-100 bg-white shadow-[0_-8px_20px_rgba(0,0,0,0.1)] z-[100] h-[110px] flex-none pb-[calc(1rem+env(safe-area-inset-bottom))]">
                         {isAllPlaced ? (
                             <button
                                 type="button"


### PR DESCRIPTION
- Changed footer from min-h-[80px] to h-[110px] for exact sizing
- Updated test to reflect new footer height class
- Footer now has fixed height and flex-none to prevent overlap
- DroppableDeckArea layout ensures no overlap with footer on both mobile and desktop