### PR TITLE
refactor(admin): extract useAdminDashboard hook

### DIFF
--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -18,7 +18,6 @@ import {
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { formatDistanceToNow, format } from 'date-fns';
-import { enUS, fr, fi } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
 
 import { Button } from '@/components/ui/button';
@@ -26,17 +25,13 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthStore } from '@/store/useAuthStore';
-import { useListStudiesApiAdminStudiesGet } from '@/api/generated';
 import { CreateStudyDialog } from '@/components/admin/CreateStudyDialog';
 import { ImportStudyDialog } from '@/components/admin/ImportStudyDialog';
-import { useAdminStore } from '@/store/useAdminStore';
 import { useTranslation } from 'react-i18next';
+import { useAdminDashboard } from '@/hooks/admin/useAdminDashboard';
 import type { StudyRead } from '@/api/model/studyRead';
 
 type TranslateFn = ReturnType<typeof useTranslation>['t'];
-
-// biome-ignore lint/suspicious/noExplicitAny: date locales from date-fns
-const DATE_LOCALES: Record<string, any> = { en: enUS, fr, fi };
 
 function getStateColor(state: string | undefined): string {
     switch (state) {
@@ -78,77 +73,26 @@ function getStateIcon(state: string | undefined) {
 export function AdminDashboard() {
     const { currentProject } = useAuthStore();
     const navigate = useNavigate();
-    const { setActiveStudy } = useAdminStore();
-    const [showCreateDialog, setShowCreateDialog] = useState(false);
-    const [showImportDialog, setShowImportDialog] = useState(false);
-    const { t, i18n } = useTranslation();
-    const currentLocale = DATE_LOCALES[i18n.language] || enUS;
-    const projectSlug = currentProject?.slug || '';
-
-    // Data fetching
-    const { data: allStudiesData, isLoading: studiesLoading } = useListStudiesApiAdminStudiesGet(
-        undefined,
-        { query: { enabled: !!currentProject?.id } }
-    );
-
-    const studies = allStudiesData?.items?.filter((s) => s.project_id === currentProject?.id);
-
-    // Derived data
-    const activeStudies = studies?.filter((s) => s.state === 'active') ?? [];
-    const draftStudies = studies?.filter((s) => s.state === 'draft') ?? [];
-    const pausedStudies = studies?.filter((s) => s.state === 'paused') ?? [];
-    const closedStudies =
-        studies?.filter((s) => s.state === 'closed' || s.state === 'archived') ?? [];
-    const totalParticipants = studies?.reduce((sum, s) => sum + (s.participant_count ?? 0), 0) ?? 0;
-
-    // Alerts
-    const alerts: Array<{
-        key: string;
-        message: string;
-        action?: () => void;
-        actionLabel?: string;
-    }> = [];
-
-    // Check for studies near deadline with low participation
-    for (const study of activeStudies) {
-        if (study.end_date) {
-            const endDate = new Date(study.end_date as string);
-            const now = new Date();
-            const daysLeft = Math.ceil((endDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-            if (daysLeft <= 7 && daysLeft > 0) {
-                const title = getStudyTitle(study);
-                alerts.push({
-                    key: `deadline-${study.id}`,
-                    message: t('admin.dashboard.alert_deadline', {
-                        study: title,
-                        days: daysLeft,
-                        count: study.participant_count ?? 0,
-                        defaultValue:
-                            '{{study}}: closing in {{days}} days with {{count}} participants',
-                    }),
-                    action: () => handleOpenStudy(study.slug),
-                    actionLabel: t('admin.dashboard.view', 'View'),
-                });
-            }
-        }
-    }
-
-    const isLoading = studiesLoading;
-
-    function getStudyTitle(study: NonNullable<typeof studies>[number]): string {
-        const translation = study.translations?.find((tr) => tr.language_code === i18n.language);
-        if (translation?.title) return translation.title;
-        const fallback = study.translations?.find((tr) => tr.language_code === 'en');
-        if (fallback?.title) return fallback.title;
-        const anyTranslation = study.translations?.find((tr) => tr.title);
-        if (anyTranslation?.title) return anyTranslation.title;
-        return study.slug;
-    }
-
-    function handleOpenStudy(studySlug: string) {
-        setActiveStudy(studySlug);
-        navigate(`/app/${projectSlug}/studies/${studySlug}`);
-    }
+    const { t } = useTranslation();
+    const {
+        isLoading,
+        hasStudies,
+        projectSlug,
+        studies,
+        activeStudies,
+        draftStudies,
+        pausedStudies,
+        closedStudies,
+        totalParticipants,
+        alerts,
+        currentLocale,
+        showCreateDialog,
+        showImportDialog,
+        setShowCreateDialog,
+        setShowImportDialog,
+        getStudyTitle,
+        handleOpenStudy,
+    } = useAdminDashboard();
 
     if (isLoading) {
         return (
@@ -163,8 +107,6 @@ export function AdminDashboard() {
             </div>
         );
     }
-
-    const hasStudies = studies && studies.length > 0;
 
     // Show onboarding only until a study is created
     if (!hasStudies) {

--- a/frontend/src/hooks/admin/useAdminDashboard.test.ts
+++ b/frontend/src/hooks/admin/useAdminDashboard.test.ts
@@ -1,0 +1,202 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Unit tests for useAdminDashboard hook.
+ *
+ * Covers state-bucket partitioning, alert computation, study-title fallback,
+ * navigation handler, and dialog open flags — without rendering JSX.
+ * Hook+JSX integration is covered by AdminDashboard.test.tsx.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AllTheProviders } from '@/test-utils/test-utils';
+import { useAdminDashboard } from './useAdminDashboard';
+import type { StudyRead } from '@/api/model';
+
+const navigate = vi.fn();
+const setActiveStudy = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock('@/store/useAuthStore', () => ({
+    useAuthStore: () => ({ currentProject: { id: 7, slug: 'demo', title: 'Demo' } }),
+}));
+
+vi.mock('@/store/useAdminStore', () => ({
+    useAdminStore: () => ({ setActiveStudy }),
+}));
+
+const { mockStudiesHook } = vi.hoisted(() => ({ mockStudiesHook: vi.fn() }));
+
+vi.mock('@/api/generated', () => ({
+    useListStudiesApiAdminStudiesGet: mockStudiesHook,
+}));
+
+function makeStudy(overrides: Partial<StudyRead> & Pick<StudyRead, 'id' | 'slug'>): StudyRead {
+    return {
+        id: overrides.id,
+        slug: overrides.slug,
+        state: 'active',
+        project_id: 7,
+        participant_count: 0,
+        end_date: null,
+        translations: [],
+        ...overrides,
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+    } as any;
+}
+
+beforeEach(() => {
+    navigate.mockReset();
+    setActiveStudy.mockReset();
+    mockStudiesHook.mockReset();
+});
+
+describe('useAdminDashboard', () => {
+    it('partitions studies into state buckets and excludes other projects', () => {
+        const items: StudyRead[] = [
+            makeStudy({ id: 1, slug: 'a', state: 'active' }),
+            makeStudy({ id: 2, slug: 'b', state: 'draft' }),
+            makeStudy({ id: 3, slug: 'c', state: 'paused' }),
+            makeStudy({ id: 4, slug: 'd', state: 'closed' }),
+            makeStudy({ id: 5, slug: 'e', state: 'archived' }),
+            makeStudy({ id: 6, slug: 'f', state: 'active', project_id: 999 }),
+        ];
+        mockStudiesHook.mockReturnValue({ data: { items }, isLoading: false });
+
+        const { result } = renderHook(() => useAdminDashboard(), { wrapper: AllTheProviders });
+
+        expect(result.current.studies?.map((s) => s.slug)).toEqual(['a', 'b', 'c', 'd', 'e']);
+        expect(result.current.activeStudies.map((s) => s.slug)).toEqual(['a']);
+        expect(result.current.draftStudies.map((s) => s.slug)).toEqual(['b']);
+        expect(result.current.pausedStudies.map((s) => s.slug)).toEqual(['c']);
+        expect(result.current.closedStudies.map((s) => s.slug)).toEqual(['d', 'e']);
+        expect(result.current.hasStudies).toBe(true);
+    });
+
+    it('sums participant counts across all studies', () => {
+        mockStudiesHook.mockReturnValue({
+            data: {
+                items: [
+                    makeStudy({ id: 1, slug: 'a', participant_count: 12, state: 'active' }),
+                    makeStudy({ id: 2, slug: 'b', participant_count: 5, state: 'closed' }),
+                    makeStudy({ id: 3, slug: 'c', participant_count: 0, state: 'draft' }),
+                ],
+            },
+            isLoading: false,
+        });
+
+        const { result } = renderHook(() => useAdminDashboard(), { wrapper: AllTheProviders });
+        expect(result.current.totalParticipants).toBe(17);
+    });
+
+    it('produces a deadline alert for active studies closing within 7 days', () => {
+        const inFiveDays = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString();
+        const inThirtyDays = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+        mockStudiesHook.mockReturnValue({
+            data: {
+                items: [
+                    makeStudy({
+                        id: 1,
+                        slug: 'urgent',
+                        state: 'active',
+                        end_date: inFiveDays,
+                        participant_count: 3,
+                    }),
+                    makeStudy({
+                        id: 2,
+                        slug: 'comfortable',
+                        state: 'active',
+                        end_date: inThirtyDays,
+                    }),
+                    makeStudy({ id: 3, slug: 'no-deadline', state: 'active', end_date: null }),
+                ],
+            },
+            isLoading: false,
+        });
+
+        const { result } = renderHook(() => useAdminDashboard(), { wrapper: AllTheProviders });
+        expect(result.current.alerts).toHaveLength(1);
+        expect(result.current.alerts[0]?.key).toBe('deadline-1');
+    });
+
+    it('produces no alerts when no active study has a near deadline', () => {
+        mockStudiesHook.mockReturnValue({
+            data: { items: [makeStudy({ id: 1, slug: 'a', state: 'active', end_date: null })] },
+            isLoading: false,
+        });
+        const { result } = renderHook(() => useAdminDashboard(), { wrapper: AllTheProviders });
+        expect(result.current.alerts).toEqual([]);
+    });
+
+    it('getStudyTitle prefers current language, then en, then any, then slug', () => {
+        mockStudiesHook.mockReturnValue({ data: { items: [] }, isLoading: false });
+        const { result } = renderHook(() => useAdminDashboard(), { wrapper: AllTheProviders });
+
+        const withCurrent = makeStudy({
+            id: 1,
+            slug: 'a',
+            translations: [
+                { language_code: 'en', title: 'EN title', description: '' },
+                { language_code: 'fr', title: 'FR title', description: '' },
+                // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+            ] as any,
+        });
+        const withEnFallback = makeStudy({
+            id: 2,
+            slug: 'b',
+            translations: [
+                { language_code: 'en', title: 'EN only', description: '' },
+                // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+            ] as any,
+        });
+        const withAnyFallback = makeStudy({
+            id: 3,
+            slug: 'c',
+            translations: [
+                { language_code: 'fi', title: 'FI only', description: '' },
+                // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+            ] as any,
+        });
+        const empty = makeStudy({ id: 4, slug: 'd-slug', translations: [] });
+
+        // Default test language is 'en' via i18n test config
+        expect(result.current.getStudyTitle(withCurrent)).toBe('EN title');
+        expect(result.current.getStudyTitle(withEnFallback)).toBe('EN only');
+        expect(result.current.getStudyTitle(withAnyFallback)).toBe('FI only');
+        expect(result.current.getStudyTitle(empty)).toBe('d-slug');
+    });
+
+    it('handleOpenStudy sets active study and navigates to study URL', () => {
+        mockStudiesHook.mockReturnValue({ data: { items: [] }, isLoading: false });
+        const { result } = renderHook(() => useAdminDashboard(), { wrapper: AllTheProviders });
+        act(() => result.current.handleOpenStudy('my-study'));
+        expect(setActiveStudy).toHaveBeenCalledWith('my-study');
+        expect(navigate).toHaveBeenCalledWith('/app/demo/studies/my-study');
+    });
+
+    it('exposes setShowCreateDialog and setShowImportDialog and reflects updates', () => {
+        mockStudiesHook.mockReturnValue({ data: { items: [] }, isLoading: false });
+        const { result } = renderHook(() => useAdminDashboard(), { wrapper: AllTheProviders });
+        expect(result.current.showCreateDialog).toBe(false);
+        expect(result.current.showImportDialog).toBe(false);
+        act(() => result.current.setShowCreateDialog(true));
+        expect(result.current.showCreateDialog).toBe(true);
+        act(() => result.current.setShowImportDialog(true));
+        expect(result.current.showImportDialog).toBe(true);
+    });
+
+    it('hasStudies is false when the project has no studies', () => {
+        mockStudiesHook.mockReturnValue({ data: { items: [] }, isLoading: false });
+        const { result } = renderHook(() => useAdminDashboard(), { wrapper: AllTheProviders });
+        expect(result.current.hasStudies).toBe(false);
+    });
+});

--- a/frontend/src/hooks/admin/useAdminDashboard.ts
+++ b/frontend/src/hooks/admin/useAdminDashboard.ts
@@ -1,0 +1,159 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * useAdminDashboard hook
+ *
+ * Encapsulates the durable state-and-effect logic for the project dashboard.
+ * AdminDashboard receives this hook's return value and renders JSX from it.
+ *
+ * Visual-only state that stays in the component:
+ * - none (all state is logical: dialog open flags, derived data)
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { enUS, fr, fi } from 'date-fns/locale';
+import type { Locale } from 'date-fns';
+import { useListStudiesApiAdminStudiesGet } from '@/api/generated';
+import type { StudyRead } from '@/api/model';
+import { useAuthStore } from '@/store/useAuthStore';
+import { useAdminStore } from '@/store/useAdminStore';
+
+const DATE_LOCALES: Record<string, Locale> = { en: enUS, fr, fi };
+
+export interface DashboardAlert {
+    key: string;
+    message: string;
+    action?: () => void;
+    actionLabel?: string;
+}
+
+export interface AdminDashboardApi {
+    isLoading: boolean;
+    hasStudies: boolean;
+    projectSlug: string;
+    studies: StudyRead[] | undefined;
+    activeStudies: StudyRead[];
+    draftStudies: StudyRead[];
+    pausedStudies: StudyRead[];
+    closedStudies: StudyRead[];
+    totalParticipants: number;
+    alerts: DashboardAlert[];
+    currentLocale: Locale;
+    showCreateDialog: boolean;
+    showImportDialog: boolean;
+    setShowCreateDialog: (open: boolean) => void;
+    setShowImportDialog: (open: boolean) => void;
+    getStudyTitle: (study: StudyRead) => string;
+    handleOpenStudy: (studySlug: string) => void;
+}
+
+const DAYS_TO_DEADLINE_ALERT = 7;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export function useAdminDashboard(): AdminDashboardApi {
+    const { currentProject } = useAuthStore();
+    const { setActiveStudy } = useAdminStore();
+    const navigate = useNavigate();
+    const { t, i18n } = useTranslation();
+
+    const [showCreateDialog, setShowCreateDialog] = useState(false);
+    const [showImportDialog, setShowImportDialog] = useState(false);
+
+    const projectSlug = currentProject?.slug ?? '';
+    const currentLocale = DATE_LOCALES[i18n.language] ?? enUS;
+
+    const { data: allStudiesData, isLoading } = useListStudiesApiAdminStudiesGet(undefined, {
+        query: { enabled: !!currentProject?.id },
+    });
+
+    const studies = useMemo(
+        () => allStudiesData?.items?.filter((s) => s.project_id === currentProject?.id),
+        [allStudiesData, currentProject?.id]
+    );
+
+    const buckets = useMemo(() => {
+        const list = studies ?? [];
+        return {
+            activeStudies: list.filter((s) => s.state === 'active'),
+            draftStudies: list.filter((s) => s.state === 'draft'),
+            pausedStudies: list.filter((s) => s.state === 'paused'),
+            closedStudies: list.filter((s) => s.state === 'closed' || s.state === 'archived'),
+        };
+    }, [studies]);
+
+    const totalParticipants = useMemo(
+        () => (studies ?? []).reduce((sum, s) => sum + (s.participant_count ?? 0), 0),
+        [studies]
+    );
+
+    const getStudyTitle = useCallback(
+        (study: StudyRead): string => {
+            const current = study.translations?.find((tr) => tr.language_code === i18n.language);
+            if (current?.title) return current.title;
+            const en = study.translations?.find((tr) => tr.language_code === 'en');
+            if (en?.title) return en.title;
+            const any = study.translations?.find((tr) => tr.title);
+            if (any?.title) return any.title;
+            return study.slug;
+        },
+        [i18n.language]
+    );
+
+    const handleOpenStudy = useCallback(
+        (studySlug: string): void => {
+            setActiveStudy(studySlug);
+            navigate(`/app/${projectSlug}/studies/${studySlug}`);
+        },
+        [setActiveStudy, navigate, projectSlug]
+    );
+
+    const alerts = useMemo<DashboardAlert[]>(() => {
+        const out: DashboardAlert[] = [];
+        const now = Date.now();
+        for (const study of buckets.activeStudies) {
+            if (!study.end_date) continue;
+            const daysLeft = Math.ceil((new Date(study.end_date).getTime() - now) / MS_PER_DAY);
+            if (daysLeft > 0 && daysLeft <= DAYS_TO_DEADLINE_ALERT) {
+                out.push({
+                    key: `deadline-${study.id}`,
+                    message: t('admin.dashboard.alert_deadline', {
+                        study: getStudyTitle(study),
+                        days: daysLeft,
+                        count: study.participant_count ?? 0,
+                        defaultValue:
+                            '{{study}}: closing in {{days}} days with {{count}} participants',
+                    }),
+                    action: () => handleOpenStudy(study.slug),
+                    actionLabel: t('admin.dashboard.view', 'View'),
+                });
+            }
+        }
+        return out;
+    }, [buckets.activeStudies, t, getStudyTitle, handleOpenStudy]);
+
+    return {
+        isLoading,
+        hasStudies: (studies?.length ?? 0) > 0,
+        projectSlug,
+        studies,
+        activeStudies: buckets.activeStudies,
+        draftStudies: buckets.draftStudies,
+        pausedStudies: buckets.pausedStudies,
+        closedStudies: buckets.closedStudies,
+        totalParticipants,
+        alerts,
+        currentLocale,
+        showCreateDialog,
+        showImportDialog,
+        setShowCreateDialog,
+        setShowImportDialog,
+        getStudyTitle,
+        handleOpenStudy,
+    };
+}


### PR DESCRIPTION
## Summary

Plan D, single PR. Extracts the durable state-and-effect logic of `AdminDashboard` into a unit-tested `useAdminDashboard` hook per the project's hook-driven-component convention (CLAUDE.md). Closes the React-review Blocker on alerts being mutated during render.

- New hook: `frontend/src/hooks/admin/useAdminDashboard.ts` (159 LOC) with typed `AdminDashboardApi` interface — exposes `studies`, four state buckets, `totalParticipants`, `alerts`, `currentLocale`, `projectSlug`, dialog flags + setters, `getStudyTitle`, `handleOpenStudy`. All derived data is `useMemo`'d; handlers are `useCallback`'d.
- New tests: `useAdminDashboard.test.ts` (202 LOC, 8 cases) covering bucket partitioning + cross-project filtering, deadline-alert production, participant total, `getStudyTitle` 4-tier fallback, navigation, and dialog open flags. No JSX rendered — pure logic verification.
- `AdminDashboard.tsx` 784 → 726 LOC (the JSX shell now destructures the hook). 

Side cleanups inline (same lines, same review):
- `DATE_LOCALES` typed `Record<string, Locale>` (was `Record<string, any>` with `// biome-ignore`).
- Dropped redundant `as string` cast on `study.end_date` (the `if` guard already narrows).

## Plan

`docs/superpowers/plans/2026-04-27-...` (will be archived in a follow-up commit).

## Test plan

- [x] `make ci-fast` green (96 test files, 673 tests, +8 from this PR)
- [x] `make ci` green (lint + types + tests + frontend build)
- [ ] Manual smoke: project dashboard with 0 studies (onboarding), 1 study (single-card), N studies (groups). Verify `Create study` and `Import` dialogs still open. Verify deadline alert appears when an active study has `end_date` within 7 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)