### PR TITLE
refactor(admin): finish <EmptyState> migrations (closes UX audit)

### DIFF
--- a/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
@@ -21,6 +21,7 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { EmptyState } from '@/components/ui/empty-state';
 
 interface AnalysisHistoryPanelProps {
     slug: string;
@@ -185,20 +186,23 @@ export function AnalysisHistoryPanel({ slug, currentRunId, onLoadRun }: Analysis
                     )}
 
                     {runsQuery.isSuccess && runs.length === 0 && (
-                        <div className="py-4 text-center space-y-1">
-                            <p className="text-sm text-slate-500">
-                                {t(
-                                    'admin.analysis.history.empty',
-                                    'No previous analyses for this study yet — run one to start the audit trail.'
-                                )}
-                            </p>
-                            <p className="text-xs text-slate-400">
-                                {t(
-                                    'admin.analysis.history.empty_explainer',
-                                    'Documenting analytical choices supports reproducibility — a core requirement of careful Q-methodological practice (Watts & Stenner 2012; Sneegas 2020). Each run is logged here so you can document and revisit every decision.'
-                                )}
-                            </p>
-                        </div>
+                        // Wave E.4 (E2 cleanup): migrated to <EmptyState>.
+                        // Inline variant, no icon (the panel already has the
+                        // ClipboardList in its header). The pedagogical
+                        // body (Watts & Stenner / Sneegas citations) is
+                        // preserved verbatim.
+                        <EmptyState
+                            title={t(
+                                'admin.analysis.history.empty',
+                                'No previous analyses for this study yet — run one to start the audit trail.'
+                            )}
+                            body={t(
+                                'admin.analysis.history.empty_explainer',
+                                'Documenting analytical choices supports reproducibility — a core requirement of careful Q-methodological practice (Watts & Stenner 2012; Sneegas 2020). Each run is logged here so you can document and revisit every decision.'
+                            )}
+                            variant="inline"
+                            headingLevel={3}
+                        />
                     )}
 
                     {runsQuery.isSuccess && runs.length > 0 && (

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -22,6 +22,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { GripVertical, Plus, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { EmptyState } from '@/components/ui/empty-state';
 import {
     Accordion,
     AccordionContent,
@@ -414,16 +415,17 @@ export function ProcessStepEditor({ readOnly }: { readOnly?: boolean }) {
                     strategy={verticalListSortingStrategy}
                 >
                     {steps.length === 0 ? (
-                        <div className="py-16 flex flex-col items-center justify-center border-2 border-dashed border-slate-200 rounded-3xl bg-slate-50/20 transition-all hover:bg-slate-50/40">
-                            <div className="bg-white p-4 rounded-2xl shadow-sm border border-slate-100 mb-6">
-                                <Plus className="h-8 w-8 text-slate-300" />
-                            </div>
-                            <p className="text-base font-bold text-slate-900 tracking-tight">
-                                {t('admin.design.intro.process_steps.empty.title')}
-                            </p>
-                            <p className="text-sm font-medium text-slate-500 mt-2 max-w-[280px] text-center leading-relaxed">
-                                {t('admin.design.intro.process_steps.empty.desc')}
-                            </p>
+                        // Wave E.4 (E2 cleanup): migrated to <EmptyState>.
+                        // Outer dashed-border wrapper retained for the visual
+                        // "drop zone" affordance specific to this empty list.
+                        <div className="border-2 border-dashed border-slate-200 rounded-3xl bg-slate-50/20 transition-all hover:bg-slate-50/40">
+                            <EmptyState
+                                icon={Plus}
+                                title={t('admin.design.intro.process_steps.empty.title')}
+                                body={t('admin.design.intro.process_steps.empty.desc')}
+                                variant="inline"
+                                headingLevel={3}
+                            />
                         </div>
                     ) : (
                         <div className="flex flex-col">

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { EmptyState } from '@/components/ui/empty-state';
 import {
     GripVertical,
     Plus,
@@ -954,16 +955,15 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                             strategy={verticalListSortingStrategy}
                         >
                             {questions.length === 0 ? (
-                                <div className="py-16 flex flex-col items-center justify-center border-2 border-dashed border-slate-200 rounded-3xl bg-slate-50/30 transition-all hover:bg-slate-50/50">
-                                    <div className="bg-white p-4 rounded-2xl shadow-sm border border-slate-100 mb-6">
-                                        <Plus className="h-8 w-8 text-slate-300" />
-                                    </div>
-                                    <p className="text-base font-bold text-slate-900 tracking-tight">
-                                        {t('admin.design.questions.empty.title')}
-                                    </p>
-                                    <p className="text-sm font-medium text-slate-500 mt-2 max-w-[280px] text-center leading-relaxed">
-                                        {t('admin.design.questions.empty.desc')}
-                                    </p>
+                                // Wave E.4 (E2 cleanup): migrated to <EmptyState>.
+                                <div className="border-2 border-dashed border-slate-200 rounded-3xl bg-slate-50/30 transition-all hover:bg-slate-50/50">
+                                    <EmptyState
+                                        icon={Plus}
+                                        title={t('admin.design.questions.empty.title')}
+                                        body={t('admin.design.questions.empty.desc')}
+                                        variant="inline"
+                                        headingLevel={3}
+                                    />
                                 </div>
                             ) : (
                                 <div className="flex flex-col">

--- a/frontend/src/pages/admin/DataLifecyclePage.tsx
+++ b/frontend/src/pages/admin/DataLifecyclePage.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { EmptyStateContract } from '@/components/admin/EmptyStateContract';
+import { EmptyState } from '@/components/ui/empty-state';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -388,9 +389,11 @@ export default function DataLifecyclePage() {
                                 </tbody>
                             </table>
                         ) : (
-                            <p className="text-sm text-slate-400 italic">
-                                {t('admin.lifecycle.locale_empty', 'No locale data yet.')}
-                            </p>
+                            // Wave E.4 (E2 cleanup): migrated to <EmptyState compact>.
+                            <EmptyState
+                                title={t('admin.lifecycle.locale_empty', 'No locale data yet.')}
+                                variant="compact"
+                            />
                         )}
                     </CardContent>
                 </Card>


### PR DESCRIPTION
## Summary

**Wave E.4 — final cleanup PR closing the UX progressive-disclosure audit.** Migrates 4 inline empty states identified by an independent backlog review (`superpowers` subagent) as worth doing; the other ~3 inline cases were assessed as below the migration threshold (filtered-table "no matches", inline help hints — bare statement is appropriate per the audit's own contract for those contexts).

## Sites migrated

| File | Variant | Notes |
|---|---|---|
| `AnalysisHistoryPanel.tsx` | `inline` (no icon) | Empty history block. Panel header already shows ClipboardList; pedagogical body (Watts & Stenner / Sneegas citations) preserved verbatim |
| `ProcessStepEditor.tsx` | `inline` + Plus icon | Empty steps placeholder on Design > Général. Outer dashed-border wrapper retained for the "drop zone" affordance |
| `QuestionBuilder.tsx` | `inline` + Plus icon | Empty questions placeholder on Design > Q-tri. Same pattern as ProcessStepEditor |
| `DataLifecyclePage.tsx` | `compact` | *"Aucune donnée de langue pour l'instant"* — italic gray inline, exactly what compact was designed for |

All 4 reuse existing translation keys; no i18n changes needed.

## Audit closure

This is the **9th and final PR** of the UX progressive-disclosure audit (`.playwright-mcp/ux-progressive-reveal/REPORT.md`). Series:

- #49 Wave A — empty-state contracts (Lifecycle/Data/Analysis)
- #50 Wave B — Study Design Général Accordion split
- #51 Wave D — 9 small consistency fixes
- #52 Wave C — Analysis advanced disclosure
- #53 Wave E.1 — save labels + sidebar rename + persistent help
- #54 Wave E.2 — Dashboard Import → ghost
- #55 Wave E.3 — `<EmptyState>` primitive
- #56 Wave E follow-ups (CommandMenu / breadcrumbs / orphan key)
- **#57 Wave E.4 — this PR**

The remaining unaddressed audit items (**E3** alert-color contract, **E6** `<StatusPill>` primitive, **E7** Q-tri bulk-vs-single inversion) were assessed by the backlog review as **below the threshold where shipping more pays back** — no live user pain to justify the cost. They can be revisited if a real complaint surfaces.

## Test plan

- [x] `make ci-fast` green (711 frontend tests)
- [x] `make ci` green (lint + types + tests + build)
- [x] `make e2e` green (23 tests, 55 s)
- [x] i18n parity en/fr/fi (no key changes — same translations reused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)