### PR TITLE
fix(admin): restore study-status badge in Overview header (e2e regression)

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1523,7 +1523,7 @@ wheels = [
 
 [[package]]
 name = "qualis-backend"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/src/pages/admin/StudyOverviewPage.tsx
+++ b/frontend/src/pages/admin/StudyOverviewPage.tsx
@@ -5,10 +5,12 @@ import RecruitmentModule from '@/components/admin/dashboard/RecruitmentModule';
 import RecentActivityCard from '@/components/admin/dashboard/RecentActivityCard';
 
 import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
 import { Users, CheckCircle2, Clock, AlertTriangle, LayoutDashboard } from 'lucide-react';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import StudyStatusControl from '@/components/admin/dashboard/StudyStatusControl';
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
 import { useAdminContext } from '@/hooks/useAdminContext';
 
 interface LoaderData {
@@ -33,11 +35,34 @@ const StudyOverviewPage = () => {
 
     const validParticipants = participants?.filter((p) => !p.is_discarded) || [];
 
+    const getStatusLabel = (state: string) => {
+        return t(`admin.status.${state}`, state.charAt(0).toUpperCase() + state.slice(1));
+    };
+
     return (
         <div className="flex flex-1 flex-col gap-4 p-4 sm:p-6 pt-2">
             <StudyPageHeader
                 title={t('admin.study_overview.title', 'Overview')}
                 icon={LayoutDashboard}
+                statusBadge={
+                    <Badge
+                        variant="outline"
+                        role="status"
+                        data-testid="study-status"
+                        className={cn(
+                            'font-semibold text-2xs px-2 py-0.5 rounded-full',
+                            study?.state === 'active'
+                                ? 'bg-emerald-50 text-emerald-700 border-emerald-100'
+                                : study?.state === 'paused'
+                                  ? 'bg-orange-50 text-orange-700 border-orange-100'
+                                  : study?.state === 'closed'
+                                    ? 'bg-slate-50 text-slate-700 border-slate-100'
+                                    : 'bg-amber-50 text-amber-700 border-amber-100'
+                        )}
+                    >
+                        {getStatusLabel(study?.state || 'draft')}
+                    </Badge>
+                }
                 actions={null}
             />
 


### PR DESCRIPTION
## Summary
- Wave F (#59) dropped the status Badge from StudyOverviewPage's header on the rationale that `StudyStatusControl` already shows the state.
- That broke two e2e specs (`admin-flow.spec.ts`, `state-management.spec.ts`) which assert via `data-testid="study-status"` — `StudyStatusControl` doesn't expose that testid.
- Restoring the Badge. Other Overview cuts from wave F are kept (subtitle removed, "Time to complete" sublabel removed).
- Also commits `backend/uv.lock` bump triggered by 0.3.0.

## Test plan
- [x] make e2e (23 passed, was 21/23 before)
- [x] make ci-fast (711 frontend tests + 192 backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)