### PR TITLE
refactor(profile): migrate ProfilePage forms to RHF + zod

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -521,7 +521,8 @@
         "saving": "Saving...",
         "success": "Profile updated successfully",
         "error": "Failed to update profile",
-        "cannot_remove_self": "You cannot remove yourself"
+        "cannot_remove_self": "You cannot remove yourself",
+        "name_required": "Full name is required"
       },
       "security": {
         "title": "Security & 2FA",
@@ -543,7 +544,9 @@
         "cancel": "Cancel",
         "enabled_success": "Two-factor authentication enabled",
         "disabled_success": "Two-factor authentication disabled",
-        "secret_copied": "Secret copied"
+        "secret_copied": "Secret copied",
+        "invalid_token": "Invalid verification code",
+        "disable_error": "Failed to disable 2FA"
       },
       "password": {
         "title": "Password management",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -506,7 +506,8 @@
                 "saving": "Tallennetaan...",
                 "success": "Profiili päivitetty onnistuneesti",
                 "error": "Profiilin päivitys epäonnistui",
-                "cannot_remove_self": "Et voi poistaa itseäsi"
+                "cannot_remove_self": "Et voi poistaa itseäsi",
+                "name_required": "Koko nimi vaaditaan"
             },
             "security": {
                 "title": "Turvallisuus & 2FA",
@@ -528,7 +529,9 @@
                 "cancel": "Peruuta",
                 "enabled_success": "Kaksivaiheinen todennus otettu käyttöön",
                 "disabled_success": "Kaksivaiheinen todennus poistettu käytöstä",
-                "secret_copied": "Salaisuus kopioitu"
+                "secret_copied": "Salaisuus kopioitu",
+                "invalid_token": "Virheellinen vahvistuskoodi",
+                "disable_error": "2FA-tunnistautumisen poistaminen epäonnistui"
             },
             "password": {
                 "title": "Salasanan hallinta",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -506,7 +506,8 @@
         "saving": "Enregistrement...",
         "success": "Profil mis à jour avec succès",
         "error": "Échec de la mise à jour du profil",
-        "cannot_remove_self": "Vous ne pouvez pas vous supprimer vous-même"
+        "cannot_remove_self": "Vous ne pouvez pas vous supprimer vous-même",
+        "name_required": "Le nom complet est requis"
       },
       "security": {
         "title": "Sécurité et 2FA",
@@ -528,7 +529,9 @@
         "verifying": "Vérification...",
         "cancel": "Annuler",
         "enabled_success": "Authentification à deux facteurs activée",
-        "disabled_success": "Authentification à deux facteurs désactivée"
+        "disabled_success": "Authentification à deux facteurs désactivée",
+        "invalid_token": "Code de vérification invalide",
+        "disable_error": "Impossible de désactiver le 2FA"
       },
       "password": {
         "title": "Mot de passe",

--- a/frontend/src/pages/admin/ProfilePage.schema.test.ts
+++ b/frontend/src/pages/admin/ProfilePage.schema.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { makeProfileSchema, makePasswordSchema } from './ProfilePage';
+
+const t = (_key: string, fallback: string) => fallback;
+
+describe('ProfilePage zod schemas', () => {
+    describe('profileSchema', () => {
+        const schema = makeProfileSchema(t);
+
+        it('accepts a valid profile', () => {
+            const result = schema.safeParse({ email: 'a@b.io', full_name: 'Ada Lovelace' });
+            expect(result.success).toBe(true);
+        });
+
+        it('rejects an empty full_name', () => {
+            const result = schema.safeParse({ email: 'a@b.io', full_name: '' });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error.issues[0]?.message).toBe('Full name is required');
+                expect(result.error.issues[0]?.path).toEqual(['full_name']);
+            }
+        });
+
+        it('accepts an undefined email (disabled field)', () => {
+            const result = schema.safeParse({ full_name: 'Ada' });
+            expect(result.success).toBe(true);
+        });
+    });
+
+    describe('passwordSchema', () => {
+        const schema = makePasswordSchema(t);
+
+        it('accepts a valid password change', () => {
+            const result = schema.safeParse({
+                current_password: 'oldpass',
+                new_password: 'longenough',
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it('rejects an empty current_password', () => {
+            const result = schema.safeParse({
+                current_password: '',
+                new_password: 'longenough',
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error.issues[0]?.message).toBe('Required');
+                expect(result.error.issues[0]?.path).toEqual(['current_password']);
+            }
+        });
+
+        it('rejects a new_password shorter than 8 characters', () => {
+            const result = schema.safeParse({
+                current_password: 'oldpass',
+                new_password: 'short',
+            });
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error.issues[0]?.message).toBe('Min 8 characters');
+                expect(result.error.issues[0]?.path).toEqual(['new_password']);
+            }
+        });
+    });
+});

--- a/frontend/src/pages/admin/ProfilePage.tsx
+++ b/frontend/src/pages/admin/ProfilePage.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/button';
@@ -11,6 +13,14 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { customInstance } from '@/api/mutator';
@@ -25,17 +35,32 @@ import { Badge } from '@/components/ui/badge';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
+import { parseApiErrorSync } from '@/lib/error-utils';
 
-// Define types manually since generation might lag
-interface UserUpdate {
-    email?: string;
-    full_name?: string;
+type Translator = (key: string, fallback: string) => string;
+
+export function makeProfileSchema(t: Translator) {
+    return z.object({
+        email: z.string().optional(),
+        full_name: z
+            .string()
+            .min(1, t('admin.profile.personal.name_required', 'Full name is required')),
+    });
 }
 
-interface PasswordChange {
-    current_password: string;
-    new_password: string;
+export function makePasswordSchema(t: Translator) {
+    return z.object({
+        current_password: z
+            .string()
+            .min(1, t('admin.profile.password.validation.required', 'Required')),
+        new_password: z
+            .string()
+            .min(8, t('admin.profile.password.validation.min_length', 'Min 8 characters')),
+    });
 }
+
+type ProfileFormValues = z.infer<ReturnType<typeof makeProfileSchema>>;
+type PasswordFormValues = z.infer<ReturnType<typeof makePasswordSchema>>;
 
 const ProfilePage = () => {
     const { user, refetch: refetchUser } = useAuth();
@@ -65,9 +90,13 @@ const ProfilePage = () => {
                 setTotpToken('');
                 refetchUser();
             },
-            // biome-ignore lint/suspicious/noExplicitAny: error handling
-            onError: (err: any) => {
-                toast.error(err?.response?.data?.detail || 'Invalid token');
+            onError: (err: unknown) => {
+                toast.error(
+                    parseApiErrorSync(
+                        err,
+                        t('admin.profile.security.invalid_token', 'Invalid verification code')
+                    )
+                );
             },
         },
     });
@@ -85,47 +114,57 @@ const ProfilePage = () => {
                 setConfirmPassword('');
                 refetchUser();
             },
-            // biome-ignore lint/suspicious/noExplicitAny: error handling
-            onError: (err: any) => {
-                toast.error(err?.response?.data?.detail || 'Failed to disable 2FA');
+            onError: (err: unknown) => {
+                toast.error(
+                    parseApiErrorSync(
+                        err,
+                        t('admin.profile.security.disable_error', 'Failed to disable 2FA')
+                    )
+                );
             },
         },
     });
 
-    const { register: registerProfile, handleSubmit: handleProfileSubmit } = useForm<UserUpdate>({
+    const profileSchema = useMemo(() => makeProfileSchema(t), [t]);
+    const passwordSchema = useMemo(() => makePasswordSchema(t), [t]);
+
+    const profileForm = useForm<ProfileFormValues>({
+        resolver: zodResolver(profileSchema),
         values: {
-            email: user?.email,
-            full_name: user?.full_name || '',
+            email: user?.email ?? undefined,
+            full_name: user?.full_name ?? '',
         },
     });
 
-    const {
-        register: registerPassword,
-        handleSubmit: handlePasswordSubmit,
-        reset: resetPassword,
-        formState: { errors: passwordErrors },
-    } = useForm<PasswordChange>();
+    const passwordForm = useForm<PasswordFormValues>({
+        resolver: zodResolver(passwordSchema),
+        defaultValues: { current_password: '', new_password: '' },
+    });
 
-    const onProfileSubmit = async (data: UserUpdate) => {
+    const onProfileSubmit = async ({ full_name }: ProfileFormValues) => {
         setIsUpdating(true);
         try {
             await customInstance<void>({
                 url: '/api/me',
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                data,
+                data: { full_name },
             });
             toast.success(t('admin.profile.personal.success', 'Profile updated successfully'));
             refetchUser();
         } catch (error) {
-            toast.error(t('admin.profile.personal.error', 'Failed to update profile'));
-            console.error(error);
+            toast.error(
+                parseApiErrorSync(
+                    error,
+                    t('admin.profile.personal.error', 'Failed to update profile')
+                )
+            );
         } finally {
             setIsUpdating(false);
         }
     };
 
-    const onPasswordSubmit = async (data: PasswordChange) => {
+    const onPasswordSubmit = async (data: PasswordFormValues) => {
         setIsChangingPassword(true);
         try {
             await customInstance<void>({
@@ -135,15 +174,17 @@ const ProfilePage = () => {
                 data,
             });
             toast.success(t('admin.profile.password.success', 'Password changed successfully'));
-            resetPassword();
+            passwordForm.reset();
         } catch (error) {
             toast.error(
-                t(
-                    'admin.profile.password.error',
-                    'Failed to change password. Check current password.'
+                parseApiErrorSync(
+                    error,
+                    t(
+                        'admin.profile.password.error',
+                        'Failed to change password. Check current password.'
+                    )
                 )
             );
-            console.error(error);
         } finally {
             setIsChangingPassword(false);
         }
@@ -175,55 +216,70 @@ const ProfilePage = () => {
                             )}
                         </CardDescription>
                     </CardHeader>
-                    <form onSubmit={handleProfileSubmit(onProfileSubmit)}>
-                        <CardContent className="space-y-4">
-                            <div className="grid gap-2">
-                                <Label
-                                    htmlFor="email"
-                                    className="text-2xs font-black text-slate-500"
-                                >
-                                    {t('admin.profile.personal.email', 'Email address')}
-                                </Label>
-                                <Input
-                                    id="email"
-                                    {...registerProfile('email')}
-                                    disabled
-                                    className="h-11 rounded-xl bg-slate-50 border-slate-200"
-                                />
-                                <p className="text-2xs text-slate-400 italic">
-                                    {t(
-                                        'admin.profile.personal.email_locked',
-                                        'Email cannot be changed directly. Contact admin.'
+                    <Form {...profileForm}>
+                        <form onSubmit={profileForm.handleSubmit(onProfileSubmit)}>
+                            <CardContent className="space-y-4">
+                                <FormField
+                                    control={profileForm.control}
+                                    name="email"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel className="text-2xs font-black text-slate-500">
+                                                {t('admin.profile.personal.email', 'Email address')}
+                                            </FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    {...field}
+                                                    value={field.value ?? ''}
+                                                    disabled
+                                                    className="h-11 rounded-xl bg-slate-50 border-slate-200"
+                                                />
+                                            </FormControl>
+                                            <p className="text-2xs text-slate-400 italic">
+                                                {t(
+                                                    'admin.profile.personal.email_locked',
+                                                    'Email cannot be changed directly. Contact admin.'
+                                                )}
+                                            </p>
+                                        </FormItem>
                                     )}
-                                </p>
-                            </div>
-                            <div className="grid gap-2">
-                                <Label
-                                    htmlFor="full_name"
-                                    className="text-2xs font-black text-slate-500"
-                                >
-                                    {t('admin.profile.personal.name', 'Full name')}
-                                </Label>
-                                <Input
-                                    id="full_name"
-                                    placeholder={t('admin.profile.personal.name', 'Full name')}
-                                    {...registerProfile('full_name')}
-                                    className="h-11 rounded-xl"
                                 />
-                            </div>
-                        </CardContent>
-                        <CardFooter className="border-t border-slate-50 px-6 py-4 justify-end">
-                            <Button
-                                type="submit"
-                                disabled={isUpdating}
-                                className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
-                            >
-                                {isUpdating
-                                    ? t('admin.profile.personal.saving', 'Saving...')
-                                    : t('admin.profile.personal.save', 'Save changes')}
-                            </Button>
-                        </CardFooter>
-                    </form>
+                                <FormField
+                                    control={profileForm.control}
+                                    name="full_name"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel className="text-2xs font-black text-slate-500">
+                                                {t('admin.profile.personal.name', 'Full name')}
+                                            </FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    {...field}
+                                                    placeholder={t(
+                                                        'admin.profile.personal.name',
+                                                        'Full name'
+                                                    )}
+                                                    className="h-11 rounded-xl"
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </CardContent>
+                            <CardFooter className="border-t border-slate-50 px-6 py-4 justify-end">
+                                <Button
+                                    type="submit"
+                                    disabled={isUpdating}
+                                    className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
+                                >
+                                    {isUpdating
+                                        ? t('admin.profile.personal.saving', 'Saving...')
+                                        : t('admin.profile.personal.save', 'Save changes')}
+                                </Button>
+                            </CardFooter>
+                        </form>
+                    </Form>
                 </Card>
 
                 {/* Two-Factor Authentication (2FA) */}
@@ -479,68 +535,64 @@ const ProfilePage = () => {
                             )}
                         </CardDescription>
                     </CardHeader>
-                    <form onSubmit={handlePasswordSubmit(onPasswordSubmit)}>
-                        <CardContent className="space-y-4">
-                            <div className="grid gap-2">
-                                <Label
-                                    htmlFor="current_password"
-                                    className="text-2xs font-black text-slate-500"
-                                >
-                                    {t('admin.profile.password.current', 'Current password')}
-                                </Label>
-                                <Input
-                                    id="current_password"
-                                    type="password"
-                                    {...registerPassword('current_password', { required: true })}
-                                    className="h-11 rounded-xl"
+                    <Form {...passwordForm}>
+                        <form onSubmit={passwordForm.handleSubmit(onPasswordSubmit)}>
+                            <CardContent className="space-y-4">
+                                <FormField
+                                    control={passwordForm.control}
+                                    name="current_password"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel className="text-2xs font-black text-slate-500">
+                                                {t(
+                                                    'admin.profile.password.current',
+                                                    'Current password'
+                                                )}
+                                            </FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    {...field}
+                                                    type="password"
+                                                    className="h-11 rounded-xl"
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
                                 />
-                                {passwordErrors.current_password && (
-                                    <span className="text-red-500 text-xs">
-                                        {t(
-                                            'admin.profile.password.validation.required',
-                                            'Required'
-                                        )}
-                                    </span>
-                                )}
-                            </div>
-                            <div className="grid gap-2">
-                                <Label
-                                    htmlFor="new_password"
-                                    className="text-2xs font-black text-slate-500"
-                                >
-                                    {t('admin.profile.password.new', 'New password')}
-                                </Label>
-                                <Input
-                                    id="new_password"
-                                    type="password"
-                                    {...registerPassword('new_password', {
-                                        required: true,
-                                        minLength: 8,
-                                    })}
-                                    className="h-11 rounded-xl"
+                                <FormField
+                                    control={passwordForm.control}
+                                    name="new_password"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel className="text-2xs font-black text-slate-500">
+                                                {t('admin.profile.password.new', 'New password')}
+                                            </FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    {...field}
+                                                    type="password"
+                                                    className="h-11 rounded-xl"
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
                                 />
-                                {passwordErrors.new_password && (
-                                    <span className="text-red-500 text-xs">
-                                        {t(
-                                            'admin.profile.password.validation.min_length',
-                                            'Min 8 characters required'
-                                        )}
-                                    </span>
-                                )}
-                            </div>
-                        </CardContent>
-                        <CardFooter className="border-t border-slate-50 px-6 py-4 justify-end">
-                            <Button
-                                type="submit"
-                                disabled={isChangingPassword}
-                                className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
-                            >
-                                {isChangingPassword
-                                    ? t('admin.profile.password.updating', 'Updating...')
-                                    : t('admin.profile.password.change_btn', 'Change password')}
-                            </Button>
-                        </CardFooter>
-                    </form>
+                            </CardContent>
+                            <CardFooter className="border-t border-slate-50 px-6 py-4 justify-end">
+                                <Button
+                                    type="submit"
+                                    disabled={isChangingPassword}
+                                    className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
+                                >
+                                    {isChangingPassword
+                                        ? t('admin.profile.password.updating', 'Updating...')
+                                        : t('admin.profile.password.change_btn', 'Change password')}
+                                </Button>
+                            </CardFooter>
+                        </form>
+                    </Form>
                 </Card>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Plan B2 (reduced scope — see below). Standardizes `ProfilePage` on the same RHF+zod form pattern that `ProjectSettingsPage` already uses, with localized error messages displayed via shadcn `<FormField>` rather than ad-hoc inline `<span className="text-red-500">` + hard-coded `Required` literal.

- **Profile form** (full_name field — email stays disabled): zod schema with `min(1, "Full name is required")` localized via `t()`.
- **Password form**: zod schema with `current_password.min(1)` and `new_password.min(8)`, both localized.
- **4 untyped error handlers replaced** with `parseApiErrorSync` + i18n keys so server-side error messages surface in the user's language: 2FA verify/disable mutations, profile submit catch, password submit catch.
- Schemas exported as factories `makeProfileSchema(t)` / `makePasswordSchema(t)` so they can be unit-tested independently of the page component (6 test cases covering pass and fail paths).
- 3 new i18n keys added in en/fr/fi: `personal.name_required`, `security.invalid_token`, `security.disable_error`.

## Plan

`docs/superpowers/plans/2026-04-27-profile-rhf-zod.md`. Original Plan B2 also targeted `GeneralSettingsPage`, but on inspection that page's only "form" is one numeric input with HTML5 `min/max` validation — RHF+zod there is YAGNI. Documented in the plan.

## Test plan

- [x] `npm run i18n-check` green (3 new keys × 3 locales in sync)
- [x] `ProfilePage.schema.test.ts` 6/6 cases passing
- [x] `make ci-fast` green (95 test files, 665 tests, +6 schema cases)
- [x] `make ci` green
- [ ] Manual smoke: `/app/<slug>/profile` → submit empty `Full name` → "Full name is required" shown below the field. Submit `new_password` "short" → "Min 8 characters" shown below the field. Both should localize when changing UI language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)