### PR TITLE
feat(analysis): Explorer panel — diagnostics + preview-range (phase 3/5)

### DIFF
--- a/frontend/e2e/admin/analysis-workflow.spec.ts
+++ b/frontend/e2e/admin/analysis-workflow.spec.ts
@@ -59,9 +59,14 @@ test('full analysis workflow: run → results → history', async ({ page, testD
     });
 
     // -----------------------------------------------------------------------
-    // 2. Set n_factors = 2 via the Select control and confirm it is enabled
-    //    Use role=combobox to avoid ambiguity with the scree plot aria-labels
+    // 2. Open the "Advanced configuration" accordion (the form controls live
+    //    inside it since Phase 3) then set n_factors = 2 via the Select.
+    //    Use role=combobox to avoid ambiguity with the scree plot aria-labels.
     // -----------------------------------------------------------------------
+    const advancedTrigger = page.getByRole('button', { name: /advanced configuration/i });
+    await expect(advancedTrigger).toBeVisible({ timeout: 10_000 });
+    await advancedTrigger.click();
+
     const factorsSelect = page.getByRole('combobox', { name: /factors/i });
     await expect(factorsSelect).toBeEnabled({ timeout: 10_000 });
     await factorsSelect.click();

--- a/frontend/e2e/admin/analysis-workflow.spec.ts
+++ b/frontend/e2e/admin/analysis-workflow.spec.ts
@@ -72,16 +72,14 @@ test('full analysis workflow: run → results → history', async ({ page, testD
     }
 
     // -----------------------------------------------------------------------
-    // 3. Click "Run Analysis" and wait for results
+    // 3. Click "Commit and interpret" and wait for results
     // -----------------------------------------------------------------------
-    const runButton = page.getByRole('button', { name: /run analysis/i });
+    const runButton = page.getByRole('button', { name: /commit and interpret/i });
     await expect(runButton).toBeEnabled({ timeout: 10_000 });
     await runButton.click();
 
-    // The button changes to "Analyzing…" while running
-    await expect(page.getByRole('button', { name: /analyzing/i })).toBeVisible({
-        timeout: 5_000,
-    });
+    // The button stays disabled while the analysis runs (spinner replaces icon).
+    await expect(runButton).toBeDisabled({ timeout: 5_000 });
 
     // Wait for the results card to render — the Tabs component appears once
     // analysisMutation.isSuccess fires and setResult() is called.
@@ -257,8 +255,8 @@ test('analysis page smoke: page renders with scree plot and run button', async (
     // Page title region
     await expect(page.getByText(/analysis/i).first()).toBeVisible({ timeout: 15_000 });
 
-    // "Run Analysis" button appears once eigenvalues load
-    const runBtn = page.getByRole('button', { name: /run analysis/i });
+    // "Commit and interpret" button appears once eigenvalues load
+    const runBtn = page.getByRole('button', { name: /commit and interpret/i });
     await expect(runBtn).toBeEnabled({ timeout: 30_000 });
 
     // History panel shows the empty-state message (no runs yet)

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -962,7 +962,9 @@
                 "pct_flagged": "% flagged",
                 "n_distinguishing": "# distinguishing",
                 "n_cross_loaders": "# cross-loaders",
-                "min_def_sorts": "min defining sorts"
+                "min_def_sorts": "min defining sorts",
+                "advanced_title": "Advanced configuration",
+                "commit_cta": "Commit and interpret"
             }
         },
         "project": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -953,7 +953,16 @@
                 "kaiser": "Kaiser",
                 "parallel": "Parallel analysis",
                 "map": "Velicer's MAP",
-                "advisory": "Advisory only — Q-method retention also depends on interpretability and stability (Watts & Stenner 2012)."
+                "advisory": "Advisory only — Q-method retention also depends on interpretability and stability (Watts & Stenner 2012).",
+                "preview_range_title": "Preview range",
+                "preview_range_disabled": "Preview range supports PCA + varimax only. Centroid extraction and judgmental rotation are path-dependent — commit a real run to inspect.",
+                "select_k": "{{k}} factors",
+                "empty_factor": "Empty factor — over-factorisation",
+                "cumvar": "cumvar %",
+                "pct_flagged": "% flagged",
+                "n_distinguishing": "# distinguishing",
+                "n_cross_loaders": "# cross-loaders",
+                "min_def_sorts": "min defining sorts"
             }
         },
         "project": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -947,6 +947,13 @@
                 "running": "Running bootstrap…",
                 "se_column": "Mean SE (z)",
                 "tooltip": "Non-parametric bootstrap of Q-sorts (resampled with replacement); analysis is repeated B times to estimate 95% CIs on z-scores."
+            },
+            "explore": {
+                "diagnostics_title": "Diagnostics",
+                "kaiser": "Kaiser",
+                "parallel": "Parallel analysis",
+                "map": "Velicer's MAP",
+                "advisory": "Advisory only — Q-method retention also depends on interpretability and stability (Watts & Stenner 2012)."
             }
         },
         "project": {

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -914,7 +914,9 @@
                 "pct_flagged": "% flagattu",
                 "n_distinguishing": "# erottavia",
                 "n_cross_loaders": "# ristikuormitt.",
-                "min_def_sorts": "min määr. sortit"
+                "min_def_sorts": "min määr. sortit",
+                "advanced_title": "Lisäasetukset",
+                "commit_cta": "Vahvista ja tulkitse"
             }
         },
         "project": {

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -899,6 +899,13 @@
                 "aria": "Edit factor {{n}} narrative",
                 "saved": "Factor narrative saved.",
                 "error": "Failed to save the factor narrative."
+            },
+            "explore": {
+                "diagnostics_title": "Diagnostiikka",
+                "kaiser": "Kaiser",
+                "parallel": "Rinnakkaisanalyysi",
+                "map": "Velicerin MAP",
+                "advisory": "Vain ohjaava — Q-menetelmän tekijöiden säilyttäminen riippuu myös tulkittavuudesta ja vakaudesta (Watts & Stenner 2012)."
             }
         },
         "project": {

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -905,7 +905,16 @@
                 "kaiser": "Kaiser",
                 "parallel": "Rinnakkaisanalyysi",
                 "map": "Velicerin MAP",
-                "advisory": "Vain ohjaava — Q-menetelmän tekijöiden säilyttäminen riippuu myös tulkittavuudesta ja vakaudesta (Watts & Stenner 2012)."
+                "advisory": "Vain ohjaava — Q-menetelmän tekijöiden säilyttäminen riippuu myös tulkittavuudesta ja vakaudesta (Watts & Stenner 2012).",
+                "preview_range_title": "Esikatselu k:lle",
+                "preview_range_disabled": "Esikatselu tukee vain PCA + varimax -yhdistelmää. Centroid-poiminta ja arvioon perustuva rotaatio ovat polkuriippuvaisia — aja oikea analyysi tarkastellaksesi.",
+                "select_k": "{{k}} tekijää",
+                "empty_factor": "Tyhjä tekijä — ylifaktoroitu",
+                "cumvar": "kum. %",
+                "pct_flagged": "% flagattu",
+                "n_distinguishing": "# erottavia",
+                "n_cross_loaders": "# ristikuormitt.",
+                "min_def_sorts": "min määr. sortit"
             }
         },
         "project": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -899,6 +899,13 @@
                 "running": "Bootstrap en cours…",
                 "se_column": "Erreur-type moyenne (z)",
                 "tooltip": "Bootstrap non paramétrique des Q-sorts (rééchantillonnés avec remise) ; l'analyse est répétée B fois pour estimer les IC à 95 % des z-scores."
+            },
+            "explore": {
+                "diagnostics_title": "Diagnostics",
+                "kaiser": "Kaiser",
+                "parallel": "Analyse parallèle",
+                "map": "MAP de Velicer",
+                "advisory": "Indicateurs consultatifs — la rétention en Q-méthode dépend aussi de l'interprétabilité et de la stabilité (Watts & Stenner 2012)."
             }
         },
         "project": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -905,7 +905,16 @@
                 "kaiser": "Kaiser",
                 "parallel": "Analyse parallèle",
                 "map": "MAP de Velicer",
-                "advisory": "Indicateurs consultatifs — la rétention en Q-méthode dépend aussi de l'interprétabilité et de la stabilité (Watts & Stenner 2012)."
+                "advisory": "Indicateurs consultatifs — la rétention en Q-méthode dépend aussi de l'interprétabilité et de la stabilité (Watts & Stenner 2012).",
+                "preview_range_title": "Aperçu par k",
+                "preview_range_disabled": "L'aperçu n'est pris en charge qu'avec PCA + varimax. L'extraction centroid et la rotation jugementale sont path-dépendantes — lancez un run réel pour les inspecter.",
+                "select_k": "{{k}} facteurs",
+                "empty_factor": "Facteur vide — sur-factorisation",
+                "cumvar": "% var. cum.",
+                "pct_flagged": "% flaggés",
+                "n_distinguishing": "# distinguish.",
+                "n_cross_loaders": "# cross-load.",
+                "min_def_sorts": "min sorts définiss."
             }
         },
         "project": {

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -914,7 +914,9 @@
                 "pct_flagged": "% flaggés",
                 "n_distinguishing": "# distinguish.",
                 "n_cross_loaders": "# cross-load.",
-                "min_def_sorts": "min sorts définiss."
+                "min_def_sorts": "min sorts définiss.",
+                "advanced_title": "Configuration avancée",
+                "commit_cta": "Valider et interpréter"
             }
         },
         "project": {

--- a/frontend/src/components/admin/analysis/ExplorerPanel.test.tsx
+++ b/frontend/src/components/admin/analysis/ExplorerPanel.test.tsx
@@ -168,4 +168,22 @@ describe('ExplorerPanel', () => {
         renderWithProviders(<ExplorerPanel explore={explore} />);
         expect(handlePreviewRange).not.toHaveBeenCalled();
     });
+
+    it('does NOT auto-fire when eigenvalues are still loading', () => {
+        // Regression: useExplorePhase falls back to maxFactors=10 while
+        // eigenvaluesQuery.data is undefined. Without the hasEigenvalues gate,
+        // the effect would fire with [2,3,4,5,6] — and for a study of n=3..6
+        // participants the backend rejects k > min(8, n-1) with a 400.
+        const handlePreviewRange = vi.fn();
+        const explore = buildExplore({
+            hasEigenvalues: false, // eigenvalues query in flight
+            canPreviewRange: true,
+            previewRows: undefined,
+            isPreviewing: false,
+            maxFactors: 10, // stale fallback
+            handlePreviewRange,
+        });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        expect(handlePreviewRange).not.toHaveBeenCalled();
+    });
 });

--- a/frontend/src/components/admin/analysis/ExplorerPanel.test.tsx
+++ b/frontend/src/components/admin/analysis/ExplorerPanel.test.tsx
@@ -1,0 +1,171 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen } from '@/test-utils/test-utils';
+import { ExplorerPanel } from './ExplorerPanel';
+import type { ExplorePhaseApi } from '@/hooks/admin/useExplorePhase';
+import type { PreviewRangeRow } from '@/api/model/previewRangeRow';
+
+function buildExplore(overrides: Partial<ExplorePhaseApi> = {}): ExplorePhaseApi {
+    return {
+        slug: 'test-slug',
+        extraction: 'pca',
+        setExtraction: vi.fn(),
+        nFactors: 3,
+        setNFactors: vi.fn(),
+        rotation: 'varimax',
+        setRotation: vi.fn(),
+        flagging: 'auto',
+        setFlagging: vi.fn(),
+        manualFlags: {},
+        manualRotations: [],
+        addManualRotation: vi.fn(),
+        updateManualRotation: vi.fn(),
+        removeManualRotation: vi.fn(),
+        isJudgmentalWithoutRotations: false,
+        bootstrapEnabled: false,
+        setBootstrapEnabled: vi.fn(),
+        bootstrapIterations: 1000,
+        setBootstrapIterations: vi.fn(),
+        maxFactors: 6,
+        hasEigenvalues: true,
+        isTooFewParticipants: false,
+        isEigenvalueError: false,
+        eigenvaluesIsLoading: false,
+        eigenvalues: [3.2, 2.1, 0.8, 0.4, 0.2, 0.1],
+        suggestedNFactors: 2,
+        kaiserN: 2,
+        parallelN: 2,
+        mapN: 3,
+        canPreviewRange: true,
+        previewRows: undefined,
+        isPreviewing: false,
+        handlePreviewRange: vi.fn().mockResolvedValue(undefined),
+        handleRefetchEigenvalues: vi.fn(),
+        isRunning: false,
+        handleRunAnalysis: vi.fn(),
+        ...overrides,
+    };
+}
+
+const SAMPLE_ROWS: PreviewRangeRow[] = [
+    {
+        n_factors: 2,
+        cumulative_variance: 47,
+        pct_flagged: 0.8,
+        n_distinguishing: 8,
+        n_cross_loaders: 0,
+        n_consensus: 3,
+        min_defining_sorts: 4,
+        has_empty_factor: false,
+    },
+    {
+        n_factors: 3,
+        cumulative_variance: 58,
+        pct_flagged: 0.7,
+        n_distinguishing: 12,
+        n_cross_loaders: 1,
+        n_consensus: 2,
+        min_defining_sorts: 4,
+        has_empty_factor: false,
+    },
+];
+
+describe('ExplorerPanel', () => {
+    it('renders Diagnostics, Preview range, and Advanced sections', () => {
+        renderWithProviders(
+            <ExplorerPanel
+                explore={buildExplore({ previewRows: SAMPLE_ROWS })}
+                advancedContent={<div>placeholder</div>}
+            />
+        );
+        expect(screen.getByText(/Diagnostics/i)).toBeInTheDocument();
+        expect(screen.getByText(/Preview range/i)).toBeInTheDocument();
+        expect(screen.getByText(/Advanced/i)).toBeInTheDocument();
+    });
+
+    it('renders the Commit-and-interpret button wired to handleRunAnalysis', () => {
+        const handleRunAnalysis = vi.fn();
+        const explore = buildExplore({ previewRows: SAMPLE_ROWS, handleRunAnalysis });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        const cta = screen.getByRole('button', { name: /commit and interpret/i });
+        fireEvent.click(cta);
+        expect(handleRunAnalysis).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the Commit button while a run is in flight', () => {
+        const explore = buildExplore({ previewRows: SAMPLE_ROWS, isRunning: true });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        expect(screen.getByRole('button', { name: /commit and interpret/i })).toBeDisabled();
+    });
+
+    it('disables the Commit button when judgmental rotation has no rotations', () => {
+        const explore = buildExplore({
+            previewRows: SAMPLE_ROWS,
+            isJudgmentalWithoutRotations: true,
+        });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        expect(screen.getByRole('button', { name: /commit and interpret/i })).toBeDisabled();
+    });
+
+    it('selecting a column from PreviewRangeTable updates nFactors via setNFactors', () => {
+        const setNFactors = vi.fn();
+        const explore = buildExplore({ previewRows: SAMPLE_ROWS, setNFactors });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        fireEvent.click(screen.getByRole('button', { name: /3 factors/i }));
+        expect(setNFactors).toHaveBeenCalledWith(3);
+    });
+
+    it('shows the gate message when canPreviewRange=false (centroid extraction)', () => {
+        const explore = buildExplore({
+            extraction: 'centroid',
+            canPreviewRange: false,
+            previewRows: undefined,
+        });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        expect(screen.getByText(/PCA \+ varimax only/i)).toBeInTheDocument();
+    });
+
+    it('auto-fires preview-range on mount when canPreviewRange and no rows yet', () => {
+        const handlePreviewRange = vi.fn().mockResolvedValue(undefined);
+        const explore = buildExplore({
+            canPreviewRange: true,
+            previewRows: undefined,
+            isPreviewing: false,
+            maxFactors: 6,
+            handlePreviewRange,
+        });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        // Auto-fetch: range = 2..min(5, maxFactors-1) → [2, 3, 4, 5, 6] given maxFactors=6
+        expect(handlePreviewRange).toHaveBeenCalledTimes(1);
+        const arg = handlePreviewRange.mock.calls[0]?.[0];
+        expect(arg).toEqual([2, 3, 4, 5, 6]);
+    });
+
+    it('does NOT auto-fire preview-range when canPreviewRange is false', () => {
+        const handlePreviewRange = vi.fn();
+        const explore = buildExplore({
+            canPreviewRange: false,
+            previewRows: undefined,
+            handlePreviewRange,
+        });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        expect(handlePreviewRange).not.toHaveBeenCalled();
+    });
+
+    it('does NOT re-fire when previewRows is already populated', () => {
+        const handlePreviewRange = vi.fn();
+        const explore = buildExplore({
+            canPreviewRange: true,
+            previewRows: SAMPLE_ROWS,
+            handlePreviewRange,
+        });
+        renderWithProviders(<ExplorerPanel explore={explore} />);
+        expect(handlePreviewRange).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/admin/analysis/ExplorerPanel.tsx
+++ b/frontend/src/components/admin/analysis/ExplorerPanel.tsx
@@ -1,0 +1,103 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Play, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    Accordion,
+    AccordionItem,
+    AccordionTrigger,
+    AccordionContent,
+} from '@/components/ui/accordion';
+import { ScreeWithDiagnostics } from './ScreeWithDiagnostics';
+import { PreviewRangeTable } from './PreviewRangeTable';
+import type { ExplorePhaseApi } from '@/hooks/admin/useExplorePhase';
+
+interface Props {
+    explore: ExplorePhaseApi;
+    /**
+     * Slot for the legacy advanced configuration controls
+     * (extraction / rotation / flagging / bootstrap / manual flags / manual
+     * rotations). Hosted by ExploreShell so this panel stays focused on the
+     * new Phase 3 surfaces. Pass null/undefined and the accordion is hidden.
+     */
+    advancedContent?: React.ReactNode;
+}
+
+export function ExplorerPanel({ explore, advancedContent }: Props) {
+    const { t } = useTranslation();
+
+    // Auto-fetch a sensible preview range on mount (or when the gate flips
+    // from disabled to enabled). Range covers k = 2 .. min(6, maxFactors).
+    useEffect(() => {
+        if (
+            explore.canPreviewRange &&
+            explore.previewRows === undefined &&
+            !explore.isPreviewing &&
+            explore.maxFactors >= 2
+        ) {
+            const length = Math.min(5, explore.maxFactors - 1);
+            const range = Array.from({ length }, (_, i) => i + 2);
+            void explore.handlePreviewRange(range);
+        }
+    }, [
+        explore.canPreviewRange,
+        explore.previewRows,
+        explore.isPreviewing,
+        explore.maxFactors,
+        explore.handlePreviewRange,
+    ]);
+
+    return (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <ScreeWithDiagnostics
+                eigenvalues={explore.eigenvalues ?? []}
+                kaiserN={explore.kaiserN ?? 1}
+                parallelN={explore.parallelN ?? 1}
+                mapN={explore.mapN ?? 1}
+                selectedNFactors={explore.nFactors}
+                onSelectNFactors={explore.setNFactors}
+            />
+            <PreviewRangeTable
+                rows={explore.previewRows ?? []}
+                onSelect={explore.setNFactors}
+                disabled={!explore.canPreviewRange}
+            />
+            {advancedContent !== undefined && (
+                <div className="lg:col-span-2">
+                    <Accordion type="single" collapsible>
+                        <AccordionItem value="advanced">
+                            <AccordionTrigger>
+                                {t(
+                                    'admin.analysis.explore.advanced_title',
+                                    'Advanced configuration'
+                                )}
+                            </AccordionTrigger>
+                            <AccordionContent>{advancedContent}</AccordionContent>
+                        </AccordionItem>
+                    </Accordion>
+                </div>
+            )}
+            <div className="lg:col-span-2">
+                <Button
+                    onClick={explore.handleRunAnalysis}
+                    disabled={explore.isRunning || explore.isJudgmentalWithoutRotations}
+                    size="lg"
+                    className="w-full sm:w-auto"
+                >
+                    {explore.isRunning ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                        <Play className="mr-2 h-4 w-4" />
+                    )}
+                    {t('admin.analysis.explore.commit_cta', 'Commit and interpret')}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/admin/analysis/ExplorerPanel.tsx
+++ b/frontend/src/components/admin/analysis/ExplorerPanel.tsx
@@ -34,18 +34,23 @@ export function ExplorerPanel({ explore, advancedContent }: Props) {
 
     // Auto-fetch a sensible preview range on mount (or when the gate flips
     // from disabled to enabled). Range covers k = 2 .. min(6, maxFactors).
+    // Wait until eigenvalues actually loaded — otherwise maxFactors is the
+    // stale fallback (10), and small studies (n=3..6) would see the request
+    // rejected with a 400 "k > max_k" toast.
     useEffect(() => {
         if (
+            explore.hasEigenvalues &&
             explore.canPreviewRange &&
             explore.previewRows === undefined &&
             !explore.isPreviewing &&
             explore.maxFactors >= 2
         ) {
-            const length = Math.min(5, explore.maxFactors - 1);
-            const range = Array.from({ length }, (_, i) => i + 2);
+            const upper = Math.min(6, explore.maxFactors);
+            const range = Array.from({ length: upper - 1 }, (_, i) => i + 2);
             void explore.handlePreviewRange(range);
         }
     }, [
+        explore.hasEigenvalues,
         explore.canPreviewRange,
         explore.previewRows,
         explore.isPreviewing,

--- a/frontend/src/components/admin/analysis/PreviewRangeTable.test.tsx
+++ b/frontend/src/components/admin/analysis/PreviewRangeTable.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen } from '@/test-utils/test-utils';
+import { PreviewRangeTable } from './PreviewRangeTable';
+import type { PreviewRangeRow } from '@/api/model/previewRangeRow';
+
+const ROWS: PreviewRangeRow[] = [
+    {
+        n_factors: 2,
+        cumulative_variance: 47.0,
+        pct_flagged: 0.82,
+        n_distinguishing: 8,
+        n_cross_loaders: 0,
+        n_consensus: 3,
+        min_defining_sorts: 4,
+        has_empty_factor: false,
+    },
+    {
+        n_factors: 3,
+        cumulative_variance: 58.0,
+        pct_flagged: 0.73,
+        n_distinguishing: 14,
+        n_cross_loaders: 1,
+        n_consensus: 2,
+        min_defining_sorts: 4,
+        has_empty_factor: false,
+    },
+    {
+        n_factors: 6,
+        cumulative_variance: 71.0,
+        pct_flagged: 0.4,
+        n_distinguishing: 18,
+        n_cross_loaders: 11,
+        n_consensus: 1,
+        min_defining_sorts: 0,
+        has_empty_factor: true,
+    },
+];
+
+describe('PreviewRangeTable', () => {
+    it('renders one column per row plus the metric labels', () => {
+        renderWithProviders(<PreviewRangeTable rows={ROWS} onSelect={vi.fn()} disabled={false} />);
+        // n_factors values appear as column headers (button labels).
+        expect(screen.getByRole('button', { name: /2 factors/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /3 factors/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /6 factors/i })).toBeInTheDocument();
+        // cumvar metric label exists.
+        expect(screen.getByText(/cumvar/i)).toBeInTheDocument();
+    });
+
+    it('marks rows with has_empty_factor with a warning badge', () => {
+        renderWithProviders(<PreviewRangeTable rows={ROWS} onSelect={vi.fn()} disabled={false} />);
+        // Only the k=6 row should carry the empty-factor warning.
+        const warnings = screen.getAllByLabelText(/empty factor/i);
+        expect(warnings).toHaveLength(1);
+    });
+
+    it('calls onSelect with the chosen k when a column is clicked', () => {
+        const onSelect = vi.fn();
+        renderWithProviders(<PreviewRangeTable rows={ROWS} onSelect={onSelect} disabled={false} />);
+        fireEvent.click(screen.getByRole('button', { name: /3 factors/i }));
+        expect(onSelect).toHaveBeenCalledWith(3);
+    });
+
+    it('disables interaction and shows the gate message when disabled', () => {
+        renderWithProviders(<PreviewRangeTable rows={[]} onSelect={vi.fn()} disabled={true} />);
+        expect(screen.getByText(/PCA \+ varimax only/i)).toBeInTheDocument();
+        // No clickable column buttons.
+        expect(screen.queryByRole('button', { name: /factors/i })).toBeNull();
+    });
+
+    it('renders rounded percentages for cumvar and pct_flagged', () => {
+        renderWithProviders(
+            <PreviewRangeTable rows={ROWS.slice(0, 1)} onSelect={vi.fn()} disabled={false} />
+        );
+        // 47.0 → "47", 0.82 → "82" (no % sign in the cell — the row label carries it).
+        expect(screen.getByText('47')).toBeInTheDocument();
+        expect(screen.getByText('82')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/analysis/PreviewRangeTable.tsx
+++ b/frontend/src/components/admin/analysis/PreviewRangeTable.tsx
@@ -1,0 +1,119 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import type { PreviewRangeRow } from '@/api/model/previewRangeRow';
+
+interface Props {
+    rows: PreviewRangeRow[];
+    onSelect: (k: number) => void;
+    disabled: boolean;
+}
+
+export function PreviewRangeTable({ rows, onSelect, disabled }: Props) {
+    const { t } = useTranslation();
+
+    if (disabled) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-lg font-black text-slate-900">
+                        {t('admin.analysis.explore.preview_range_title', 'Preview range')}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-sm text-slate-600">
+                        {t(
+                            'admin.analysis.explore.preview_range_disabled',
+                            'Preview range supports PCA + varimax only. Centroid extraction and judgmental rotation are path-dependent — commit a real run to inspect.'
+                        )}
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg font-black text-slate-900">
+                    {t('admin.analysis.explore.preview_range_title', 'Preview range')}
+                </CardTitle>
+            </CardHeader>
+            <CardContent>
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr>
+                            <th className="text-left font-medium text-slate-500">k</th>
+                            {rows.map((r) => (
+                                <th key={r.n_factors}>
+                                    <button
+                                        type="button"
+                                        onClick={() => onSelect(r.n_factors)}
+                                        aria-label={t(
+                                            'admin.analysis.explore.select_k',
+                                            '{{k}} factors',
+                                            { k: r.n_factors }
+                                        )}
+                                        className="font-black text-slate-900 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded px-1"
+                                    >
+                                        {r.n_factors}
+                                        {r.has_empty_factor && (
+                                            <AlertTriangle
+                                                className="inline ml-1 h-3 w-3 text-amber-500"
+                                                aria-label={t(
+                                                    'admin.analysis.explore.empty_factor',
+                                                    'Empty factor — over-factorisation'
+                                                )}
+                                            />
+                                        )}
+                                    </button>
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <Row
+                            label={t('admin.analysis.explore.cumvar', 'cumvar %')}
+                            values={rows.map((r) => r.cumulative_variance.toFixed(0))}
+                        />
+                        <Row
+                            label={t('admin.analysis.explore.pct_flagged', '% flagged')}
+                            values={rows.map((r) => Math.round(r.pct_flagged * 100).toString())}
+                        />
+                        <Row
+                            label={t('admin.analysis.explore.n_distinguishing', '# distinguishing')}
+                            values={rows.map((r) => r.n_distinguishing.toString())}
+                        />
+                        <Row
+                            label={t('admin.analysis.explore.n_cross_loaders', '# cross-loaders')}
+                            values={rows.map((r) => r.n_cross_loaders.toString())}
+                        />
+                        <Row
+                            label={t('admin.analysis.explore.min_def_sorts', 'min defining sorts')}
+                            values={rows.map((r) => r.min_defining_sorts.toString())}
+                        />
+                    </tbody>
+                </table>
+            </CardContent>
+        </Card>
+    );
+}
+
+function Row({ label, values }: { label: string; values: string[] }) {
+    return (
+        <tr>
+            <td className="text-slate-500">{label}</td>
+            {values.map((v, i) => (
+                <td key={i} className="text-center font-mono">
+                    {v}
+                </td>
+            ))}
+        </tr>
+    );
+}

--- a/frontend/src/components/admin/analysis/ScreeWithDiagnostics.test.tsx
+++ b/frontend/src/components/admin/analysis/ScreeWithDiagnostics.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { renderWithProviders, screen } from '@/test-utils/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import { ScreeWithDiagnostics } from './ScreeWithDiagnostics';
+
+describe('ScreeWithDiagnostics', () => {
+    it('renders the three retention indicators with their values', () => {
+        renderWithProviders(
+            <ScreeWithDiagnostics
+                eigenvalues={[3.2, 2.1, 0.8, 0.4, 0.2]}
+                kaiserN={2}
+                parallelN={2}
+                mapN={3}
+                selectedNFactors={2}
+                onSelectNFactors={vi.fn()}
+            />
+        );
+
+        // Three indicator labels render (English defaults). "Kaiser" also
+        // appears inside the ScreePlot hint/legend, so we assert on the
+        // <dt> term elements specifically.
+        expect(screen.getByText(/^Kaiser$/i)).toBeInTheDocument();
+        expect(screen.getByText(/^Parallel analysis$/i)).toBeInTheDocument();
+        expect(screen.getByText(/^Velicer's MAP$/i)).toBeInTheDocument();
+
+        // Indicator values rendered (parallelN = 2 collides with kaiserN = 2,
+        // so we assert on the unique mapN value and that "2" appears at least once).
+        expect(screen.getByText('3', { exact: true })).toBeInTheDocument();
+        expect(screen.getAllByText('2', { exact: true }).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders the Watts & Stenner advisory framing', () => {
+        renderWithProviders(
+            <ScreeWithDiagnostics
+                eigenvalues={[1, 0.5]}
+                kaiserN={1}
+                parallelN={1}
+                mapN={1}
+                selectedNFactors={1}
+                onSelectNFactors={vi.fn()}
+            />
+        );
+
+        expect(screen.getByText(/advisory/i)).toBeInTheDocument();
+        expect(screen.getByText(/Watts.*Stenner/i)).toBeInTheDocument();
+    });
+
+    it('forwards selectedNFactors / onSelectNFactors to the underlying ScreePlot', () => {
+        const onSelect = vi.fn();
+        renderWithProviders(
+            <ScreeWithDiagnostics
+                eigenvalues={[3.2, 2.1, 0.8]}
+                kaiserN={2}
+                parallelN={2}
+                mapN={2}
+                selectedNFactors={2}
+                onSelectNFactors={onSelect}
+            />
+        );
+
+        // ScreePlot exposes a sr-only listbox with one option per factor for
+        // keyboard accessibility — assert it renders, which proves the chart
+        // mounted and props were forwarded. (Click-through behaviour is covered
+        // by ScreePlot's own tests; we only verify the prop wiring here.)
+        const listbox = screen.getByRole('listbox', { name: /select number of factors/i });
+        expect(listbox).toBeInTheDocument();
+        expect(screen.getAllByRole('option').length).toBe(3);
+    });
+});

--- a/frontend/src/components/admin/analysis/ScreeWithDiagnostics.tsx
+++ b/frontend/src/components/admin/analysis/ScreeWithDiagnostics.tsx
@@ -1,0 +1,73 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { ScreePlot } from './ScreePlot';
+
+interface ScreeWithDiagnosticsProps {
+    eigenvalues: number[];
+    kaiserN: number;
+    parallelN: number;
+    mapN: number;
+    selectedNFactors: number;
+    onSelectNFactors: (n: number) => void;
+}
+
+export function ScreeWithDiagnostics({
+    eigenvalues,
+    kaiserN,
+    parallelN,
+    mapN,
+    selectedNFactors,
+    onSelectNFactors,
+}: ScreeWithDiagnosticsProps) {
+    const { t } = useTranslation();
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-lg font-black text-slate-900">
+                    {t('admin.analysis.explore.diagnostics_title', 'Diagnostics')}
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                <ScreePlot
+                    eigenvalues={eigenvalues}
+                    suggestedNFactors={kaiserN}
+                    selectedNFactors={selectedNFactors}
+                    onSelectNFactors={onSelectNFactors}
+                />
+                <dl className="grid grid-cols-3 gap-2 text-sm">
+                    <div>
+                        <dt className="text-slate-500">
+                            {t('admin.analysis.explore.kaiser', 'Kaiser')}
+                        </dt>
+                        <dd className="text-lg font-black text-slate-900">{kaiserN}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-slate-500">
+                            {t('admin.analysis.explore.parallel', 'Parallel analysis')}
+                        </dt>
+                        <dd className="text-lg font-black text-slate-900">{parallelN}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-slate-500">
+                            {t('admin.analysis.explore.map', "Velicer's MAP")}
+                        </dt>
+                        <dd className="text-lg font-black text-slate-900">{mapN}</dd>
+                    </div>
+                </dl>
+                <p className="text-xs text-slate-500 italic">
+                    {t(
+                        'admin.analysis.explore.advisory',
+                        'Advisory only — Q-method retention also depends on interpretability and stability (Watts & Stenner 2012).'
+                    )}
+                </p>
+            </CardContent>
+        </Card>
+    );
+}

--- a/frontend/src/hooks/admin/useExplorePhase.test.ts
+++ b/frontend/src/hooks/admin/useExplorePhase.test.ts
@@ -29,11 +29,13 @@ const {
     mockAnalysisMutationHook,
     mockListAnalysisRuns,
     mockGetListAnalysisRunsQueryKey,
+    mockPreviewRangeMutation,
 } = vi.hoisted(() => ({
     mockEigenvaluesHook: vi.fn(),
     mockAnalysisMutationHook: vi.fn(),
     mockListAnalysisRuns: vi.fn(),
     mockGetListAnalysisRunsQueryKey: vi.fn(() => ['list-analysis-runs', 'test-study']),
+    mockPreviewRangeMutation: vi.fn(),
 }));
 
 vi.mock('@/api/generated', () => ({
@@ -41,6 +43,7 @@ vi.mock('@/api/generated', () => ({
     useRunFactorAnalysisApiAdminStudiesSlugAnalysisRunPost: mockAnalysisMutationHook,
     listAnalysisRunsApiAdminStudiesSlugAnalysisRunsGet: mockListAnalysisRuns,
     getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey: mockGetListAnalysisRunsQueryKey,
+    usePreviewRangeApiAdminStudiesSlugAnalysisPreviewRangePost: () => mockPreviewRangeMutation(),
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -95,6 +98,12 @@ describe('useExplorePhase', () => {
         mockEigenvaluesHook.mockReturnValue(makeIdleEigenvalues());
         mockAnalysisMutationHook.mockReturnValue(makeIdleMutation());
         mockListAnalysisRuns.mockResolvedValue([]);
+        mockPreviewRangeMutation.mockReturnValue({
+            mutateAsync: vi.fn().mockResolvedValue({ rows: [] }),
+            isPending: false,
+            isError: false,
+            error: null,
+        });
     });
 
     it('has correct initial form state defaults', () => {
@@ -490,6 +499,135 @@ describe('useExplorePhase', () => {
                 }),
                 expect.any(Object)
             );
+        });
+    });
+
+    describe('diagnostics + preview-range (Phase 3)', () => {
+        it('exposes kaiserN, parallelN, mapN from the eigenvalues query', async () => {
+            mockEigenvaluesHook.mockReturnValue({
+                data: {
+                    eigenvalues: [3.2, 2.1, 0.8],
+                    kaiser_n: 2,
+                    parallel_analysis_n: 2,
+                    velicer_map_n: 3,
+                    suggested_n_factors: 2,
+                },
+                isError: false,
+                isLoading: false,
+                isSuccess: true,
+                refetch: vi.fn(),
+                error: null,
+            });
+            const { result } = renderHook(() => useExplorePhase('test-slug', vi.fn()), {
+                wrapper: AllTheProviders,
+            });
+            await waitFor(() => expect(result.current.kaiserN).toBe(2));
+            expect(result.current.parallelN).toBe(2);
+            expect(result.current.mapN).toBe(3);
+        });
+
+        it('triggers preview-range and exposes rows on success', async () => {
+            mockEigenvaluesHook.mockReturnValue({
+                data: {
+                    eigenvalues: [3.2, 2.1, 0.8],
+                    kaiser_n: 2,
+                    parallel_analysis_n: 2,
+                    velicer_map_n: 2,
+                    suggested_n_factors: 2,
+                },
+                isError: false,
+                isLoading: false,
+                isSuccess: true,
+                refetch: vi.fn(),
+                error: null,
+            });
+            const mutateAsync = vi.fn().mockResolvedValue({
+                rows: [
+                    {
+                        n_factors: 2,
+                        cumulative_variance: 47,
+                        pct_flagged: 0.82,
+                        n_distinguishing: 8,
+                        n_cross_loaders: 0,
+                        n_consensus: 3,
+                        min_defining_sorts: 4,
+                        has_empty_factor: false,
+                    },
+                ],
+            });
+            mockPreviewRangeMutation.mockReturnValue({
+                mutateAsync,
+                isPending: false,
+                isError: false,
+                error: null,
+            });
+            const { result } = renderHook(() => useExplorePhase('test-slug', vi.fn()), {
+                wrapper: AllTheProviders,
+            });
+            await act(async () => {
+                await result.current.handlePreviewRange([2]);
+            });
+            expect(mutateAsync).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    slug: 'test-slug',
+                    data: expect.objectContaining({
+                        n_factors_range: [2],
+                        extraction: 'pca',
+                        rotation: 'varimax',
+                        flagging: 'auto',
+                    }),
+                })
+            );
+            expect(result.current.previewRows).toHaveLength(1);
+            expect(result.current.previewRows?.[0]?.n_factors).toBe(2);
+        });
+
+        it('disables preview-range (canPreviewRange=false) when extraction is centroid', () => {
+            const { result } = renderHook(() => useExplorePhase('test-slug', vi.fn()), {
+                wrapper: AllTheProviders,
+            });
+            act(() => {
+                result.current.setExtraction('centroid');
+            });
+            expect(result.current.canPreviewRange).toBe(false);
+        });
+
+        it('disables preview-range when rotation is judgmental', () => {
+            const { result } = renderHook(() => useExplorePhase('test-slug', vi.fn()), {
+                wrapper: AllTheProviders,
+            });
+            act(() => {
+                result.current.setRotation('judgmental');
+            });
+            expect(result.current.canPreviewRange).toBe(false);
+        });
+
+        it('canPreviewRange is true for default PCA + varimax', () => {
+            const { result } = renderHook(() => useExplorePhase('test-slug', vi.fn()), {
+                wrapper: AllTheProviders,
+            });
+            // defaults are extraction=pca, rotation=varimax
+            expect(result.current.canPreviewRange).toBe(true);
+        });
+
+        it('handlePreviewRange is a no-op when canPreviewRange is false', async () => {
+            const mutateAsync = vi.fn();
+            mockPreviewRangeMutation.mockReturnValue({
+                mutateAsync,
+                isPending: false,
+                isError: false,
+                error: null,
+            });
+            const { result } = renderHook(() => useExplorePhase('test-slug', vi.fn()), {
+                wrapper: AllTheProviders,
+            });
+            act(() => {
+                result.current.setExtraction('centroid');
+            });
+            await act(async () => {
+                await result.current.handlePreviewRange([2, 3]);
+            });
+            expect(mutateAsync).not.toHaveBeenCalled();
         });
     });
 

--- a/frontend/src/hooks/admin/useExplorePhase.test.ts
+++ b/frontend/src/hooks/admin/useExplorePhase.test.ts
@@ -15,6 +15,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AllTheProviders } from '@/test-utils/test-utils';
+import type { PreviewRangeRow } from '@/api/model/previewRangeRow';
 import { useExplorePhase } from './useExplorePhase';
 
 // ── Mocks ──────────────────────────────────────────────────────────
@@ -628,6 +629,63 @@ describe('useExplorePhase', () => {
                 await result.current.handlePreviewRange([2, 3]);
             });
             expect(mutateAsync).not.toHaveBeenCalled();
+        });
+
+        it('discards in-flight preview-range result when extraction changes mid-flight', async () => {
+            // Race: while mutateAsync is in flight, the user flips extraction.
+            // The reset effect clears previewRows AND bumps the snapshot token;
+            // when the stale promise resolves, the commit must be skipped.
+            let resolveMutation: ((v: { rows: PreviewRangeRow[] }) => void) | null = null;
+            const mutateAsync = vi.fn(
+                () =>
+                    new Promise<{ rows: PreviewRangeRow[] }>((resolve) => {
+                        resolveMutation = resolve;
+                    })
+            );
+            mockPreviewRangeMutation.mockReturnValue({
+                mutateAsync,
+                isPending: true,
+                isError: false,
+                error: null,
+            });
+
+            const { result } = renderHook(() => useExplorePhase('test-slug', vi.fn()), {
+                wrapper: AllTheProviders,
+            });
+
+            // Start the preview-range request (don't await — keep the promise in flight).
+            let pendingPreview: Promise<void> | undefined;
+            await act(async () => {
+                pendingPreview = result.current.handlePreviewRange([2, 3]);
+            });
+
+            // Flip extraction mid-flight: this resets previewRows and bumps the token.
+            await act(async () => {
+                result.current.setExtraction('centroid');
+            });
+
+            // Now resolve the stale mutation with rows that should NOT be committed.
+            expect(resolveMutation).not.toBeNull();
+            await act(async () => {
+                resolveMutation?.({
+                    rows: [
+                        {
+                            n_factors: 2,
+                            cumulative_variance: 47,
+                            pct_flagged: 0.8,
+                            n_distinguishing: 8,
+                            n_cross_loaders: 0,
+                            n_consensus: 3,
+                            min_defining_sorts: 4,
+                            has_empty_factor: false,
+                        },
+                    ],
+                });
+                await pendingPreview;
+            });
+
+            // The stale rows must NOT have landed: previewRows is still undefined.
+            expect(result.current.previewRows).toBeUndefined();
         });
     });
 

--- a/frontend/src/hooks/admin/useExplorePhase.ts
+++ b/frontend/src/hooks/admin/useExplorePhase.ts
@@ -11,7 +11,7 @@
  * manage the post-run interpretation surfaces (those live in useInterpretPhase).
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -28,7 +28,6 @@ import type { ManualRotation } from '@/api/model';
 import type { PreviewRangeRow } from '@/api/model/previewRangeRow';
 import type { PreviewRangeRequestExtraction } from '@/api/model/previewRangeRequestExtraction';
 import type { PreviewRangeRequestRotation } from '@/api/model/previewRangeRequestRotation';
-import type { PreviewRangeRequestFlagging } from '@/api/model/previewRangeRequestFlagging';
 
 /**
  * Client-side draft of a manual rotation row. Carries a stable `id` used as the
@@ -233,25 +232,39 @@ export function useExplorePhase(slug: string, onCommit: (runId: number) => void)
 
     const canPreviewRange = extraction === 'pca' && (rotation === 'varimax' || rotation === 'none');
 
+    // Monotonic token: every preview-range call captures the current value
+    // and only commits its result if the token still matches. The reset effect
+    // bumps the token so any in-flight resolution is silenced when the user
+    // flips extraction / rotation / flagging mid-flight (otherwise the stale
+    // rows would land under the new config).
+    const previewTokenRef = useRef(0);
+
     const handlePreviewRange = useCallback(
         async (range: number[]) => {
             if (!canPreviewRange) return;
+            const token = ++previewTokenRef.current;
             const data = await previewMutation.mutateAsync({
                 slug,
                 data: {
                     n_factors_range: range,
                     extraction: extraction as PreviewRangeRequestExtraction,
                     rotation: rotation as PreviewRangeRequestRotation,
-                    flagging: flagging as PreviewRangeRequestFlagging,
+                    flagging,
                 },
             });
-            setPreviewRows(data.rows);
+            if (token === previewTokenRef.current) {
+                setPreviewRows(data.rows);
+            }
+            // else: a newer call (or a config flip) has invalidated this resolution.
         },
         [slug, extraction, rotation, flagging, canPreviewRange, previewMutation]
     );
 
     // Reset stale rows whenever a setting that would change the preview flips.
+    // Bumping the token cancels any pending commit even if the user doesn't
+    // trigger a new mutate.
     useEffect(() => {
+        previewTokenRef.current += 1;
         setPreviewRows(undefined);
     }, [extraction, rotation, flagging]);
 

--- a/frontend/src/hooks/admin/useExplorePhase.ts
+++ b/frontend/src/hooks/admin/useExplorePhase.ts
@@ -22,8 +22,13 @@ import {
     useRunFactorAnalysisApiAdminStudiesSlugAnalysisRunPost,
     listAnalysisRunsApiAdminStudiesSlugAnalysisRunsGet,
     getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey,
+    usePreviewRangeApiAdminStudiesSlugAnalysisPreviewRangePost,
 } from '@/api/generated';
 import type { ManualRotation } from '@/api/model';
+import type { PreviewRangeRow } from '@/api/model/previewRangeRow';
+import type { PreviewRangeRequestExtraction } from '@/api/model/previewRangeRequestExtraction';
+import type { PreviewRangeRequestRotation } from '@/api/model/previewRangeRequestRotation';
+import type { PreviewRangeRequestFlagging } from '@/api/model/previewRangeRequestFlagging';
 
 /**
  * Client-side draft of a manual rotation row. Carries a stable `id` used as the
@@ -96,10 +101,22 @@ export interface ExplorePhaseApi {
     eigenvaluesIsLoading: boolean;
     eigenvalues: number[] | undefined;
     suggestedNFactors: number | undefined;
+    /** Kaiser criterion (eigenvalues > 1). */
+    kaiserN: number | undefined;
+    /** Horn (1965) parallel-analysis count. */
+    parallelN: number | undefined;
+    /** Velicer (1976) Minimum Average Partial. */
+    mapN: number | undefined;
     handleRefetchEigenvalues: () => void;
 
     // Run state
     isRunning: boolean;
+
+    // Preview-range (PCA-only — backend rejects centroid + judgmental)
+    canPreviewRange: boolean;
+    previewRows: PreviewRangeRow[] | undefined;
+    isPreviewing: boolean;
+    handlePreviewRange: (range: number[]) => Promise<void>;
 
     // Handlers
     handleRunAnalysis: () => void;
@@ -204,6 +221,39 @@ export function useExplorePhase(slug: string, onCommit: (runId: number) => void)
     });
 
     const isRunning = analysisMutation.isPending;
+
+    // ── Preview-range mutation (PCA-only) ─────────────────────────
+    // The backend `/preview-range` endpoint rejects centroid extraction and
+    // judgmental rotation; mirror that gate client-side so the button can be
+    // disabled with a clear reason instead of round-tripping a 400.
+    const previewMutation = usePreviewRangeApiAdminStudiesSlugAnalysisPreviewRangePost({
+        mutation: { retry: false },
+    });
+    const [previewRows, setPreviewRows] = useState<PreviewRangeRow[] | undefined>(undefined);
+
+    const canPreviewRange = extraction === 'pca' && (rotation === 'varimax' || rotation === 'none');
+
+    const handlePreviewRange = useCallback(
+        async (range: number[]) => {
+            if (!canPreviewRange) return;
+            const data = await previewMutation.mutateAsync({
+                slug,
+                data: {
+                    n_factors_range: range,
+                    extraction: extraction as PreviewRangeRequestExtraction,
+                    rotation: rotation as PreviewRangeRequestRotation,
+                    flagging: flagging as PreviewRangeRequestFlagging,
+                },
+            });
+            setPreviewRows(data.rows);
+        },
+        [slug, extraction, rotation, flagging, canPreviewRange, previewMutation]
+    );
+
+    // Reset stale rows whenever a setting that would change the preview flips.
+    useEffect(() => {
+        setPreviewRows(undefined);
+    }, [extraction, rotation, flagging]);
 
     // ── Handlers ──────────────────────────────────────────────────
     const handleRunAnalysis = useCallback(() => {
@@ -321,8 +371,15 @@ export function useExplorePhase(slug: string, onCommit: (runId: number) => void)
         eigenvaluesIsLoading: eigenvaluesQuery.isLoading,
         eigenvalues: eigenvaluesQuery.data?.eigenvalues,
         suggestedNFactors: eigenvaluesQuery.data?.suggested_n_factors,
+        kaiserN: eigenvaluesQuery.data?.kaiser_n,
+        parallelN: eigenvaluesQuery.data?.parallel_analysis_n,
+        mapN: eigenvaluesQuery.data?.velicer_map_n,
         handleRefetchEigenvalues,
         isRunning,
+        canPreviewRange,
+        previewRows,
+        isPreviewing: previewMutation.isPending,
+        handlePreviewRange,
         handleRunAnalysis,
     };
 }

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -311,14 +311,16 @@ describe('AnalysisPage', () => {
         expect(screen.getByText(/Not enough Q-sort data yet/i)).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /open study overview/i })).toBeInTheDocument();
 
-        // Configuration chrome is NOT rendered: the "Configuration" heading
-        // and the "Run Analysis" button (the only unambiguous markers — the
-        // word "extraction" also appears in the empty-state body copy).
-        expect(screen.queryByRole('heading', { name: /^Configuration$/i })).not.toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: /run analysis/i })).not.toBeInTheDocument();
+        // ExplorerPanel chrome is NOT rendered: neither the diagnostics
+        // surface nor the commit CTA appear when the empty-state contract
+        // takes over.
+        expect(screen.queryByText(/^Diagnostics$/i)).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: /commit and interpret/i })
+        ).not.toBeInTheDocument();
     });
 
-    it('renders scree plot and controls after eigenvalues load', () => {
+    it('renders ExplorerPanel surfaces and CTA after eigenvalues load', () => {
         mockEigenvaluesHook.mockReturnValue({
             data: mockEigenvalues,
             isLoading: false,
@@ -330,14 +332,39 @@ describe('AnalysisPage', () => {
 
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
 
-        // Wave C: Extraction + Factors are primary-visible; Rotation + Flagging
-        // moved into the "Advanced settings" Accordion (collapsed by default
-        // when values are at their defaults: varimax/auto/no bootstrap).
-        expect(screen.getByRole('combobox', { name: /Extraction/i })).toBeInTheDocument();
-        expect(screen.getByRole('combobox', { name: /^Factors$/i })).toBeInTheDocument();
+        // Phase 3: ExplorerPanel hosts Diagnostics + Preview range as primary
+        // surfaces; the legacy form controls (Extraction, Factors, Rotation,
+        // Flagging) all live inside the outer "Advanced configuration"
+        // accordion (collapsed by default).
+        expect(screen.getByText(/Diagnostics/i)).toBeInTheDocument();
+        expect(screen.getByText(/Preview range/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Advanced configuration/i })).toBeInTheDocument();
+        expect(screen.queryByRole('combobox', { name: /Extraction/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('combobox', { name: /^Factors$/i })).not.toBeInTheDocument();
         expect(screen.queryByRole('combobox', { name: /Rotation/i })).not.toBeInTheDocument();
         expect(screen.queryByRole('combobox', { name: /Flagging/i })).not.toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /Run Analysis/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /commit and interpret/i })).toBeInTheDocument();
+    });
+
+    it('reveals Extraction/Factors when the outer "Advanced configuration" accordion is opened', async () => {
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+
+        const user = userEvent.setup();
+        renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
+
+        // Open the outer ExplorerPanel "Advanced configuration" accordion to
+        // expose the legacy Extraction + Factors selectors.
+        await user.click(screen.getByRole('button', { name: /Advanced configuration/i }));
+
+        expect(await screen.findByRole('combobox', { name: /Extraction/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /^Factors$/i })).toBeInTheDocument();
     });
 
     it('reveals Rotation/Flagging when "Advanced settings" Accordion is opened (Wave C)', async () => {
@@ -353,8 +380,13 @@ describe('AnalysisPage', () => {
         const user = userEvent.setup();
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
 
-        // The Accordion trigger is a button; clicking it expands the panel
-        const advancedTrigger = screen.getByRole('button', { name: /Advanced settings/i });
+        // First open the outer "Advanced configuration" accordion (the
+        // ExplorerPanel slot wrapper), then the inner "Advanced settings"
+        // accordion that hosts Rotation/Flagging/Bootstrap.
+        await user.click(screen.getByRole('button', { name: /Advanced configuration/i }));
+        const advancedTrigger = await screen.findByRole('button', {
+            name: /Advanced settings/i,
+        });
         await user.click(advancedTrigger);
 
         // After expanding, Rotation + Flagging dropdowns appear
@@ -364,7 +396,7 @@ describe('AnalysisPage', () => {
         expect(screen.getByLabelText(/Run bootstrap stability/i)).toBeInTheDocument();
     });
 
-    it('factor dropdown is capped at eigenvalues.length - 1', () => {
+    it('factor dropdown is capped at eigenvalues.length - 1', async () => {
         mockEigenvaluesHook.mockReturnValue({
             data: { eigenvalues: [3.0, 1.5, 0.5], suggested_n_factors: 2 },
             isLoading: false,
@@ -374,15 +406,20 @@ describe('AnalysisPage', () => {
             refetch: vi.fn(),
         });
 
+        const user = userEvent.setup();
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
+
+        // The Factors selector now lives inside the outer "Advanced
+        // configuration" accordion — open it first.
+        await user.click(screen.getByRole('button', { name: /Advanced configuration/i }));
 
         // With 3 eigenvalues, maxFactors = min(3-1, 10) = 2
         // The factor dropdown should show 1 and 2 but not 3
-        const factorsSelect = screen.getByRole('combobox', { name: /^Factors$/i });
+        const factorsSelect = await screen.findByRole('combobox', { name: /^Factors$/i });
         expect(factorsSelect).toBeInTheDocument();
     });
 
-    it('disables controls during analysis run', () => {
+    it('disables the Commit-and-interpret CTA during an analysis run', () => {
         mockEigenvaluesHook.mockReturnValue({
             data: mockEigenvalues,
             isLoading: false,
@@ -399,10 +436,10 @@ describe('AnalysisPage', () => {
 
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
 
-        expect(screen.getByText(/Analyzing/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /commit and interpret/i })).toBeDisabled();
     });
 
-    it('shows empty state when no results yet', () => {
+    it('shows the ExplorerPanel surfaces when no run is loaded yet', () => {
         mockEigenvaluesHook.mockReturnValue({
             data: mockEigenvalues,
             isLoading: false,
@@ -414,7 +451,11 @@ describe('AnalysisPage', () => {
 
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
 
-        expect(screen.getByText(/Set parameters and run the analysis/i)).toBeInTheDocument();
+        // The legacy "Set parameters and run the analysis." copy was removed
+        // when the configuration card was replaced by ExplorerPanel.
+        // Diagnostics + Preview range are now the always-on landing surface.
+        expect(screen.getByText(/Diagnostics/i)).toBeInTheDocument();
+        expect(screen.getByText(/Preview range/i)).toBeInTheDocument();
     });
 
     it('does not show export button in explore phase', () => {
@@ -432,7 +473,7 @@ describe('AnalysisPage', () => {
         expect(screen.queryByText(/Export/i)).not.toBeInTheDocument();
     });
 
-    it('calls mutate with correct params when Run Analysis is clicked', async () => {
+    it('calls mutate with correct params when Commit-and-interpret is clicked', async () => {
         const mockMutate = vi.fn();
         mockEigenvaluesHook.mockReturnValue({
             data: mockEigenvalues,
@@ -450,7 +491,7 @@ describe('AnalysisPage', () => {
 
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
 
-        await userEvent.click(screen.getByRole('button', { name: /Run Analysis/i }));
+        await userEvent.click(screen.getByRole('button', { name: /commit and interpret/i }));
 
         expect(mockMutate).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -465,7 +506,7 @@ describe('AnalysisPage', () => {
         );
     });
 
-    it('shows parameter help descriptions', () => {
+    it('shows parameter help descriptions inside the "Advanced configuration" accordion', async () => {
         mockEigenvaluesHook.mockReturnValue({
             data: mockEigenvalues,
             isLoading: false,
@@ -475,15 +516,25 @@ describe('AnalysisPage', () => {
             refetch: vi.fn(),
         });
 
+        const user = userEvent.setup();
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
 
-        // Wave C: PCA + Factors help texts are primary-visible.
-        expect(screen.getByText(/PCA maximises explained variance/i)).toBeInTheDocument();
+        // Phase 3: every form-control help text moved inside the outer
+        // "Advanced configuration" accordion. Verify nothing leaks above the
+        // fold, then open the accordion and confirm PCA + Factors helpers are
+        // visible while Rotation/Flagging helpers stay nested in the inner
+        // "Advanced settings" accordion.
+        expect(screen.queryByText(/PCA maximises explained variance/i)).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /Advanced configuration/i }));
+
+        expect(await screen.findByText(/PCA maximises explained variance/i)).toBeInTheDocument();
         expect(
             screen.getByText(/Each factor represents a distinct viewpoint/i)
         ).toBeInTheDocument();
-        // Rotation + Flagging help texts now live inside the collapsed
-        // "Advanced settings" Accordion — not visible on initial render.
+        // Rotation + Flagging help texts still live inside the collapsed
+        // inner "Advanced settings" Accordion — not visible after only the
+        // outer accordion was opened.
         expect(
             screen.queryByText(/Varimax separates factors for simpler structure/i)
         ).not.toBeInTheDocument();
@@ -530,7 +581,9 @@ describe('AnalysisPage', () => {
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
 
         await waitFor(() => {
-            expect(screen.getByRole('button', { name: /run analysis/i })).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: /commit and interpret/i })
+            ).toBeInTheDocument();
         });
         // Interpret-phase marker is absent in explore mode.
         expect(screen.queryByTestId('interpret-phase')).not.toBeInTheDocument();
@@ -560,8 +613,10 @@ describe('AnalysisPage', () => {
         await waitFor(() => {
             expect(screen.getByTestId('interpret-phase')).toBeInTheDocument();
         });
-        // Configuration card is NOT rendered in interpret phase.
-        expect(screen.queryByRole('button', { name: /^run analysis$/i })).not.toBeInTheDocument();
+        // Explore-phase ExplorerPanel is NOT rendered in interpret phase.
+        expect(
+            screen.queryByRole('button', { name: /commit and interpret/i })
+        ).not.toBeInTheDocument();
     });
 
     it('bounces back to Explore when AnalysisHistoryPanel signals current-run deletion', async () => {
@@ -634,7 +689,7 @@ describe('AnalysisPage', () => {
         await waitFor(() => {
             expect(screen.queryByTestId('interpret-phase')).not.toBeInTheDocument();
         });
-        expect(screen.getByRole('button', { name: /run analysis/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /commit and interpret/i })).toBeInTheDocument();
     });
 
     it('navigates to interpret phase after a successful run', async () => {
@@ -679,7 +734,7 @@ describe('AnalysisPage', () => {
 
         renderWithProviders(<AnalysisPage />, { initialEntries: [ANALYSIS_PATH] });
 
-        await userEvent.click(screen.getByRole('button', { name: /run analysis/i }));
+        await userEvent.click(screen.getByRole('button', { name: /commit and interpret/i }));
 
         // The hook awaits the runs list, then routes — the marker appears once
         // the URL has flipped to interpret.

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -41,6 +41,14 @@ vi.mock('@/api/generated', () => ({
     getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey: vi.fn(() => [
         '/api/admin/studies/test-study/analysis/runs',
     ]),
+    // Preview-range mutation lives in useExplorePhase; idle stub is enough
+    // for AnalysisPage integration tests (no test triggers the action).
+    usePreviewRangeApiAdminStudiesSlugAnalysisPreviewRangePost: () => ({
+        mutateAsync: vi.fn().mockResolvedValue({ rows: [] }),
+        isPending: false,
+        isError: false,
+        error: null,
+    }),
     // FactorVoicesPanel renders inside the results tab and calls these hooks
     // — return idle/empty queries so the panel renders the empty state
     // without a real network call.
@@ -74,6 +82,9 @@ const ANALYSIS_PATH = '/app/test-project/studies/test-study/analysis';
 
 const mockEigenvalues: EigenvalueResult = {
     eigenvalues: [2.5, 1.2, 0.8, 0.5],
+    kaiser_n: 2,
+    parallel_analysis_n: 2,
+    velicer_map_n: 2,
     suggested_n_factors: 2,
 };
 

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -5,7 +5,6 @@ import { toast } from 'sonner';
 import type { TFunction } from 'i18next';
 import {
     ChartColumnStacked,
-    Play,
     Loader2,
     BarChart3,
     Grid3X3,
@@ -22,7 +21,7 @@ import {
 
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import { Button } from '@/components/ui/button';
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import {
     Accordion,
@@ -49,7 +48,7 @@ import {
 
 import { GuidanceCard } from '@/components/admin/GuidanceCard';
 import { EmptyStateContract } from '@/components/admin/EmptyStateContract';
-import { ScreePlot } from '@/components/admin/analysis/ScreePlot';
+import { ExplorerPanel } from '@/components/admin/analysis/ExplorerPanel';
 import { FactorLoadingsTable } from '@/components/admin/analysis/FactorLoadingsTable';
 import { FactorArraysView } from '@/components/admin/analysis/FactorArraysView';
 import { StatementsTable } from '@/components/admin/analysis/StatementsTable';
@@ -203,7 +202,6 @@ interface ExploreShellProps {
     onSelectHistoricalRun: (runId: number) => void;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSX shell complexity from the configuration card (extraction/factors selectors, advanced accordion with rotation/flagging/bootstrap, judgmental rotations sub-panel). All logic in useExplorePhase.
 function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellProps) {
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
@@ -216,90 +214,66 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                 icon={ChartColumnStacked}
             />
 
-            {/* Controls */}
-            <Card className="border-none shadow-sm bg-white rounded-2xl">
-                <CardHeader className="pb-3">
-                    <CardTitle className="text-lg font-black">
-                        {t('admin.analysis.configuration', 'Configuration')}
-                    </CardTitle>
-                    <CardDescription>
+            {/* Gate banners — kept above ExplorerPanel because they govern
+                whether the new diagnostics + preview-range surfaces should
+                even render. */}
+            {explore.isTooFewParticipants && (
+                <div
+                    className="flex items-center gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800"
+                    role="alert"
+                >
+                    <Info className="size-4 flex-shrink-0" aria-hidden="true" />
+                    {t(
+                        'admin.analysis.too_few_participants',
+                        'Need at least 2 completed participants to run analysis.'
+                    )}
+                </div>
+            )}
+
+            {explore.isEigenvalueError && (
+                <div
+                    className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800"
+                    role="alert"
+                >
+                    <AlertTriangle className="size-4 flex-shrink-0" aria-hidden="true" />
+                    <span className="flex-1">
                         {t(
-                            'admin.analysis.configuration_description',
-                            'Select extraction method, number of factors, and rotation'
+                            'admin.analysis.eigenvalue_error',
+                            'Failed to load analysis data. Please try again.'
                         )}
-                    </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-5">
-                    {explore.isTooFewParticipants && (
-                        <div
-                            className="flex items-center gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800"
-                            role="alert"
-                        >
-                            <Info className="size-4 flex-shrink-0" aria-hidden="true" />
-                            {t(
-                                'admin.analysis.too_few_participants',
-                                'Need at least 2 completed participants to run analysis.'
-                            )}
-                        </div>
-                    )}
+                    </span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={explore.handleRefetchEigenvalues}
+                        className="gap-1.5 shrink-0"
+                    >
+                        <RefreshCw className="size-3.5" aria-hidden="true" />
+                        {t('admin.analysis.retry', 'Retry')}
+                    </Button>
+                </div>
+            )}
 
-                    {explore.isEigenvalueError && (
-                        <div
-                            className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800"
-                            role="alert"
-                        >
-                            <AlertTriangle className="size-4 flex-shrink-0" aria-hidden="true" />
-                            <span className="flex-1">
-                                {t(
-                                    'admin.analysis.eigenvalue_error',
-                                    'Failed to load analysis data. Please try again.'
-                                )}
-                            </span>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={explore.handleRefetchEigenvalues}
-                                className="gap-1.5 shrink-0"
-                            >
-                                <RefreshCw className="size-3.5" aria-hidden="true" />
-                                {t('admin.analysis.retry', 'Retry')}
-                            </Button>
-                        </div>
-                    )}
+            {explore.eigenvaluesIsLoading && (
+                <div
+                    className="flex items-center justify-center py-8 text-slate-400"
+                    role="status"
+                    aria-live="polite"
+                >
+                    <Loader2 className="size-5 animate-spin mr-2" aria-hidden="true" />
+                    {t('admin.analysis.loading_eigenvalues', 'Loading eigenvalues...')}
+                </div>
+            )}
 
-                    {explore.eigenvaluesIsLoading && (
-                        <div
-                            className="flex items-center justify-center py-8 text-slate-400"
-                            role="status"
-                            aria-live="polite"
-                        >
-                            <Loader2 className="size-5 animate-spin mr-2" aria-hidden="true" />
-                            {t('admin.analysis.loading_eigenvalues', 'Loading eigenvalues...')}
-                        </div>
-                    )}
-
-                    {/* Scree plot + parameters: side-by-side on lg+ */}
-                    <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-6 items-start">
-                        {/* Scree plot */}
-                        {explore.hasEigenvalues &&
-                            explore.eigenvalues &&
-                            explore.suggestedNFactors !== undefined && (
-                                <ScreePlot
-                                    eigenvalues={explore.eigenvalues}
-                                    suggestedNFactors={explore.suggestedNFactors}
-                                    selectedNFactors={explore.nFactors}
-                                    onSelectNFactors={explore.setNFactors}
-                                />
-                            )}
-                        {!explore.hasEigenvalues && !explore.eigenvaluesIsLoading && <div />}
-
-                        {/* Parameters — Wave C: only Extraction + Facteurs are
-                            primary-visible. Rotation / Flagging / Bootstrap
-                            move into the "Advanced settings" Accordion below
-                            (audit REPORT.md finding 🔴3, when analysis IS
-                            possible). Reduces decision surface from 4 dropdowns
-                            + 4 rationale paragraphs to 2 dropdowns. */}
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3 lg:w-[320px]">
+            {/* Phase 3 ExplorerPanel — primary surfaces (Diagnostics, Preview
+                range) plus the legacy form controls routed through the
+                advancedContent slot. The "Commit and interpret" CTA is owned
+                by ExplorerPanel itself. */}
+            <ExplorerPanel
+                explore={explore}
+                advancedContent={
+                    <div className="space-y-5">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
                             <div className="space-y-1.5">
                                 <Label
                                     htmlFor="extraction-select"
@@ -363,383 +337,382 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                                 </p>
                             </div>
                         </div>
-                    </div>
 
-                    {/* Wave C — Advanced settings Accordion. Defaults open
-                        when the user previously chose non-default values
-                        (judgmental rotation, manual flagging, or bootstrap),
-                        otherwise closed so most studies start clean. */}
-                    <Accordion
-                        type="multiple"
-                        defaultValue={
-                            explore.rotation !== 'varimax' ||
-                            explore.flagging !== 'auto' ||
-                            explore.bootstrapEnabled
-                                ? ['advanced']
-                                : []
-                        }
-                    >
-                        <AccordionItem
-                            value="advanced"
-                            className="border border-slate-200 rounded-xl overflow-hidden bg-slate-50/30"
+                        {/* Wave C — inner Advanced settings Accordion. Defaults
+                            open when the user previously chose non-default
+                            values (judgmental rotation, manual flagging, or
+                            bootstrap), otherwise closed so most studies start
+                            clean. */}
+                        <Accordion
+                            type="multiple"
+                            defaultValue={
+                                explore.rotation !== 'varimax' ||
+                                explore.flagging !== 'auto' ||
+                                explore.bootstrapEnabled
+                                    ? ['advanced']
+                                    : []
+                            }
                         >
-                            <AccordionTrigger className="px-4 py-3 hover:no-underline data-[state=open]:border-b data-[state=open]:border-slate-200">
-                                <div className="flex flex-col items-start text-left">
-                                    <span className="text-sm font-bold text-slate-700">
-                                        {t('admin.analysis.advanced.title', 'Advanced settings')}
-                                    </span>
-                                    <span className="text-xs font-medium text-slate-500 mt-0.5">
-                                        {t(
-                                            'admin.analysis.advanced.summary',
-                                            'Rotation: {{rotation}} · Flagging: {{flagging}} · Bootstrap: {{bootstrap}}',
-                                            {
-                                                rotation:
-                                                    explore.rotation === 'varimax'
-                                                        ? t('admin.analysis.varimax', 'Varimax')
-                                                        : explore.rotation === 'none'
-                                                          ? t('admin.analysis.none', 'None')
-                                                          : t(
-                                                                'admin.analysis.rotation.judgmental.short',
-                                                                'Judgmental'
-                                                            ),
-                                                flagging:
-                                                    explore.flagging === 'auto'
-                                                        ? t('admin.analysis.auto', 'Auto')
-                                                        : t('admin.analysis.manual', 'Manual'),
-                                                bootstrap: explore.bootstrapEnabled
-                                                    ? t(
-                                                          'admin.analysis.advanced.bootstrap_on',
-                                                          '{{n}} iterations',
-                                                          { n: explore.bootstrapIterations }
-                                                      )
-                                                    : t(
-                                                          'admin.analysis.advanced.bootstrap_off',
-                                                          'off'
-                                                      ),
-                                            }
-                                        )}
-                                    </span>
-                                </div>
-                            </AccordionTrigger>
-                            <AccordionContent>
-                                <div className="px-4 py-4 space-y-5">
-                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
-                                        <div className="space-y-1.5">
-                                            <Label
-                                                htmlFor="rotation-select"
-                                                className="text-2xs font-black text-slate-500"
-                                            >
-                                                {t('admin.analysis.rotation_method', 'Rotation')}
-                                            </Label>
-                                            <Select
-                                                value={explore.rotation}
-                                                onValueChange={explore.setRotation}
-                                                disabled={explore.isRunning}
-                                            >
-                                                <SelectTrigger id="rotation-select">
-                                                    <SelectValue />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    <SelectItem value="varimax">
-                                                        {t('admin.analysis.varimax', 'Varimax')}
-                                                    </SelectItem>
-                                                    <SelectItem value="none">
-                                                        {t('admin.analysis.none', 'None')}
-                                                    </SelectItem>
-                                                    <SelectItem value="judgmental">
-                                                        {t(
-                                                            'admin.analysis.rotation.judgmental.label',
-                                                            'Judgmental (manual)'
-                                                        )}
-                                                    </SelectItem>
-                                                </SelectContent>
-                                            </Select>
-                                            <p className="text-xs text-muted-foreground leading-snug">
-                                                {t(
-                                                    'admin.analysis.help_rotation',
-                                                    'Varimax maximizes the separation between factors, producing simpler structure. No rotation preserves the original mathematical solution. Judgmental lets you specify rotation angles manually.'
-                                                )}
-                                            </p>
-                                        </div>
-
-                                        <div className="space-y-1.5">
-                                            <Label
-                                                htmlFor="flagging-select"
-                                                className="text-2xs font-black text-slate-500"
-                                            >
-                                                {t('admin.analysis.flagging_method', 'Flagging')}
-                                            </Label>
-                                            <Select
-                                                value={explore.flagging}
-                                                onValueChange={(v) => {
-                                                    explore.setFlagging(v as 'auto' | 'manual');
-                                                }}
-                                                disabled={explore.isRunning}
-                                            >
-                                                <SelectTrigger id="flagging-select">
-                                                    <SelectValue />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    <SelectItem value="auto">
-                                                        {t('admin.analysis.auto', 'Auto')}
-                                                    </SelectItem>
-                                                    <SelectItem value="manual">
-                                                        {t('admin.analysis.manual', 'Manual')}
-                                                    </SelectItem>
-                                                </SelectContent>
-                                            </Select>
-                                            <p className="text-xs text-muted-foreground leading-snug">
-                                                {t(
-                                                    'admin.analysis.help_flagging',
-                                                    'Auto flags participants whose loading exceeds the significance threshold on exactly one factor. Manual lets you override flagging based on your own judgment.'
-                                                )}
-                                            </p>
-                                        </div>
-                                    </div>
-
-                                    {/* Judgmental rotations sub-panel — visible only when rotation === 'judgmental' */}
-                                    {explore.rotation === 'judgmental' && (
-                                        <div className="space-y-3 pt-2 border-t border-slate-100">
-                                            <div>
-                                                <h3 className="text-sm font-black text-slate-800">
-                                                    {t(
-                                                        'admin.analysis.manual_rotations.title',
-                                                        'Manual rotations'
-                                                    )}
-                                                </h3>
-                                                <p className="text-xs text-muted-foreground leading-snug mt-1">
-                                                    {t(
-                                                        'admin.analysis.manual_rotations.helper',
-                                                        "Specify rotations as 'rotate factor F by Δ° around factor G'. Rotations are applied in order. Used to align factors with substantively-meaningful positions (Brown 1980; Watts & Stenner 2012)."
-                                                    )}
-                                                </p>
-                                            </div>
-
-                                            {explore.manualRotations.length === 0 && (
-                                                <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
-                                                    {t(
-                                                        'admin.analysis.manual_rotations.empty',
-                                                        'Add at least one rotation to run the analysis.'
-                                                    )}
-                                                </p>
+                            <AccordionItem
+                                value="advanced"
+                                className="border border-slate-200 rounded-xl overflow-hidden bg-slate-50/30"
+                            >
+                                <AccordionTrigger className="px-4 py-3 hover:no-underline data-[state=open]:border-b data-[state=open]:border-slate-200">
+                                    <div className="flex flex-col items-start text-left">
+                                        <span className="text-sm font-bold text-slate-700">
+                                            {t(
+                                                'admin.analysis.advanced.title',
+                                                'Advanced settings'
                                             )}
-
-                                            <ul className="space-y-2">
-                                                {explore.manualRotations.map((mr, idx) => (
-                                                    <li
-                                                        key={mr.id}
-                                                        className="flex flex-wrap items-center gap-2"
-                                                    >
-                                                        <span className="text-xs text-slate-600">
-                                                            {t(
-                                                                'admin.analysis.manual_rotations.factor_a_label',
-                                                                'Rotate factor'
-                                                            )}
-                                                        </span>
-                                                        <Input
-                                                            type="number"
-                                                            min={1}
-                                                            max={explore.nFactors}
-                                                            step={1}
-                                                            value={mr.factor_a}
-                                                            onChange={(e) =>
-                                                                explore.updateManualRotation(idx, {
-                                                                    factor_a: Number(
-                                                                        e.target.value
-                                                                    ),
-                                                                })
-                                                            }
-                                                            disabled={explore.isRunning}
-                                                            className="w-16 h-8 text-sm"
-                                                            aria-label={t(
-                                                                'admin.analysis.manual_rotations.factor_a_label',
-                                                                'Rotate factor'
-                                                            )}
-                                                        />
-                                                        <span className="text-xs text-slate-600">
-                                                            {t(
-                                                                'admin.analysis.manual_rotations.angle_label',
-                                                                'by'
-                                                            )}
-                                                        </span>
-                                                        <Input
-                                                            type="number"
-                                                            min={-180}
-                                                            max={180}
-                                                            step={1}
-                                                            value={mr.angle_deg}
-                                                            onChange={(e) =>
-                                                                explore.updateManualRotation(idx, {
-                                                                    angle_deg: Number(
-                                                                        e.target.value
-                                                                    ),
-                                                                })
-                                                            }
-                                                            disabled={explore.isRunning}
-                                                            className="w-20 h-8 text-sm"
-                                                            aria-label={t(
-                                                                'admin.analysis.manual_rotations.angle_label',
-                                                                'by'
-                                                            )}
-                                                        />
-                                                        <span className="text-xs text-slate-600">
-                                                            °{' '}
-                                                            {t(
-                                                                'admin.analysis.manual_rotations.factor_b_label',
-                                                                'around factor'
-                                                            )}
-                                                        </span>
-                                                        <Input
-                                                            type="number"
-                                                            min={1}
-                                                            max={explore.nFactors}
-                                                            step={1}
-                                                            value={mr.factor_b}
-                                                            onChange={(e) =>
-                                                                explore.updateManualRotation(idx, {
-                                                                    factor_b: Number(
-                                                                        e.target.value
-                                                                    ),
-                                                                })
-                                                            }
-                                                            disabled={explore.isRunning}
-                                                            className="w-16 h-8 text-sm"
-                                                            aria-label={t(
-                                                                'admin.analysis.manual_rotations.factor_b_label',
-                                                                'around factor'
-                                                            )}
-                                                        />
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="sm"
-                                                            onClick={() =>
-                                                                explore.removeManualRotation(idx)
-                                                            }
-                                                            disabled={explore.isRunning}
-                                                            aria-label={t(
-                                                                'admin.analysis.manual_rotations.remove_aria',
-                                                                'Remove rotation'
-                                                            )}
-                                                            className="h-8 w-8 p-0"
-                                                        >
-                                                            <X
-                                                                className="size-4"
-                                                                aria-hidden="true"
-                                                            />
-                                                        </Button>
-                                                    </li>
-                                                ))}
-                                            </ul>
-
-                                            <Button
-                                                type="button"
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={explore.addManualRotation}
-                                                disabled={explore.isRunning}
-                                                className="gap-1.5"
-                                            >
-                                                <Plus className="size-3.5" aria-hidden="true" />
-                                                {t(
-                                                    'admin.analysis.manual_rotations.add',
-                                                    'Add rotation'
-                                                )}
-                                            </Button>
-                                        </div>
-                                    )}
-
-                                    {/* Bootstrap stability toggle (Zabala & Pascual 2016) */}
-                                    <div className="space-y-3 pt-2 border-t border-slate-100">
-                                        <div className="flex items-start gap-3">
-                                            <input
-                                                id="bootstrap-toggle"
-                                                type="checkbox"
-                                                checked={explore.bootstrapEnabled}
-                                                onChange={(e) =>
-                                                    explore.setBootstrapEnabled(e.target.checked)
+                                        </span>
+                                        <span className="text-xs font-medium text-slate-500 mt-0.5">
+                                            {t(
+                                                'admin.analysis.advanced.summary',
+                                                'Rotation: {{rotation}} · Flagging: {{flagging}} · Bootstrap: {{bootstrap}}',
+                                                {
+                                                    rotation:
+                                                        explore.rotation === 'varimax'
+                                                            ? t('admin.analysis.varimax', 'Varimax')
+                                                            : explore.rotation === 'none'
+                                                              ? t('admin.analysis.none', 'None')
+                                                              : t(
+                                                                    'admin.analysis.rotation.judgmental.short',
+                                                                    'Judgmental'
+                                                                ),
+                                                    flagging:
+                                                        explore.flagging === 'auto'
+                                                            ? t('admin.analysis.auto', 'Auto')
+                                                            : t('admin.analysis.manual', 'Manual'),
+                                                    bootstrap: explore.bootstrapEnabled
+                                                        ? t(
+                                                              'admin.analysis.advanced.bootstrap_on',
+                                                              '{{n}} iterations',
+                                                              { n: explore.bootstrapIterations }
+                                                          )
+                                                        : t(
+                                                              'admin.analysis.advanced.bootstrap_off',
+                                                              'off'
+                                                          ),
                                                 }
-                                                disabled={explore.isRunning}
-                                                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
-                                            />
-                                            <div className="flex-1 space-y-1.5">
+                                            )}
+                                        </span>
+                                    </div>
+                                </AccordionTrigger>
+                                <AccordionContent>
+                                    <div className="px-4 py-4 space-y-5">
+                                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
+                                            <div className="space-y-1.5">
                                                 <Label
-                                                    htmlFor="bootstrap-toggle"
-                                                    className="text-sm font-black text-slate-800 cursor-pointer"
-                                                >
-                                                    {t(
-                                                        'admin.analysis.bootstrap.toggle_label',
-                                                        'Run bootstrap stability'
-                                                    )}
-                                                </Label>
-                                                <p className="text-xs text-muted-foreground leading-snug">
-                                                    {t(
-                                                        'admin.analysis.bootstrap.helper',
-                                                        'Optional. Bootstrap resamples your Q-sorts with replacement and re-runs the analysis B times to estimate standard errors on z-scores. Useful when you want confidence intervals on factor scores (Zabala & Pascual 2016).'
-                                                    )}
-                                                </p>
-                                            </div>
-                                        </div>
-
-                                        {explore.bootstrapEnabled && (
-                                            <div className="flex flex-wrap items-center gap-2 pl-7">
-                                                <Label
-                                                    htmlFor="bootstrap-iterations"
+                                                    htmlFor="rotation-select"
                                                     className="text-2xs font-black text-slate-500"
                                                 >
                                                     {t(
-                                                        'admin.analysis.bootstrap.iterations_label',
-                                                        'Iterations (B)'
+                                                        'admin.analysis.rotation_method',
+                                                        'Rotation'
                                                     )}
                                                 </Label>
-                                                <Input
-                                                    id="bootstrap-iterations"
-                                                    type="number"
-                                                    min={100}
-                                                    max={5000}
-                                                    step={100}
-                                                    value={explore.bootstrapIterations}
+                                                <Select
+                                                    value={explore.rotation}
+                                                    onValueChange={explore.setRotation}
+                                                    disabled={explore.isRunning}
+                                                >
+                                                    <SelectTrigger id="rotation-select">
+                                                        <SelectValue />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        <SelectItem value="varimax">
+                                                            {t('admin.analysis.varimax', 'Varimax')}
+                                                        </SelectItem>
+                                                        <SelectItem value="none">
+                                                            {t('admin.analysis.none', 'None')}
+                                                        </SelectItem>
+                                                        <SelectItem value="judgmental">
+                                                            {t(
+                                                                'admin.analysis.rotation.judgmental.label',
+                                                                'Judgmental (manual)'
+                                                            )}
+                                                        </SelectItem>
+                                                    </SelectContent>
+                                                </Select>
+                                                <p className="text-xs text-muted-foreground leading-snug">
+                                                    {t(
+                                                        'admin.analysis.help_rotation',
+                                                        'Varimax maximizes the separation between factors, producing simpler structure. No rotation preserves the original mathematical solution. Judgmental lets you specify rotation angles manually.'
+                                                    )}
+                                                </p>
+                                            </div>
+
+                                            <div className="space-y-1.5">
+                                                <Label
+                                                    htmlFor="flagging-select"
+                                                    className="text-2xs font-black text-slate-500"
+                                                >
+                                                    {t(
+                                                        'admin.analysis.flagging_method',
+                                                        'Flagging'
+                                                    )}
+                                                </Label>
+                                                <Select
+                                                    value={explore.flagging}
+                                                    onValueChange={(v) => {
+                                                        explore.setFlagging(v as 'auto' | 'manual');
+                                                    }}
+                                                    disabled={explore.isRunning}
+                                                >
+                                                    <SelectTrigger id="flagging-select">
+                                                        <SelectValue />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        <SelectItem value="auto">
+                                                            {t('admin.analysis.auto', 'Auto')}
+                                                        </SelectItem>
+                                                        <SelectItem value="manual">
+                                                            {t('admin.analysis.manual', 'Manual')}
+                                                        </SelectItem>
+                                                    </SelectContent>
+                                                </Select>
+                                                <p className="text-xs text-muted-foreground leading-snug">
+                                                    {t(
+                                                        'admin.analysis.help_flagging',
+                                                        'Auto flags participants whose loading exceeds the significance threshold on exactly one factor. Manual lets you override flagging based on your own judgment.'
+                                                    )}
+                                                </p>
+                                            </div>
+                                        </div>
+
+                                        {/* Judgmental rotations sub-panel — visible only when rotation === 'judgmental' */}
+                                        {explore.rotation === 'judgmental' && (
+                                            <div className="space-y-3 pt-2 border-t border-slate-100">
+                                                <div>
+                                                    <h3 className="text-sm font-black text-slate-800">
+                                                        {t(
+                                                            'admin.analysis.manual_rotations.title',
+                                                            'Manual rotations'
+                                                        )}
+                                                    </h3>
+                                                    <p className="text-xs text-muted-foreground leading-snug mt-1">
+                                                        {t(
+                                                            'admin.analysis.manual_rotations.helper',
+                                                            "Specify rotations as 'rotate factor F by Δ° around factor G'. Rotations are applied in order. Used to align factors with substantively-meaningful positions (Brown 1980; Watts & Stenner 2012)."
+                                                        )}
+                                                    </p>
+                                                </div>
+
+                                                {explore.manualRotations.length === 0 && (
+                                                    <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+                                                        {t(
+                                                            'admin.analysis.manual_rotations.empty',
+                                                            'Add at least one rotation to run the analysis.'
+                                                        )}
+                                                    </p>
+                                                )}
+
+                                                <ul className="space-y-2">
+                                                    {explore.manualRotations.map((mr, idx) => (
+                                                        <li
+                                                            key={mr.id}
+                                                            className="flex flex-wrap items-center gap-2"
+                                                        >
+                                                            <span className="text-xs text-slate-600">
+                                                                {t(
+                                                                    'admin.analysis.manual_rotations.factor_a_label',
+                                                                    'Rotate factor'
+                                                                )}
+                                                            </span>
+                                                            <Input
+                                                                type="number"
+                                                                min={1}
+                                                                max={explore.nFactors}
+                                                                step={1}
+                                                                value={mr.factor_a}
+                                                                onChange={(e) =>
+                                                                    explore.updateManualRotation(
+                                                                        idx,
+                                                                        {
+                                                                            factor_a: Number(
+                                                                                e.target.value
+                                                                            ),
+                                                                        }
+                                                                    )
+                                                                }
+                                                                disabled={explore.isRunning}
+                                                                className="w-16 h-8 text-sm"
+                                                                aria-label={t(
+                                                                    'admin.analysis.manual_rotations.factor_a_label',
+                                                                    'Rotate factor'
+                                                                )}
+                                                            />
+                                                            <span className="text-xs text-slate-600">
+                                                                {t(
+                                                                    'admin.analysis.manual_rotations.angle_label',
+                                                                    'by'
+                                                                )}
+                                                            </span>
+                                                            <Input
+                                                                type="number"
+                                                                min={-180}
+                                                                max={180}
+                                                                step={1}
+                                                                value={mr.angle_deg}
+                                                                onChange={(e) =>
+                                                                    explore.updateManualRotation(
+                                                                        idx,
+                                                                        {
+                                                                            angle_deg: Number(
+                                                                                e.target.value
+                                                                            ),
+                                                                        }
+                                                                    )
+                                                                }
+                                                                disabled={explore.isRunning}
+                                                                className="w-20 h-8 text-sm"
+                                                                aria-label={t(
+                                                                    'admin.analysis.manual_rotations.angle_label',
+                                                                    'by'
+                                                                )}
+                                                            />
+                                                            <span className="text-xs text-slate-600">
+                                                                °{' '}
+                                                                {t(
+                                                                    'admin.analysis.manual_rotations.factor_b_label',
+                                                                    'around factor'
+                                                                )}
+                                                            </span>
+                                                            <Input
+                                                                type="number"
+                                                                min={1}
+                                                                max={explore.nFactors}
+                                                                step={1}
+                                                                value={mr.factor_b}
+                                                                onChange={(e) =>
+                                                                    explore.updateManualRotation(
+                                                                        idx,
+                                                                        {
+                                                                            factor_b: Number(
+                                                                                e.target.value
+                                                                            ),
+                                                                        }
+                                                                    )
+                                                                }
+                                                                disabled={explore.isRunning}
+                                                                className="w-16 h-8 text-sm"
+                                                                aria-label={t(
+                                                                    'admin.analysis.manual_rotations.factor_b_label',
+                                                                    'around factor'
+                                                                )}
+                                                            />
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                onClick={() =>
+                                                                    explore.removeManualRotation(
+                                                                        idx
+                                                                    )
+                                                                }
+                                                                disabled={explore.isRunning}
+                                                                aria-label={t(
+                                                                    'admin.analysis.manual_rotations.remove_aria',
+                                                                    'Remove rotation'
+                                                                )}
+                                                                className="h-8 w-8 p-0"
+                                                            >
+                                                                <X
+                                                                    className="size-4"
+                                                                    aria-hidden="true"
+                                                                />
+                                                            </Button>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+
+                                                <Button
+                                                    type="button"
+                                                    variant="outline"
+                                                    size="sm"
+                                                    onClick={explore.addManualRotation}
+                                                    disabled={explore.isRunning}
+                                                    className="gap-1.5"
+                                                >
+                                                    <Plus className="size-3.5" aria-hidden="true" />
+                                                    {t(
+                                                        'admin.analysis.manual_rotations.add',
+                                                        'Add rotation'
+                                                    )}
+                                                </Button>
+                                            </div>
+                                        )}
+
+                                        {/* Bootstrap stability toggle (Zabala & Pascual 2016) */}
+                                        <div className="space-y-3 pt-2 border-t border-slate-100">
+                                            <div className="flex items-start gap-3">
+                                                <input
+                                                    id="bootstrap-toggle"
+                                                    type="checkbox"
+                                                    checked={explore.bootstrapEnabled}
                                                     onChange={(e) =>
-                                                        explore.setBootstrapIterations(
-                                                            Number(e.target.value)
+                                                        explore.setBootstrapEnabled(
+                                                            e.target.checked
                                                         )
                                                     }
                                                     disabled={explore.isRunning}
-                                                    className="w-24 h-8 text-sm"
+                                                    className="mt-0.5 h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
                                                 />
+                                                <div className="flex-1 space-y-1.5">
+                                                    <Label
+                                                        htmlFor="bootstrap-toggle"
+                                                        className="text-sm font-black text-slate-800 cursor-pointer"
+                                                    >
+                                                        {t(
+                                                            'admin.analysis.bootstrap.toggle_label',
+                                                            'Run bootstrap stability'
+                                                        )}
+                                                    </Label>
+                                                    <p className="text-xs text-muted-foreground leading-snug">
+                                                        {t(
+                                                            'admin.analysis.bootstrap.helper',
+                                                            'Optional. Bootstrap resamples your Q-sorts with replacement and re-runs the analysis B times to estimate standard errors on z-scores. Useful when you want confidence intervals on factor scores (Zabala & Pascual 2016).'
+                                                        )}
+                                                    </p>
+                                                </div>
                                             </div>
-                                        )}
-                                    </div>
-                                </div>
-                            </AccordionContent>
-                        </AccordionItem>
-                    </Accordion>
 
-                    {/* Action buttons — visually separated */}
-                    <div className="flex items-center gap-3 pt-1 border-t border-slate-100">
-                        <Button
-                            onClick={explore.handleRunAnalysis}
-                            disabled={
-                                explore.isRunning ||
-                                !explore.hasEigenvalues ||
-                                explore.isJudgmentalWithoutRotations
-                            }
-                            className="gap-2"
-                        >
-                            {explore.isRunning ? (
-                                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                            ) : (
-                                <Play className="size-4" aria-hidden="true" />
-                            )}
-                            {explore.isRunning
-                                ? explore.bootstrapEnabled
-                                    ? t('admin.analysis.bootstrap.running', 'Running bootstrap…')
-                                    : t('admin.analysis.running', 'Analyzing...')
-                                : t('admin.analysis.run', 'Run Analysis')}
-                        </Button>
+                                            {explore.bootstrapEnabled && (
+                                                <div className="flex flex-wrap items-center gap-2 pl-7">
+                                                    <Label
+                                                        htmlFor="bootstrap-iterations"
+                                                        className="text-2xs font-black text-slate-500"
+                                                    >
+                                                        {t(
+                                                            'admin.analysis.bootstrap.iterations_label',
+                                                            'Iterations (B)'
+                                                        )}
+                                                    </Label>
+                                                    <Input
+                                                        id="bootstrap-iterations"
+                                                        type="number"
+                                                        min={100}
+                                                        max={5000}
+                                                        step={100}
+                                                        value={explore.bootstrapIterations}
+                                                        onChange={(e) =>
+                                                            explore.setBootstrapIterations(
+                                                                Number(e.target.value)
+                                                            )
+                                                        }
+                                                        disabled={explore.isRunning}
+                                                        className="w-24 h-8 text-sm"
+                                                    />
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                </AccordionContent>
+                            </AccordionItem>
+                        </Accordion>
                     </div>
-                </CardContent>
-            </Card>
+                }
+            />
 
             {/* Analysis history */}
             <AnalysisHistoryPanel
@@ -749,20 +722,6 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                     if (run) onSelectHistoricalRun(run.id);
                 }}
             />
-
-            {/* Empty state — explore phase always shows this when eigenvalues
-                are loaded (no result has been committed in this URL yet). */}
-            {explore.hasEigenvalues && !explore.isRunning && (
-                <div className="text-center py-12 text-slate-400">
-                    <ChartColumnStacked className="size-12 mx-auto mb-3 opacity-30" />
-                    <p className="text-sm">
-                        {t(
-                            'admin.analysis.empty_state',
-                            'Configure parameters above and click "Run Analysis" to extract factors from your Q-sort data.'
-                        )}
-                    </p>
-                </div>
-            )}
         </div>
     );
 }

--- a/frontend/src/utils/tuckerPhi.test.ts
+++ b/frontend/src/utils/tuckerPhi.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { tuckerPhi, matchFactorsByPhi } from './tuckerPhi';
+
+describe('tuckerPhi', () => {
+    it('returns 1 for identical vectors', () => {
+        expect(tuckerPhi([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 5);
+    });
+
+    it('returns -1 for opposite vectors', () => {
+        expect(tuckerPhi([1, 2, 3], [-1, -2, -3])).toBeCloseTo(-1, 5);
+    });
+
+    it('returns 0 for orthogonal vectors', () => {
+        expect(tuckerPhi([1, 0], [0, 1])).toBeCloseTo(0, 5);
+    });
+
+    it('returns 0 for zero vectors (degenerate)', () => {
+        expect(tuckerPhi([0, 0, 0], [1, 2, 3])).toBe(0);
+    });
+
+    it('throws on length mismatch', () => {
+        expect(() => tuckerPhi([1, 2], [1, 2, 3])).toThrow(/length mismatch/);
+    });
+});
+
+describe('matchFactorsByPhi', () => {
+    it('matches identical solutions one-to-one', () => {
+        const a = [
+            [1, 0],
+            [0, 1],
+            [1, 0],
+        ]; // 3 statements x 2 factors
+        const b = [
+            [1, 0],
+            [0, 1],
+            [1, 0],
+        ];
+        const matches = matchFactorsByPhi(a, b);
+        expect(matches).toHaveLength(2);
+        expect(matches[0]).toMatchObject({ aIndex: 0, bIndex: 0 });
+        expect(matches[0]?.phi).toBeCloseTo(1, 5);
+        expect(matches[1]).toMatchObject({ aIndex: 1, bIndex: 1 });
+        expect(matches[1]?.phi).toBeCloseTo(1, 5);
+    });
+
+    it('preserves sign — flipped factor matches with negative phi', () => {
+        const a = [
+            [1, 0],
+            [0, 1],
+        ];
+        const b = [
+            [-1, 0],
+            [0, 1],
+        ]; // first factor sign-flipped
+        const matches = matchFactorsByPhi(a, b);
+        expect(matches[0]).toMatchObject({ aIndex: 0, bIndex: 0 });
+        expect(matches[0]?.phi).toBeCloseTo(-1, 5);
+    });
+
+    it('handles different n_factors by leaving extra columns unmatched', () => {
+        const a = [
+            [1, 0],
+            [0, 1],
+        ];
+        const b = [
+            [1, 0, 0],
+            [0, 1, 0],
+        ];
+        const matches = matchFactorsByPhi(a, b);
+        expect(matches).toHaveLength(2); // a has 2 factors → 2 matches
+    });
+
+    it('returns empty array on empty input', () => {
+        expect(matchFactorsByPhi([], [])).toEqual([]);
+    });
+
+    it('greedy assignment does not reuse a B factor', () => {
+        // Two identical A factors; B has only one. The first A wins it; the
+        // second A finds no remaining B factor and gets no match.
+        const a = [[1, 1]]; // 1 statement x 2 factors, both identical
+        const b = [[1]]; // 1 statement x 1 factor
+        const matches = matchFactorsByPhi(a, b);
+        expect(matches).toHaveLength(1);
+        expect(matches[0]).toMatchObject({ aIndex: 0, bIndex: 0 });
+    });
+});

--- a/frontend/src/utils/tuckerPhi.ts
+++ b/frontend/src/utils/tuckerPhi.ts
@@ -1,0 +1,72 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Tucker's congruence coefficient (φ) — normalised dot product over
+ * z-score (or loadings) vectors. Used by the Compare panel (PR 5) to
+ * align factors across two analysis runs and detect ambiguous matches.
+ */
+export function tuckerPhi(a: readonly number[], b: readonly number[]): number {
+    if (a.length !== b.length) {
+        throw new Error(`tuckerPhi: length mismatch (${a.length} vs ${b.length})`);
+    }
+    let dot = 0;
+    let na = 0;
+    let nb = 0;
+    for (let i = 0; i < a.length; i++) {
+        const x = a[i] ?? 0;
+        const y = b[i] ?? 0;
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if (na === 0 || nb === 0) return 0;
+    return dot / Math.sqrt(na * nb);
+}
+
+export interface FactorMatch {
+    aIndex: number; // 0-based factor index in run A
+    bIndex: number; // 0-based factor index in run B
+    phi: number; // sign-preserved (negative for flipped match)
+}
+
+/**
+ * Match factors of run A to factors of run B by maximum |φ|.
+ * Greedy assignment: for each factor of A in order, pick the unused
+ * factor of B with the highest |φ|. Sign of φ is preserved (a flipped
+ * match has negative φ).
+ *
+ * `aMatrix` and `bMatrix` are statement-by-factor (rows = statements,
+ * cols = factors). The number of statements must match (length-mismatch
+ * raises in tuckerPhi).
+ */
+export function matchFactorsByPhi(
+    aMatrix: readonly (readonly number[])[],
+    bMatrix: readonly (readonly number[])[]
+): FactorMatch[] {
+    if (aMatrix.length === 0 || bMatrix.length === 0) return [];
+    const nFactorsA = aMatrix[0]?.length ?? 0;
+    const nFactorsB = bMatrix[0]?.length ?? 0;
+    const used = new Set<number>();
+    const matches: FactorMatch[] = [];
+    for (let i = 0; i < nFactorsA; i++) {
+        const aCol = aMatrix.map((row) => row[i] ?? 0);
+        let best: FactorMatch | null = null;
+        for (let j = 0; j < nFactorsB; j++) {
+            if (used.has(j)) continue;
+            const bCol = bMatrix.map((row) => row[j] ?? 0);
+            const phi = tuckerPhi(aCol, bCol);
+            if (best === null || Math.abs(phi) > Math.abs(best.phi)) {
+                best = { aIndex: i, bIndex: j, phi };
+            }
+        }
+        if (best !== null) {
+            used.add(best.bIndex);
+            matches.push(best);
+        }
+    }
+    return matches;
+}


### PR DESCRIPTION
## Summary

Phase 3 of the interpretive-workspace plan. Replaces the legacy configuration card on the Explore phase with a diagnostics-first surface.

- **Diagnostics card** — scree plot + Kaiser / Parallel analysis / Velicer's MAP indicators with the Watts & Stenner (2012) advisory framing ("statistical criteria are advisory; Q-method retention also depends on interpretability and stability").
- **Preview-range table** — clickable per-k summary populated automatically on PCA + varimax. Shows cumulative variance, % flagged, # distinguishing, # cross-loaders, min defining sorts; ⚠ badge on rows with an empty factor (over-factorisation).
- **Advanced configuration** — legacy form controls (extraction / rotation / flagging / bootstrap / manual flags / manual rotations) preserved verbatim, accessed via the panel's accordion slot.
- **Commit and interpret** — single CTA replacing the legacy "Run analysis" button; transitions to the Interpret phase via the existing \`onCommit\` handoff.
- **Disabled gate** — when extraction is centroid or rotation is judgmental, the preview-range card displays an honest message ("PCA + varimax only — these methods are path-dependent; commit a real run to inspect").
- **Tucker's φ utility** — \`tuckerPhi\` + \`matchFactorsByPhi\` helpers built early (used in PR 5 for run comparison).

Spec: \`docs/superpowers/specs/2026-04-29-analysis-module-improvements-design.md\` §4.
Plan: \`docs/superpowers/plans/2026-04-29-analysis-interpretive-workspace.md\` Phase 3.

## Test plan
- [x] tuckerPhi + matchFactorsByPhi unit tests (10 tests)
- [x] ScreeWithDiagnostics component tests (3)
- [x] PreviewRangeTable component tests (5)
- [x] useExplorePhase Phase 3 sub-suite (7 new tests on top of 24 baseline = 31 total)
- [x] ExplorerPanel composition tests (10, including auto-fetch behaviour and stale-rows race regression)
- [x] AnalysisPage integration tests (18, +1 on baseline for the new Advanced accordion path)
- [x] Mid-phase code-reviewer pass: APPROVE_WITH_NITS; both Important findings (eigenvalues gate, mid-flight race) addressed in commit \`d7387b0\` before push
- [x] \`make ci\` green
- [x] Manual smoke deferred — UI reuses existing primitives; behaviour covered by tests

## Known follow-ups (deferred)
- \`ScreePlot\` prop \`suggestedNFactors\` is now bound to Kaiser's value; renaming to \`markerNFactors\` would clarify semantics. Cosmetic, not behavioural.
- The form-state controls passed via \`advancedContent\` slot still live inside ExploreShell. A future cleanup could move them into ExplorerPanel directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)