### PR TITLE
refactor(admin): unify header policy (breadcrumb / H1 / CardTitle)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,3 +174,26 @@ fires on the JSX shell itself. Adding a `// biome-ignore lint/complexity/noExces
 on the page component is the documented exception (precedent: AnalysisPage,
 StudyDesignPage, RecruitmentPage, ConcourseDetailPage). Only suppress on the
 shell, never inside the hook.
+
+### Admin header policy
+
+Three layers, one role each. The breadcrumb is the single source of truth for
+hierarchy; every other piece of header chrome must respect that.
+
+- **L1 Breadcrumb** (`AdminLayout.tsx`): hierarchy. Format `[Project] > [Study?] > [Section]`.
+  No local breadcrumbs in pages. Every static URL segment must have an entry in the
+  `mapping` table (no fallback to `last.charAt(0).toUpperCase()`); detail routes
+  (`…/concourses/:id`, `…/participants/:id`) get a typed special case.
+- **L2 Page header** (`StudyPageHeader`): the page's function. Two patterns:
+  - **Entity entry-point pages** → H1 = entity name. Project Dashboard = `project.title`,
+    Study Overview = `study.translations[0].title`, Participant detail = "Participant #N".
+  - **All other pages** → H1 = functional name ("Settings", "Analysis", "Data", "Access",
+    "Project settings", "Profile"). Never `project.title` / `study.title` — those are in
+    the breadcrumb already.
+- **L3 Section titles** (`CardTitle` / `<h2>`): typography is `text-lg font-black text-slate-900`.
+  L4 item titles inside cards may use `font-semibold` (precedent: AdminDashboard study cards).
+
+**Naming canon.** One label per section, propagated to three keys:
+`admin.sidebar.<s>` (may use a shorter variant if width-constrained),
+`admin.breadcrumbs.<s>`, `admin.<s>.title`. Default values in `t(key, 'fallback')` must
+match the canonical English label.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualis-backend"
-version = "0.3.0"
+version = "0.3.1"
 description = "Backend for Qualis"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/frontend/e2e/admin/participant-discard.spec.ts
+++ b/frontend/e2e/admin/participant-discard.spec.ts
@@ -72,7 +72,7 @@ test.describe('Participant Discard E2E Tests (Real Backend)', () => {
 
         // Click on first participant row to open detail
         await page.locator('tbody tr').first().click();
-        await expect(page.getByRole('heading', { name: /participant profile/i })).toBeVisible();
+        await expect(page.getByRole('heading', { name: /participant\s*#?\s*\d+/i })).toBeVisible();
 
         // The card's "Discard"/"Restore" button only opens an AlertDialog;
         // the actual mutation happens when the user clicks the dialog's

--- a/frontend/e2e/admin/study-setup-onboarding.spec.ts
+++ b/frontend/e2e/admin/study-setup-onboarding.spec.ts
@@ -89,7 +89,7 @@ test.describe('Study setup onboarding', () => {
 
         // The recruitment page shows the study URL card
         await expect(
-            page.getByRole('heading', { name: /access.*recruitment|recruitment/i }).first()
+            page.getByRole('heading', { name: /^access$/i }).first()
         ).toBeVisible({ timeout: 15_000 });
 
         // The study URL panel is present and contains the study slug in the URL

--- a/frontend/e2e/integration/state-management.spec.ts
+++ b/frontend/e2e/integration/state-management.spec.ts
@@ -94,8 +94,9 @@ test.describe('State Management Flow Tests', () => {
         const workspaceSlug = testDb.getWorkspaceSlug();
         await testDb.loginToAdminUI(adminPage);
         await adminPage.goto(`/app/${workspaceSlug}/studies/${study.slug}`);
-        // Wait for study page to load by checking h1 (Title is "Overview" + Badge)
-        await expect(adminPage.locator('h1')).toContainText('Overview');
+        // Wait for study page to load by checking h1 (now shows the study title per
+        // admin header policy: entity entry-point pages display the entity name).
+        await expect(adminPage.locator('h1')).toContainText('Test Study');
         await expect(adminPage).toHaveURL(
             new RegExp(`/app/${workspaceSlug}/studies/${study.slug}`)
         );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "qualis",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "qualis",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "qualis",
     "private": true,
-    "version": "0.3.0",
+    "version": "0.3.1",
     "type": "module",
     "engines": {
         "node": "24.x"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -539,7 +539,7 @@
             "admin_user": "Admin user"
         },
         "profile": {
-            "title": "Profile & security",
+            "title": "Profile",
             "description": "Manage your personal information and security settings.",
             "personal": {
                 "title": "Personal information",
@@ -987,7 +987,7 @@
             }
         },
         "recruitment": {
-            "title": "Access & Recruitment",
+            "title": "Access",
             "description": "Configure the study URL, manage participant access, and track recruitment efficiency.",
             "study_url": {
                 "title": "Study URL",
@@ -1137,9 +1137,12 @@
             "design": "Design",
             "participants": "Participants",
             "team": "Team",
-            "recruitment": "Recruit",
+            "recruitment": "Access",
             "exports": "Data",
             "data": "Data",
+            "lifecycle": "Data lifecycle",
+            "profile": "Profile",
+            "participant_n": "Participant #{{id}}",
             "analysis": "Analysis",
             "settings": "Settings",
             "concourse": "Concourse"
@@ -1905,7 +1908,7 @@
             }
         },
         "data": {
-            "title": "Data explorer",
+            "title": "Data",
             "description": "Monitor real-time participation, analyze data quality, and manage research sessions.",
             "sections": {
                 "key_indicators": "Key indicators",
@@ -2012,6 +2015,7 @@
             },
             "detail": {
                 "participant": "Participant",
+                "participant_n": "Participant #{{id}}",
                 "not_found": "Participant not found",
                 "title": "Participant profile",
                 "session": "Session",
@@ -2201,7 +2205,7 @@
             }
         },
         "lifecycle": {
-            "title": "Data inventory & lifecycle",
+            "title": "Data lifecycle",
             "header_desc": "Inventory & anonymisation",
             "load_error": "Failed to load data inventory.",
             "participants_title": "Participants snapshot",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -491,7 +491,7 @@
             "admin_user": "Ylläpitäjä"
         },
         "profile": {
-            "title": "Profiili ja turvallisuus",
+            "title": "Profiili",
             "description": "Hallitse henkilökohtaisia tietojasi ja turvallisuusasetuksia.",
             "personal": {
                 "title": "Henkilökohtaiset tiedot",
@@ -939,7 +939,7 @@
             }
         },
         "recruitment": {
-            "title": "Pääsy & Rekrytointi",
+            "title": "Pääsy",
             "description": "Määritä tutkimuksen URL-osoite, hallitse osallistujien pääsyä ja seuraa rekrytoinnin tehokkuutta.",
             "study_url": {
                 "title": "Tutkimuksen URL",
@@ -1089,9 +1089,12 @@
             "design": "Suunnittelu",
             "participants": "Osallistujat",
             "team": "Tiimi",
-            "recruitment": "Rekrytointi",
+            "recruitment": "Pääsy",
             "exports": "Tiedot",
             "data": "Tiedot",
+            "lifecycle": "Tietojen elinkaari",
+            "profile": "Profiili",
+            "participant_n": "Osallistuja #{{id}}",
             "analysis": "Analyysi",
             "settings": "Asetukset",
             "concourse": "Concourse"
@@ -1857,7 +1860,7 @@
             }
         },
         "data": {
-            "title": "Analytiikka & Tiedot",
+            "title": "Tiedot",
             "description": "Tarkastele osallistujien suorituksia, laadullista palautetta ja vie tietoaineistoja.",
             "sections": {
                 "key_indicators": "Avainmittarit",
@@ -1964,6 +1967,7 @@
             },
             "detail": {
                 "participant": "Osallistuja",
+                "participant_n": "Osallistuja #{{id}}",
                 "not_found": "Osallistujaa ei löytynyt",
                 "title": "Osallistujan profiili",
                 "session": "Istunto",
@@ -2330,7 +2334,7 @@
             }
         },
         "lifecycle": {
-            "title": "Data inventory & lifecycle",
+            "title": "Tietojen elinkaari",
             "header_desc": "Inventory & anonymisation",
             "load_error": "Failed to load data inventory.",
             "participants_title": "Participants snapshot",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -491,7 +491,7 @@
             "admin_user": "Administrateur"
         },
         "profile": {
-            "title": "Profil et sécurité",
+            "title": "Profil",
             "description": "Gérez vos informations personnelles et la sécurité de votre compte.",
             "personal": {
                 "title": "Informations personnelles",
@@ -939,7 +939,7 @@
             }
         },
         "recruitment": {
-            "title": "Accès & Recrutement",
+            "title": "Accès",
             "description": "Configurez l'URL de l'étude, gérez l'accès des participants et suivez l'efficacité du recrutement.",
             "study_url": {
                 "title": "URL de l'étude",
@@ -1089,9 +1089,12 @@
             "design": "Conception",
             "participants": "Participants",
             "team": "Équipe",
-            "recruitment": "Recrutement",
+            "recruitment": "Accès",
             "exports": "Données",
             "data": "Données",
+            "lifecycle": "Cycle de vie",
+            "profile": "Profil",
+            "participant_n": "Participant nº{{id}}",
             "analysis": "Analyse",
             "settings": "Réglages",
             "concourse": "Concours"
@@ -1895,7 +1898,7 @@
             }
         },
         "data": {
-            "title": "Explorateur de données",
+            "title": "Données",
             "description": "Suivi de la participation en temps réel, analyse de la qualité et gestion des sessions.",
             "sections": {
                 "key_indicators": "Indicateurs clés",
@@ -2002,6 +2005,7 @@
             },
             "detail": {
                 "participant": "Participant",
+                "participant_n": "Participant nº{{id}}",
                 "not_found": "Participant introuvable",
                 "title": "Profil participant",
                 "session": "Session",
@@ -2153,7 +2157,7 @@
             }
         },
         "lifecycle": {
-            "title": "Inventaire des données & cycle de vie",
+            "title": "Cycle de vie des données",
             "header_desc": "Inventaire & anonymisation",
             "load_error": "Impossible de charger l'inventaire des données.",
             "participants_title": "Instantané des participants",

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -112,7 +112,7 @@ export function AdminDashboard() {
                 <div>
                     <div className="flex items-center gap-2.5">
                         <Briefcase className="h-6 w-6 text-indigo-500" />
-                        <h1 className="text-2xl font-bold tracking-tight">
+                        <h1 className="text-2xl font-black tracking-tight text-slate-900">
                             {currentProject?.title}
                         </h1>
                     </div>
@@ -123,7 +123,7 @@ export function AdminDashboard() {
 
                 <Card className="border-dashed">
                     <CardContent className="pt-6">
-                        <h2 className="text-lg font-semibold mb-6">
+                        <h2 className="text-lg font-black text-slate-900 mb-6">
                             {t('admin.dashboard.onboarding_title', 'First steps')}
                         </h2>
                         <ol className="space-y-4">
@@ -195,7 +195,7 @@ export function AdminDashboard() {
                 <div>
                     <div className="flex items-center gap-2.5">
                         <Briefcase className="h-6 w-6 text-indigo-500" />
-                        <h1 className="text-2xl font-bold tracking-tight">
+                        <h1 className="text-2xl font-black tracking-tight text-slate-900">
                             {currentProject?.title}
                         </h1>
                     </div>
@@ -320,7 +320,7 @@ export function AdminDashboard() {
                 <>
                     <div className="flex items-center gap-2">
                         <FlaskConical className="h-5 w-5 text-indigo-500" />
-                        <h2 className="text-lg font-semibold">
+                        <h2 className="text-lg font-black text-slate-900">
                             {t('admin.dashboard.studies', 'Studies')}
                         </h2>
                     </div>
@@ -430,7 +430,7 @@ function SingleStudyCard({
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                     <FlaskConical className="h-5 w-5 text-indigo-500" />
-                    <h2 className="text-lg font-semibold">
+                    <h2 className="text-lg font-black text-slate-900">
                         {t('admin.dashboard.studies', 'Studies')}
                     </h2>
                 </div>

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -49,6 +49,8 @@ export default function AdminLayout() {
             design: t('admin.breadcrumbs.design'),
             recruitment: t('admin.breadcrumbs.recruitment'),
             data: t('admin.breadcrumbs.data', 'Data'),
+            lifecycle: t('admin.breadcrumbs.lifecycle', 'Data lifecycle'),
+            profile: t('admin.breadcrumbs.profile', 'Profile'),
             analysis: t('admin.breadcrumbs.analysis', 'Analysis'),
             exports: t('admin.breadcrumbs.exports'),
             settings: t('admin.breadcrumbs.settings'),
@@ -65,6 +67,10 @@ export default function AdminLayout() {
         const prev = segments[segments.length - 2];
         if (prev === 'concourses' && /^\d+$/.test(last)) {
             return t('admin.breadcrumbs.concourse', 'Concourse');
+        }
+        // Participant detail page: /participants/:id → show "Participant #N"
+        if (prev === 'participants' && /^\d+$/.test(last)) {
+            return t('admin.breadcrumbs.participant_n', 'Participant #{{id}}', { id: last });
         }
 
         return mapping[last] || last.charAt(0).toUpperCase() + last.slice(1);

--- a/frontend/src/pages/admin/CreateProjectPage.tsx
+++ b/frontend/src/pages/admin/CreateProjectPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import ApiClient from '@/api/client';
 import { useAuthStore } from '@/store/useAuthStore';
 import type { ProjectWithRole } from '@/types/backend';
@@ -101,14 +102,7 @@ export default function CreateProjectPage() {
 
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-8 max-w-4xl mx-auto w-full">
-            <div className="flex items-center gap-3 mb-2">
-                <div className="p-2.5 bg-indigo-50 border border-indigo-100 rounded-xl text-indigo-600 shadow-sm">
-                    <Plus className="size-6" />
-                </div>
-                <h1 className="text-3xl font-black tracking-tight text-slate-900">
-                    {t('admin.project.create.title')}
-                </h1>
-            </div>
+            <StudyPageHeader title={t('admin.project.create.title')} icon={Plus} />
 
             <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
                 <CardHeader className="border-b border-slate-50 pb-6">

--- a/frontend/src/pages/admin/DataLifecyclePage.test.tsx
+++ b/frontend/src/pages/admin/DataLifecyclePage.test.tsx
@@ -104,7 +104,7 @@ describe('DataLifecyclePage', () => {
         renderWithProviders(<DataLifecyclePage />);
 
         // Page header
-        expect(screen.getByText('Data inventory & lifecycle')).toBeInTheDocument();
+        expect(screen.getByText('Data lifecycle')).toBeInTheDocument();
 
         // Participant stats (Total stat removed in text-trim wave; Started/Completed/Discarded/Anonymised remain)
         expect(screen.getByText('30')).toBeInTheDocument(); // completed
@@ -141,7 +141,7 @@ describe('DataLifecyclePage', () => {
         renderWithProviders(<DataLifecyclePage />);
 
         // Header is still shown
-        expect(screen.getByText('Data inventory & lifecycle')).toBeInTheDocument();
+        expect(screen.getByText('Data lifecycle')).toBeInTheDocument();
         // Stats table should not be there
         expect(screen.queryByText('Participants snapshot')).not.toBeInTheDocument();
     });

--- a/frontend/src/pages/admin/DataLifecyclePage.tsx
+++ b/frontend/src/pages/admin/DataLifecyclePage.tsx
@@ -168,7 +168,7 @@ export default function DataLifecyclePage() {
         return (
             <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
                 <StudyPageHeader
-                    title={t('admin.lifecycle.title', 'Data inventory & lifecycle')}
+                    title={t('admin.lifecycle.title', 'Data lifecycle')}
                     description={t('admin.lifecycle.header_desc', 'Inventory & anonymisation')}
                     icon={ShieldCheck}
                 />
@@ -181,7 +181,7 @@ export default function DataLifecyclePage() {
         return (
             <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
                 <StudyPageHeader
-                    title={t('admin.lifecycle.title', 'Data inventory & lifecycle')}
+                    title={t('admin.lifecycle.title', 'Data lifecycle')}
                     description={t('admin.lifecycle.header_desc', 'Inventory & anonymisation')}
                     icon={ShieldCheck}
                 />
@@ -205,7 +205,7 @@ export default function DataLifecyclePage() {
         return (
             <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
                 <StudyPageHeader
-                    title={t('admin.lifecycle.title', 'Data inventory & lifecycle')}
+                    title={t('admin.lifecycle.title', 'Data lifecycle')}
                     description={t('admin.lifecycle.header_desc', 'Inventory & anonymisation')}
                     icon={ShieldCheck}
                 />
@@ -226,7 +226,7 @@ export default function DataLifecyclePage() {
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
             <StudyPageHeader
-                title={t('admin.lifecycle.title', 'Data inventory & lifecycle')}
+                title={t('admin.lifecycle.title', 'Data lifecycle')}
                 description={t('admin.lifecycle.header_desc', 'Inventory & anonymisation')}
                 icon={ShieldCheck}
             />

--- a/frontend/src/pages/admin/ParticipantDetailsPage.tsx
+++ b/frontend/src/pages/admin/ParticipantDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import {
     useGetStudyApiAdminStudiesSlugGet,
     useGetParticipantApiAdminStudiesParticipantsParticipantIdGet,
@@ -7,14 +7,6 @@ import {
 } from '@/api/generated';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import { Button } from '@/components/ui/button';
-import {
-    Breadcrumb,
-    BreadcrumbItem,
-    BreadcrumbLink,
-    BreadcrumbList,
-    BreadcrumbPage,
-    BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
 import { ArrowLeft, ChevronLeft, ChevronRight, User } from 'lucide-react';
 import type { DumpResponse, DumpParticipant } from '@/components/admin/dashboard/types';
 import { ParticipantDetailContent } from '@/components/admin/dashboard/ParticipantDetailContent';
@@ -254,39 +246,11 @@ export default function ParticipantDetailsPage() {
     return (
         <div className="flex flex-1 flex-col h-full overflow-hidden bg-slate-50/30">
             <div className="flex-none p-6 pb-0 space-y-3">
-                <Breadcrumb>
-                    <BreadcrumbList>
-                        <BreadcrumbItem>
-                            <BreadcrumbLink asChild>
-                                <Link
-                                    to={`/app/${currentWorkspace?.slug || 'default'}/studies/${effectiveSlug}`}
-                                >
-                                    {study?.translations?.[0]?.title || study?.slug}
-                                </Link>
-                            </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                        <BreadcrumbItem>
-                            <BreadcrumbLink asChild>
-                                <Link
-                                    to={`/app/${currentWorkspace?.slug || 'default'}/studies/${effectiveSlug}/data`}
-                                >
-                                    {t('admin.sidebar.data', 'Data')}
-                                </Link>
-                            </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                        <BreadcrumbItem>
-                            <BreadcrumbPage>
-                                {t('admin.data.detail.participant', 'Participant')} #{participantId}
-                            </BreadcrumbPage>
-                        </BreadcrumbItem>
-                    </BreadcrumbList>
-                </Breadcrumb>
-
                 <div className="flex items-center justify-between gap-4">
                     <StudyPageHeader
-                        title={t('admin.data.detail.title', 'Participant Details')}
+                        title={t('admin.data.detail.participant_n', 'Participant #{{id}}', {
+                            id: participantId,
+                        })}
                         icon={User}
                     />
 

--- a/frontend/src/pages/admin/ProfilePage.tsx
+++ b/frontend/src/pages/admin/ProfilePage.tsx
@@ -193,7 +193,7 @@ const ProfilePage = () => {
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
             <StudyPageHeader
-                title={t('admin.profile.title', 'Profile & security')}
+                title={t('admin.profile.title', 'Profile')}
                 description={t(
                     'admin.profile.description',
                     'Manage your personal information and account security.'

--- a/frontend/src/pages/admin/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/admin/ProjectSettingsPage.tsx
@@ -219,7 +219,7 @@ export default function ProjectSettingsPage() {
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
             <StudyPageHeader
-                title={project.title}
+                title={t('admin.projects.settings.title', 'Project settings')}
                 description={t('admin.projects.settings.identity_desc')}
                 icon={Briefcase}
             />

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -100,7 +100,7 @@ const RecruitmentPage = () => {
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
             <StudyPageHeader
-                title={t('admin.recruitment.title', 'Access & Recruitment')}
+                title={t('admin.recruitment.title', 'Access')}
                 description={t(
                     'admin.recruitment.description',
                     'Configure the study URL, manage participant access, and track recruitment efficiency.'

--- a/frontend/src/pages/admin/StudyOverviewPage.tsx
+++ b/frontend/src/pages/admin/StudyOverviewPage.tsx
@@ -42,7 +42,9 @@ const StudyOverviewPage = () => {
     return (
         <div className="flex flex-1 flex-col gap-4 p-4 sm:p-6 pt-2">
             <StudyPageHeader
-                title={t('admin.study_overview.title', 'Overview')}
+                title={
+                    study?.translations?.[0]?.title || t('admin.study_overview.title', 'Overview')
+                }
                 icon={LayoutDashboard}
                 statusBadge={
                     <Badge


### PR DESCRIPTION
## Summary

Resolves cross-page incoherence in admin titles, sub-titles, sections, and breadcrumbs. Establishes a 3-layer policy documented in `CLAUDE.md`.

### Policy

- **L1 Breadcrumb** (`AdminLayout.tsx`): hierarchy `[Project] > [Study?] > [Section]`. Single source of truth — no local breadcrumbs in pages.
- **L2 Page header** (`StudyPageHeader`): the page's *function*.
  - Entity entry-point pages (Project Dashboard, Study Overview, Participant detail) → H1 = entity name.
  - All other pages → H1 = functional name (never `project.title` / `study.title`).
- **L3 Section titles** (`CardTitle` / `<h2>`): `text-lg font-black text-slate-900`.

### Naming canon

One canonical label per section, propagated to `admin.sidebar.<s>`, `admin.breadcrumbs.<s>`, `admin.<s>.title`:

| Section | Before | After |
|---|---|---|
| Recruitment | "Access & Recruitment" / "Recruit" / "Access" | **Access** everywhere |
| Data | "Data explorer" / "Data" | **Data** everywhere |
| Lifecycle | "Data inventory & lifecycle" / (missing) / "Data lifecycle" | **Data lifecycle** everywhere |
| Profile | "Profile & security" / (missing) | **Profile** everywhere |

### Page fixes

- `ProjectSettings` H1: `project.title` → "Project settings" (project name already in breadcrumb).
- `StudyOverview` H1: "Overview" → study title (entry-point convention).
- `CreateProject`: manual H1 → `StudyPageHeader` for typography parity.
- `ParticipantDetails`: removed local breadcrumb (duplicated global); H1 now "Participant #N" matching breadcrumb special case.
- `AdminDashboard` H1: `font-bold` → `font-black`; CardTitle H2s realigned `font-semibold` → `font-black`.

### Breadcrumb mapping (`AdminLayout.tsx`)

Added: `lifecycle`, `profile`. Special case for `…/participants/:id` → "Participant #{{id}}".

Version bump: 0.3.0 → 0.3.1 (`frontend/package.json`, `frontend/package-lock.json`, `backend/pyproject.toml`).

## Test plan

- [x] `npm run i18n-check` (3 locales in sync)
- [x] `make ci-fast` — 716 frontend tests pass
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean (12s)
- [ ] Manual smoke of 8 admin routes:
  - `/app/:p/dashboard` → breadcrumb "[Project] > Dashboard", H1 = project name
  - `/app/:p/settings` → "[Project] > Settings", H1 "Project settings"
  - `/app/:p/profile` → "[Project] > Profile", H1 "Profile"
  - `/app/:p/studies/:s` → "[Project] > [Study] > Overview", H1 = study name
  - `/app/:p/studies/:s/lifecycle` → "[Project] > [Study] > Data lifecycle", H1 "Data lifecycle"
  - `/app/:p/studies/:s/recruitment` → "[Project] > [Study] > Access", H1 "Access"
  - `/app/:p/studies/:s/data` → breadcrumb + H1 "Data"
  - `/app/:p/studies/:s/participants/123` → "[Project] > [Study] > Participant #123", H1 idem, single breadcrumb

🤖 Generated with [Claude Code](https://claude.com/claude-code)