### PR TITLE
Improve participant details accessibility with 44px minimum touch targets

### DIFF
--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
@@ -317,19 +317,25 @@ export function ParticipantDetailContent({
 
             <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 flex flex-col">
                 <div className="flex items-center justify-between px-3 sm:px-6 border-b border-slate-50 bg-white sticky top-0 z-10">
-                    <TabsList className="h-12 sm:h-14 bg-transparent p-0 gap-1 sm:gap-4 overflow-x-auto">
+                    <TabsList className="h-12 sm:h-14 bg-transparent p-0 gap-0 sm:gap-4 overflow-x-auto">
                         {['session', 'presort', 'grid', 'postsort'].map((tab) => (
                             <TabsTrigger
                                 key={tab}
                                 value={tab}
-                                className="h-12 sm:h-14 rounded-none border-b-2 border-transparent px-0 text-[11px] sm:text-xs font-black uppercase tracking-widest text-slate-400 data-[state=active]:border-indigo-500 data-[state=active]:text-indigo-600 data-[state=active]:bg-transparent transition-all"
+                                className="min-h-[44px] sm:h-14 min-w-[44px] rounded-none border-b-2 border-transparent px-3 sm:px-0 text-[11px] sm:text-xs font-black uppercase tracking-widest text-slate-400 data-[state=active]:border-indigo-500 data-[state=active]:text-indigo-600 data-[state=active]:bg-transparent transition-all"
                             >
                                 <div className="flex items-center gap-2">
-                                    {tab === 'session' && <Fingerprint className="w-3.5 h-3.5" />}
-                                    {tab === 'presort' && <ClipboardList className="w-3.5 h-3.5" />}
-                                    {tab === 'grid' && <LayoutGrid className="w-3.5 h-3.5" />}
+                                    {tab === 'session' && (
+                                        <Fingerprint className="w-4 h-4 sm:w-3.5 sm:h-3.5" />
+                                    )}
+                                    {tab === 'presort' && (
+                                        <ClipboardList className="w-4 h-4 sm:w-3.5 sm:h-3.5" />
+                                    )}
+                                    {tab === 'grid' && (
+                                        <LayoutGrid className="w-4 h-4 sm:w-3.5 sm:h-3.5" />
+                                    )}
                                     {tab === 'postsort' && (
-                                        <MessageSquare className="w-3.5 h-3.5" />
+                                        <MessageSquare className="w-4 h-4 sm:w-3.5 sm:h-3.5" />
                                     )}
                                     <span className="hidden sm:inline">
                                         {t(
@@ -353,22 +359,22 @@ export function ParticipantDetailContent({
                             size="sm"
                             disabled={isExporting}
                             onClick={handleExportCSV}
-                            className="h-10 w-10 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-400 hover:text-indigo-600"
+                            className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-400 hover:text-indigo-600"
                             title={t('admin.export.csv', 'Export CSV')}
                             aria-label={t('admin.export.csv', 'Export CSV')}
                         >
-                            <FileSpreadsheet className="w-4 h-4" />
+                            <FileSpreadsheet className="w-5 h-5 sm:w-4 sm:h-4" />
                         </Button>
                         <Button
                             variant="ghost"
                             size="sm"
                             disabled={isExporting}
                             onClick={handleExportJSON}
-                            className="h-10 w-10 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-400 hover:text-indigo-600"
+                            className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-400 hover:text-indigo-600"
                             title={t('admin.export.json', 'Export JSON')}
                             aria-label={t('admin.export.json', 'Export JSON')}
                         >
-                            <FileJson className="w-4 h-4" />
+                            <FileJson className="w-5 h-5 sm:w-4 sm:h-4" />
                         </Button>
                         {hasAudioRecordings && (
                             <Button
@@ -376,10 +382,11 @@ export function ParticipantDetailContent({
                                 size="sm"
                                 disabled={isExporting}
                                 onClick={handleExportAudio}
-                                className="text-slate-400 hover:text-indigo-600"
+                                className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-400 hover:text-indigo-600"
                                 title={t('admin.export.audio', 'Export Audio (ZIP)')}
+                                aria-label={t('admin.export.audio', 'Export Audio (ZIP)')}
                             >
-                                <FileArchive className="w-4 h-4" />
+                                <FileArchive className="w-5 h-5 sm:w-4 sm:h-4" />
                             </Button>
                         )}
                     </div>

--- a/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
@@ -96,7 +96,7 @@ export function ParticipantMetadataCard({
                                 onClick={() => setDiscardDialogOpen(true)}
                                 disabled={isDiscardPending}
                                 className={cn(
-                                    'h-9 px-3 text-[11px] font-bold uppercase tracking-wider',
+                                    'min-h-[44px] px-4 text-xs sm:text-[11px] font-bold uppercase tracking-wider',
                                     isDiscarded
                                         ? 'text-emerald-600 hover:text-emerald-700 hover:bg-emerald-50'
                                         : 'text-red-500 hover:text-red-600 hover:bg-red-50'


### PR DESCRIPTION
Tabs, export buttons, and discard/restore button were below WCAG 2.5.5
minimum touch target sizes on mobile. Updated to min-h/min-w 44px,
increased icon sizes on mobile (w-5 h-5), added proper horizontal
padding on tabs, and added missing aria-label on audio export button.

https://claude.ai/code/session_01XCSPcsqd8EkE4rEuX2Hhwi