### PR TITLE
refactor(admin): text-trim wave F + bump 0.3.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualis-backend"
-version = "0.2.0"
+version = "0.3.0"
 description = "Backend for Qualis"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "qualis",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "qualis",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "qualis",
     "private": true,
-    "version": "0.2.0",
+    "version": "0.3.0",
     "type": "module",
     "engines": {
         "node": "24.x"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -166,22 +166,17 @@
   },
   "auth": {
     "login": {
-      "title": "Admin login",
       "email_label": "Email address",
       "password_label": "Password",
       "submit": "Continue",
       "forgot_password": "Forgot?",
       "loading": "Authenticating...",
-      "subtitle": "Enter your credentials to manage your studies",
       "card_title": "Sign in",
-      "card_description": "Secure access to your research dashboard",
-      "privacy": "By signing in, you agree to our terms and privacy policy.",
-      "powered_by": "Powered by",
       "welcome_back": "Welcome back!",
       "error_401": "Invalid email or password",
       "error_generic": "Something went wrong. Please try again.",
       "reason_session_expired": "Your session has expired. Please sign in again.",
-      "reason_auth_required": "Please sign in to access the admin panel."
+      "reason_auth_required": "Please sign in to continue."
     },
     "register": {
       "title": "Create account",
@@ -454,14 +449,14 @@
     "study_design": {
       "distribution_mode": {
         "title": "Distribution mode",
-        "helper": "Choose how strictly the Q-sort grid is enforced. Forced: each column must be filled to its declared capacity (the most common choice; Brown 1980; Watts & Stenner 2012). Free: any number of cards per column, total = Q-set size (Brown et al. 2015 argue distribution shape barely affects results). Flexible: total enforced, columns are soft hints.",
+        "helper": "Choose how strictly the Q-sort grid is enforced. Forced: each column must be filled to its declared capacity (the most common choice). Free: any number of cards per column, total = Q-set size. Flexible: total enforced, columns are soft hints.",
         "forced": {
           "label": "Forced",
-          "tooltip": "Each column must hold exactly its declared capacity. Brown 1980; Watts & Stenner 2012."
+          "tooltip": "Each column must hold exactly its declared capacity."
         },
         "free": {
           "label": "Free",
-          "tooltip": "Total cards = Q-set size; per-column count is unconstrained. Brown et al. 2015."
+          "tooltip": "Total cards = Q-set size; per-column count is unconstrained."
         },
         "flexible": {
           "label": "Flexible",
@@ -515,9 +510,8 @@
       "description": "Manage your personal information and security settings.",
       "personal": {
         "title": "Personal information",
-        "description": "Your account details and contact information.",
         "email": "Email address",
-        "email_locked": "Email cannot be changed directly. Contact admin.",
+        "email_locked": "Contact an admin to change.",
         "name": "Full name",
         "save": "Save",
         "saving": "Saving...",
@@ -530,15 +524,11 @@
         "title": "Security & 2FA",
         "description": "Secure your account with two-factor authentication.",
         "enabled": "Enabled",
-        "status_active": "Your account is secured with two-factor authentication.",
-        "status_inactive": "Account security is low",
-        "status_inactive_desc": "Enable two-factor authentication to protect your sensitive data and studies.",
         "setup_cta": "Setup 2FA now",
         "configure_title": "Configure authenticator app",
         "scan_desc": "Scan this QR code with your authenticator app (google authenticator, authy, etc.)",
         "enter_code": "Enter 6-digit code",
         "enable_btn": "Enable 2FA",
-        "active_msg": "2FA is active",
         "disable_btn": "Disable 2FA",
         "confirm_disable": "Confirm disable",
         "confirm_password_label": "Confirm with your password",
@@ -552,7 +542,6 @@
       },
       "password": {
         "title": "Password management",
-        "description": "Update your password to keep your account secure.",
         "current": "Current password",
         "new": "New password",
         "change_btn": "Change password",
@@ -617,7 +606,6 @@
       "empty_title": "No concourses yet",
       "empty_desc": "Create a concourse to start collecting and organizing candidate statements for your Q-methodology research.",
       "add_item": "Add Item",
-      "add_item_desc": "Add a new candidate statement to this concourse.",
       "bulk_import": "Bulk Import",
       "import_desc": "Paste statements separated by newlines. Each line becomes one item.",
       "import_prefix": "Code prefix",
@@ -644,7 +632,7 @@
       "deleted": "Concourse deleted",
       "delete_error": "Failed to delete concourse",
       "delete_item_title": "Delete Item",
-      "delete_item_confirm": "Are you sure you want to delete this item? This cannot be undone.",
+      "delete_item_confirm": "Delete this item? Cannot be undone.",
       "status": {
         "proposed": "Proposed",
         "accepted": "Accepted",
@@ -662,7 +650,6 @@
       "version_label": "v{{n}}",
       "item_detail_desc": "History and comments for this item",
       "manage_tags": "Tags",
-      "manage_tags_desc": "Create and manage tags to categorize concourse items by theme or dimension.",
       "tag_name_placeholder": "Tag name",
       "tag_color": "Tag color",
       "tag_created": "Tag created",
@@ -707,15 +694,13 @@
         "title": "Construction memo",
         "summary_empty": "Optional · for transparency about the curation process",
         "summary_filled": "{{n}} characters · click to view or edit",
-        "helper": "Optional. Document how this concourse was constructed: sources canvassed, voices retained or set aside, sampling rationale. Useful for transparency about the curation process (Sneegas 2020; Robbins & Krueger 2000). Leave blank if not applicable to your design.",
         "placeholder": "Document how this concourse was constructed: sources, voices retained or excluded, sampling rationale...",
         "save": "Save memo",
         "saved": "Construction memo saved",
         "save_error": "Failed to save construction memo"
       },
-      "status_pills_aria": "Accepted: {{a}}; Proposed: {{p}}; Rejected: {{r}}",
       "import_from_csv": "Import CSV/TSV…",
-      "import_csv_hint": "CSV/TSV must have headers code, language, text. Rows in the selected language are loaded into the textarea above.",
+      "import_csv_hint": "CSV/TSV needs columns: code, language, text.",
       "import_csv_no_match": "No rows match the selected language ({{lang}}).",
       "import_csv_skipped": "Skipped {{count}} row(s) in other languages: {{langs}}.",
       "import_csv_more_errors": "{{count}} more issues"
@@ -774,7 +759,7 @@
       "eigenvalue_error": "Failed to load analysis data. Please try again.",
       "scree_plot_label": "Scree plot showing eigenvalues for {{n}} factors",
       "loading_eigenvalues": "Loading eigenvalues...",
-      "empty_state": "Configure parameters above and click \"Run Analysis\" to extract factors from your Q-sort data.",
+      "empty_state": "Set parameters and run the analysis.",
       "empty": {
         "contract_title": "Not enough Q-sort data yet",
         "contract_body": "Q-methodology factor analysis requires at least 2 participants who have completed the sort. Configuration choices (extraction, factors, rotation, flagging) carry meaning once data exists. Share the study link from the overview to start collecting responses.",
@@ -826,9 +811,9 @@
       "no_statement_scores": "No statement scores available. Ensure participants are flagged for at least one factor.",
       "no_characteristics": "No factor characteristics available.",
       "export": "Export",
-      "export_loadings": "CSV — Factor Loadings",
-      "export_scores": "CSV — Statement Scores",
-      "export_xlsx": "XLSX — Complete Analysis",
+      "export_loadings": "Factor loadings (CSV)",
+      "export_scores": "Statement scores (CSV)",
+      "export_xlsx": "Complete analysis (XLSX)",
       "export_error": "Failed to generate XLSX export.",
       "select_factors": "Select number of factors",
       "loadings_help": "Factor loadings show how strongly each participant's sort correlates with each factor. Highlighted cells exceed the significance threshold shown above.",
@@ -842,30 +827,22 @@
       "z_scores_description": "Z-scores and factor array positions per statement",
       "factor_statistics": "Factor Statistics",
       "characteristics_help": "Eigenvalues reflect the amount of variance explained. Composite reliability reflects internal consistency among flagged sorts. SE of factor scores reflects the precision of the composite estimate.",
-      "help_extraction": "PCA maximizes explained variance across factors. Centroid produces less mathematically constrained factors, which some Q researchers prefer for theoretical reasons.",
-      "help_n_factors": "Each factor represents a distinct viewpoint. More factors capture more nuance but may split coherent views; fewer factors give broader groupings.",
-      "help_rotation": "Varimax maximizes the separation between factors, producing simpler structure. No rotation preserves the original mathematical solution.",
-      "help_flagging": "Auto flags participants whose loading exceeds the significance threshold on exactly one factor. Manual lets you override flagging based on your own judgment.",
+      "help_extraction": "PCA maximises explained variance. Centroid is less mathematically constrained.",
+      "help_n_factors": "Each factor represents a distinct viewpoint.",
+      "help_rotation": "Varimax separates factors for simpler structure.",
+      "help_flagging": "Auto: flag participants loading on exactly one factor. Manual: override per participant.",
       "guide_loadings_title": "Reading Factor Loadings",
       "guide_loadings_1": "Each loading is a correlation (-1 to +1) between a participant and a factor (shared viewpoint).",
       "guide_loadings_2": "Highlighted values exceed the significance threshold shown above the table.",
-      "guide_loadings_3": "A \"flagged\" participant defines that factor. Look for clean structure: each person on one factor.",
-      "guide_loadings_4": "Participants not flagged on any factor hold a unique view not captured by the solution.",
       "guide_arrays_title": "Interpreting Factor Arrays",
       "guide_arrays_1": "Each factor array is the composite Q-sort representing one shared viewpoint.",
       "guide_arrays_2": "Read left-to-right as most disagreed to most agreed. Extreme positions carry the strongest signal for interpretation.",
-      "guide_arrays_3": "Amber-highlighted statements are distinguishing — placed significantly differently compared to other factors.",
-      "guide_arrays_4": "Compare arrays across factors to see where viewpoints diverge and converge.",
       "guide_statements_title": "Understanding Statement Scores",
       "guide_statements_1": "Z-scores show how strongly each factor agrees or disagrees with each statement (0 = neutral).",
       "guide_statements_2": "D = distinguishing (placed significantly differently across factors). Stars indicate significance level.",
-      "guide_statements_3": "C = consensus (all factors agree on placement). These don't help differentiate viewpoints.",
-      "guide_statements_4": "D statements reveal what makes each viewpoint unique. C statements show where viewpoints converge.",
       "guide_summary_title": "Evaluating Your Solution",
       "guide_summary_1": "Eigenvalues measure how much variance a factor explains. The Kaiser criterion (eigenvalue > 1) is one common heuristic for deciding how many factors to retain.",
       "guide_summary_2": "Composite reliability reflects how consistently the flagged sorts define each factor. Higher values mean the factor estimate is based on more agreement among its defining sorts.",
-      "guide_summary_3": "Factor correlations show how much overlap exists between viewpoints. Higher correlations mean the factors share more common ground; lower correlations mean they are more distinct.",
-      "guide_summary_4": "Total variance explained indicates how much of the overall variation in sorting patterns is captured by your solution.",
       "benchmark_above": "Above threshold",
       "benchmark_below": "Below threshold",
       "history": {
@@ -873,7 +850,7 @@
         "loading": "Loading history…",
         "fetch_error": "Could not load analysis history.",
         "empty": "No previous analyses for this study yet — run one to start the audit trail.",
-        "empty_explainer": "Documenting analytical choices supports reproducibility — a core requirement of careful Q-methodological practice (Watts & Stenner 2012; Sneegas 2020). Each run is logged here so you can document and revisit every decision.",
+        "empty_explainer": "Each run is logged here so you can document and revisit every decision.",
         "load_error": "Failed to load the analysis run.",
         "load_run_aria": "Load analysis run from {{date}}",
         "loading_run": "Loading…",
@@ -904,7 +881,7 @@
         "no_material": "No post-sort audio recordings or written comments from participants flagged on this factor.",
         "loading": "Loading recordings…",
         "error": "Could not load audio recordings. Please try again.",
-        "context": "Grounding factor interpretation in participants' own words — their audio rationales and their written card comments — is a core element of careful Q-methodological practice (Watts & Stenner 2012; Sneegas 2020).",
+        "context": "Ground factor interpretation in participants' own words — their audio rationales and their written card comments.",
         "context_aria": "About this panel",
         "audio_label": "Recording: {{key}} by {{participant}}",
         "url_unavailable": "Audio URL not available.",
@@ -926,12 +903,12 @@
         "judgmental": {
           "label": "Judgmental (manual)",
           "short": "Judgmental",
-          "tooltip": "Manually rotate factor pairs by chosen angles to align factors with substantively-meaningful positions (Brown 1980; Watts & Stenner 2012)."
+          "tooltip": "Manually rotate factor pairs by chosen angles to align factors with substantively-meaningful positions."
         }
       },
       "manual_rotations": {
         "title": "Manual rotations",
-        "helper": "Specify rotations as 'rotate factor F by Δ° around factor G'. Rotations are applied in order. Used to align factors with substantively-meaningful positions (Brown 1980; Watts & Stenner 2012).",
+        "helper": "Specify rotations as 'rotate factor F by Δ° around factor G'. Rotations are applied in order.",
         "add": "Add rotation",
         "remove_aria": "Remove rotation",
         "empty": "Add at least one rotation to run the analysis.",
@@ -942,10 +919,10 @@
       "bootstrap": {
         "toggle_label": "Run bootstrap stability",
         "iterations_label": "Iterations (B)",
-        "helper": "Optional. Bootstrap resamples your Q-sorts with replacement and re-runs the analysis B times to estimate standard errors on z-scores. Useful when you want confidence intervals on factor scores (Zabala & Pascual 2016).",
+        "helper": "Optional. Resamples Q-sorts B times to estimate confidence intervals on factor scores.",
         "running": "Running bootstrap…",
         "se_column": "Mean SE (z)",
-        "tooltip": "Non-parametric bootstrap of Q-sorts (resampled with replacement); the analysis is repeated B times to estimate SEs and 95% CIs on z-scores (Zabala & Pascual 2016)."
+        "tooltip": "Non-parametric bootstrap of Q-sorts (resampled with replacement); analysis is repeated B times to estimate 95% CIs on z-scores."
       }
     },
     "project": {
@@ -972,9 +949,7 @@
       },
       "create": {
         "title": "Create project",
-        "description": "Create a new organization to manage your studies and team.",
         "card_title": "Project details",
-        "card_description": "Enter the name and URL slug for your new project.",
         "name_label": "Project name",
         "name_placeholder": "My university research group",
         "url_label": "Project URL",
@@ -998,9 +973,7 @@
         "slug_description": "The unique identifier used in the study URL. Lowercase letters, numbers, and hyphens only.",
         "slug_locked": "The URL slug can only be changed while the study is in draft mode."
       },
-      "guidance_title": "How participant access works",
-      "guidance_body": "The Study URL is the public web address for your study. Recruitment links append unique tokens to this URL to control and track who can participate. Share links directly, via email, or print QR codes for physical materials.",
-      "state_draft": "Your study is in draft mode. Configure the URL and prepare recruitment links — participants cannot access the study until it is activated.",
+      "state_draft": "Draft mode — links work after you activate the study.",
       "state_closed": "This study is closed. Existing links remain visible but new participants cannot start.",
       "state_archived": "This study is archived. All recruitment data is read-only.",
       "empty_title": "No recruitment links yet",
@@ -1033,7 +1006,6 @@
       },
       "new_link": "New access link",
       "create_title": "Create access links",
-      "create_description": "Target specific cohorts or create general access. Each link type has different security and usage properties.",
       "link_type": "Access strategy",
       "select_type": "Choose a recruitment type...",
       "campaign_name": "Channel / campaign name",
@@ -1044,11 +1016,9 @@
       "no_links": "No recruitment links generated yet.",
       "unnamed": "Unnamed channel",
       "revoked": "Access revoked",
-      "qr_title": "Share access code",
-      "qr_desc": "Participants can scan this code to leap directly into the study.",
-      "copy_link": "Copy secure URL",
-      "table_title": "Access control panel",
-      "table_description": "Active channels and link lifecycle management.",
+      "qr_title": "Share via QR",
+      "copy_link": "Copy URL",
+      "table_title": "Recruitment links",
       "share_title": "Share study",
       "share_desc": "Distribute your study URL to invite participants.",
       "public_url_label": "Public participation URL",
@@ -1352,7 +1322,6 @@
     },
     "study_overview": {
       "title": "Overview",
-      "subtitle": "",
       "back_to_overview": "Back to overview",
       "sample_size": "Number of participants (P-Set)",
       "valid": "valid",
@@ -1361,7 +1330,6 @@
       "mobile": "mobile",
       "median_duration": "Median duration",
       "suspect": "Suspect",
-      "time_to_complete": "Time to complete",
       "recent_activity": "Recent activity",
       "latest_participants": "Latest participants (last {{count}} of {{total}})",
       "recently_completed": "Recently completed",
@@ -1446,7 +1414,6 @@
     "design": {
       "title": "Study design",
       "translation_needed": "Review required (copy)",
-      "translation_needed_desc": "This content was automatically copied from another language. Please review and localize it.",
       "reset_defaults": "Reset to defaults",
       "editing_language_banner": "Editing the {{language}} version. Use the language selector in the toolbar to switch.",
       "multilang": {
@@ -1502,7 +1469,7 @@
         "editing_language": "Editing language",
         "manage_langs": "Manage languages",
         "select_lang": "Select language",
-        "test_run_help": "Open a participant preview. Test runs are flagged as is_test_run=true and never count toward your published data.",
+        "test_run_help": "Preview as a participant. These runs aren't included in your data.",
         "more_actions": "More actions"
       },
       "sync": {
@@ -1519,7 +1486,7 @@
       },
       "validation": {
         "failed_title": "Configuration incomplete",
-        "failed_desc": "Your study cannot be activated yet. Please fix the following issues:",
+        "failed_desc": "Fix these issues to activate:",
         "errors": {
           "no_statements": "Study must have at least one statement.",
           "no_grid": "Grid configuration is missing.",
@@ -1761,12 +1728,9 @@
           "tooltip_desc": "Q-methodology uses a quasi-normal distribution (kurtosis > 0) to ensure participants make meaningful distinctions. The pyramid shape prevents central tendency bias.",
           "locked": "Design locked",
           "locked_desc": "Structural changes (statement codes, grid) are disabled because the study has collected data or is no longer in draft mode. You can still edit text translations.",
-          "locked_active": "Study is active",
-          "locked_active_desc": "The study is currently collecting data. To modify the design, you must first revert it to draft mode.",
-          "locked_paused": "Study is paused",
-          "locked_paused_desc": "The study is currently paused. Design remains locked to protect existing data.",
-          "locked_closed": "Study is closed",
-          "locked_closed_desc": "This study is completed. The design is archived and cannot be changed.",
+          "locked_active": "Study is active — switch to draft to edit",
+          "locked_paused": "Study is paused — switch to draft to edit",
+          "locked_closed": "Study is closed — design is archived",
           "mismatch_title": "Grid capacity mismatch",
           "mismatch_desc": "You have {{statements}} statements but the grid only has slots for {{slots}} items. Please adjust the columns below to match.",
           "unlock_hint": "Go to data explorer to purge sessions and unlock structure"
@@ -1901,7 +1865,7 @@
       "methodology_memo": {
         "title": "Methodology memo",
         "summary": "Optional · for replication & pre-registration",
-        "help": "Optional. Document why this distribution, these conditions of instruction, this Q-set size. Useful for replication and pre-registration (Watts & Stenner 2012; Sneegas 2020). Leave empty if not relevant.",
+        "help": "Optional. Document the rationale for this distribution, conditions of instruction, and Q-set size.",
         "label": "Memo (any language)",
         "placeholder": "Document the rationale behind your design choices…"
       },
@@ -2088,7 +2052,7 @@
         "no_participants_title": "No participants yet",
         "no_participants_desc": "Share your study link to start collecting responses.",
         "contract_title": "No submissions yet",
-        "contract_body": "This page will list participant submissions and offer CSV/JSON exports as soon as the first response arrives. Share the study link from the overview to start collecting data.",
+        "contract_body": "Submissions and exports will appear here. Share the study link to start collecting.",
         "contract_cta": "Open study overview"
       },
       "pagination": {
@@ -2176,7 +2140,7 @@
         "delete_button": "Delete study",
         "delete_confirm": "Are you sure? This action is IRREVERSIBLE.",
         "delete_dialog_title": "Delete this study?",
-        "delete_dialog_intro": "All sorts, audio recordings, and analysis runs for this study will be permanently deleted. This cannot be undone.",
+        "delete_dialog_intro": "Permanently deletes sorts, audio, and analysis runs.",
         "delete_dialog_typed_label": "Type the study slug to confirm",
         "delete_dialog_action": "Delete permanently"
       },
@@ -2195,13 +2159,10 @@
       "delete_error_desc": "Failed to delete study.",
       "storage": {
         "title": "Audio Storage Usage",
-        "description": "Monitor audio recording storage for this study.",
         "used": "Storage Used",
         "quota": "Quota",
         "quota_label": "Storage Quota",
         "quota_help": "Maximum total audio storage for this study (10–1000 MB).",
-        "files_count": "Files: {{count}}",
-        "percent_used": "{{percent}}% used",
         "error": "Failed to load storage usage.",
         "warning_high_usage": "Storage usage is high. Consider increasing the quota or removing old recordings.",
         "save_success": "Storage quota updated",
@@ -2209,9 +2170,8 @@
       },
       "retention": {
         "title": "Data retention",
-        "description": "Number of months to keep identifiable participant data before recommending anonymisation. Drives the default cutoff in Data Lifecycle. Leave empty to use the system default (12 months).",
         "months_label": "Retention (months)",
-        "help": "Researchers in the EU should align this with their RGPD retention policy. Common values: 6, 12, 24, 60.",
+        "help": "Common values: 6, 12, 24, 60 months. Leave empty for system default (12).",
         "save_success": "Data retention policy updated",
         "save_error": "Failed to update data retention policy",
         "range_error": "Retention must be an integer between 1 and 240 months."
@@ -2219,12 +2179,9 @@
     },
     "lifecycle": {
       "title": "Data inventory & lifecycle",
-      "header_desc": "GDPR Art. 5 data minimisation controls",
-      "intro": "This page gives you a real-time snapshot of personal data held for this study and lets you anonymise older records in bulk. Use it to enforce GDPR Art. 5 data-minimisation obligations once data collection is complete.",
+      "header_desc": "Inventory & anonymisation",
       "load_error": "Failed to load data inventory.",
       "participants_title": "Participants snapshot",
-      "participants_desc": "Current status of all participants in this study",
-      "stat_total": "Total",
       "stat_started": "Started",
       "stat_completed": "Completed",
       "stat_discarded": "Discarded",
@@ -2248,20 +2205,20 @@
       "cutoff_help": "Only completed participants submitted strictly before this date will be anonymised.",
       "preview_label": "Candidates:",
       "preview_zero": "No participants qualify for this cutoff. Try an earlier date.",
-      "anonymise_button": "Anonymise older than {{date}}",
+      "anonymise_button": "Anonymise",
       "anonymise_success": "Anonymisation complete",
       "anonymise_success_desc": "{{n}} participant(s) anonymised, {{s}} already anonymous.",
       "anonymise_error": "Anonymisation failed",
       "confirm_title": "Anonymise participant data?",
       "confirm_candidates": "{{count}} completed participant(s) submitted before {{date}} will be anonymised.",
-      "confirm_preserved": "Q-sort statement rankings will be preserved as anonymous research data — they will no longer link to any individual.",
+      "confirm_preserved": "Q-sort rankings are kept; identity is removed.",
       "confirm_irreversible": "This action is immediate and cannot be undone.",
       "confirm_in_progress": "Anonymising…",
       "confirm_action": "Yes, anonymise",
       "cutoff_from_policy": "Default derived from study retention policy ({{months}} months).",
       "empty": {
         "title": "No participant data yet",
-        "body": "This page will activate the inventory dashboards and bulk-anonymisation controls (GDPR Art. 5) as soon as the first participant submits a Q-sort. Until then, share the study link from the overview to start collecting responses.",
+        "body": "This page activates once participants submit. Share the study link first.",
         "cta": "Open study overview"
       }
     },
@@ -2305,36 +2262,30 @@
             "title": "Permissions matrix",
             "admin": {
               "label": "Admin",
-              "badge": "Full access",
               "desc": "Can manage project settings, members, and all studies."
             },
             "owner": {
               "label": "Owner",
-              "badge": "Full access",
-              "desc": "Manages project settings, members, and all studies. Can promote or remove other members."
+              "desc": "Full project, member, and study control."
             },
             "researcher": {
               "label": "Researcher",
-              "badge": "Creation",
               "desc": "Can create and manage all studies. Restricted from project settings."
             },
             "viewer": {
               "label": "Viewer",
-              "badge": "Read only",
               "desc": "Read-only access to all studies and data in the project."
             }
           },
           "coming_soon": "Coming soon",
           "invite_modal": {
             "title": "Invite collaborator",
-            "desc": "Send a secure invitation to join your research team.",
             "email_label": "Collaborator email",
             "role_label": "Assigned role",
             "success": "Invitation link generated!",
             "error": "Failed to create invitation.",
             "send": "Create & send invitation",
-            "copy_success": "Link copied to clipboard!",
-            "copy_hint": "Copy this link and send it manually if the email fails."
+            "copy_success": "Link copied to clipboard!"
           }
         }
       }

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -166,22 +166,17 @@
     },
     "auth": {
         "login": {
-            "title": "Järjestelmänvalvojan kirjautuminen",
             "email_label": "Sähköpostiosoite",
             "password_label": "Salasana",
             "submit": "Jatka",
             "forgot_password": "Unohditko?",
             "loading": "Tunnistaudutaan...",
-            "subtitle": "Syötä tunnistetietosi tutkimusten hallintaa varten",
             "card_title": "Kirjaudu sisään",
-            "card_description": "Suojattu pääsy tutkimuksen hallintapaneeliin",
-            "privacy": "Kirjautumalla sisään hyväksyt käyttöehdot ja tietosuojakäytäntömme.",
-            "powered_by": "Tarjoaa",
             "welcome_back": "Tervetuloa takaisin!",
             "error_401": "Virheellinen sähköposti tai salasana",
             "error_generic": "Jotain meni vikaan. Yritä uudelleen.",
             "reason_session_expired": "Istuntosi on vanhentunut. Kirjaudu sisään uudelleen.",
-            "reason_auth_required": "Kirjaudu sisään päästäksesi hallintapaneeliin."
+            "reason_auth_required": "Kirjaudu sisään jatkaaksesi."
         },
         "register": {
             "title": "Luo tili",
@@ -439,14 +434,14 @@
         "study_design": {
             "distribution_mode": {
                 "title": "Jakauman tila",
-                "helper": "Valitse, kuinka tiukasti Q-lajitteluruudukkoa noudatetaan. Pakotettu: jokainen sarake on täytettävä ilmoitettuun kapasiteettiinsa (yleisin valinta; Brown 1980; Watts & Stenner 2012). Vapaa: mikä tahansa määrä kortteja sarakkeessa, kokonaismäärä = Q-joukon koko (Brown ym. 2015 mukaan jakauman muoto vaikuttaa tuloksiin vain vähän). Joustava: kokonaismäärä pakotettu, sarakkeiden kapasiteetit ovat ohjeellisia.",
+                "helper": "Valitse, kuinka tiukasti Q-lajitteluruudukkoa noudatetaan. Pakotettu: jokainen sarake on täytettävä ilmoitettuun kapasiteettiinsa (yleisin valinta). Vapaa: mikä tahansa määrä kortteja sarakkeessa, kokonaismäärä = Q-joukon koko. Joustava: kokonaismäärä pakotettu, sarakkeiden kapasiteetit ovat ohjeellisia.",
                 "forced": {
                     "label": "Pakotettu",
-                    "tooltip": "Jokaisen sarakkeen on sisällettävä täsmälleen ilmoitettu kapasiteettinsa. Brown 1980; Watts & Stenner 2012."
+                    "tooltip": "Jokaisen sarakkeen on sisällettävä täsmälleen ilmoitettu kapasiteettinsa."
                 },
                 "free": {
                     "label": "Vapaa",
-                    "tooltip": "Korttien kokonaismäärä = Q-joukon koko; sarakekohtainen määrä on rajoittamaton. Brown ym. 2015."
+                    "tooltip": "Korttien kokonaismäärä = Q-joukon koko; sarakekohtainen määrä on rajoittamaton."
                 },
                 "flexible": {
                     "label": "Joustava",
@@ -500,9 +495,8 @@
             "description": "Hallitse henkilökohtaisia tietojasi ja turvallisuusasetuksia.",
             "personal": {
                 "title": "Henkilökohtaiset tiedot",
-                "description": "Tilisi tiedot ja yhteystiedot.",
                 "email": "Sähköpostiosoite",
-                "email_locked": "Sähköpostia ei voi muuttaa suoraan. Ota yhteys ylläpitoon.",
+                "email_locked": "Pyydä ylläpitäjää muuttamaan.",
                 "name": "Koko nimi",
                 "save": "Tallenna",
                 "saving": "Tallennetaan...",
@@ -515,15 +509,11 @@
                 "title": "Turvallisuus & 2FA",
                 "description": "Suojaa tilisi kaksivaiheisella todennuksella.",
                 "enabled": "Käytössä",
-                "status_active": "Tilisi on suojattu kaksivaiheisella todennuksella.",
-                "status_inactive": "Tilin turvallisuus on alhainen",
-                "status_inactive_desc": "Ota kaksivaiheinen todennus käyttöön suojataksesi tietosi ja tutkimuksesi.",
                 "setup_cta": "Ota 2FA käyttöön",
                 "configure_title": "Määritä todennussovellus",
                 "scan_desc": "Skannaa tämä QR-koodi todennussovelluksellasi (Google Authenticator, Authy, jne.)",
                 "enter_code": "Syötä 6-numeroinen koodi",
                 "enable_btn": "Ota 2FA käyttöön",
-                "active_msg": "2FA on aktiivinen",
                 "disable_btn": "Poista 2FA käytöstä",
                 "confirm_disable": "Vahvista poistaminen",
                 "confirm_password_label": "Vahvista salasanalla",
@@ -537,7 +527,6 @@
             },
             "password": {
                 "title": "Salasanan hallinta",
-                "description": "Päivitä salasanasi pitääksesi tilisi turvassa.",
                 "current": "Nykyinen salasana",
                 "new": "Uusi salasana",
                 "change_btn": "Vaihda salasana",
@@ -602,7 +591,6 @@
             "empty_title": "Ei lausekokoelmia",
             "empty_desc": "Luo lausekokoelma aloittaaksesi ehdokaslauseiden keräämisen ja järjestämisen Q-metodologiatutkimustasi varten.",
             "add_item": "Lisää kohde",
-            "add_item_desc": "Lisää uusi ehdokaslause tähän lausekokoelmaan.",
             "bulk_import": "Massatuonti",
             "import_desc": "Liitä lauseet rivivälein erotettuna. Jokaisesta rivistä tulee yksi kohde.",
             "import_prefix": "Koodietuliite",
@@ -629,7 +617,7 @@
             "deleted": "Lausekokoelma poistettu",
             "delete_error": "Lausekokoelman poisto epäonnistui",
             "delete_item_title": "Poista kohde",
-            "delete_item_confirm": "Haluatko varmasti poistaa tämän kohteen? Tätä ei voi peruuttaa.",
+            "delete_item_confirm": "Poistetaanko tämä kohde? Toimintoa ei voi peruuttaa.",
             "status": {
                 "proposed": "Ehdotettu",
                 "accepted": "Hyväksytty",
@@ -647,7 +635,6 @@
             "version_label": "v{{n}}",
             "item_detail_desc": "Kohteen historia ja kommentit",
             "manage_tags": "Tunnisteet",
-            "manage_tags_desc": "Luo ja hallitse tunnisteita luokitellaksesi lausekokoelman kohteita teeman tai ulottuvuuden mukaan.",
             "tag_name_placeholder": "Tunnisteen nimi",
             "tag_color": "Tunnisteen väri",
             "tag_created": "Tunniste luotu",
@@ -692,15 +679,13 @@
                 "title": "Rakentamisen muistio",
                 "summary_empty": "Valinnainen · kuratointiprosessin läpinäkyvyyteen",
                 "summary_filled": "{{n}} merkkiä · klikkaa nähdäksesi tai muokataksesi",
-                "helper": "Valinnainen. Dokumentoi, kuinka tämä lausekokoelma rakennettiin: kartoitetut lähteet, säilytetyt tai pois jätetyt äänet, otantaperuste. Hyödyllinen kuratointiprosessin läpinäkyvyyden kannalta (Sneegas 2020; Robbins & Krueger 2000). Jätä tyhjäksi, jos ei sovi tutkimusasetelmaasi.",
                 "placeholder": "Dokumentoi, kuinka tämä lausekokoelma rakennettiin: lähteet, säilytetyt tai pois jätetyt äänet, otantaperuste…",
                 "save": "Tallenna muistio",
                 "saved": "Rakentamisen muistio tallennettu",
                 "save_error": "Rakentamisen muistion tallennus epäonnistui"
             },
-            "status_pills_aria": "Hyväksytty: {{a}}; Ehdotettu: {{p}}; Hylätty: {{r}}",
             "import_from_csv": "Tuo CSV/TSV…",
-            "import_csv_hint": "CSV/TSV-tiedostossa on oltava otsikot code, language, text. Valitun kielen rivit ladataan yllä olevaan tekstilaatikkoon.",
+            "import_csv_hint": "CSV/TSV: sarakkeet code, language, text.",
             "import_csv_no_match": "Mikään rivi ei vastaa valittua kieltä ({{lang}}).",
             "import_csv_skipped": "Ohitettu {{count}} rivi(ä) muilla kielillä: {{langs}}.",
             "import_csv_more_errors": "{{count}} lisää ongelmaa"
@@ -759,7 +744,7 @@
             "eigenvalue_error": "Analyysitietojen lataaminen epäonnistui. Yritä uudelleen.",
             "scree_plot_label": "Ominaisarvokaavio {{n}} faktorille",
             "loading_eigenvalues": "Ladataan ominaisarvoja...",
-            "empty_state": "Määritä parametrit yllä ja napsauta \"Suorita analyysi\" poimimaan faktorit Q-lajittelutiedoistasi.",
+            "empty_state": "Määritä parametrit ja suorita analyysi.",
             "empty": {
                 "contract_title": "Q-lajitteludataa ei ole vielä riittävästi",
                 "contract_body": "Q-metodologian faktorianalyysi vaatii vähintään 2 osallistujaa, jotka ovat suorittaneet lajittelun. Konfiguraatiovalinnat (poimintatapa, faktorit, rotaatio, merkintä) saavat merkityksensä, kun dataa on saatavilla. Jaa tutkimuslinkki yleisnäkymästä aloittaaksesi vastausten keräämisen.",
@@ -811,9 +796,9 @@
             "no_statement_scores": "Väittämäpisteitä ei saatavilla. Varmista, että osallistujia on merkitty vähintään yhdelle faktorille.",
             "no_characteristics": "Faktorien ominaisuustietoja ei saatavilla.",
             "export": "Vie",
-            "export_loadings": "CSV — Faktorikuormitukset",
-            "export_scores": "CSV — Väittämäpisteet",
-            "export_xlsx": "XLSX — Koko analyysi",
+            "export_loadings": "Faktorikuormitukset (CSV)",
+            "export_scores": "Väittämäpisteet (CSV)",
+            "export_xlsx": "Koko analyysi (XLSX)",
             "export_error": "XLSX-viennin luominen epäonnistui.",
             "select_factors": "Valitse faktorien lukumäärä",
             "loadings_help": "Faktorikuormitukset osoittavat, kuinka voimakkaasti kunkin osallistujan lajittelu korreloi kunkin faktorin kanssa. Korostetut solut ylittävät yllä näkyvän merkitsevyyskynnyksen.",
@@ -827,20 +812,20 @@
             "z_scores_description": "Väittämien z-arvot ja faktorijärjestyksen sijoitukset",
             "factor_statistics": "Faktoritilastot",
             "characteristics_help": "Ominaisarvot kuvastavat selitetyn varianssin määrää. Komposiittireliabiliteetti kuvastaa merkittyjen lajittelujen sisäistä yhdenmukaisuutta. Faktoripisteiden keskivirhe kuvastaa komposiittiestimaatin tarkkuutta.",
-            "help_extraction": "PCA maksimoi selitetyn varianssin faktorien välillä. Sentroidi tuottaa matemaattisesti vähemmän rajoitettuja faktoreita, mitä jotkut Q-tutkijat suosivat teoreettisista syistä.",
-            "help_n_factors": "Jokainen faktori edustaa erillistä näkökulmaa. Useammat faktorit tallentavat enemmän vivahteita mutta voivat jakaa yhtenäisiä näkemyksiä; vähemmän faktoreita antaa laajempia ryhmiä.",
-            "help_rotation": "Varimax maksimoi faktorien välisen erottelun, tuottaen yksinkertaisemman rakenteen. Ilman rotaatiota alkuperäinen matemaattinen ratkaisu säilyy. Harkintaan perustuva rotaatio antaa määrittää rotaatiokulmat manuaalisesti.",
-            "help_flagging": "Automaattinen merkitsee osallistujat, joiden kuormitus ylittää merkitsevyyskynnyksen täsmälleen yhdellä faktorilla. Manuaalinen antaa sinun määrittää merkinnät oman harkintasi mukaan.",
+            "help_extraction": "PCA maksimoi selitetyn varianssin. Sentroidi on matemaattisesti vähemmän rajoitettu.",
+            "help_n_factors": "Jokainen faktori edustaa erillistä näkökulmaa.",
+            "help_rotation": "Varimax erottaa faktorit yksinkertaisempaa rakennetta varten.",
+            "help_flagging": "Automaattinen: merkitsee yhdellä faktorilla kuormittavat osallistujat. Manuaalinen: säätö osallistujakohtaisesti.",
             "rotation": {
                 "judgmental": {
                     "label": "Harkintaan perustuva (manuaalinen)",
                     "short": "Harkintaan",
-                    "tooltip": "Käännä faktoripareja manuaalisesti valituilla kulmilla, jotta faktorit saadaan kohdistettua sisällöllisesti merkityksellisiin asentoihin (Brown 1980; Watts & Stenner 2012)."
+                    "tooltip": "Käännä faktoripareja manuaalisesti valituilla kulmilla, jotta faktorit saadaan kohdistettua sisällöllisesti merkityksellisiin asentoihin."
                 }
             },
             "manual_rotations": {
                 "title": "Manuaaliset rotaatiot",
-                "helper": "Määritä rotaatiot muodossa 'käännä faktoria F kulmalla Δ° faktorin G ympäri'. Rotaatiot suoritetaan järjestyksessä. Käytetään faktorien kohdistamiseen sisällöllisesti merkityksellisiin asentoihin (Brown 1980; Watts & Stenner 2012).",
+                "helper": "Määritä rotaatiot muodossa 'käännä faktoria F kulmalla Δ° faktorin G ympäri'. Rotaatiot suoritetaan järjestyksessä.",
                 "add": "Lisää rotaatio",
                 "remove_aria": "Poista rotaatio",
                 "empty": "Lisää vähintään yksi rotaatio analyysin suorittamiseksi.",
@@ -851,31 +836,23 @@
             "bootstrap": {
                 "toggle_label": "Suorita bootstrap-vakausanalyysi",
                 "iterations_label": "Iteraatiot (B)",
-                "helper": "Valinnainen. Bootstrap ottaa Q-lajitteluistasi otokset takaisinpalauttaen ja toistaa analyysin B kertaa arvioidakseen z-arvojen keskivirheet. Hyödyllinen, kun haluat luottamusvälit faktoripisteille (Zabala & Pascual 2016).",
+                "helper": "Valinnainen. Ottaa Q-lajitteluista otokset B kertaa luottamusvälien arvioimiseksi faktoripisteille.",
                 "running": "Bootstrap käynnissä…",
                 "se_column": "Keskim. KV (z)",
-                "tooltip": "Q-lajittelujen ei-parametrinen bootstrap (otokset takaisinpalauttaen); analyysi toistetaan B kertaa z-arvojen keskivirheiden ja 95 %:n luottamusvälien arvioimiseksi (Zabala & Pascual 2016)."
+                "tooltip": "Q-lajittelujen ei-parametrinen bootstrap (otokset takaisinpalauttaen); analyysi toistetaan B kertaa 95 %:n luottamusvälien arvioimiseksi z-arvoille."
             },
             "guide_loadings_title": "Faktorikuormitusten lukeminen",
             "guide_loadings_1": "Jokainen kuormitus on korrelaatio (-1 – +1) osallistujan ja faktorin (jaetun näkökulman) välillä.",
             "guide_loadings_2": "Korostetut arvot ylittävät taulukon yläpuolella näkyvän merkitsevyyskynnyksen.",
-            "guide_loadings_3": "\"Merkitty\" osallistuja määrittää kyseisen faktorin. Etsi selkeää rakennetta: kukin henkilö yhdellä faktorilla.",
-            "guide_loadings_4": "Millekään faktorille merkitsemättömillä osallistujilla on ainutlaatuinen näkemys, jota ratkaisu ei kata.",
             "guide_arrays_title": "Faktoritaulukoiden tulkinta",
             "guide_arrays_1": "Jokainen faktoritaulukko on komposiitti-Q-lajittelu, joka edustaa yhtä jaettua näkökulmaa.",
             "guide_arrays_2": "Lue vasemmalta oikealle: eniten eri mieltä – eniten samaa mieltä. Ääriasennot kantavat vahvimman signaalin tulkintaa varten.",
-            "guide_arrays_3": "Keltaisella korostetut väittämät ovat erottelevia — sijoitettu merkitsevästi eri tavalla muihin faktoreihin verrattuna.",
-            "guide_arrays_4": "Vertaa taulukoita faktorien välillä nähdäksesi, missä näkökulmat eroavat ja yhtyvät.",
             "guide_statements_title": "Väittämäpisteiden ymmärtäminen",
             "guide_statements_1": "Z-arvot osoittavat, kuinka voimakkaasti kukin faktori on samaa tai eri mieltä kunkin väittämän kanssa (0 = neutraali).",
             "guide_statements_2": "D = erotteleva (sijoitettu merkitsevästi eri tavalla faktorien välillä). Tähdet ilmaisevat merkitsevyystason.",
-            "guide_statements_3": "C = konsensus (kaikki faktorit ovat samaa mieltä sijoituksesta). Nämä eivät auta erottamaan näkökulmia.",
-            "guide_statements_4": "D-väittämät paljastavat, mikä tekee kustakin näkökulmasta ainutlaatuisen. C-väittämät osoittavat, missä näkökulmat yhtyvät.",
             "guide_summary_title": "Ratkaisun arviointi",
             "guide_summary_1": "Ominaisarvot mittaavat, kuinka paljon varianssia faktori selittää. Kaiserin kriteeri (ominaisarvo > 1) on yleinen heuristiikka säilytettävien faktorien lukumäärän päättämiseen.",
             "guide_summary_2": "Komposiittireliabiliteetti kuvastaa, kuinka yhdenmukaisesti merkityt lajittelut määrittävät kunkin faktorin. Korkeammat arvot tarkoittavat, että faktoriestimaatti perustuu suurempaan yksimielisyyteen sen määrittävien lajittelujen kesken.",
-            "guide_summary_3": "Faktorikorrelaatiot osoittavat, kuinka paljon päällekkäisyyttä näkökulmien välillä on. Korkeammat korrelaatiot tarkoittavat, että faktoreilla on enemmän yhteistä pohjaa; matalammat korrelaatiot tarkoittavat, että ne ovat erillisempiä.",
-            "guide_summary_4": "Kokonaisvarianssi kuvaa, kuinka suuri osa lajittelumallien kokonaisvaihtelusta on ratkaisusi kattama.",
             "benchmark_above": "Kynnyksen yläpuolella",
             "benchmark_below": "Kynnyksen alapuolella",
             "history": {
@@ -883,7 +860,7 @@
                 "loading": "Loading history…",
                 "fetch_error": "Could not load analysis history.",
                 "empty": "No previous analyses for this study yet — run one to start the audit trail.",
-                "empty_explainer": "Documenting analytical choices supports reproducibility — a core requirement of careful Q-methodological practice (Watts & Stenner 2012; Sneegas 2020). Each run is logged here so you can document and revisit every decision.",
+                "empty_explainer": "Each run is logged here so you can document and revisit every decision.",
                 "load_error": "Failed to load the analysis run.",
                 "load_run_aria": "Load analysis run from {{date}}",
                 "loading_run": "Loading…",
@@ -914,7 +891,7 @@
                 "no_material": "No post-sort audio recordings or written comments from participants flagged on this factor.",
                 "loading": "Loading recordings…",
                 "error": "Could not load audio recordings. Please try again.",
-                "context": "Grounding factor interpretation in participants' own words — their audio rationales and their written card comments — is a core element of careful Q-methodological practice (Watts & Stenner 2012; Sneegas 2020).",
+                "context": "Ground factor interpretation in participants' own words — their audio rationales and their written card comments.",
                 "context_aria": "About this panel",
                 "audio_label": "Recording: {{key}} by {{participant}}",
                 "url_unavailable": "Audio URL not available.",
@@ -951,9 +928,7 @@
             },
             "create": {
                 "title": "Luo projekti",
-                "description": "Luo uusi organisaatio hallinnoidaksesi tutkimuksiasi ja tiimiäsi.",
                 "card_title": "Projektin tiedot",
-                "card_description": "Syötä nimi ja URL-tunnus uudelle projektillesi.",
                 "name_label": "Projektin nimi",
                 "name_placeholder": "Yliopiston tutkimusryhmäni",
                 "url_label": "Projektin URL",
@@ -983,9 +958,7 @@
                 "slug_description": "Tutkimuksen URL-osoitteessa käytettävä yksilöllinen tunniste. Vain pienet kirjaimet, numerot ja väliviivat.",
                 "slug_locked": "URL-tunnistetta voi muuttaa vain kun tutkimus on luonnostilassa."
             },
-            "guidance_title": "Miten osallistujien pääsy toimii",
-            "guidance_body": "Tutkimuksen URL on tutkimuksesi julkinen verkko-osoite. Rekrytointilinkit lisäävät yksilöllisiä tunnuksia tähän URL-osoitteeseen osallistujien hallinnan ja seurannan mahdollistamiseksi. Jaa linkkejä suoraan, sähköpostitse tai tulosta QR-koodeja fyysisiin materiaaleihin.",
-            "state_draft": "Tutkimuksesi on luonnostilassa. Määritä URL ja valmistele rekrytointilinkit — osallistujat eivät pääse tutkimukseen ennen sen aktivointia.",
+            "state_draft": "Luonnostila — linkit toimivat aktivoinnin jälkeen.",
             "state_closed": "Tämä tutkimus on suljettu. Olemassa olevat linkit näkyvät edelleen, mutta uudet osallistujat eivät voi aloittaa.",
             "state_archived": "Tämä tutkimus on arkistoitu. Kaikki rekrytointitiedot ovat vain luku -tilassa.",
             "empty_title": "Ei rekrytointilinkkejä vielä",
@@ -1018,7 +991,6 @@
             },
             "new_link": "Uusi pääsulinkki",
             "create_title": "Luo pääsulinkejä",
-            "create_description": "Kohdista linkit erityisryhmille tai yleiseen jakeluun. Jokaisella linkillä on eri tietoturva- ja käyttöominaisuudet.",
             "link_type": "Pääsystrategia",
             "select_type": "Valitse rekrytointityyppi...",
             "campaign_name": "Kanava / Kampanjan nimi",
@@ -1029,11 +1001,9 @@
             "no_links": "Ei vielä luotuja rekrytointilinkkejä.",
             "unnamed": "Nimetön kanava",
             "revoked": "Pääsy peruutettu",
-            "qr_title": "Jaa pääsykoodi",
-            "qr_desc": "Osallistujat voivat skannata tämän koodin siirtyäkseen suoraan tutkimukseen.",
-            "copy_link": "Kopioi turvallinen URL",
-            "table_title": "Pääsynhallintapaneeli",
-            "table_description": "Aktiiviset kanavat ja linkkien elinkaaren hallinta.",
+            "qr_title": "Jaa QR-koodina",
+            "copy_link": "Kopioi URL",
+            "table_title": "Rekrytointilinkit",
             "share_title": "Jaa tutkimus",
             "share_desc": "Levitä tutkimuslinkkiä kutsuaksesi osallistujia.",
             "public_url_label": "Julkinen osallistumislinkki",
@@ -1337,7 +1307,6 @@
         },
         "study_overview": {
             "title": "Hallintapaneeli",
-            "subtitle": "",
             "back_to_overview": "Takaisin yhteenvetoon",
             "sample_size": "Osallistujamäärä (P-Set)",
             "valid": "kelvollinen",
@@ -1346,7 +1315,6 @@
             "mobile": "mobiili",
             "median_duration": "Keston mediaani",
             "suspect": "Epäilyttävä",
-            "time_to_complete": "Suoritusaika",
             "recent_activity": "Viimeaikainen toiminta",
             "latest_participants": "Viimeisimmät osallistujat ({{count}} / {{total}})",
             "recently_completed": "Viimeksi valmistuneet",
@@ -1430,7 +1398,6 @@
         },
         "design": {
             "translation_needed": "Tarkistus vaaditaan (Kopio)",
-            "translation_needed_desc": "Tämä sisältö on kopioitu automaattisesti toisesta kielestä. Tarkista ja lokalisoi se.",
             "reset_defaults": "Palauta oletukset",
             "editing_language_banner": "Muokkaat versiota {{language}}. Vaihda työkalupalkin kielivalitsimella.",
             "multilang": {
@@ -1486,7 +1453,7 @@
                 "editing_language": "Muokkauskieli",
                 "manage_langs": "Kielten hallinta",
                 "select_lang": "Valitse kieli",
-                "test_run_help": "Avaa osallistujan esikatselun. Testiajot merkitään is_test_run=true eivätkä koskaan sisälly julkaistuihin tietoihin.",
+                "test_run_help": "Esikatsele osallistujan tavoin. Testiajoja ei sisällytetä tietoihisi.",
                 "more_actions": "Lisää toimintoja"
             },
             "sync": {
@@ -1503,7 +1470,7 @@
             },
             "validation": {
                 "failed_title": "Määritys puutteellinen",
-                "failed_desc": "Tutkimustasi ei voida vielä aktivoida. Korjaa seuraavat ongelmat:",
+                "failed_desc": "Korjaa nämä ongelmat aktivoidaksesi:",
                 "errors": {
                     "no_statements": "Tutkimuksessa on oltava vähintään yksi väite.",
                     "no_grid": "Ruudukon määritykset puuttuvat.",
@@ -1745,12 +1712,9 @@
                     "tooltip_desc": "Q-metodologiassa pakotettu jakauma on yleensä lähes normaali. Tämä pakottaa osallistujan tekemään vaikeita valintoja ja erottelemaan kohteet selkeästi.",
                     "locked": "Suunnittelu lukittu",
                     "locked_desc": "Rakenteelliset muutokset (väittämäkoodit, ruudukko) on poistettu käytöstä, koska tutkimus on kerännyt aineistoa tai se ei ole enää luonnostilassa. Voit silti muokata käännöksiä.",
-                    "locked_active": "Tutkimus on aktiivinen",
-                    "locked_active_desc": "Tutkimus kerää parhaillaan tietoja. Muokataksesi suunnittelua, sinun on ensin palautettava se luonnostilaan.",
-                    "locked_paused": "Tutkimus on keskeytetty",
-                    "locked_paused_desc": "Tutkimus on tällä hetkellä keskeytetty. Suunnittelu pysyy lukittuna olemassa olevien tietojen suojaamiseksi.",
-                    "locked_closed": "Tutkimus on suljettu",
-                    "locked_closed_desc": "Tämä tutkimus on valmis. Suunnittelu on arkistoitu eikä sitä voi muuttaa.",
+                    "locked_active": "Tutkimus aktiivinen — palauta luonnostilaan muokataksesi",
+                    "locked_paused": "Tutkimus keskeytetty — palauta luonnostilaan muokataksesi",
+                    "locked_closed": "Tutkimus suljettu — suunnittelu on arkistoitu",
                     "mismatch_title": "Ruudukon kapasiteetti ei täsmää",
                     "mismatch_desc": "Sinulla on {{statements}} väitettä, mutta ruudukossa on vain {{slots}} paikkaa. Säädä sarakkeita alla.",
                     "unlock_hint": "Siirry Data-selaimeen tyhjentääksesi vastaukset ja avataksesi rakenteen muokkauksen"
@@ -1886,7 +1850,7 @@
             "methodology_memo": {
                 "title": "Metodologinen muistio",
                 "summary": "Valinnainen · toistettavuuteen & esirekisteröintiin",
-                "help": "Valinnainen. Dokumentoi miksi tämä jakauma, nämä ohjeet, tämä Q-setin koko. Hyödyllistä toistettavuuden ja esirekisteröinnin kannalta (Watts & Stenner 2012; Sneegas 2020). Jätä tyhjäksi, jos ei ole olennaista.",
+                "help": "Valinnainen. Dokumentoi peruste tälle jakaumalle, näille ohjeille ja Q-setin koolle.",
                 "label": "Muistio (mikä tahansa kieli)",
                 "placeholder": "Dokumentoi suunnitteluvalintojesi rationaali…"
             },
@@ -2073,7 +2037,7 @@
                 "no_participants_title": "Ei vielä osallistujia",
                 "no_participants_desc": "Jaa tutkimuksesi linkki aloittaaksesi vastausten keräämisen.",
                 "contract_title": "Ei vielä lähetyksiä",
-                "contract_body": "Tämä sivu listaa osallistujien lähetykset ja tarjoaa CSV/JSON-vientejä heti kun ensimmäinen vastaus saapuu. Jaa tutkimuslinkki yleisnäkymästä aloittaaksesi tietojen keräämisen.",
+                "contract_body": "Lähetykset ja viennit ilmestyvät tähän. Jaa tutkimuslinkki aloittaaksesi keräämisen.",
                 "contract_cta": "Avaa tutkimuksen yleisnäkymä"
             },
             "pagination": {
@@ -2161,7 +2125,7 @@
                 "delete_button": "Poista tutkimus",
                 "delete_confirm": "Oletko varma? Tätä toimintoa EI VOI PERUUTTAA.",
                 "delete_dialog_title": "Poistetaanko tämä tutkimus?",
-                "delete_dialog_intro": "Kaikki lajittelut, äänitallenteet ja analyysit poistetaan pysyvästi. Tätä ei voi kumota.",
+                "delete_dialog_intro": "Poistaa pysyvästi lajittelut, äänet ja analyysit.",
                 "delete_dialog_typed_label": "Vahvista kirjoittamalla tutkimuksen slug",
                 "delete_dialog_action": "Poista pysyvästi"
             },
@@ -2180,13 +2144,10 @@
             "delete_error_desc": "Tutkimuksen poistaminen epäonnistui.",
             "storage": {
                 "title": "Äänitallenteiden tallennustila",
-                "description": "Seuraa tämän tutkimuksen äänitallenteiden tallennustilan käyttöä.",
                 "used": "Käytetty tallennustila",
                 "quota": "Kiintiö",
                 "quota_label": "Tallennustilakiintiö",
                 "quota_help": "Tämän tutkimuksen äänitallenteiden enimmäistallennustila (10–1000 Mt).",
-                "files_count": "Tiedostoja: {{count}}",
-                "percent_used": "{{percent}} % käytetty",
                 "error": "Tallennustilan käytön lataaminen epäonnistui.",
                 "warning_high_usage": "Tallennustilan käyttö on korkea. Harkitse kiintiön kasvattamista tai vanhojen tallenteiden poistamista.",
                 "save_success": "Tallennustilakiintiö päivitetty",
@@ -2194,9 +2155,8 @@
             },
             "retention": {
                 "title": "Tietojen säilytys",
-                "description": "Kuukausien määrä, jonka ajan tunnistettavia osallistujatietoja säilytetään ennen anonymisoinnin suosittelua. Määrittää oletusrajan tietojen elinkaarella. Jätä tyhjäksi käyttääksesi järjestelmän oletusta (12 kuukautta).",
                 "months_label": "Säilytys (kuukautta)",
-                "help": "EU-tutkijoiden tulisi sovittaa tämä RGPD-säilytyspolitiikkaansa. Yleisiä arvoja: 6, 12, 24, 60.",
+                "help": "Yleisiä arvoja: 6, 12, 24, 60 kuukautta. Jätä tyhjäksi (oletus 12).",
                 "save_success": "Säilytyspolitiikka päivitetty",
                 "save_error": "Säilytyspolitiikan päivitys epäonnistui",
                 "range_error": "Säilytyksen on oltava kokonaisluku väliltä 1–240 kuukautta."
@@ -2242,36 +2202,30 @@
                         "title": "Käyttöoikeusmatriisi",
                         "admin": {
                             "label": "Admin",
-                            "badge": "Täysi pääsy",
                             "desc": "Voi hallita projektin asetuksia, jäseniä ja kaikkia tutkimuksia."
                         },
                         "owner": {
                             "label": "Omistaja",
-                            "badge": "Täysi pääsy",
-                            "desc": "Hallinnoi projektin asetuksia, jäseniä ja kaikkia tutkimuksia. Voi ylentää tai poistaa muita jäseniä."
+                            "desc": "Täysi hallinta projektista, jäsenistä ja tutkimuksista."
                         },
                         "researcher": {
                             "label": "Tutkija",
-                            "badge": "Luonti",
                             "desc": "Voi luoda ja hallita kaikkia tutkimuksia. Rajoitettu pääsy projektin asetuksiin."
                         },
                         "viewer": {
                             "label": "Katsoja",
-                            "badge": "Luku-oikeus",
                             "desc": "Vain luku -pääsy kaikkiin projektin tutkimuksiin ja tietoihin."
                         }
                     },
                     "coming_soon": "Tulossa pian",
                     "invite_modal": {
                         "title": "Kutsu yhteistyökumppani",
-                        "desc": "Lähetä suojattu kutsu liittyäksesi tutkimustiimiisi.",
                         "email_label": "Yhteistyökumppanin sähköposti",
                         "role_label": "Määritetty rooli",
                         "success": "Kutsulinkki luotu!",
                         "error": "Kutsun luominen epäonnistui.",
                         "send": "Luo ja lähetä kutsu",
-                        "copy_success": "Linkki kopioitu leikepöydälle!",
-                        "copy_hint": "Kopioi tämä linkki ja lähetä se manuaalisesti, jos sähköposti epäonnistuu."
+                        "copy_success": "Linkki kopioitu leikepöydälle!"
                     }
                 }
             }
@@ -2354,12 +2308,9 @@
         },
         "lifecycle": {
             "title": "Data inventory & lifecycle",
-            "header_desc": "GDPR Art. 5 data minimisation controls",
-            "intro": "This page gives you a real-time snapshot of personal data held for this study and lets you anonymise older records in bulk. Use it to enforce GDPR Art. 5 data-minimisation obligations once data collection is complete.",
+            "header_desc": "Inventory & anonymisation",
             "load_error": "Failed to load data inventory.",
             "participants_title": "Participants snapshot",
-            "participants_desc": "Current status of all participants in this study",
-            "stat_total": "Total",
             "stat_started": "Started",
             "stat_completed": "Completed",
             "stat_discarded": "Discarded",
@@ -2383,20 +2334,20 @@
             "cutoff_help": "Only completed participants submitted strictly before this date will be anonymised.",
             "preview_label": "Ehdokkaat:",
             "preview_zero": "Tällä rajalla ei ole sopivia osallistujia. Kokeile aikaisempaa päivämäärää.",
-            "anonymise_button": "Anonymise older than {{date}}",
+            "anonymise_button": "Anonymise",
             "anonymise_success": "Anonymisation complete",
             "anonymise_success_desc": "{{n}} participant(s) anonymised, {{s}} already anonymous.",
             "anonymise_error": "Anonymisation failed",
             "confirm_title": "Anonymise participant data?",
             "confirm_candidates": "{{count}} completed participant(s) submitted before {{date}} will be anonymised.",
-            "confirm_preserved": "Q-sort statement rankings will be preserved as anonymous research data — they will no longer link to any individual.",
+            "confirm_preserved": "Q-sort rankings are kept; identity is removed.",
             "confirm_irreversible": "This action is immediate and cannot be undone.",
             "confirm_in_progress": "Anonymising…",
             "confirm_action": "Yes, anonymise",
             "cutoff_from_policy": "Oletusarvo johdettu tutkimuksen säilytyspolitiikasta ({{months}} kuukautta).",
             "empty": {
                 "title": "Ei vielä osallistujadataa",
-                "body": "Tämä sivu aktivoi inventaarion ja joukkonimellistämisen ohjaimet (GDPR Art. 5) heti kun ensimmäinen osallistuja lähettää Q-lajittelun. Sitä ennen jaa tutkimuslinkki yleisnäkymästä aloittaaksesi vastausten keräämisen.",
+                "body": "Sivu aktivoituu, kun osallistujat lähettävät vastauksensa. Jaa ensin tutkimuslinkki.",
                 "cta": "Avaa tutkimuksen yleisnäkymä"
             }
         }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -166,22 +166,17 @@
   },
   "auth": {
     "login": {
-      "title": "Panneau d'administration",
       "email_label": "Adresse e-mail",
       "password_label": "Mot de passe",
       "submit": "Continuer",
       "forgot_password": "Oublié ?",
       "loading": "Authentification...",
-      "subtitle": "Entrez vos identifiants pour gérer vos études",
       "card_title": "Se connecter",
-      "card_description": "Accès sécurisé à votre tableau de bord de recherche",
-      "privacy": "En vous connectant, vous acceptez nos conditions d'utilisation et notre politique de confidentialité.",
-      "powered_by": "Propulsé par",
       "welcome_back": "Ravi de vous revoir !",
       "error_401": "E-mail ou mot de passe invalide",
       "error_generic": "Une erreur est survenue. Veuillez réessayer.",
       "reason_session_expired": "Votre session a expiré. Veuillez vous reconnecter.",
-      "reason_auth_required": "Connectez-vous pour accéder au panneau d'administration."
+      "reason_auth_required": "Veuillez vous connecter pour continuer."
     },
     "register": {
       "title": "Créer un compte",
@@ -439,14 +434,14 @@
     "study_design": {
       "distribution_mode": {
         "title": "Mode de distribution",
-        "helper": "Choisissez le degré de contrainte appliqué à la grille de tri Q. Forcée : chaque colonne doit être remplie à sa capacité déclarée (le choix le plus courant ; Brown 1980 ; Watts & Stenner 2012). Libre : nombre quelconque de cartes par colonne, total = taille du jeu Q (Brown et al. 2015 considèrent que la forme de la distribution influe peu sur les résultats). Flexible : total imposé, capacités par colonne données à titre indicatif.",
+        "helper": "Choisissez le degré de contrainte appliqué à la grille de tri Q. Forcée : chaque colonne doit être remplie à sa capacité déclarée (le choix le plus courant). Libre : nombre quelconque de cartes par colonne, total = taille du jeu Q. Flexible : total imposé, capacités par colonne données à titre indicatif.",
         "forced": {
           "label": "Forcée",
-          "tooltip": "Chaque colonne doit contenir exactement sa capacité déclarée. Brown 1980 ; Watts & Stenner 2012."
+          "tooltip": "Chaque colonne doit contenir exactement sa capacité déclarée."
         },
         "free": {
           "label": "Libre",
-          "tooltip": "Total de cartes = taille du jeu Q ; nombre par colonne libre. Brown et al. 2015."
+          "tooltip": "Total de cartes = taille du jeu Q ; nombre par colonne libre."
         },
         "flexible": {
           "label": "Flexible",
@@ -500,9 +495,8 @@
       "description": "Gérez vos informations personnelles et la sécurité de votre compte.",
       "personal": {
         "title": "Informations personnelles",
-        "description": "Vos coordonnées et détails de compte.",
         "email": "Adresse e-mail",
-        "email_locked": "L'email ne peut pas être modifié directement. Contactez l'administrateur.",
+        "email_locked": "Contactez un administrateur pour modifier.",
         "name": "Nom complet",
         "save": "Enregistrer",
         "saving": "Enregistrement...",
@@ -514,9 +508,6 @@
       "security": {
         "title": "Sécurité et 2FA",
         "description": "Ajoutez une couche de sécurité supplémentaire avec TOTP.",
-        "status_active": "La sécurité du compte est active",
-        "status_inactive": "La sécurité du compte est faible",
-        "status_inactive_desc": "Activez l'authentification à deux facteurs pour protéger vos données et vos études.",
         "enabled": "Activé",
         "setup_cta": "Configurer la 2FA",
         "configure_title": "Configurer l'application d'authentification",
@@ -524,7 +515,6 @@
         "secret_copied": "Secret copié",
         "enter_code": "2. Entrez le code à 6 chiffres",
         "enable_btn": "Activer la 2FA",
-        "active_msg": "La 2FA est active",
         "disable_btn": "Désactiver la 2FA",
         "confirm_disable": "Confirmer la désactivation",
         "confirm_password_label": "Confirmez avec votre mot de passe",
@@ -537,7 +527,6 @@
       },
       "password": {
         "title": "Mot de passe",
-        "description": "Mettez à jour votre mot de passe.",
         "current": "Mot de passe actuel",
         "new": "Nouveau mot de passe",
         "change_btn": "Changer le mot de passe",
@@ -602,7 +591,6 @@
       "empty_title": "Aucun concours",
       "empty_desc": "Créez un concours pour commencer à collecter et organiser les énoncés candidats pour votre recherche en Q-méthodologie.",
       "add_item": "Ajouter un élément",
-      "add_item_desc": "Ajouter un nouvel énoncé candidat à ce concours.",
       "bulk_import": "Import en masse",
       "import_desc": "Collez les énoncés séparés par des retours à la ligne. Chaque ligne devient un élément.",
       "import_prefix": "Préfixe de code",
@@ -629,7 +617,7 @@
       "deleted": "Concours supprimé",
       "delete_error": "Échec de la suppression du concours",
       "delete_item_title": "Supprimer l'élément",
-      "delete_item_confirm": "Êtes-vous sûr de vouloir supprimer cet élément ? Cette action est irréversible.",
+      "delete_item_confirm": "Supprimer cet élément ? Action irréversible.",
       "status": {
         "proposed": "Proposé",
         "accepted": "Accepté",
@@ -647,7 +635,6 @@
       "version_label": "v{{n}}",
       "item_detail_desc": "Historique et commentaires de cet élément",
       "manage_tags": "Étiquettes",
-      "manage_tags_desc": "Créez et gérez des étiquettes pour catégoriser les éléments du concours par thème ou dimension.",
       "tag_name_placeholder": "Nom de l'étiquette",
       "tag_color": "Couleur de l'étiquette",
       "tag_created": "Étiquette créée",
@@ -692,15 +679,13 @@
         "title": "Mémo de construction",
         "summary_empty": "Optionnel · pour la transparence du processus de curation",
         "summary_filled": "{{n}} caractères · cliquez pour voir ou modifier",
-        "helper": "Optionnel. Documentez comment ce concours a été constitué : sources mobilisées, voix retenues ou écartées, rationnel d'échantillonnage. Utile pour rendre transparent le processus de curation (Sneegas 2020 ; Robbins & Krueger 2000). Laissez vide si non pertinent pour votre design.",
         "placeholder": "Documentez comment ce concours a été construit : sources, voix retenues ou écartées, rationnel de l'échantillonnage…",
         "save": "Enregistrer le mémo",
         "saved": "Mémo de construction enregistré",
         "save_error": "Échec de l'enregistrement du mémo de construction"
       },
-      "status_pills_aria": "Accepté : {{a}} ; Proposé : {{p}} ; Rejeté : {{r}}",
       "import_from_csv": "Importer CSV/TSV…",
-      "import_csv_hint": "Le fichier CSV/TSV doit avoir les en-têtes code, language, text. Les lignes dans la langue sélectionnée sont chargées dans la zone de texte ci-dessus.",
+      "import_csv_hint": "CSV/TSV : colonnes code, language, text.",
       "import_csv_no_match": "Aucune ligne ne correspond à la langue sélectionnée ({{lang}}).",
       "import_csv_skipped": "{{count}} ligne(s) ignorée(s) dans d’autres langues : {{langs}}.",
       "import_csv_more_errors": "{{count}} autres problèmes"
@@ -759,7 +744,7 @@
       "eigenvalue_error": "Impossible de charger les données d'analyse. Veuillez réessayer.",
       "scree_plot_label": "Diagramme d'éboulis montrant les valeurs propres pour {{n}} facteurs",
       "loading_eigenvalues": "Chargement des valeurs propres...",
-      "empty_state": "Configurez les paramètres ci-dessus et cliquez sur « Lancer l'analyse » pour extraire les facteurs de vos données Q-sort.",
+      "empty_state": "Configurez les paramètres et lancez l'analyse.",
       "empty": {
         "contract_title": "Pas encore assez de données Q-sort",
         "contract_body": "L'analyse factorielle Q nécessite au moins 2 participants ayant complété le tri. Les choix de configuration (extraction, facteurs, rotation, marquage) prennent leur sens une fois les données disponibles. Partagez le lien d'étude depuis la vue d'ensemble pour commencer à collecter des réponses.",
@@ -811,9 +796,9 @@
       "no_statement_scores": "Aucun score d'énoncé disponible. Assurez-vous que des participants sont marqués pour au moins un facteur.",
       "no_characteristics": "Aucune caractéristique factorielle disponible.",
       "export": "Exporter",
-      "export_loadings": "CSV — Saturations factorielles",
-      "export_scores": "CSV — Scores des énoncés",
-      "export_xlsx": "XLSX — Analyse complète",
+      "export_loadings": "Saturations factorielles (CSV)",
+      "export_scores": "Scores des énoncés (CSV)",
+      "export_xlsx": "Analyse complète (XLSX)",
       "export_error": "Échec de la génération de l'export XLSX.",
       "select_factors": "Sélectionner le nombre de facteurs",
       "loadings_help": "Les saturations factorielles montrent la corrélation entre le tri de chaque participant et chaque facteur. Les cellules surlignées dépassent le seuil de significativité indiqué ci-dessus.",
@@ -827,30 +812,22 @@
       "z_scores_description": "Scores z et positions dans le tableau factoriel par énoncé",
       "factor_statistics": "Statistiques factorielles",
       "characteristics_help": "Les valeurs propres reflètent la quantité de variance expliquée. La fiabilité composite reflète la cohérence interne entre les tris marqués. L'ET des scores factoriels reflète la précision de l'estimation composite.",
-      "help_extraction": "L'ACP maximise la variance expliquée entre les facteurs. Le centroïde produit des facteurs moins contraints mathématiquement, ce que certains chercheurs en Q préfèrent pour des raisons théoriques.",
-      "help_n_factors": "Chaque facteur représente un point de vue distinct. Plus de facteurs capturent plus de nuances mais peuvent fragmenter des vues cohérentes ; moins de facteurs donnent des regroupements plus larges.",
-      "help_rotation": "Varimax maximise la séparation entre les facteurs, produisant une structure plus simple. Sans rotation, la solution mathématique originale est préservée.",
-      "help_flagging": "Auto marque les participants dont la saturation dépasse le seuil de significativité sur exactement un facteur. Manuel permet de définir le marquage selon votre propre jugement.",
+      "help_extraction": "L'ACP maximise la variance expliquée. Le centroïde est moins contraint mathématiquement.",
+      "help_n_factors": "Chaque facteur représente un point de vue distinct.",
+      "help_rotation": "Varimax sépare les facteurs pour une structure plus simple.",
+      "help_flagging": "Auto : marque les participants saturant sur un seul facteur. Manuel : ajustement participant par participant.",
       "guide_loadings_title": "Lire les saturations factorielles",
       "guide_loadings_1": "Chaque saturation est une corrélation (-1 à +1) entre un participant et un facteur (point de vue partagé).",
       "guide_loadings_2": "Les valeurs surlignées dépassent le seuil de significativité indiqué au-dessus du tableau.",
-      "guide_loadings_3": "Un participant « marqué » définit ce facteur. Recherchez une structure claire : chaque personne sur un seul facteur.",
-      "guide_loadings_4": "Les participants non marqués ont un point de vue unique non capturé par la solution.",
       "guide_arrays_title": "Interpréter les tableaux factoriels",
       "guide_arrays_1": "Chaque tableau factoriel est le Q-sort composite représentant un point de vue partagé.",
       "guide_arrays_2": "Lisez de gauche à droite : du plus en désaccord au plus en accord. Les positions extrêmes portent le signal le plus fort pour l'interprétation.",
-      "guide_arrays_3": "Les énoncés surlignés en ambre sont distinctifs — placés de manière significativement différente par rapport aux autres facteurs.",
-      "guide_arrays_4": "Comparez les tableaux entre facteurs pour voir où les points de vue divergent et convergent.",
       "guide_statements_title": "Comprendre les scores des énoncés",
       "guide_statements_1": "Les scores z montrent à quel point chaque facteur est en accord ou en désaccord avec chaque énoncé (0 = neutre).",
       "guide_statements_2": "D = distinctif (placé de manière significativement différente entre facteurs). Les étoiles indiquent le niveau de significativité.",
-      "guide_statements_3": "C = consensus (tous les facteurs s'accordent sur le placement). Ils n'aident pas à différencier les points de vue.",
-      "guide_statements_4": "Les énoncés D révèlent ce qui rend chaque point de vue unique. Les énoncés C montrent où les points de vue convergent.",
       "guide_summary_title": "Évaluer votre solution",
       "guide_summary_1": "Les valeurs propres mesurent la variance expliquée par chaque facteur. Le critère de Kaiser (valeur propre > 1) est une heuristique courante pour décider du nombre de facteurs à retenir.",
       "guide_summary_2": "La fiabilité composite reflète la cohérence entre les tris marqués pour chaque facteur. Des valeurs plus élevées signifient que l'estimation du facteur repose sur davantage d'accord entre ses tris définissants.",
-      "guide_summary_3": "Les corrélations entre facteurs montrent le degré de chevauchement entre les points de vue. Des corrélations plus élevées signifient que les facteurs partagent davantage de terrain commun ; des corrélations plus faibles signifient qu'ils sont plus distincts.",
-      "guide_summary_4": "La variance totale expliquée indique quelle part de la variation globale dans les patterns de tri est capturée par votre solution.",
       "benchmark_above": "Au-dessus du seuil",
       "benchmark_below": "En dessous du seuil",
       "history": {
@@ -858,7 +835,7 @@
         "loading": "Chargement de l'historique…",
         "fetch_error": "Impossible de charger l'historique des analyses.",
         "empty": "Aucune analyse précédente pour cette étude — lancez-en une pour démarrer la piste d'audit.",
-        "empty_explainer": "Documenter les choix analytiques favorise la reproductibilité — exigence centrale d'une pratique Q-méthodologique rigoureuse (Watts & Stenner 2012 ; Sneegas 2020). Chaque exécution est enregistrée ici afin de documenter et réexaminer chaque décision.",
+        "empty_explainer": "Chaque exécution est enregistrée ici afin de documenter et réexaminer chaque décision.",
         "load_error": "Impossible de charger cette analyse.",
         "load_run_aria": "Charger l'analyse du {{date}}",
         "loading_run": "Chargement…",
@@ -889,7 +866,7 @@
         "no_material": "Aucun enregistrement audio ni commentaire écrit des participants définissant ce facteur.",
         "loading": "Chargement des enregistrements…",
         "error": "Impossible de charger les enregistrements audio. Veuillez réessayer.",
-        "context": "Ancrer l'interprétation des facteurs dans les mots des participants eux-mêmes — leurs justifications audio comme leurs commentaires écrits sur les cartes — est un élément central d'une pratique Q-méthodologique rigoureuse (Watts & Stenner 2012 ; Sneegas 2020).",
+        "context": "Ancrez l'interprétation des facteurs dans les mots des participants — leurs justifications audio comme leurs commentaires écrits sur les cartes.",
         "context_aria": "À propos de ce panneau",
         "audio_label": "Enregistrement : {{key}} par {{participant}}",
         "url_unavailable": "URL audio non disponible.",
@@ -911,12 +888,12 @@
         "judgmental": {
           "label": "Manuelle (jugement)",
           "short": "Manuelle",
-          "tooltip": "Pivote manuellement les paires de facteurs selon des angles choisis pour aligner les facteurs sur des positions substantiellement significatives (Brown 1980 ; Watts & Stenner 2012)."
+          "tooltip": "Pivote manuellement les paires de facteurs selon des angles choisis pour aligner les facteurs sur des positions substantiellement significatives."
         }
       },
       "manual_rotations": {
         "title": "Rotations manuelles",
-        "helper": "Spécifiez les rotations sous la forme « pivoter le facteur F de Δ° autour du facteur G ». Les rotations sont appliquées dans l'ordre. Utilisées pour aligner les facteurs sur des positions substantiellement significatives (Brown 1980 ; Watts & Stenner 2012).",
+        "helper": "Spécifiez les rotations sous la forme « pivoter le facteur F de Δ° autour du facteur G ». Les rotations sont appliquées dans l'ordre.",
         "add": "Ajouter une rotation",
         "remove_aria": "Supprimer la rotation",
         "empty": "Ajoutez au moins une rotation pour lancer l'analyse.",
@@ -927,10 +904,10 @@
       "bootstrap": {
         "toggle_label": "Lancer le bootstrap de stabilité",
         "iterations_label": "Itérations (B)",
-        "helper": "Optionnel. Le bootstrap rééchantillonne vos Q-sorts avec remise et relance l'analyse B fois pour estimer les erreurs-types des z-scores. Utile lorsque vous voulez des intervalles de confiance sur les scores factoriels (Zabala & Pascual 2016).",
+        "helper": "Optionnel. Rééchantillonne les Q-sorts B fois pour estimer des intervalles de confiance sur les scores factoriels.",
         "running": "Bootstrap en cours…",
         "se_column": "Erreur-type moyenne (z)",
-        "tooltip": "Bootstrap non paramétrique des Q-sorts (rééchantillonnés avec remise) ; l'analyse est répétée B fois pour estimer les erreurs-types et les IC à 95 % des z-scores (Zabala & Pascual 2016)."
+        "tooltip": "Bootstrap non paramétrique des Q-sorts (rééchantillonnés avec remise) ; l'analyse est répétée B fois pour estimer les IC à 95 % des z-scores."
       }
     },
     "project": {
@@ -951,9 +928,7 @@
       },
       "create": {
         "title": "Créer un projet",
-        "description": "Créez une nouvelle organisation pour gérer vos études et votre équipe.",
         "card_title": "Détails du projet",
-        "card_description": "Entrez le nom et l'identifiant URL de votre nouveau projet.",
         "name_label": "Nom du projet",
         "name_placeholder": "Mon groupe de recherche universitaire",
         "url_label": "URL du projet",
@@ -983,9 +958,7 @@
         "slug_description": "L'identifiant unique utilisé dans l'URL de l'étude. Lettres minuscules, chiffres et tirets uniquement.",
         "slug_locked": "Le slug de l'URL ne peut être modifié que lorsque l'étude est en mode brouillon."
       },
-      "guidance_title": "Comment fonctionne l'accès des participants",
-      "guidance_body": "L'URL de l'étude est l'adresse web publique de votre étude. Les liens de recrutement ajoutent des jetons uniques à cette URL pour contrôler et suivre qui peut participer. Partagez les liens directement, par e-mail, ou imprimez des codes QR pour vos supports physiques.",
-      "state_draft": "Votre étude est en mode brouillon. Configurez l'URL et préparez les liens de recrutement — les participants ne pourront pas accéder à l'étude tant qu'elle n'est pas activée.",
+      "state_draft": "Mode brouillon — les liens fonctionneront après activation.",
       "state_closed": "Cette étude est fermée. Les liens existants restent visibles mais les nouveaux participants ne peuvent pas commencer.",
       "state_archived": "Cette étude est archivée. Toutes les données de recrutement sont en lecture seule.",
       "empty_title": "Aucun lien de recrutement",
@@ -1018,7 +991,6 @@
       },
       "new_link": "Nouveau lien d'accès",
       "create_title": "Créer des liens d'accès",
-      "create_description": "Ciblez des cohortes spécifiques ou créez un accès général. Chaque type de lien a des propriétés de sécurité différentes.",
       "link_type": "Stratégie d'accès",
       "select_type": "Choisir le type de recrutement...",
       "campaign_name": "Nom du canal / de la campagne",
@@ -1029,11 +1001,9 @@
       "no_links": "Aucun lien de recrutement généré pour le moment.",
       "unnamed": "Canal sans nom",
       "revoked": "Accès révoqué",
-      "qr_title": "Partager le code d'accès",
-      "qr_desc": "Les participants peuvent scanner ce code pour accéder directement à l'étude.",
-      "copy_link": "Copier l'URL sécurisée",
-      "table_title": "Panneau de contrôle d'accès",
-      "table_description": "Canaux actifs et gestion du cycle de vie des liens.",
+      "qr_title": "Partager via QR",
+      "copy_link": "Copier l'URL",
+      "table_title": "Liens de recrutement",
       "share_title": "Partager l'étude",
       "share_desc": "Distribuez l'URL de votre étude pour inviter des participants.",
       "public_url_label": "URL publique de participation",
@@ -1337,7 +1307,6 @@
     },
     "study_overview": {
       "title": "Tableau de bord",
-      "subtitle": "",
       "back_to_overview": "Retour à la vue d'ensemble",
       "sample_size": "Nombre de participations (P-Set)",
       "valid": "validé(s)",
@@ -1346,7 +1315,6 @@
       "mobile": "mobile",
       "median_duration": "Durée médiane",
       "suspect": "Suspect",
-      "time_to_complete": "Temps de complétion",
       "recent_activity": "Activité récente",
       "latest_participants": "Dernières participations ({{count}} sur {{total}})",
       "recently_completed": "Récemment complété",
@@ -1468,7 +1436,6 @@
     },
     "design": {
       "translation_needed": "Révision requise (Copie)",
-      "translation_needed_desc": "Ce contenu a été automatiquement copié d'une autre langue. Veuillez le réviser et le localiser.",
       "reset_defaults": "Réinitialiser par défaut",
       "editing_language_banner": "Vous éditez la version {{language}}. Utilisez le sélecteur de langue dans la barre d'outils pour changer.",
       "multilang": {
@@ -1524,7 +1491,7 @@
         "editing_language": "Édition",
         "manage_langs": "Gérer les langues",
         "select_lang": "Choisir la langue",
-        "test_run_help": "Ouvre un aperçu participant. Les runs de test sont marqués is_test_run=true et n’entrent jamais dans les données publiées.",
+        "test_run_help": "Aperçu en tant que participant. Ces runs ne sont pas comptés dans vos données.",
         "more_actions": "Autres actions"
       },
       "sync": {
@@ -1541,7 +1508,7 @@
       },
       "validation": {
         "failed_title": "Configuration incomplète",
-        "failed_desc": "Votre étude ne peut pas encore être activée. Veuillez corriger les problèmes suivants :",
+        "failed_desc": "Corrigez ces problèmes pour activer :",
         "errors": {
           "no_statements": "L'étude doit contenir au moins un énoncé.",
           "no_grid": "La configuration de la grille est manquante.",
@@ -1783,12 +1750,9 @@
           "tooltip_desc": "Dans la méthode Q, une distribution forcée est généralement quasi-normale. Cela oblige le participant à faire des choix difficiles et à discriminer clairement entre les items.",
           "locked": "Conception verrouillée",
           "locked_desc": "Les changements structurels (codes des énoncés, grille) sont désactivés car l'étude a recueilli des données ou n'est plus en mode brouillon. Vous pouvez toujours modifier les textes des traductions.",
-          "locked_active": "L'étude est active",
-          "locked_active_desc": "L'étude collecte actuellement des données. Pour modifier la conception, vous devez d'abord la repasser en brouillon.",
-          "locked_paused": "L'étude est en pause",
-          "locked_paused_desc": "L'étude est actuellement en pause. La conception reste verrouillée pour protéger les données existantes.",
-          "locked_closed": "L'étude est clôturée",
-          "locked_closed_desc": "Cette étude est terminée. La conception est archivée et ne peut plus être modifiée.",
+          "locked_active": "Étude active — repassez en brouillon pour éditer",
+          "locked_paused": "Étude en pause — repassez en brouillon pour éditer",
+          "locked_closed": "Étude clôturée — la conception est archivée",
           "mismatch_title": "Capacité de grille incorrecte",
           "mismatch_desc": "Vous avez {{statements}} énoncés mais la grille n'a que {{slots}} emplacements. Veuillez ajuster les colonnes ci-dessous.",
           "unlock_hint": "Aller dans l'explorateur de données pour purger les sessions et débloquer la structure"
@@ -1924,7 +1888,7 @@
       "methodology_memo": {
         "title": "Mémo méthodologique",
         "summary": "Optionnel · pour la réplication & la préinscription",
-        "help": "Optionnel. Documentez pourquoi cette distribution, ces consignes, cette taille de Q-set. Utile pour la réplication et la préinscription (Watts & Stenner 2012 ; Sneegas 2020). Laissez vide si non pertinent.",
+        "help": "Optionnel. Documentez le rationnel de cette distribution, ces consignes, et cette taille de Q-set.",
         "label": "Mémo (toutes langues)",
         "placeholder": "Documentez le rationnel de vos choix de design…"
       },
@@ -2111,7 +2075,7 @@
         "no_participants_title": "Aucun participant pour l'instant",
         "no_participants_desc": "Partagez le lien de votre étude pour commencer à collecter des réponses.",
         "contract_title": "Aucune soumission pour le moment",
-        "contract_body": "Cette page listera les soumissions des participants et proposera les exports CSV/JSON dès la première réponse. Partagez le lien d'étude depuis la vue d'ensemble pour commencer à collecter des données.",
+        "contract_body": "Les soumissions et exports apparaîtront ici. Partagez le lien d'étude pour commencer la collecte.",
         "contract_cta": "Ouvrir la vue d'ensemble"
       },
       "pagination": {
@@ -2161,7 +2125,7 @@
         "delete_button": "Supprimer l'étude",
         "delete_confirm": "Êtes-vous sûr ? Cette action est IRRÉVERSIBLE.",
         "delete_dialog_title": "Supprimer cette étude ?",
-        "delete_dialog_intro": "Tous les tris, enregistrements audio et analyses de cette étude seront supprimés définitivement. Cette action est irréversible.",
+        "delete_dialog_intro": "Supprime définitivement tris, audio et analyses.",
         "delete_dialog_typed_label": "Saisir le slug de l'étude pour confirmer",
         "delete_dialog_action": "Supprimer définitivement"
       },
@@ -2180,13 +2144,10 @@
       "delete_error_desc": "Échec de la suppression de l'étude.",
       "storage": {
         "title": "Utilisation du stockage audio",
-        "description": "Surveillez le stockage des enregistrements audio de cette étude.",
         "used": "Stockage utilisé",
         "quota": "Quota",
         "quota_label": "Quota de stockage",
         "quota_help": "Stockage audio maximal pour cette étude (10–1000 Mo).",
-        "files_count": "Fichiers : {{count}}",
-        "percent_used": "{{percent}} % utilisé",
         "error": "Échec du chargement de l'utilisation du stockage.",
         "warning_high_usage": "L'utilisation du stockage est élevée. Envisagez d'augmenter le quota ou de supprimer d'anciens enregistrements.",
         "save_success": "Quota de stockage mis à jour",
@@ -2194,9 +2155,8 @@
       },
       "retention": {
         "title": "Conservation des données",
-        "description": "Nombre de mois pendant lesquels conserver des données identifiables avant de recommander l’anonymisation. Détermine la date seuil par défaut dans Cycle de vie des données. Laissez vide pour utiliser la valeur système (12 mois).",
         "months_label": "Conservation (mois)",
-        "help": "Les chercheurs UE doivent aligner cette valeur sur leur politique de conservation RGPD. Valeurs courantes : 6, 12, 24, 60.",
+        "help": "Valeurs courantes : 6, 12, 24, 60 mois. Laissez vide pour la valeur système (12).",
         "save_success": "Politique de conservation mise à jour",
         "save_error": "Échec de la mise à jour de la politique de conservation",
         "range_error": "La durée de conservation doit être un entier entre 1 et 240 mois."
@@ -2204,12 +2164,9 @@
     },
     "lifecycle": {
       "title": "Inventaire des données & cycle de vie",
-      "header_desc": "Contrôles de minimisation des données (RGPD art. 5)",
-      "intro": "Cette page vous offre un instantané en temps réel des données personnelles détenues pour cette étude et vous permet d'anonymiser les enregistrements anciens en masse. Utilisez-la pour respecter l'obligation de minimisation des données de l'art. 5 du RGPD une fois la collecte terminée.",
+      "header_desc": "Inventaire & anonymisation",
       "load_error": "Impossible de charger l'inventaire des données.",
       "participants_title": "Instantané des participants",
-      "participants_desc": "État actuel de tous les participants de cette étude",
-      "stat_total": "Total",
       "stat_started": "Commencé",
       "stat_completed": "Complété",
       "stat_discarded": "Rejeté",
@@ -2233,20 +2190,20 @@
       "cutoff_help": "Seuls les participants complétés soumis strictement avant cette date seront anonymisés.",
       "preview_label": "Candidats :",
       "preview_zero": "Aucun participant ne correspond à ce seuil. Essayez une date antérieure.",
-      "anonymise_button": "Anonymiser antérieurs au {{date}}",
+      "anonymise_button": "Anonymiser",
       "anonymise_success": "Anonymisation terminée",
       "anonymise_success_desc": "{{n}} participant(s) anonymisé(s), {{s}} déjà anonyme(s).",
       "anonymise_error": "Échec de l'anonymisation",
       "confirm_title": "Anonymiser les données des participants ?",
       "confirm_candidates": "{{count}} participant(s) complété(s) soumis avant le {{date}} seront anonymisés.",
-      "confirm_preserved": "Les classements des énoncés seront conservés en tant que données de recherche anonymes — ils ne seront plus liés à aucun individu.",
+      "confirm_preserved": "Les classements Q-sort sont conservés ; l'identité est supprimée.",
       "confirm_irreversible": "Cette action est immédiate et irréversible.",
       "confirm_in_progress": "Anonymisation en cours…",
       "confirm_action": "Oui, anonymiser",
       "cutoff_from_policy": "Valeur par défaut dérivée de la politique de conservation de l’étude ({{months}} mois).",
       "empty": {
         "title": "Aucune donnée participante pour le moment",
-        "body": "Cette page activera les tableaux d'inventaire et les contrôles d'anonymisation en masse (RGPD art. 5) dès la première soumission d'un participant. En attendant, partagez le lien d'étude depuis la vue d'ensemble pour commencer à collecter des réponses.",
+        "body": "Cette page s'active dès qu'un participant soumet. Partagez d'abord le lien d'étude.",
         "cta": "Ouvrir la vue d'ensemble"
       }
     },
@@ -2290,36 +2247,30 @@
             "title": "Matrice des permissions",
             "admin": {
               "label": "Admin",
-              "badge": "Accès complet",
               "desc": "Peut gérer les paramètres du projet, les membres et toutes les études."
             },
             "owner": {
               "label": "Propriétaire",
-              "badge": "Accès complet",
-              "desc": "Gère les paramètres du projet, les membres et toutes les études. Peut promouvoir ou retirer d'autres membres."
+              "desc": "Contrôle complet du projet, des membres et des études."
             },
             "researcher": {
               "label": "Chercheur",
-              "badge": "Création",
               "desc": "Peut créer et gérer toutes les études. Accès restreint aux paramètres du projet."
             },
             "viewer": {
               "label": "Observateur",
-              "badge": "Lecture seule",
               "desc": "Accès en lecture seule à toutes les études et données du projet."
             }
           },
           "coming_soon": "Bientôt disponible",
           "invite_modal": {
             "title": "Inviter un collaborateur",
-            "desc": "Envoyez une invitation sécurisée pour rejoindre votre équipe de recherche.",
             "email_label": "E-mail du collaborateur",
             "role_label": "Rôle assigné",
             "success": "Lien d'invitation généré !",
             "error": "Échec de la création de l'invitation.",
             "send": "Créer et envoyer l'invitation",
-            "copy_success": "Lien copié dans le presse-papier !",
-            "copy_hint": "Copiez ce lien et envoyez-le manuellement si l'e-mail échoue."
+            "copy_success": "Lien copié dans le presse-papier !"
           }
         }
       }

--- a/frontend/src/components/admin/analysis/AnalysisHistory.test.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistory.test.tsx
@@ -129,7 +129,7 @@ describe('AnalysisHistoryPanel', () => {
 
         expect(screen.getByText(/No previous analyses for this study yet/i)).toBeInTheDocument();
         expect(
-            screen.getByText(/Documenting analytical choices supports reproducibility/i)
+            screen.getByText(/Each run is logged here so you can document/i)
         ).toBeInTheDocument();
     });
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -10,14 +10,7 @@ import { useAdminStore } from '@/store/useAdminStore';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardFooter,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { toast } from 'sonner';
 import { Loader2, Lock, AtSign, ArrowRight, ShieldCheck, Info } from 'lucide-react';
 import { motion } from 'framer-motion';
@@ -118,23 +111,18 @@ const LoginPage = () => {
                 transition={{ duration: 0.5, ease: 'easeOut' }}
                 className="w-full max-w-[400px] z-10"
             >
-                <div className="flex flex-col items-center mb-8">
-                    <div className="w-12 h-12 bg-slate-900 rounded-xl flex items-center justify-center shadow-lg mb-4">
+                <div className="flex justify-center mb-8">
+                    <div className="w-12 h-12 bg-slate-900 rounded-xl flex items-center justify-center shadow-lg">
                         <ShieldCheck className="text-white h-7 w-7" />
                     </div>
-                    <h1 className="text-2xl font-bold tracking-tight text-slate-900">
-                        {t('auth.login.title')}
-                    </h1>
-                    <p className="text-sm text-slate-500 mt-2">{t('auth.login.subtitle')}</p>
                 </div>
 
                 <Card className="border-none shadow-[0_8px_30px_rgb(0,0,0,0.04)] bg-white/80 backdrop-blur-md">
                     <form onSubmit={handleLogin}>
-                        <CardHeader className="space-y-1 pb-4">
+                        <CardHeader className="pb-4">
                             <CardTitle className="text-xl font-black">
                                 {t('auth.login.card_title')}
                             </CardTitle>
-                            <CardDescription>{t('auth.login.card_description')}</CardDescription>
                         </CardHeader>
                         {(() => {
                             const reason = searchParams.get('reason');
@@ -148,7 +136,7 @@ const LoginPage = () => {
                             const fallback =
                                 reason === 'session_expired'
                                     ? 'Your session has expired. Please sign in again.'
-                                    : 'Please sign in to access the admin panel.';
+                                    : 'Please sign in to continue.';
                             return (
                                 <div className="px-6 pb-2">
                                     <div

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -377,7 +377,7 @@ describe('AnalysisPage', () => {
 
         renderWithProviders(<AnalysisPage />);
 
-        expect(screen.getByText(/Configure parameters above/i)).toBeInTheDocument();
+        expect(screen.getByText(/Set parameters and run the analysis/i)).toBeInTheDocument();
     });
 
     it('does not show export button when no results', () => {
@@ -441,16 +441,16 @@ describe('AnalysisPage', () => {
         renderWithProviders(<AnalysisPage />);
 
         // Wave C: PCA + Factors help texts are primary-visible.
-        expect(screen.getByText(/PCA maximizes explained variance/i)).toBeInTheDocument();
+        expect(screen.getByText(/PCA maximises explained variance/i)).toBeInTheDocument();
         expect(
             screen.getByText(/Each factor represents a distinct viewpoint/i)
         ).toBeInTheDocument();
         // Rotation + Flagging help texts now live inside the collapsed
         // "Advanced settings" Accordion — not visible on initial render.
-        expect(screen.queryByText(/Varimax maximizes the separation/i)).not.toBeInTheDocument();
         expect(
-            screen.queryByText(/Auto flags participants whose loading/i)
+            screen.queryByText(/Varimax separates factors for simpler structure/i)
         ).not.toBeInTheDocument();
+        expect(screen.queryByText(/Auto: flag participants loading/i)).not.toBeInTheDocument();
     });
 
     it('shows interpretation guidance in results tabs', async () => {

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -823,18 +823,6 @@ export default function AnalysisPage() {
                                                 'Highlighted values exceed the significance threshold shown above the table.'
                                             )}
                                         </li>
-                                        <li>
-                                            {t(
-                                                'admin.analysis.guide_loadings_3',
-                                                'A "flagged" participant defines that factor. Look for clean structure: each person on one factor.'
-                                            )}
-                                        </li>
-                                        <li>
-                                            {t(
-                                                'admin.analysis.guide_loadings_4',
-                                                'Participants not flagged on any factor hold a unique view not captured by the solution.'
-                                            )}
-                                        </li>
                                     </ul>
                                 </GuidanceCard>
                                 <FactorLoadingsTable
@@ -866,18 +854,6 @@ export default function AnalysisPage() {
                                             {t(
                                                 'admin.analysis.guide_arrays_2',
                                                 'Read left-to-right as most disagreed to most agreed. Extreme positions carry the strongest signal for interpretation.'
-                                            )}
-                                        </li>
-                                        <li>
-                                            {t(
-                                                'admin.analysis.guide_arrays_3',
-                                                'Amber-highlighted statements are distinguishing — placed significantly differently compared to other factors.'
-                                            )}
-                                        </li>
-                                        <li>
-                                            {t(
-                                                'admin.analysis.guide_arrays_4',
-                                                'Compare arrays across factors to see where viewpoints diverge and converge.'
                                             )}
                                         </li>
                                     </ul>
@@ -916,18 +892,6 @@ export default function AnalysisPage() {
                                                 'D = distinguishing (placed significantly differently across factors). Stars indicate significance level.'
                                             )}
                                         </li>
-                                        <li>
-                                            {t(
-                                                'admin.analysis.guide_statements_3',
-                                                "C = consensus (all factors agree on placement). These don't help differentiate viewpoints."
-                                            )}
-                                        </li>
-                                        <li>
-                                            {t(
-                                                'admin.analysis.guide_statements_4',
-                                                'D statements reveal what makes each viewpoint unique. C statements show where viewpoints converge.'
-                                            )}
-                                        </li>
                                     </ul>
                                 </GuidanceCard>
                                 <StatementsTable result={analysisResult} />
@@ -954,18 +918,6 @@ export default function AnalysisPage() {
                                             {t(
                                                 'admin.analysis.guide_summary_2',
                                                 'Composite reliability reflects how consistently the flagged sorts define each factor. Higher values mean the factor estimate is based on more agreement among its defining sorts.'
-                                            )}
-                                        </li>
-                                        <li>
-                                            {t(
-                                                'admin.analysis.guide_summary_3',
-                                                'Factor correlations show how much overlap exists between viewpoints. Higher correlations mean the factors share more common ground; lower correlations mean they are more distinct.'
-                                            )}
-                                        </li>
-                                        <li>
-                                            {t(
-                                                'admin.analysis.guide_summary_4',
-                                                'Total variance explained indicates how much of the overall variation in sorting patterns is captured by your solution.'
                                             )}
                                         </li>
                                     </ul>

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -315,12 +315,6 @@ export default function ConcourseDetailPage() {
                     </AccordionTrigger>
                     <AccordionContent>
                         <CardContent className="p-4 sm:p-6 space-y-3">
-                            <p className="text-xs text-slate-500 leading-relaxed">
-                                {t(
-                                    'admin.concourse.construction_memo.helper',
-                                    'Optional. Document how this concourse was constructed: sources canvassed, voices retained or set aside, sampling rationale. Useful for transparency about the curation process (Sneegas 2020; Robbins & Krueger 2000). Leave blank if not applicable to your design.'
-                                )}
-                            </p>
                             <Textarea
                                 id="construction-memo"
                                 rows={8}
@@ -531,43 +525,6 @@ export default function ConcourseDetailPage() {
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-3">
-                                    <div
-                                        role="group"
-                                        className="flex items-center gap-2 text-xs"
-                                        aria-label={t(
-                                            'admin.concourse.status_pills_aria',
-                                            'Accepted: {{a}}; Proposed: {{p}}; Rejected: {{r}}',
-                                            { a: acceptedCt, p: proposedCt, r: rejectedCt }
-                                        )}
-                                    >
-                                        <span
-                                            title={t('admin.concourse.status.accepted', 'Accepted')}
-                                            className={cn(
-                                                'rounded-lg border px-2 py-0.5 font-bold cursor-help',
-                                                STATUS_COLORS.accepted
-                                            )}
-                                        >
-                                            {acceptedCt}
-                                        </span>
-                                        <span
-                                            title={t('admin.concourse.status.proposed', 'Proposed')}
-                                            className={cn(
-                                                'rounded-lg border px-2 py-0.5 font-bold cursor-help',
-                                                STATUS_COLORS.proposed
-                                            )}
-                                        >
-                                            {proposedCt}
-                                        </span>
-                                        <span
-                                            title={t('admin.concourse.status.rejected', 'Rejected')}
-                                            className={cn(
-                                                'rounded-lg border px-2 py-0.5 font-bold cursor-help',
-                                                STATUS_COLORS.rejected
-                                            )}
-                                        >
-                                            {rejectedCt}
-                                        </span>
-                                    </div>
                                     <Button
                                         variant="outline"
                                         size="sm"
@@ -1223,12 +1180,6 @@ export default function ConcourseDetailPage() {
                         <DialogTitle className="text-lg font-black text-slate-900">
                             {t('admin.concourse.add_item', 'Add Item')}
                         </DialogTitle>
-                        <DialogDescription className="text-sm text-slate-500">
-                            {t(
-                                'admin.concourse.add_item_desc',
-                                'Add a new candidate statement to this concourse.'
-                            )}
-                        </DialogDescription>
                     </DialogHeader>
                     <div className="space-y-3 py-2">
                         <div className="space-y-1">
@@ -1410,7 +1361,7 @@ export default function ConcourseDetailPage() {
                         <DialogDescription className="text-sm text-slate-500">
                             {t(
                                 'admin.concourse.delete_item_confirm',
-                                'Are you sure you want to delete this item? This cannot be undone.'
+                                'Delete this item? Cannot be undone.'
                             )}
                         </DialogDescription>
                     </DialogHeader>
@@ -1539,7 +1490,7 @@ export default function ConcourseDetailPage() {
                             <p className="text-xs text-slate-400">
                                 {t(
                                     'admin.concourse.import_csv_hint',
-                                    'CSV/TSV must have headers code, language, text. Rows in the selected language are loaded into the textarea above.'
+                                    'CSV/TSV needs columns: code, language, text.'
                                 )}
                             </p>
                             {csvErrors.length > 0 && (
@@ -1605,12 +1556,6 @@ export default function ConcourseDetailPage() {
                         <DialogTitle className="text-lg font-black text-slate-900">
                             {t('admin.concourse.manage_tags', 'Tags')}
                         </DialogTitle>
-                        <DialogDescription className="text-sm text-slate-500">
-                            {t(
-                                'admin.concourse.manage_tags_desc',
-                                'Create and manage tags to categorize concourse items by theme or dimension.'
-                            )}
-                        </DialogDescription>
                     </DialogHeader>
                     <div className="space-y-4 py-2">
                         <div className="flex gap-2">

--- a/frontend/src/pages/admin/CreateProjectPage.tsx
+++ b/frontend/src/pages/admin/CreateProjectPage.tsx
@@ -21,7 +21,7 @@ import {
     FormDescription,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import ApiClient from '@/api/client';
 import { useAuthStore } from '@/store/useAuthStore';
 import type { ProjectWithRole } from '@/types/backend';
@@ -101,18 +101,13 @@ export default function CreateProjectPage() {
 
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-8 max-w-4xl mx-auto w-full">
-            <div className="flex flex-col gap-2 mb-2">
-                <div className="flex items-center gap-3">
-                    <div className="p-2.5 bg-indigo-50 border border-indigo-100 rounded-xl text-indigo-600 shadow-sm">
-                        <Plus className="size-6" />
-                    </div>
-                    <h1 className="text-3xl font-black tracking-tight text-slate-900">
-                        {t('admin.project.create.title')}
-                    </h1>
+            <div className="flex items-center gap-3 mb-2">
+                <div className="p-2.5 bg-indigo-50 border border-indigo-100 rounded-xl text-indigo-600 shadow-sm">
+                    <Plus className="size-6" />
                 </div>
-                <p className="text-slate-500 font-medium pl-1">
-                    {t('admin.project.create.description')}
-                </p>
+                <h1 className="text-3xl font-black tracking-tight text-slate-900">
+                    {t('admin.project.create.title')}
+                </h1>
             </div>
 
             <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
@@ -121,9 +116,6 @@ export default function CreateProjectPage() {
                         <Briefcase className="size-5 text-indigo-500" />
                         {t('admin.project.create.card_title')}
                     </CardTitle>
-                    <CardDescription className="text-sm font-medium text-slate-500">
-                        {t('admin.project.create.card_description')}
-                    </CardDescription>
                 </CardHeader>
                 <CardContent className="pt-8">
                     <Form {...form}>

--- a/frontend/src/pages/admin/DataExportsPage.tsx
+++ b/frontend/src/pages/admin/DataExportsPage.tsx
@@ -32,7 +32,7 @@ export default function DataExportsPage() {
                     title={t('admin.data.empty.contract_title', 'No submissions yet')}
                     body={t(
                         'admin.data.empty.contract_body',
-                        'This page will list participant submissions and offer CSV/JSON exports as soon as the first response arrives. Share the study link from the overview to start collecting data.'
+                        'Submissions and exports will appear here. Share the study link to start collecting.'
                     )}
                     ctaLabel={t('admin.data.empty.contract_cta', 'Open study overview')}
                     ctaTo={`/app/${projectSlug ?? ''}/studies/${studySlug ?? ''}`}

--- a/frontend/src/pages/admin/DataLifecyclePage.test.tsx
+++ b/frontend/src/pages/admin/DataLifecyclePage.test.tsx
@@ -106,8 +106,7 @@ describe('DataLifecyclePage', () => {
         // Page header
         expect(screen.getByText('Data inventory & lifecycle')).toBeInTheDocument();
 
-        // Participant stats
-        expect(screen.getByText('50')).toBeInTheDocument(); // total
+        // Participant stats (Total stat removed in text-trim wave; Started/Completed/Discarded/Anonymised remain)
         expect(screen.getByText('30')).toBeInTheDocument(); // completed
         expect(screen.getByText('5')).toBeInTheDocument(); // anonymised
 
@@ -187,7 +186,7 @@ describe('DataLifecyclePage', () => {
 
         // The anonymise button should be enabled (18 candidates for 1-year cutoff default)
         const anonymiseBtn = screen.getByRole('button', {
-            name: /anonymise older than/i,
+            name: /^anonymise$/i,
         });
         expect(anonymiseBtn).not.toBeDisabled();
 
@@ -198,9 +197,7 @@ describe('DataLifecyclePage', () => {
         expect(dialog).toBeInTheDocument();
         expect(screen.getByText(/anonymise participant data/i)).toBeInTheDocument();
         expect(screen.getByText(/18 completed participant/i)).toBeInTheDocument();
-        expect(
-            screen.getByText(/q-sort statement rankings will be preserved/i)
-        ).toBeInTheDocument();
+        expect(screen.getByText(/q-sort rankings are kept/i)).toBeInTheDocument();
         expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument();
 
         // Confirm
@@ -258,8 +255,6 @@ describe('DataLifecyclePage', () => {
         // Inventory chrome is NOT shown
         expect(screen.queryByText('Participants snapshot')).not.toBeInTheDocument();
         expect(screen.queryByText('Bulk anonymisation')).not.toBeInTheDocument();
-        expect(
-            screen.queryByRole('button', { name: /anonymise older than/i })
-        ).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /^anonymise$/i })).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/admin/DataLifecyclePage.tsx
+++ b/frontend/src/pages/admin/DataLifecyclePage.tsx
@@ -169,10 +169,7 @@ export default function DataLifecyclePage() {
             <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
                 <StudyPageHeader
                     title={t('admin.lifecycle.title', 'Data inventory & lifecycle')}
-                    description={t(
-                        'admin.lifecycle.header_desc',
-                        'GDPR Art. 5 data minimisation controls'
-                    )}
+                    description={t('admin.lifecycle.header_desc', 'Inventory & anonymisation')}
                     icon={ShieldCheck}
                 />
                 <InventorySkeleton />
@@ -185,10 +182,7 @@ export default function DataLifecyclePage() {
             <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
                 <StudyPageHeader
                     title={t('admin.lifecycle.title', 'Data inventory & lifecycle')}
-                    description={t(
-                        'admin.lifecycle.header_desc',
-                        'GDPR Art. 5 data minimisation controls'
-                    )}
+                    description={t('admin.lifecycle.header_desc', 'Inventory & anonymisation')}
                     icon={ShieldCheck}
                 />
                 <Alert className="bg-red-50 border-red-200 max-w-4xl">
@@ -212,10 +206,7 @@ export default function DataLifecyclePage() {
             <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
                 <StudyPageHeader
                     title={t('admin.lifecycle.title', 'Data inventory & lifecycle')}
-                    description={t(
-                        'admin.lifecycle.header_desc',
-                        'GDPR Art. 5 data minimisation controls'
-                    )}
+                    description={t('admin.lifecycle.header_desc', 'Inventory & anonymisation')}
                     icon={ShieldCheck}
                 />
                 <EmptyStateContract
@@ -236,20 +227,9 @@ export default function DataLifecyclePage() {
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
             <StudyPageHeader
                 title={t('admin.lifecycle.title', 'Data inventory & lifecycle')}
-                description={t(
-                    'admin.lifecycle.header_desc',
-                    'GDPR Art. 5 data minimisation controls'
-                )}
+                description={t('admin.lifecycle.header_desc', 'Inventory & anonymisation')}
                 icon={ShieldCheck}
             />
-
-            {/* Intro */}
-            <p className="text-sm text-slate-600 max-w-2xl leading-relaxed">
-                {t(
-                    'admin.lifecycle.intro',
-                    'This page gives you a real-time snapshot of personal data held for this study and lets you anonymise older records in bulk. Use it to enforce GDPR Art. 5 data-minimisation obligations once data collection is complete.'
-                )}
-            </p>
 
             <div className="space-y-6 max-w-4xl">
                 {/* ── Section 1: Participants ─────────────────────────────── */}
@@ -261,19 +241,9 @@ export default function DataLifecyclePage() {
                                 {t('admin.lifecycle.participants_title', 'Participants snapshot')}
                             </CardTitle>
                         </div>
-                        <CardDescription className="text-sm font-medium text-slate-500">
-                            {t(
-                                'admin.lifecycle.participants_desc',
-                                'Current status of all participants in this study'
-                            )}
-                        </CardDescription>
                     </CardHeader>
                     <CardContent className="p-6">
                         <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-                            <Stat
-                                label={t('admin.lifecycle.stat_total', 'Total')}
-                                value={participants.total}
-                            />
                             <Stat
                                 label={t('admin.lifecycle.stat_started', 'Started')}
                                 value={participants.started}
@@ -509,11 +479,7 @@ export default function DataLifecyclePage() {
                             ) : (
                                 <ShieldAlert className="w-4 h-4 mr-2" />
                             )}
-                            {t(
-                                'admin.lifecycle.anonymise_button',
-                                'Anonymise older than {{date}}',
-                                { date: cutoffDate }
-                            )}
+                            {t('admin.lifecycle.anonymise_button', 'Anonymise')}
                         </Button>
                     </CardContent>
                 </Card>

--- a/frontend/src/pages/admin/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/admin/GeneralSettingsPage.tsx
@@ -241,12 +241,6 @@ export default function GeneralSettingsPage() {
                                     {t('admin.settings.storage.title', 'Audio Storage Usage')}
                                 </CardTitle>
                             </div>
-                            <CardDescription className="text-sm font-medium text-slate-500">
-                                {t(
-                                    'admin.settings.storage.description',
-                                    'Monitor audio recording storage for this study'
-                                )}
-                            </CardDescription>
                         </CardHeader>
 
                         <CardContent className="p-6">
@@ -289,26 +283,6 @@ export default function GeneralSettingsPage() {
                                             value={storageUsage.usage_percent}
                                             className="h-3"
                                         />
-
-                                        <div className="flex justify-between text-xs text-slate-500">
-                                            <span>
-                                                {t(
-                                                    'admin.settings.storage.files_count',
-                                                    'Files: {{count}}',
-                                                    { count: storageUsage.file_count }
-                                                )}
-                                            </span>
-                                            <span>
-                                                {t(
-                                                    'admin.settings.storage.percent_used',
-                                                    '{{percent}}% used',
-                                                    {
-                                                        percent:
-                                                            storageUsage.usage_percent.toFixed(1),
-                                                    }
-                                                )}
-                                            </span>
-                                        </div>
                                     </div>
 
                                     {storageUsage.usage_percent > 80 && (
@@ -393,12 +367,6 @@ export default function GeneralSettingsPage() {
                                 {t('admin.settings.retention.title', 'Data retention')}
                             </CardTitle>
                         </div>
-                        <CardDescription className="text-sm font-medium text-slate-500">
-                            {t(
-                                'admin.settings.retention.description',
-                                'Number of months to keep identifiable participant data before recommending anonymisation. Drives the default cutoff in Data Lifecycle. Leave empty to use the system default (12 months).'
-                            )}
-                        </CardDescription>
                     </CardHeader>
                     <CardContent className="p-6 space-y-3">
                         <Label
@@ -424,7 +392,7 @@ export default function GeneralSettingsPage() {
                         <p className="text-xs text-slate-500">
                             {t(
                                 'admin.settings.retention.help',
-                                'Researchers in the EU should align this with their RGPD retention policy. Common values: 6, 12, 24, 60.'
+                                'Common values: 6, 12, 24, 60 months. Leave empty for system default (12).'
                             )}
                         </p>
                     </CardContent>
@@ -488,11 +456,6 @@ export default function GeneralSettingsPage() {
                                     <Archive className="w-4 h-4 mr-2" />
                                     {t('admin.settings.lifecycle.archive_button')}
                                 </Button>
-                                {!isClosed && (
-                                    <p className="text-2xs text-slate-400 font-medium ml-1">
-                                        * {t('admin.settings.lifecycle.notice').split('.')[0]}.
-                                    </p>
-                                )}
                             </>
                         )}
                     </CardFooter>
@@ -554,7 +517,7 @@ export default function GeneralSettingsPage() {
                             <span className="block">
                                 {t(
                                     'admin.settings.danger.delete_dialog_intro',
-                                    'All sorts, audio recordings, and analysis runs for this study will be permanently deleted. This cannot be undone.'
+                                    'Permanently deletes sorts, audio, and analysis runs.'
                                 )}
                             </span>
                         </AlertDialogDescription>

--- a/frontend/src/pages/admin/ParticipantDetailsPage.tsx
+++ b/frontend/src/pages/admin/ParticipantDetailsPage.tsx
@@ -287,9 +287,6 @@ export default function ParticipantDetailsPage() {
                 <div className="flex items-center justify-between gap-4">
                     <StudyPageHeader
                         title={t('admin.data.detail.title', 'Participant Details')}
-                        description={`${t('admin.sidebar.study', 'Study')}: ${
-                            study?.translations?.[0]?.title || study?.slug
-                        }`}
                         icon={User}
                     />
 

--- a/frontend/src/pages/admin/ProfilePage.tsx
+++ b/frontend/src/pages/admin/ProfilePage.tsx
@@ -30,7 +30,7 @@ import {
     useDisableTotpApiMe2faDisablePost,
 } from '@/api/generated';
 import { QRCodeSVG } from 'qrcode.react';
-import { Shield, ShieldCheck, ShieldAlert, Key, Copy, AlertCircle } from 'lucide-react';
+import { Shield, ShieldCheck, Key, Copy, AlertCircle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import { cn } from '@/lib/utils';
@@ -212,12 +212,6 @@ const ProfilePage = () => {
                             <Key className="size-5 text-indigo-500" />
                             {t('admin.profile.personal.title', 'Personal information')}
                         </CardTitle>
-                        <CardDescription className="text-sm font-medium text-slate-500">
-                            {t(
-                                'admin.profile.personal.description',
-                                'Update your name and contact details.'
-                            )}
-                        </CardDescription>
                     </CardHeader>
                     <Form {...profileForm}>
                         <form onSubmit={profileForm.handleSubmit(onProfileSubmit)}>
@@ -241,7 +235,7 @@ const ProfilePage = () => {
                                             <p className="text-2xs text-slate-400 italic">
                                                 {t(
                                                     'admin.profile.personal.email_locked',
-                                                    'Email cannot be changed directly. Contact admin.'
+                                                    'Contact an admin to change.'
                                                 )}
                                             </p>
                                         </FormItem>
@@ -315,33 +309,12 @@ const ProfilePage = () => {
                     </CardHeader>
                     <CardContent className="space-y-6">
                         {!user?.is_totp_enabled && !is2FASetupMode && (
-                            <div className="flex flex-col items-start gap-4 p-6 border rounded-2xl bg-slate-50 border-slate-100 shadow-inner">
-                                <div className="flex items-start gap-4">
-                                    <div className="p-2.5 bg-white rounded-xl border border-slate-200 shadow-sm mt-1">
-                                        <ShieldAlert size={24} className="text-amber-500" />
-                                    </div>
-                                    <div className="space-y-1">
-                                        <h4 className="font-bold text-slate-900">
-                                            {t(
-                                                'admin.profile.security.status_inactive',
-                                                'Account security is low'
-                                            )}
-                                        </h4>
-                                        <p className="text-sm text-slate-500 font-medium">
-                                            {t(
-                                                'admin.profile.security.status_inactive_desc',
-                                                'Enable two-factor authentication to protect your sensitive data and studies.'
-                                            )}
-                                        </p>
-                                    </div>
-                                </div>
-                                <Button
-                                    onClick={() => setIs2FASetupMode(true)}
-                                    className="h-11 rounded-xl px-8 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
-                                >
-                                    {t('admin.profile.security.setup_cta', 'Setup 2FA now')}
-                                </Button>
-                            </div>
+                            <Button
+                                onClick={() => setIs2FASetupMode(true)}
+                                className="h-11 rounded-xl px-8 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
+                            >
+                                {t('admin.profile.security.setup_cta', 'Setup 2FA now')}
+                            </Button>
                         )}
 
                         {!user?.is_totp_enabled && is2FASetupMode && (
@@ -453,24 +426,6 @@ const ProfilePage = () => {
 
                         {user?.is_totp_enabled && (
                             <div className="space-y-6">
-                                <div className="p-4 border border-green-100 bg-green-50/50 rounded-xl flex items-start gap-3">
-                                    <ShieldCheck size={20} className="text-green-600 mt-1" />
-                                    <div className="space-y-1">
-                                        <h4 className="font-semibold text-green-900">
-                                            {t(
-                                                'admin.profile.security.active_msg',
-                                                '2FA is active'
-                                            )}
-                                        </h4>
-                                        <p className="text-sm text-green-700/80">
-                                            {t(
-                                                'admin.profile.security.status_active',
-                                                'Your account is secured with two-factor authentication.'
-                                            )}
-                                        </p>
-                                    </div>
-                                </div>
-
                                 {!showDisableConfirm ? (
                                     <Button
                                         variant="outline"
@@ -531,12 +486,6 @@ const ProfilePage = () => {
                             <Shield size={20} className="text-indigo-500" />
                             {t('admin.profile.password.title', 'Password management')}
                         </CardTitle>
-                        <CardDescription className="text-sm font-medium text-slate-500">
-                            {t(
-                                'admin.profile.password.description',
-                                'Update your password to keep your account secure.'
-                            )}
-                        </CardDescription>
                     </CardHeader>
                     <Form {...passwordForm}>
                         <form onSubmit={passwordForm.handleSubmit(onPasswordSubmit)}>

--- a/frontend/src/pages/admin/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/admin/ProjectSettingsPage.tsx
@@ -40,12 +40,10 @@ import {
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import {
     Dialog,
     DialogContent,
-    DialogDescription,
     DialogFooter,
     DialogHeader,
     DialogTitle,
@@ -519,50 +517,26 @@ export default function ProjectSettingsPage() {
                         </CardHeader>
                         <CardContent className="space-y-4 pt-2">
                             <div className="space-y-3">
-                                {/* Wave D — D4: Owner role was undocumented in
-                                    the matrix even though it appears in the
-                                    members-table dropdown (audit 🟡10). */}
                                 <div className="space-y-1">
-                                    <div className="flex items-center justify-between">
-                                        <span className="text-2xs font-black text-slate-900">
-                                            {t(
-                                                'admin.projects.settings.team.permissions_matrix.owner.label',
-                                                'Owner'
-                                            )}
-                                        </span>
-                                        <Badge
-                                            variant="outline"
-                                            className="text-[8px] h-4 bg-indigo-50 border-indigo-100 text-indigo-700"
-                                        >
-                                            {t(
-                                                'admin.projects.settings.team.permissions_matrix.owner.badge',
-                                                'Full access'
-                                            )}
-                                        </Badge>
-                                    </div>
+                                    <span className="text-2xs font-black text-slate-900 block">
+                                        {t(
+                                            'admin.projects.settings.team.permissions_matrix.owner.label',
+                                            'Owner'
+                                        )}
+                                    </span>
                                     <p className="text-2xs text-slate-500 leading-tight">
                                         {t(
                                             'admin.projects.settings.team.permissions_matrix.owner.desc',
-                                            'Manages project settings, members, and all studies. Can promote or remove other members.'
+                                            'Full project, member, and study control.'
                                         )}
                                     </p>
                                 </div>
                                 <div className="space-y-1">
-                                    <div className="flex items-center justify-between">
-                                        <span className="text-2xs font-black text-slate-900">
-                                            {t(
-                                                'admin.projects.settings.team.permissions_matrix.researcher.label'
-                                            )}
-                                        </span>
-                                        <Badge
-                                            variant="outline"
-                                            className="text-[8px] h-4 bg-emerald-50 border-emerald-100 text-emerald-700"
-                                        >
-                                            {t(
-                                                'admin.projects.settings.team.permissions_matrix.researcher.badge'
-                                            )}
-                                        </Badge>
-                                    </div>
+                                    <span className="text-2xs font-black text-slate-900 block">
+                                        {t(
+                                            'admin.projects.settings.team.permissions_matrix.researcher.label'
+                                        )}
+                                    </span>
                                     <p className="text-2xs text-slate-500 leading-tight">
                                         {t(
                                             'admin.projects.settings.team.permissions_matrix.researcher.desc'
@@ -570,21 +544,11 @@ export default function ProjectSettingsPage() {
                                     </p>
                                 </div>
                                 <div className="space-y-1">
-                                    <div className="flex items-center justify-between">
-                                        <span className="text-2xs font-black text-slate-900">
-                                            {t(
-                                                'admin.projects.settings.team.permissions_matrix.viewer.label'
-                                            )}
-                                        </span>
-                                        <Badge
-                                            variant="outline"
-                                            className="text-[8px] h-4 bg-slate-50 border-slate-100 text-slate-500"
-                                        >
-                                            {t(
-                                                'admin.projects.settings.team.permissions_matrix.viewer.badge'
-                                            )}
-                                        </Badge>
-                                    </div>
+                                    <span className="text-2xs font-black text-slate-900 block">
+                                        {t(
+                                            'admin.projects.settings.team.permissions_matrix.viewer.label'
+                                        )}
+                                    </span>
                                     <p className="text-2xs text-slate-500 leading-tight">
                                         {t(
                                             'admin.projects.settings.team.permissions_matrix.viewer.desc'
@@ -684,9 +648,6 @@ function InviteMemberModal({ slug, isAdmin }: { slug: string; isAdmin: boolean }
                         <DialogTitle className="text-xl font-black text-slate-900 leading-tight">
                             {t('admin.projects.settings.team.invite_modal.title')}
                         </DialogTitle>
-                        <DialogDescription className="text-sm font-medium text-slate-500 mt-2">
-                            {t('admin.projects.settings.team.invite_modal.desc')}
-                        </DialogDescription>
                     </DialogHeader>
 
                     {!inviteUrl ? (
@@ -778,9 +739,6 @@ function InviteMemberModal({ slug, isAdmin }: { slug: string; isAdmin: boolean }
                                         )}
                                     </Button>
                                 </div>
-                                <p className="text-2xs text-emerald-600/70 italic">
-                                    {t('admin.projects.settings.team.invite_modal.copy_hint')}
-                                </p>
                             </div>
                             <Button
                                 variant="outline"

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -20,7 +20,6 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
-import { GuidanceCard } from '@/components/admin/GuidanceCard';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -36,7 +35,6 @@ import {
 import {
     Dialog,
     DialogContent,
-    DialogDescription,
     DialogFooter,
     DialogHeader,
     DialogTitle,
@@ -114,21 +112,6 @@ const RecruitmentPage = () => {
                 sessions. First-time visitors see it open; once dismissed it
                 stays collapsed so returning admins aren't re-greeted by help
                 they have already read (audit REPORT.md finding H6). */}
-            <GuidanceCard
-                type="info"
-                collapsible
-                defaultOpen
-                persistKey="recruitment.guidance"
-                title={t('admin.recruitment.guidance_title', 'How participant access works')}
-            >
-                <p className="text-sm font-medium opacity-80 leading-relaxed max-w-2xl">
-                    {t(
-                        'admin.recruitment.guidance_body',
-                        'The Study URL is the public web address for your study. Recruitment links append unique tokens to this URL to control and track who can participate. Share links directly, via email, or print QR codes for physical materials.'
-                    )}
-                </p>
-            </GuidanceCard>
-
             {/* State-aware banner */}
             {study.state === 'draft' && (
                 <div
@@ -138,7 +121,7 @@ const RecruitmentPage = () => {
                     <FileEdit className="size-4 shrink-0" />
                     {t(
                         'admin.recruitment.state_draft',
-                        'Your study is in draft mode. Configure the URL and prepare recruitment links — participants cannot access the study until it is activated.'
+                        'Draft mode — links work after you activate the study.'
                     )}
                 </div>
             )}
@@ -199,7 +182,7 @@ const RecruitmentPage = () => {
                                 size="icon"
                                 className="h-10 w-10 rounded-xl shrink-0"
                                 onClick={() => copyToClipboard(studyUrl)}
-                                aria-label={t('admin.recruitment.copy_link', 'Copy secure URL')}
+                                aria-label={t('admin.recruitment.copy_link', 'Copy URL')}
                             >
                                 <Copy className="h-4 w-4" />
                             </Button>
@@ -221,14 +204,8 @@ const RecruitmentPage = () => {
                                             <QrCode className="h-8 w-8 text-indigo-600" />
                                         </div>
                                         <DialogTitle className="text-xl font-black tracking-tight">
-                                            {t('admin.recruitment.qr_title', 'Share Access')}
+                                            {t('admin.recruitment.qr_title', 'Share via QR')}
                                         </DialogTitle>
-                                        <DialogDescription className="max-w-[280px]">
-                                            {t(
-                                                'admin.recruitment.qr_desc',
-                                                'Participants can scan this code to access the study instantly.'
-                                            )}
-                                        </DialogDescription>
                                     </DialogHeader>
                                     <div className="p-6 bg-white rounded-xl shadow-inner border border-slate-100 my-4">
                                         <QRCodeSVG
@@ -354,12 +331,6 @@ const RecruitmentPage = () => {
                     >
                         {/* Password Protection */}
                         <div className="space-y-4">
-                            <Label className="text-2xs font-black text-slate-400 uppercase tracking-wider">
-                                {t(
-                                    'admin.recruitment.access_rules.password_toggle',
-                                    'Require a password'
-                                )}
-                            </Label>
                             <div className="flex items-center justify-between gap-4 p-4 bg-slate-50/50 rounded-xl border border-slate-100">
                                 <div className="space-y-0.5">
                                     <p className="text-sm font-bold text-slate-700">
@@ -614,14 +585,8 @@ const RecruitmentPage = () => {
                     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                         <div>
                             <CardTitle className="text-sm font-black text-slate-500">
-                                {t('admin.recruitment.table_title', 'Participant Access Control')}
+                                {t('admin.recruitment.table_title', 'Recruitment links')}
                             </CardTitle>
-                            <CardDescription className="text-sm font-medium text-slate-500">
-                                {t(
-                                    'admin.recruitment.table_description',
-                                    'Generate and manage secure entry points for your study cohorts.'
-                                )}
-                            </CardDescription>
                         </div>
                         <div className="flex items-center gap-3">
                             <Dialog
@@ -648,12 +613,6 @@ const RecruitmentPage = () => {
                                                 'Create Access Links'
                                             )}
                                         </DialogTitle>
-                                        <DialogDescription className="pt-2">
-                                            {t(
-                                                'admin.recruitment.create_description',
-                                                'Generate links for your participants. Individual links are valid for one submission only.'
-                                            )}
-                                        </DialogDescription>
                                     </DialogHeader>
                                     <div className="grid gap-5 py-4">
                                         <div className="grid gap-2">
@@ -681,59 +640,32 @@ const RecruitmentPage = () => {
                                                     />
                                                 </SelectTrigger>
                                                 <SelectContent>
-                                                    {/* Each option shows its title + a one-line
-                                                        rationale so users can compare strategies
-                                                        without trial-selecting each one. */}
                                                     <SelectItem value="public">
-                                                        <div className="flex flex-col gap-0.5 py-0.5">
-                                                            <span className="flex items-center gap-2 font-medium">
-                                                                <Globe className="h-4 w-4 text-blue-500 flex-shrink-0" />
-                                                                {t(
-                                                                    'admin.recruitment.types.public',
-                                                                    'Public (Multiple usage)'
-                                                                )}
-                                                            </span>
-                                                            <span className="text-xs text-slate-500 italic pl-6">
-                                                                {t(
-                                                                    'admin.recruitment.guidance.public',
-                                                                    'Ideal for social media or generic newsletters. Anyone with this link can participate multiple times.'
-                                                                )}
-                                                            </span>
-                                                        </div>
+                                                        <span className="flex items-center gap-2 font-medium">
+                                                            <Globe className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                                                            {t(
+                                                                'admin.recruitment.types.public',
+                                                                'Public (Multiple usage)'
+                                                            )}
+                                                        </span>
                                                     </SelectItem>
                                                     <SelectItem value="individual">
-                                                        <div className="flex flex-col gap-0.5 py-0.5">
-                                                            <span className="flex items-center gap-2 font-medium">
-                                                                <Users className="h-4 w-4 text-indigo-500 flex-shrink-0" />
-                                                                {t(
-                                                                    'admin.recruitment.types.individual',
-                                                                    'Individual (Single usage)'
-                                                                )}
-                                                            </span>
-                                                            <span className="text-xs text-slate-500 italic pl-6">
-                                                                {t(
-                                                                    'admin.recruitment.guidance.individual',
-                                                                    'Each link is unique and expires after one submission. Best for controlled samples.'
-                                                                )}
-                                                            </span>
-                                                        </div>
+                                                        <span className="flex items-center gap-2 font-medium">
+                                                            <Users className="h-4 w-4 text-indigo-500 flex-shrink-0" />
+                                                            {t(
+                                                                'admin.recruitment.types.individual',
+                                                                'Individual (Single usage)'
+                                                            )}
+                                                        </span>
                                                     </SelectItem>
                                                     <SelectItem value="limited">
-                                                        <div className="flex flex-col gap-0.5 py-0.5">
-                                                            <span className="flex items-center gap-2 font-medium">
-                                                                <Lock className="h-4 w-4 text-orange-500 flex-shrink-0" />
-                                                                {t(
-                                                                    'admin.recruitment.types.limited',
-                                                                    'Limited (Set capacity)'
-                                                                )}
-                                                            </span>
-                                                            <span className="text-xs text-slate-500 italic pl-6">
-                                                                {t(
-                                                                    'admin.recruitment.guidance.limited',
-                                                                    'Set a maximum number of submissions for a single link. Good for small target groups.'
-                                                                )}
-                                                            </span>
-                                                        </div>
+                                                        <span className="flex items-center gap-2 font-medium">
+                                                            <Lock className="h-4 w-4 text-orange-500 flex-shrink-0" />
+                                                            {t(
+                                                                'admin.recruitment.types.limited',
+                                                                'Limited (Set capacity)'
+                                                            )}
+                                                        </span>
                                                     </SelectItem>
                                                 </SelectContent>
                                             </Select>
@@ -1097,15 +1029,9 @@ const RecruitmentPage = () => {
                                                             <DialogTitle className="text-xl font-black tracking-tight">
                                                                 {t(
                                                                     'admin.recruitment.qr_title',
-                                                                    'Share Access'
+                                                                    'Share via QR'
                                                                 )}
                                                             </DialogTitle>
-                                                            <DialogDescription className="max-w-[280px]">
-                                                                {t(
-                                                                    'admin.recruitment.qr_desc',
-                                                                    'Participants can scan this code to access the study instantly.'
-                                                                )}
-                                                            </DialogDescription>
                                                         </DialogHeader>
                                                         <div className="p-6 bg-white rounded-xl shadow-inner border border-slate-100 my-4">
                                                             <QRCodeSVG

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -219,7 +219,7 @@ const StudyDesignPage = () => {
                                 disabled={!api.isLaunchReady}
                                 title={t(
                                     'admin.design.toolbar.test_run_help',
-                                    'Open a participant preview. Test runs are flagged as is_test_run=true and never count toward your published data.'
+                                    "Preview as a participant. These runs aren't included in your data."
                                 )}
                                 className={cn(
                                     'gap-2 h-9 font-bold rounded-lg shadow-sm transition-all px-2 sm:px-3',
@@ -322,30 +322,6 @@ const StudyDesignPage = () => {
                                 </DropdownMenuContent>
                             </DropdownMenu>
                         </div>
-
-                        <div className="h-6 w-px bg-slate-200 hidden md:block" />
-
-                        {/* Activate Button — opens confirmation dialog */}
-                        <Button
-                            size="sm"
-                            onClick={() => setActivateDialogOpen(true)}
-                            disabled={api.isActivating || api.isFullyReadOnly}
-                            className={cn(
-                                'transition-all h-9 font-bold rounded-lg shadow-sm px-3 sm:px-4',
-                                !api.isFullyReadOnly
-                                    ? 'bg-indigo-600 hover:bg-indigo-700 text-white shadow-indigo-200'
-                                    : 'bg-slate-100 text-slate-400'
-                            )}
-                        >
-                            {api.isActivating ? (
-                                <Loader2 className="h-4 w-4 md:mr-2 animate-spin" />
-                            ) : (
-                                <Rocket className="h-4 w-4 md:mr-2" />
-                            )}
-                            <span className="hidden md:inline">
-                                {t('admin.study_status.state.activate', 'Activate Study')}
-                            </span>
-                        </Button>
                     </div>
                 </div>
             </div>
@@ -386,20 +362,13 @@ const StudyDesignPage = () => {
                                     <Lock className="h-10 w-10" />
                                 )}
                             </div>
-                            <h3 className="text-2xl font-bold text-slate-800 tracking-normal">
+                            <h3 className="text-2xl font-bold text-slate-800 tracking-normal mb-8">
                                 {draft.state === 'active'
                                     ? t('admin.design.qsort.grid.locked_active')
                                     : draft.state === 'paused'
                                       ? t('admin.design.qsort.grid.locked_paused')
                                       : t('admin.design.qsort.grid.locked_closed')}
                             </h3>
-                            <p className="text-base font-medium text-slate-500 mt-4 mb-8 text-pretty leading-relaxed">
-                                {draft.state === 'active'
-                                    ? t('admin.design.qsort.grid.locked_active_desc')
-                                    : draft.state === 'paused'
-                                      ? t('admin.design.qsort.grid.locked_paused_desc')
-                                      : t('admin.design.qsort.grid.locked_closed_desc')}
-                            </p>
                             {draft.state === 'active' && (
                                 <div className="flex flex-col sm:flex-row gap-3 justify-center">
                                     <Button
@@ -612,9 +581,6 @@ const StudyDesignPage = () => {
                                                 'Translation Required'
                                             )}
                                         </h4>
-                                        <p className="text-sm text-rose-900/70 font-bold leading-relaxed">
-                                            {t('admin.design.translation_needed_desc')}
-                                        </p>
                                     </div>
                                 </div>
                             );
@@ -844,31 +810,25 @@ const StudyDesignPage = () => {
                                         key={lang.code}
                                         className="flex items-center justify-between p-2 rounded-lg bg-slate-50 border border-slate-100"
                                     >
-                                        <div className="flex items-center gap-2">
-                                            <span className="text-xs font-black text-slate-700">
-                                                {lang.code}
-                                            </span>
-                                        </div>
+                                        <span className="text-xs font-black text-slate-700">
+                                            {lang.code}
+                                        </span>
                                         {lang.isReady ? (
-                                            <div className="flex items-center gap-1.5 px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded-md">
-                                                <CheckCircle className="h-3 w-3" />
-                                                <span className="text-2xs font-bold">
-                                                    {t(
-                                                        'admin.design.checklist.status_ready',
-                                                        'Ready'
-                                                    )}
-                                                </span>
-                                            </div>
+                                            <CheckCircle
+                                                className="h-4 w-4 text-emerald-600"
+                                                aria-label={t(
+                                                    'admin.design.checklist.status_ready',
+                                                    'Ready'
+                                                )}
+                                            />
                                         ) : (
-                                            <div className="flex items-center gap-1.5 px-2 py-0.5 bg-amber-100 text-amber-700 rounded-md">
-                                                <CircleDashed className="h-3 w-3" />
-                                                <span className="text-2xs font-bold">
-                                                    {t(
-                                                        'admin.design.checklist.status_pending',
-                                                        'Pending'
-                                                    )}
-                                                </span>
-                                            </div>
+                                            <CircleDashed
+                                                className="h-4 w-4 text-amber-600"
+                                                aria-label={t(
+                                                    'admin.design.checklist.status_pending',
+                                                    'Pending'
+                                                )}
+                                            />
                                         )}
                                     </div>
                                 ))}
@@ -890,7 +850,7 @@ const StudyDesignPage = () => {
                         <DialogDescription className="text-sm font-medium text-slate-500 mt-2">
                             {t(
                                 'admin.design.validation.failed_desc',
-                                'Your study cannot be activated yet. Please fix the following issues:'
+                                'Fix these issues to activate:'
                             )}
                         </DialogDescription>
                     </DialogHeader>

--- a/frontend/src/pages/admin/StudyOverviewPage.tsx
+++ b/frontend/src/pages/admin/StudyOverviewPage.tsx
@@ -4,12 +4,10 @@ import type { StudyRead, ParticipantRead, StudyStatsRead } from '@/api/model';
 import RecruitmentModule from '@/components/admin/dashboard/RecruitmentModule';
 import RecentActivityCard from '@/components/admin/dashboard/RecentActivityCard';
 
-import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Users, CheckCircle2, Clock, AlertTriangle, LayoutDashboard } from 'lucide-react';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import StudyStatusControl from '@/components/admin/dashboard/StudyStatusControl';
-import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 import { useAdminContext } from '@/hooks/useAdminContext';
 
@@ -35,38 +33,11 @@ const StudyOverviewPage = () => {
 
     const validParticipants = participants?.filter((p) => !p.is_discarded) || [];
 
-    const getStatusLabel = (state: string) => {
-        return t(`admin.status.${state}`, state.charAt(0).toUpperCase() + state.slice(1));
-    };
-
     return (
         <div className="flex flex-1 flex-col gap-4 p-4 sm:p-6 pt-2">
             <StudyPageHeader
                 title={t('admin.study_overview.title', 'Overview')}
-                description={t(
-                    'admin.study_overview.subtitle',
-                    'Real-time analytics and participant overview for this study.'
-                )}
                 icon={LayoutDashboard}
-                statusBadge={
-                    <Badge
-                        variant="outline"
-                        role="status"
-                        data-testid="study-status"
-                        className={cn(
-                            'font-semibold text-2xs px-2 py-0.5 rounded-full',
-                            study?.state === 'active'
-                                ? 'bg-emerald-50 text-emerald-700 border-emerald-100'
-                                : study?.state === 'paused'
-                                  ? 'bg-orange-50 text-orange-700 border-orange-100'
-                                  : study?.state === 'closed'
-                                    ? 'bg-slate-50 text-slate-700 border-slate-100'
-                                    : 'bg-amber-50 text-amber-700 border-amber-100'
-                        )}
-                    >
-                        {getStatusLabel(study?.state || 'draft')}
-                    </Badge>
-                }
                 actions={null}
             />
 
@@ -165,9 +136,6 @@ const StudyOverviewPage = () => {
                                         </span>
                                     )}
                             </div>
-                            <p className="text-2xs text-slate-400 font-medium">
-                                {t('admin.study_overview.time_to_complete', 'Time to complete')}
-                            </p>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Remove redundant card descriptions, moralistic framings, and scientific citations (Brown 1980, Watts & Stenner 2012, Sneegas 2020, Robbins & Krueger 2000, Zabala & Pascual 2016) from admin UI helpers / tooltips / empty states.
- 13 admin pages trimmed; ~50 individual cuts; **-588 lines** of user-facing text + JSX across en/fr/fi.
- Bump version to 0.3.0.

## Highlights
- **LoginPage** — 5-layer "log in to admin" stack collapses to a single CardTitle + button; dead i18n keys (privacy, powered_by, etc.) cleaned.
- **AnalysisPage** — 4-bullet GuidanceCards reduced to 2; helpers shortened (PCA / Centroid / rotation / flagging); export menu format inverted ("CSV — Loadings" → "Factor loadings (CSV)"); empty state from 1 sentence with quoted CTA to "Set parameters and run the analysis."
- **DataLifecyclePage** — GDPR Art. 5 paragraph removed; "Total" stat dropped (sum of others); confirm dialog message + empty-state body shortened; Anonymise button no longer interpolates the date.
- **ConcourseDetailPage** — Construction-memo helper deleted (placeholder already says it); 3 status pills dropped (progress bar + sub-text already encode them); add_item_desc / manage_tags_desc removed; delete_item_confirm shortened.
- **RecruitmentPage** — Top GuidanceCard removed (duplicates page header); inline italic SelectItem rationales dropped (kept the bottom block under the Select); QR dialog description removed; password_toggle uppercase Label dedup; "Copy secure URL" → "Copy URL".
- **StudyDesignPage** — 3 locked-overlay paragraphs (active/paused/closed) collapsed to single titles; `is_test_run=true` backend jargon removed from tooltip; toolbar Activate button removed (step-flow Activate kept); language sidebar text-badges → icons.
- **ProfilePage** — 2FA inactive subblock collapsed to a single Setup button; status_active text dropped (Badge "Enabled" suffices).
- **GeneralSettingsPage** — Retention card description folded into help; "EU researchers should align…" moralism gone; storage card Files/% used text dropped (progress bar encodes); delete dialog intro shortened.
- **CreateProjectPage / ProjectSettingsPage** — Card descriptions dropped where they redundantly described the card title; permission badges removed (label + desc only); Invite modal description + copy hint dropped.
- **StudyOverviewPage** — Subtitle dropped; "Time to complete" sublabel under "Median duration" dropped; status badge in header dedup with StudyStatusControl.

## Test plan
- [x] make ci-fast (192 backend + 711 frontend tests, 6 skipped)
- [x] npm run i18n-check (en/fr/fi parity)
- [ ] Visual check on local dev build

🤖 Generated with [Claude Code](https://claude.com/claude-code)