### PR TITLE
fix(admin): UX wave E follow-ups from code review (CommandMenu label, EN/FI breadcrumbs, orphan tooltip key)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1139,7 +1139,7 @@
     "breadcrumbs": {
       "admin": "Admin",
       "dashboard": "Dashboard",
-      "study_dashboard": "Dashboard",
+      "study_dashboard": "Overview",
       "design": "Design",
       "participants": "Participants",
       "team": "Team",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -1123,8 +1123,8 @@
         },
         "breadcrumbs": {
             "admin": "Ylläpito",
-            "dashboard": "Yhteenveto",
-            "study_dashboard": "Yhteenveto",
+            "dashboard": "Hallintapaneeli",
+            "study_dashboard": "Yleisnäkymä",
             "design": "Suunnittelu",
             "participants": "Osallistujat",
             "team": "Tiimi",

--- a/frontend/src/components/admin/CommandMenu.tsx
+++ b/frontend/src/components/admin/CommandMenu.tsx
@@ -211,7 +211,13 @@ export const CommandMenu = () => {
                                 <div className="flex h-6 w-6 items-center justify-center rounded bg-indigo-100 dark:bg-indigo-900/40">
                                     <LayoutDashboard className="h-3.5 w-3.5 text-indigo-600 dark:text-indigo-400" />
                                 </div>
-                                <span>{t('admin.sidebar.dashboard')}</span>
+                                {/* Wave E follow-up: the study-scope item was renamed to
+                                    'Vue d'ensemble' / 'Overview' / 'Yleisnäkymä' in PR #53
+                                    (key admin.sidebar.overview). The Command-K palette was
+                                    missed in that pass and still showed the project-scope
+                                    "Tableau de bord" / "Dashboard" / "Hallintapaneeli" label
+                                    for the same target. */}
+                                <span>{t('admin.sidebar.overview')}</span>
                             </Command.Item>
                             <Command.Item
                                 value="design study"

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -243,7 +243,10 @@ const StudyDesignPage = () => {
                                 size="sm"
                                 variant="outline"
                                 onClick={api.save}
-                                title={t('admin.design.toolbar.save_changes', 'Save Changes')}
+                                // Use the standardised toolbar.save key (Wave E.1).
+                                // The previous "save_changes" key was orphaned —
+                                // never present in any locale file.
+                                title={t('admin.design.toolbar.save', 'Save')}
                                 disabled={
                                     api.syncStatus === 'synced' ||
                                     api.syncStatus === 'saving' ||


### PR DESCRIPTION
## Summary

Three small follow-ups surfaced by an independent `superpowers:code-reviewer` pass on PRs #53/#54/#55 (the Wave E series). Each is a **missed propagation** of an earlier wave's standardisation, not new work.

## What changed

### 1. `CommandMenu.tsx:214` — palette label aligned with sidebar

The Command-K palette item that navigates to the study-scope overview still labelled it via `admin.sidebar.dashboard` ("Tableau de bord" / "Dashboard" / "Hallintapaneeli"). PR #53's E4 fix renamed that target to `admin.sidebar.overview` in the sidebar, but missed the palette. Same target now reads the same label in both surfaces.

### 2. EN + FI breadcrumb labels match the new sidebar

PR #53's description argued *"the sidebar now agrees with the breadcrumb that has always said 'Vue d'ensemble'"* — true only in French. EN and FI breadcrumbs still said *"Dashboard"* and *"Yhteenveto"* respectively, identical to the project-scope breadcrumb (so the disambiguation was incomplete in those locales).

- `en/translation.json:1142` `breadcrumbs.study_dashboard`: `"Dashboard"` → `"Overview"`
- `fi/translation.json:1126-7` `breadcrumbs.dashboard`: `"Yhteenveto"` → `"Hallintapaneeli"` (project-scope)
- `fi/translation.json:1127` `breadcrumbs.study_dashboard`: `"Yhteenveto"` → `"Yleisnäkymä"` (study-scope)

Now the sidebar / breadcrumb / Command-K palette all use matching labels in all 3 locales.

### 3. `StudyDesignPage.tsx:246` — orphan tooltip key replaced

The Save-button `title=` tooltip used `admin.design.toolbar.save_changes` — a key never present in any locale file. The tooltip rendered the EN fallback *"Save Changes"* in every language. Predates Wave E (history goes back to PR #46) but adjacent to E1's *"Save Changes"* → *"Save"* standardisation. Switched to the standardised `admin.design.toolbar.save` key (which exists in all 3 locales).

## Test plan

- [x] `make ci-fast` green (711 frontend tests)
- [x] `make ci` green (lint + types + tests + build)
- [x] `make e2e` green (23 tests, 1.9 min)
- [x] i18n parity en/fr/fi

## What this does NOT change

- No new features
- No new components or primitives
- No backend changes
- All semantic targets unchanged — only label strings updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)