### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualis-backend"
-version = "0.1.0"
+version = "0.2.0"
 description = "Backend for Qualis"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1523,7 +1523,7 @@ wheels = [
 
 [[package]]
 name = "qualis-backend"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "qualis",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "qualis",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "qualis",
     "private": true,
-    "version": "0.1.0",
+    "version": "0.2.0",
     "type": "module",
     "engines": {
         "node": "24.x"


### PR DESCRIPTION
## Summary

Bump `qualis` and `qualis-backend` from `0.1.0` → `0.2.0` (minor) to mark the 9-PR UX progressive-disclosure audit cycle.

## Audit cycle shipped in 0.2.0

- **#49** Wave A — empty-state contracts (Lifecycle/Data/Analysis)
- **#50** Wave B — Study Design Général Accordion split
- **#51** Wave D — 9 consistency fixes
- **#52** Wave C — Analysis advanced disclosure
- **#53** Wave E.1 — save labels + sidebar rename + persistent help
- **#54** Wave E.2 — Dashboard Import → ghost
- **#55** Wave E.3 — `<EmptyState>` primitive
- **#56** Wave E follow-ups (CommandMenu / breadcrumbs / orphan key)
- **#57** Wave E.4 — final `<EmptyState>` migrations (closes audit)

## Files

- `frontend/package.json` + `frontend/package-lock.json` (regenerated via `npm install --package-lock-only`)
- `backend/pyproject.toml` + `backend/uv.lock` (regenerated via `uv sync`)

## Test plan

- [x] `make ci-fast` green (711 frontend tests, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)