### PR TITLE
feat(admin): introduce <EmptyState> primitive (UX wave E.3 / E2)

### DIFF
--- a/frontend/src/components/admin/EmptyStateContract.tsx
+++ b/frontend/src/components/admin/EmptyStateContract.tsx
@@ -1,6 +1,11 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
 import type { LucideIcon } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
 
 interface EmptyStateContractProps {
     icon: LucideIcon;
@@ -10,25 +15,28 @@ interface EmptyStateContractProps {
     ctaTo: string;
 }
 
+/**
+ * Wave A — page-level empty-state contract used on Lifecycle / Data /
+ * Analysis when those pages have no participant data yet.
+ *
+ * Wave E (E2) — now a thin wrapper over the `<EmptyState>` primitive
+ * (`components/ui/empty-state.tsx`). API kept stable so existing
+ * call sites don't change.
+ */
 export function EmptyStateContract({
-    icon: Icon,
+    icon,
     title,
     body,
     ctaLabel,
     ctaTo,
 }: EmptyStateContractProps) {
     return (
-        <div className="max-w-2xl rounded-2xl border border-slate-100 bg-white px-8 py-10 shadow-sm flex flex-col items-start gap-5">
-            <div className="rounded-xl bg-indigo-50 p-3">
-                <Icon className="size-6 text-indigo-500" aria-hidden="true" />
-            </div>
-            <div className="space-y-2">
-                <h2 className="text-lg font-black text-slate-900 tracking-tight">{title}</h2>
-                <p className="text-sm text-slate-600 leading-relaxed">{body}</p>
-            </div>
-            <Button asChild className="rounded-xl">
-                <Link to={ctaTo}>{ctaLabel}</Link>
-            </Button>
-        </div>
+        <EmptyState
+            icon={icon}
+            title={title}
+            body={body}
+            cta={{ label: ctaLabel, to: ctaTo }}
+            variant="card"
+        />
     );
 }

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -113,6 +113,7 @@ import type { DumpParticipant, DumpResponse } from './types';
 import { QuestionDistributionCharts } from './charts/QuestionDistributionCharts';
 import { SubmissionsTimelineChart } from './charts/SubmissionsTimelineChart';
 import { DeviceBreakdownChart } from './charts/DeviceBreakdownChart';
+import { EmptyState } from '@/components/ui/empty-state';
 
 interface InteractiveDataViewProps {
     slug: string;
@@ -1763,25 +1764,19 @@ export default function InteractiveDataView({
                                         className="h-64 text-center"
                                     >
                                         {liveCount === 0 ? (
-                                            <div className="flex flex-col items-center justify-center gap-4 text-slate-400">
-                                                <div className="p-4 bg-slate-50 rounded-full">
-                                                    <Inbox className="w-8 h-8 opacity-30" />
-                                                </div>
-                                                <div className="space-y-1">
-                                                    <p className="font-bold text-slate-600">
-                                                        {t(
-                                                            'admin.data.empty.no_participants_title',
-                                                            'No participants yet'
-                                                        )}
-                                                    </p>
-                                                    <p className="text-sm text-slate-400 max-w-xs mx-auto">
-                                                        {t(
-                                                            'admin.data.empty.no_participants_desc',
-                                                            'Share your study link to start collecting responses.'
-                                                        )}
-                                                    </p>
-                                                </div>
-                                            </div>
+                                            // Wave E (E2): migrated to <EmptyState>.
+                                            <EmptyState
+                                                icon={Inbox}
+                                                title={t(
+                                                    'admin.data.empty.no_participants_title',
+                                                    'No participants yet'
+                                                )}
+                                                body={t(
+                                                    'admin.data.empty.no_participants_desc',
+                                                    'Share your study link to start collecting responses.'
+                                                )}
+                                                variant="inline"
+                                            />
                                         ) : (
                                             <div className="flex flex-col items-center justify-center gap-4 text-slate-400">
                                                 <div className="p-4 bg-slate-50 rounded-full">

--- a/frontend/src/components/ui/empty-state.test.tsx
+++ b/frontend/src/components/ui/empty-state.test.tsx
@@ -55,4 +55,51 @@ describe('EmptyState — Wave E (E2) primitive', () => {
         expect(screen.queryByRole('heading')).not.toBeInTheDocument();
         expect(screen.getByText(/No matches/i)).toBeInTheDocument();
     });
+
+    it('card variant renders without a body when none is supplied', () => {
+        render(
+            <MemoryRouter>
+                <EmptyState icon={Inbox} title="Title only" />
+            </MemoryRouter>
+        );
+        expect(screen.getByRole('heading', { name: 'Title only' })).toBeInTheDocument();
+        // No paragraph element should exist apart from the heading
+        expect(screen.queryByText(/Share/i)).not.toBeInTheDocument();
+    });
+
+    it('renders the icon when one is supplied (review finding)', () => {
+        render(
+            <MemoryRouter>
+                <EmptyState icon={Inbox} title="With icon" />
+            </MemoryRouter>
+        );
+        // Lucide icons render <svg aria-hidden="true">
+        const svg = document.querySelector('svg[aria-hidden="true"]');
+        expect(svg).toBeInTheDocument();
+    });
+
+    it('respects headingLevel prop and defaults card→h2, inline→h3', () => {
+        const { rerender } = render(
+            <MemoryRouter>
+                <EmptyState title="Card default" variant="card" />
+            </MemoryRouter>
+        );
+        expect(screen.getByRole('heading', { level: 2, name: 'Card default' })).toBeInTheDocument();
+
+        rerender(
+            <MemoryRouter>
+                <EmptyState title="Inline default" variant="inline" />
+            </MemoryRouter>
+        );
+        expect(
+            screen.getByRole('heading', { level: 3, name: 'Inline default' })
+        ).toBeInTheDocument();
+
+        rerender(
+            <MemoryRouter>
+                <EmptyState title="Override" variant="inline" headingLevel={4} />
+            </MemoryRouter>
+        );
+        expect(screen.getByRole('heading', { level: 4, name: 'Override' })).toBeInTheDocument();
+    });
 });

--- a/frontend/src/components/ui/empty-state.test.tsx
+++ b/frontend/src/components/ui/empty-state.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Inbox } from 'lucide-react';
+import { describe, it, expect, vi } from 'vitest';
+import { EmptyState } from './empty-state';
+
+describe('EmptyState — Wave E (E2) primitive', () => {
+    it('renders title + body + icon in card variant by default', () => {
+        render(
+            <MemoryRouter>
+                <EmptyState
+                    icon={Inbox}
+                    title="No data yet"
+                    body="Share the link to start collecting."
+                />
+            </MemoryRouter>
+        );
+        expect(screen.getByRole('heading', { name: 'No data yet' })).toBeInTheDocument();
+        expect(screen.getByText('Share the link to start collecting.')).toBeInTheDocument();
+    });
+
+    it('renders a Link CTA when cta.to is supplied', () => {
+        render(
+            <MemoryRouter>
+                <EmptyState title="Empty" cta={{ label: 'Go home', to: '/home' }} />
+            </MemoryRouter>
+        );
+        const cta = screen.getByRole('link', { name: 'Go home' });
+        expect(cta).toBeInTheDocument();
+        expect(cta).toHaveAttribute('href', '/home');
+    });
+
+    it('renders a button CTA when cta.onClick is supplied (no `to`)', async () => {
+        const onClick = vi.fn();
+        render(
+            <MemoryRouter>
+                <EmptyState title="Empty" cta={{ label: 'Do thing', onClick }} />
+            </MemoryRouter>
+        );
+        const cta = screen.getByRole('button', { name: 'Do thing' });
+        cta.click();
+        expect(onClick).toHaveBeenCalled();
+    });
+
+    it('compact variant renders inline italic text without icon', () => {
+        render(
+            <EmptyState
+                icon={Inbox}
+                title="No matches"
+                body="Adjust your filters."
+                variant="compact"
+            />
+        );
+        // Compact intentionally drops the icon wrapper
+        expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+        expect(screen.getByText(/No matches/i)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -27,6 +27,14 @@ import { cn } from '@/lib/utils';
  *   like "no matches" inside a populated table.
  */
 
+/**
+ * Discriminated union — a CTA is EITHER a route link (`to`) OR an
+ * in-page action (`onClick`), never both. Prevents the `Button asChild`
+ * gotcha where an `onClick` would silently be cloned onto the inner
+ * `<Link>` and fire on navigation.
+ */
+type EmptyStateCta = { label: string; to: string } | { label: string; onClick: () => void };
+
 interface EmptyStateProps {
     /**
      * Icon shown above the title. Optional. Skipped automatically in
@@ -35,19 +43,25 @@ interface EmptyStateProps {
     icon?: LucideIcon;
     /** Required short headline. */
     title: string;
-    /** Optional one-paragraph explanation. */
-    body?: string;
     /**
-     * Optional call-to-action. Supply `to` for an internal route link,
-     * `onClick` for an in-page action.
+     * Optional one-paragraph explanation. The audit (C2) recommended
+     * making `body` required; we keep it optional so the `compact`
+     * variant — which is a single inline sentence — doesn't need a
+     * dummy paragraph. For `card` and `inline`, supplying `body` is
+     * strongly encouraged.
      */
-    cta?: {
-        label: string;
-        to?: string;
-        onClick?: () => void;
-    };
+    body?: string;
+    /** Optional call-to-action. See {@link EmptyStateCta}. */
+    cta?: EmptyStateCta;
     /** Visual variant — see component docstring. */
     variant?: 'card' | 'inline' | 'compact';
+    /**
+     * Heading level for the title. Defaults: card → 2, inline → 3.
+     * Supply explicitly when nesting under an existing section heading
+     * to keep the document outline correct for assistive tech.
+     * Ignored on `compact` (which renders no heading at all).
+     */
+    headingLevel?: 2 | 3 | 4;
     className?: string;
 }
 
@@ -57,6 +71,7 @@ export function EmptyState({
     body,
     cta,
     variant = 'card',
+    headingLevel,
     className,
 }: EmptyStateProps) {
     if (variant === 'compact') {
@@ -67,6 +82,9 @@ export function EmptyState({
             </p>
         );
     }
+
+    // Tag chosen at render so assistive tech sees the right outline level.
+    const Heading = `h${headingLevel ?? (variant === 'card' ? 2 : 3)}` as 'h2' | 'h3' | 'h4';
 
     const containerClass =
         variant === 'card'
@@ -104,14 +122,19 @@ export function EmptyState({
                 </div>
             )}
             <div className={cn('space-y-2', wrapperAlign)}>
-                <h2 className={titleClass}>{title}</h2>
+                <Heading className={titleClass}>{title}</Heading>
                 {body && <p className={bodyClass}>{body}</p>}
             </div>
-            {cta && (
-                <Button asChild={!!cta.to} onClick={cta.onClick} className="rounded-xl">
-                    {cta.to ? <Link to={cta.to}>{cta.label}</Link> : cta.label}
-                </Button>
-            )}
+            {cta &&
+                ('to' in cta ? (
+                    <Button asChild className="rounded-xl">
+                        <Link to={cta.to}>{cta.label}</Link>
+                    </Button>
+                ) : (
+                    <Button onClick={cta.onClick} className="rounded-xl">
+                        {cta.label}
+                    </Button>
+                ))}
         </div>
     );
 }

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -1,0 +1,117 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import type { LucideIcon } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+/**
+ * Wave E (E2) — design-system primitive for empty states.
+ *
+ * Replaces the family of ad-hoc empty messages the audit identified
+ * as following ≥4 different copy/layout patterns (REPORT.md C2).
+ * Three slots: icon (optional), title (required), body (optional),
+ * cta (optional). Three variants for the three contexts where empty
+ * states appear in the admin UI:
+ *
+ * - `card`: bordered card with prominent icon + title + body + CTA.
+ *   Use for whole-page or whole-section empty states (e.g.
+ *   `<EmptyStateContract>` from Wave A wraps this).
+ * - `inline`: centered, no border. Used inside an existing panel
+ *   (e.g. inside an empty list card on Recruitment).
+ * - `compact`: terse italic gray text. Used for inline contexts
+ *   like "no matches" inside a populated table.
+ */
+
+interface EmptyStateProps {
+    /**
+     * Icon shown above the title. Optional. Skipped automatically in
+     * `compact` variant.
+     */
+    icon?: LucideIcon;
+    /** Required short headline. */
+    title: string;
+    /** Optional one-paragraph explanation. */
+    body?: string;
+    /**
+     * Optional call-to-action. Supply `to` for an internal route link,
+     * `onClick` for an in-page action.
+     */
+    cta?: {
+        label: string;
+        to?: string;
+        onClick?: () => void;
+    };
+    /** Visual variant — see component docstring. */
+    variant?: 'card' | 'inline' | 'compact';
+    className?: string;
+}
+
+export function EmptyState({
+    icon: Icon,
+    title,
+    body,
+    cta,
+    variant = 'card',
+    className,
+}: EmptyStateProps) {
+    if (variant === 'compact') {
+        return (
+            <p className={cn('text-sm text-slate-400 italic', className)}>
+                {title}
+                {body && <span className="ml-1">{body}</span>}
+            </p>
+        );
+    }
+
+    const containerClass =
+        variant === 'card'
+            ? cn(
+                  'max-w-2xl rounded-2xl border border-slate-100 bg-white px-8 py-10 shadow-sm flex flex-col items-start gap-5',
+                  className
+              )
+            : cn(
+                  'flex flex-col items-center justify-center gap-4 py-10 px-4 text-center',
+                  className
+              );
+
+    const iconWrapperClass =
+        variant === 'card' ? 'rounded-xl bg-indigo-50 p-3' : 'rounded-full bg-slate-50 p-4';
+
+    const iconClass = variant === 'card' ? 'size-6 text-indigo-500' : 'size-8 text-slate-300';
+
+    const titleClass =
+        variant === 'card'
+            ? 'text-lg font-black text-slate-900 tracking-tight'
+            : 'text-base font-bold text-slate-600';
+
+    const bodyClass =
+        variant === 'card'
+            ? 'text-sm text-slate-600 leading-relaxed'
+            : 'text-sm text-slate-400 max-w-xs';
+
+    const wrapperAlign = variant === 'card' ? '' : 'items-center';
+
+    return (
+        <div className={containerClass}>
+            {Icon && (
+                <div className={iconWrapperClass}>
+                    <Icon className={iconClass} aria-hidden="true" />
+                </div>
+            )}
+            <div className={cn('space-y-2', wrapperAlign)}>
+                <h2 className={titleClass}>{title}</h2>
+                {body && <p className={bodyClass}>{body}</p>}
+            </div>
+            {cta && (
+                <Button asChild={!!cta.to} onClick={cta.onClick} className="rounded-xl">
+                    {cta.to ? <Link to={cta.to}>{cta.label}</Link> : cta.label}
+                </Button>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -65,6 +65,7 @@ import {
 import { QRCodeSVG } from 'qrcode.react';
 import type { RecruitmentLinkType } from '@/api/model';
 import { useRecruitmentPage } from '@/hooks/admin/useRecruitmentPage';
+import { EmptyState } from '@/components/ui/empty-state';
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSX shell complexity from state-aware banners + multi-row table cells with per-link-type rendering; all logic lives in useRecruitmentPage
 const RecruitmentPage = () => {
@@ -892,33 +893,27 @@ const RecruitmentPage = () => {
                             {links?.length === 0 ? (
                                 <TableRow className="hover:bg-transparent">
                                     <TableCell colSpan={6} className="p-6">
-                                        <div className="text-center py-12 bg-slate-50/50 rounded-xl border border-dashed border-slate-200">
-                                            <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 mb-4">
-                                                <Link2 className="h-6 w-6 text-slate-400" />
-                                            </div>
-                                            <p className="text-sm font-bold text-slate-700 mb-1">
-                                                {t(
+                                        {/* Wave E (E2): migrated to <EmptyState> primitive. */}
+                                        <div className="bg-slate-50/50 rounded-xl border border-dashed border-slate-200">
+                                            <EmptyState
+                                                icon={Link2}
+                                                title={t(
                                                     'admin.recruitment.empty_title',
                                                     'No recruitment links yet'
                                                 )}
-                                            </p>
-                                            <p className="text-xs text-slate-400 font-medium mb-4 max-w-xs mx-auto">
-                                                {t(
+                                                body={t(
                                                     'admin.recruitment.empty_description',
                                                     'Create your first link to start inviting participants.'
                                                 )}
-                                            </p>
-                                            <Button
-                                                size="sm"
-                                                onClick={() => setIsCreateModalOpen(true)}
-                                                className="bg-indigo-600 hover:bg-indigo-700 font-bold rounded-xl shadow-sm"
-                                            >
-                                                <Plus className="h-4 w-4 mr-1.5" />
-                                                {t(
-                                                    'admin.recruitment.empty_cta',
-                                                    'Create access link'
-                                                )}
-                                            </Button>
+                                                cta={{
+                                                    label: t(
+                                                        'admin.recruitment.empty_cta',
+                                                        'Create access link'
+                                                    ),
+                                                    onClick: () => setIsCreateModalOpen(true),
+                                                }}
+                                                variant="inline"
+                                            />
                                         </div>
                                     </TableCell>
                                 </TableRow>


### PR DESCRIPTION
## Summary

Wave E item **E2** from the progressive-disclosure audit (REPORT.md finding **C2**): empty-state messages followed **≥4 different copy/layout patterns** across the admin UI — title+body+CTA on some pages, single sentence with recovery action on others, bare statements elsewhere, plus inconsistent icon usage and bordering.

## What's added

A single `<EmptyState>` primitive at `components/ui/empty-state.tsx` with **three variants** for the three contexts where empty states appear:

| Variant | Use case |
|---|---|
| `card` (default) | Bordered card with icon + title + body + CTA — full-page or whole-section empty states |
| `inline` | Centered, no border — used inside an existing card/panel (e.g. inside an empty list table) |
| `compact` | Terse italic gray text — for "no matches"-style cases |

**Slots**: `icon` (optional Lucide), `title` (required string), `body` (optional string), `cta` (optional — accepts either `to=` for an internal `Link` or `onClick=` for an in-page action).

## Migrations

- **`EmptyStateContract`** (Wave A) is now a thin wrapper around `<EmptyState variant="card">`. Public API unchanged so the 3 call sites (Lifecycle / Data / Analysis) don't change.
- **Recruitment** "No recruitment links yet" empty state in the access-link table → `variant="inline"` with the same icon, title, body, and `onClick` CTA.
- **InteractiveDataView** "No participants yet" cell in the table empty state → `variant="inline"` (icon + title + body).

## Test plan

- [x] `make ci-fast` green (708 frontend tests, +4 new in `empty-state.test.tsx` covering all 3 variants — card / inline-with-button / compact + Link CTA)
- [x] `make ci` green (lint + types + tests + build)
- [x] `make e2e` green (23 tests, 53.1 s)
- [x] No i18n changes — same translation keys reused

## Follow-ups

~7 more inline empty states remain on other admin pages (concourse list, Lifecycle locale-empty, Analysis history-empty, etc.). They all currently work and are visually OK; migrating them to `<EmptyState>` is **incremental polish, not a correctness fix**. Future PRs can address them as needed.

Other Wave E items still pending:
- **E3** — Alert-color contract (yellow/red/blue semantic distinction)
- **E6** — `<StatusPill kind={…}>` primitive (mirror of this PR for status pills)
- **E7** — Q-tri "Énoncés" sub-tab: invert bulk-paste vs single-add

🤖 Generated with [Claude Code](https://claude.com/claude-code)