### PR TITLE
feat(admin): demote dashboard Import button to ghost variant (UX wave E.2)

### DIFF
--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -255,7 +255,13 @@ export function AdminDashboard() {
                     </div>
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
-                    <Button onClick={() => setShowImportDialog(true)} variant="outline" size="sm">
+                    {/* Wave E (E8): "Import" demoted from outline to ghost so
+                        the visual hierarchy reflects relative frequency —
+                        most projects create studies; importing from a JSON
+                        config is the rarer, power-user path. The primary
+                        "Create study" stays a filled blue CTA (audit
+                        REPORT.md finding H4). */}
+                    <Button onClick={() => setShowImportDialog(true)} variant="ghost" size="sm">
                         <Upload className="mr-2 h-3.5 w-3.5" />
                         {t('admin.dashboard.import_study', 'Import')}
                     </Button>


### PR DESCRIPTION
## Summary

Wave E item **E8** (audit REPORT.md finding H4): the dashboard top-right button cluster gave equal visual weight to *"Create study"* (filled blue primary CTA) and *"Import"* (outline border). Importing a study from a JSON config is the rarer, power-user path; equal weight implied equal prevalence and forced the user to disambiguate on every visit.

## What changed

`AdminDashboard.tsx`:
- Import button: `variant="outline"` → `variant="ghost"`. No border, transparent background.
- Visual hierarchy now reflects relative frequency: **Create** is the primary CTA, **Import** is the secondary affordance.

Functionality unchanged.

## Note on E9

The audit also listed E9 — *"move Tester l'étude out of the publication cluster into the editing-context cluster"*. **Already implemented in Wave B (PR #50)**: the toolbar now reads `[FR ▾ · Tester]` | sep | `[Save · ⋯ Import/Export]` | sep | `[Activer l'étude]`. The Test button sits in the editing-context cluster (with the language picker), separated from the publication cluster (Save / Activate). No further change needed.

## Test plan

- [x] `make ci-fast` green (704 frontend tests)
- [x] `make ci` green (lint + types + tests + build)
- [x] `make e2e` green (23 tests, 52.5 s)
- [x] No i18n changes

## Wave E remaining

Larger items still pending, best in dedicated PRs:
- **E2** — `<EmptyState>` primitive + migrate ≥10 inline empty states
- **E6** — `<StatusPill kind={…}>` design-system component
- **E3** — Alert-color contract (yellow=guidance, red=blocker, blue=context)
- **E7** — Q-tri "Énoncés" sub-tab: invert bulk-paste vs single-add hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)