### PR TITLE
feat(analysis): factor canvas — per-factor focus mode + quote picker (phase 4/5)

### DIFF
--- a/frontend/e2e/admin/analysis-workflow.spec.ts
+++ b/frontend/e2e/admin/analysis-workflow.spec.ts
@@ -86,11 +86,16 @@ test('full analysis workflow: run → results → history', async ({ page, testD
     // The button stays disabled while the analysis runs (spinner replaces icon).
     await expect(runButton).toBeDisabled({ timeout: 5_000 });
 
-    // Wait for the results card to render — the Tabs component appears once
-    // analysisMutation.isSuccess fires and setResult() is called.
-    // We wait for the "Loadings" tab-trigger (first tab) as the readiness signal.
+    // Wait for the Interpret phase to render. After Phase 4, the page lands
+    // on Focus mode by default (FactorCanvas with F1/F2/F3 chips). Switch to
+    // Overview mode so the legacy four tabs (loadings/arrays/statements/
+    // summary) become visible — that's the surface this E2E exercises.
+    const overviewToggle = page.getByRole('button', { name: /^overview$/i });
+    await expect(overviewToggle).toBeVisible({ timeout: 60_000 });
+    await overviewToggle.click();
+
     const loadingsTab = page.getByRole('tab', { name: /loadings/i });
-    await expect(loadingsTab).toBeVisible({ timeout: 60_000 });
+    await expect(loadingsTab).toBeVisible({ timeout: 10_000 });
 
     // -----------------------------------------------------------------------
     // 4. Assert Region 1 — Factor Loadings table (default "Loadings" tab)

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -965,7 +965,14 @@
                 "min_def_sorts": "min defining sorts",
                 "advanced_title": "Advanced configuration",
                 "commit_cta": "Commit and interpret"
-            }
+            },
+            "interpret": {
+                "def_sorts": "Defining sorts: {{n}}",
+                "statements_title": "Statements",
+                "narrative_title": "Narrative — F{{n}}",
+                "insert_comment_quote": "Insert comment as quote"
+            },
+            "quote_insert_format": "> {{text}}\n> — {{p}}, on statement {{code}}: \"{{stmt}}…\""
         },
         "project": {
             "remove_member": "Remove member",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -970,7 +970,10 @@
                 "def_sorts": "Defining sorts: {{n}}",
                 "statements_title": "Statements",
                 "narrative_title": "Narrative — F{{n}}",
-                "insert_comment_quote": "Insert comment as quote"
+                "insert_comment_quote": "Insert comment as quote",
+                "focus_mode": "Per-factor focus",
+                "overview_mode": "Overview",
+                "mode_toggle": "View mode"
             },
             "quote_insert_format": "> {{text}}\n> — {{p}}, on statement {{code}}: \"{{stmt}}\""
         },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -972,7 +972,7 @@
                 "narrative_title": "Narrative — F{{n}}",
                 "insert_comment_quote": "Insert comment as quote"
             },
-            "quote_insert_format": "> {{text}}\n> — {{p}}, on statement {{code}}: \"{{stmt}}…\""
+            "quote_insert_format": "> {{text}}\n> — {{p}}, on statement {{code}}: \"{{stmt}}\""
         },
         "project": {
             "remove_member": "Remove member",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -917,7 +917,14 @@
                 "min_def_sorts": "min määr. sortit",
                 "advanced_title": "Lisäasetukset",
                 "commit_cta": "Vahvista ja tulkitse"
-            }
+            },
+            "interpret": {
+                "def_sorts": "Määrittäviä lajitteluja: {{n}}",
+                "statements_title": "Väittämät",
+                "narrative_title": "Narratiivi — F{{n}}",
+                "insert_comment_quote": "Lisää kommentti lainauksena"
+            },
+            "quote_insert_format": "> {{text}}\n> — {{p}}, väittämästä {{code}}: \"{{stmt}}…\""
         },
         "project": {
             "remove_member": "Poista jäsen",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -922,7 +922,10 @@
                 "def_sorts": "Määrittäviä lajitteluja: {{n}}",
                 "statements_title": "Väittämät",
                 "narrative_title": "Narratiivi — F{{n}}",
-                "insert_comment_quote": "Lisää kommentti lainauksena"
+                "insert_comment_quote": "Lisää kommentti lainauksena",
+                "focus_mode": "Tekijäkohtainen näkymä",
+                "overview_mode": "Yleisnäkymä",
+                "mode_toggle": "Näkymätila"
             },
             "quote_insert_format": "> {{text}}\n> — {{p}}, väittämästä {{code}}: \"{{stmt}}\""
         },

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -924,7 +924,7 @@
                 "narrative_title": "Narratiivi — F{{n}}",
                 "insert_comment_quote": "Lisää kommentti lainauksena"
             },
-            "quote_insert_format": "> {{text}}\n> — {{p}}, väittämästä {{code}}: \"{{stmt}}…\""
+            "quote_insert_format": "> {{text}}\n> — {{p}}, väittämästä {{code}}: \"{{stmt}}\""
         },
         "project": {
             "remove_member": "Poista jäsen",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -917,7 +917,14 @@
                 "min_def_sorts": "min sorts définiss.",
                 "advanced_title": "Configuration avancée",
                 "commit_cta": "Valider et interpréter"
-            }
+            },
+            "interpret": {
+                "def_sorts": "Sorts définissants : {{n}}",
+                "statements_title": "Énoncés",
+                "narrative_title": "Narration — F{{n}}",
+                "insert_comment_quote": "Insérer le commentaire comme citation"
+            },
+            "quote_insert_format": "> {{text}}\n> — {{p}}, sur l'énoncé {{code}} : « {{stmt}}… »"
         },
         "project": {
             "remove_member": "Retirer le membre",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -922,7 +922,10 @@
                 "def_sorts": "Sorts définissants : {{n}}",
                 "statements_title": "Énoncés",
                 "narrative_title": "Narration — F{{n}}",
-                "insert_comment_quote": "Insérer le commentaire comme citation"
+                "insert_comment_quote": "Insérer le commentaire comme citation",
+                "focus_mode": "Focus par facteur",
+                "overview_mode": "Vue d'ensemble",
+                "mode_toggle": "Mode d'affichage"
             },
             "quote_insert_format": "> {{text}}\n> — {{p}}, sur l'énoncé {{code}} : « {{stmt}} »"
         },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -924,7 +924,7 @@
                 "narrative_title": "Narration — F{{n}}",
                 "insert_comment_quote": "Insérer le commentaire comme citation"
             },
-            "quote_insert_format": "> {{text}}\n> — {{p}}, sur l'énoncé {{code}} : « {{stmt}}… »"
+            "quote_insert_format": "> {{text}}\n> — {{p}}, sur l'énoncé {{code}} : « {{stmt}} »"
         },
         "project": {
             "remove_member": "Retirer le membre",

--- a/frontend/src/components/admin/analysis/FactorCanvas.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorCanvas.test.tsx
@@ -1,0 +1,252 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { renderWithProviders, screen, fireEvent, waitFor } from '@/test-utils/test-utils';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { FactorCanvas } from './FactorCanvas';
+import type { InterpretPhaseApi } from '@/hooks/admin/useInterpretPhase';
+import type { ParticipantAudioRecording } from '@/api/model/participantAudioRecording';
+import type { ParticipantCardComment } from '@/api/model/participantCardComment';
+
+// ── Hoisted mocks for the generated API hooks ─────────────────────────────────
+const { mockAudiosHook, mockCommentsHook, mockUpdateHook, mockListRunsKey } = vi.hoisted(() => ({
+    mockAudiosHook: vi.fn(),
+    mockCommentsHook: vi.fn(),
+    mockUpdateHook: vi.fn(),
+    mockListRunsKey: vi.fn(() => ['/api/admin/studies/s/analysis/runs']),
+}));
+
+vi.mock('@/api/generated', () => ({
+    useListAudiosForParticipantsApiAdminStudiesSlugAnalysisAudiosGet: mockAudiosHook,
+    useListCommentsForParticipantsApiAdminStudiesSlugAnalysisCommentsGet: mockCommentsHook,
+    useUpdateAnalysisRunApiAdminStudiesSlugAnalysisRunsRunIdPatch: mockUpdateHook,
+    getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey: mockListRunsKey,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function emptyOk<T>(): {
+    data: T[];
+    isLoading: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+} {
+    return { data: [], isLoading: false, isSuccess: true, isError: false };
+}
+
+function dataOk<T>(data: T[]): {
+    data: T[];
+    isLoading: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+} {
+    return { data, isLoading: false, isSuccess: true, isError: false };
+}
+
+function buildInterpret(overrides: Partial<InterpretPhaseApi> = {}): InterpretPhaseApi {
+    const run = {
+        id: 42,
+        ran_at: '2026-04-29T10:00:00Z',
+        n_factors: 3,
+        extraction: 'pca',
+        rotation: 'varimax',
+        flagging: 'auto',
+        notes: null,
+        factor_notes: { '1': '' },
+        result: {
+            n_participants: 2,
+            n_statements: 1,
+            n_factors: 3,
+            extraction: 'pca',
+            rotation: 'varimax',
+            eigenvalues: [3.0, 1.5, 0.8],
+            total_variance_explained: 0.7,
+            loadings: [[0.78, 0.0, 0.1]],
+            rotated_loadings: [[0.78, 0.0, 0.1]],
+            flags: [[true, false, false]],
+            participants: [
+                {
+                    db_id: 1,
+                    label: 'P1',
+                    loadings: [0.78, 0.0, 0.1],
+                    flagged_factors: [1],
+                },
+            ],
+            statement_scores: [
+                {
+                    statement_id: 7,
+                    code: 'S07',
+                    text: 'Local food sovereignty matters more than ever to the community',
+                    z_scores: [2.41, 0.1, -0.3],
+                    factor_arrays: [4, 0, -2],
+                },
+            ],
+            distinguishing: [
+                {
+                    statement_id: 7,
+                    code: 'S07',
+                    text: 'Local food sovereignty matters more than ever to the community',
+                    z_scores: [2.41, 0.1, -0.3],
+                    factor_arrays: [4, 0, -2],
+                    significance: { '1': '*' },
+                },
+            ],
+            consensus: [],
+            factor_characteristics: [],
+            correlation_matrix: [
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ],
+        },
+    };
+    const base: InterpretPhaseApi = {
+        // The orval `AnalysisRunRead.result` type is JSONB-shaped; cast through
+        // unknown so the fixture object is accepted as-is.
+        run: run as unknown as InterpretPhaseApi['run'],
+        isLoading: false,
+        isError: false,
+        activeFactor: 1,
+        flaggedParticipants: [
+            { db_id: 1, label: 'P1', loadings: [0.78, 0.0, 0.1], flagged_factors: [1] },
+        ],
+        narrativeDraft: '',
+        setNarrativeDraft: vi.fn(),
+        appendToNarrative: vi.fn(),
+        showFactorNarratives: true,
+        setShowFactorNarratives: vi.fn(),
+        compareRun: null,
+        deltaByStatement: null,
+    };
+    return { ...base, ...overrides };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('FactorCanvas', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAudiosHook.mockReturnValue(emptyOk<ParticipantAudioRecording>());
+        mockCommentsHook.mockReturnValue(emptyOk<ParticipantCardComment>());
+        mockUpdateHook.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    });
+
+    it('renders factor selector chips with active factor highlighted', () => {
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+        );
+        const chips = screen.getAllByRole('tab');
+        expect(chips).toHaveLength(3);
+        expect(chips[0]).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('calls onFocusChange when a different chip is clicked', () => {
+        const onFocusChange = vi.fn();
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={onFocusChange} />
+        );
+        const chips = screen.getAllByRole('tab');
+        const second = chips[1];
+        if (!second) throw new Error('expected at least 2 chips');
+        fireEvent.click(second);
+        expect(onFocusChange).toHaveBeenCalledWith(2);
+    });
+
+    it('renders Statements panel with top |z| of active factor', () => {
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+        );
+        expect(screen.getByText(/Local food sovereignty/)).toBeInTheDocument();
+        expect(screen.getByText('+2.41')).toBeInTheDocument();
+        expect(screen.getByText('S07')).toBeInTheDocument();
+    });
+
+    it('flags distinguishing statements with a D badge', () => {
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+        );
+        expect(screen.getByLabelText(/distinguishing statement/i)).toBeInTheDocument();
+    });
+
+    it('shows defining-sorts count from interpret.flaggedParticipants.length', () => {
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+        );
+        expect(screen.getByText(/Defining sorts:\s*1/i)).toBeInTheDocument();
+    });
+
+    it('renders the Narrative editor with the active factor in title', () => {
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+        );
+        expect(screen.getByText(/Narrative.*F1/i)).toBeInTheDocument();
+    });
+
+    it('returns null when run.result is missing', () => {
+        const empty = buildInterpret({ run: null });
+        const { container } = renderWithProviders(
+            <FactorCanvas slug="s" interpret={empty} onFocusChange={vi.fn()} />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('clicking a comment ▸+ button calls handleInsertCommentQuote → appendToNarrative', async () => {
+        mockCommentsHook.mockReturnValue(
+            dataOk<ParticipantCardComment>([
+                {
+                    participant_db_id: 1,
+                    statement_id: 7,
+                    statement_code: 'S07',
+                    statement_text: 'Local food sovereignty matters',
+                    grid_score: 4,
+                    comment: 'Because food sovereignty matters',
+                },
+            ])
+        );
+
+        const appendToNarrative = vi.fn();
+        const interpret = buildInterpret({ appendToNarrative });
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={interpret} onFocusChange={vi.fn()} />
+        );
+
+        const insertBtn = await screen.findByLabelText(/insert comment as quote/i);
+        fireEvent.click(insertBtn);
+
+        expect(appendToNarrative).toHaveBeenCalledTimes(1);
+        const snippet = appendToNarrative.mock.calls[0]?.[0] as string;
+        expect(snippet).toContain('Because food sovereignty matters');
+        expect(snippet).toMatch(/^> /);
+        expect(snippet).toContain('P1');
+        expect(snippet).toContain('S07');
+    });
+
+    it('does NOT render an insert button on audio rows', async () => {
+        mockAudiosHook.mockReturnValue(
+            dataOk<ParticipantAudioRecording>([
+                {
+                    id: 1,
+                    participant_db_id: 1,
+                    question_key: 'rationale',
+                    mime_type: 'audio/webm',
+                    file_size_bytes: 1000,
+                    s3_key: 'recordings/1.webm',
+                    created_at: '2026-04-29T10:00:00Z',
+                    presigned_url: '/fake/audio.webm',
+                },
+            ])
+        );
+        // Comments are empty, so the only voices content is the audio row.
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+        );
+        await waitFor(() => {
+            expect(document.querySelectorAll('audio')).toHaveLength(1);
+        });
+        expect(screen.queryByLabelText(/insert audio.*quote/i)).toBeNull();
+        expect(screen.queryByLabelText(/insert comment as quote/i)).toBeNull();
+    });
+});

--- a/frontend/src/components/admin/analysis/FactorCanvas.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorCanvas.test.tsx
@@ -193,7 +193,7 @@ describe('FactorCanvas', () => {
         expect(container.firstChild).toBeNull();
     });
 
-    it('clicking a comment ▸+ button calls handleInsertCommentQuote → appendToNarrative', async () => {
+    it('clicking a comment ▸+ button inserts the formatted snippet into the editor', async () => {
         mockCommentsHook.mockReturnValue(
             dataOk<ParticipantCardComment>([
                 {
@@ -207,6 +207,7 @@ describe('FactorCanvas', () => {
             ])
         );
 
+        // Spy on appendToNarrative to confirm the dual-write was removed.
         const appendToNarrative = vi.fn();
         const interpret = buildInterpret({ appendToNarrative });
         renderWithProviders(
@@ -216,12 +217,67 @@ describe('FactorCanvas', () => {
         const insertBtn = await screen.findByLabelText(/insert comment as quote/i);
         fireEvent.click(insertBtn);
 
-        expect(appendToNarrative).toHaveBeenCalledTimes(1);
-        const snippet = appendToNarrative.mock.calls[0]?.[0] as string;
-        expect(snippet).toContain('Because food sovereignty matters');
-        expect(snippet).toMatch(/^> /);
-        expect(snippet).toContain('P1');
-        expect(snippet).toContain('S07');
+        // appendQuote forces edit mode → textarea now visible with the snippet.
+        const textarea = await screen.findByRole('textbox');
+        const value = (textarea as HTMLTextAreaElement).value;
+        expect(value).toContain('Because food sovereignty matters');
+        expect(value).toMatch(/^> /);
+        expect(value).toContain('P1');
+        expect(value).toContain('S07');
+
+        // Negative test: dual-write was removed, hook-level draft is no longer
+        // touched from FactorCanvas.
+        expect(appendToNarrative).not.toHaveBeenCalled();
+    });
+
+    it('formatQuote does not append ellipsis on short statements', async () => {
+        mockCommentsHook.mockReturnValue(
+            dataOk<ParticipantCardComment>([
+                {
+                    participant_db_id: 1,
+                    statement_id: 7,
+                    statement_code: 'S07',
+                    statement_text: 'Short text', // < 60 chars
+                    grid_score: 4,
+                    comment: 'Because',
+                },
+            ])
+        );
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+        );
+        const insertBtn = await screen.findByLabelText(/insert comment as quote/i);
+        fireEvent.click(insertBtn);
+        const textarea = await screen.findByRole('textbox');
+        const value = (textarea as HTMLTextAreaElement).value;
+        expect(value).toContain('"Short text"');
+        expect(value).not.toContain('…');
+    });
+
+    it('formatQuote appends ellipsis only when statement is truncated', async () => {
+        const longText =
+            'This is a very long statement that exceeds the truncation threshold of sixty characters by quite a bit.';
+        mockCommentsHook.mockReturnValue(
+            dataOk<ParticipantCardComment>([
+                {
+                    participant_db_id: 1,
+                    statement_id: 7,
+                    statement_code: 'S07',
+                    statement_text: longText,
+                    grid_score: 4,
+                    comment: 'Because',
+                },
+            ])
+        );
+        renderWithProviders(
+            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+        );
+        const insertBtn = await screen.findByLabelText(/insert comment as quote/i);
+        fireEvent.click(insertBtn);
+        const textarea = await screen.findByRole('textbox');
+        const value = (textarea as HTMLTextAreaElement).value;
+        expect(value).toContain('…');
+        expect(value).toContain(longText.slice(0, 60));
     });
 
     it('does NOT render an insert button on audio rows', async () => {

--- a/frontend/src/components/admin/analysis/FactorCanvas.tsx
+++ b/frontend/src/components/admin/analysis/FactorCanvas.tsx
@@ -1,0 +1,181 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { useCallback, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FactorSelectorChips } from './FactorSelectorChips';
+import { FactorNoteEditor, type FactorNoteEditorHandle } from './FactorNoteEditor';
+import { FactorVoicesPanel } from './FactorVoicesPanel';
+import type { ParticipantCardComment } from '@/api/model/participantCardComment';
+import type { AnalysisResult } from '@/api/model/analysisResult';
+import type { InterpretPhaseApi } from '@/hooks/admin/useInterpretPhase';
+
+interface Props {
+    slug: string;
+    interpret: InterpretPhaseApi;
+    onFocusChange: (factor: number) => void;
+}
+
+const TOP_STATEMENTS_LIMIT = 12;
+const QUOTE_TRUNCATE = 60;
+
+/**
+ * Per-factor focus mode: brings together the top/bottom statements (sorted
+ * by |z|), the voices of flagged participants (audio + comments), and the
+ * factor narrative editor in a single canvas. The "quote picker" on each
+ * comment fires `appendQuote()` on the editor, inserting a markdown
+ * blockquote with attribution.
+ *
+ * Audio insertion is intentionally NOT supported (no transcription
+ * pipeline). Statement insertion is also out of scope (z-scores are
+ * already visible in StatementsTable / Statements panel).
+ */
+export function FactorCanvas({ slug, interpret, onFocusChange }: Props) {
+    const { t } = useTranslation();
+    const editorRef = useRef<FactorNoteEditorHandle>(null);
+    const run = interpret.run;
+    // The orval-generated `AnalysisRunRead.result` is typed as
+    // `{ [key: string]: unknown }` (JSONB column). Narrow once for the body.
+    const result = (run?.result as unknown as AnalysisResult | undefined) ?? null;
+
+    // Top/bottom statements by |z| for the active factor; sliced to a
+    // sensible UI cap. Distinguishing statements get a `D` badge but no
+    // re-sorting (|z| ordering already surfaces them).
+    const topStatements = useMemo(() => {
+        if (!result) return [];
+        const factorIdx = interpret.activeFactor - 1;
+        const distinguishingIds = new Set(result.distinguishing.map((d) => d.statement_id));
+        return result.statement_scores
+            .map((s) => ({
+                statement_id: s.statement_id,
+                code: s.code,
+                text: s.text,
+                z: s.z_scores[factorIdx] ?? 0,
+                isDistinguishing: distinguishingIds.has(s.statement_id),
+            }))
+            .sort((a, b) => Math.abs(b.z) - Math.abs(a.z))
+            .slice(0, TOP_STATEMENTS_LIMIT);
+    }, [result, interpret.activeFactor]);
+
+    const handleInsertCommentQuote = useCallback(
+        (comment: ParticipantCardComment, participantLabel: string) => {
+            const snippet = formatQuote(t, comment, participantLabel);
+            editorRef.current?.appendQuote(snippet);
+            interpret.appendToNarrative(snippet);
+        },
+        [t, interpret]
+    );
+
+    if (!run || !result) {
+        return null;
+    }
+
+    const definingSorts = interpret.flaggedParticipants.length;
+    const factorKey = String(interpret.activeFactor);
+    const factorNotes = run.factor_notes as
+        | { [key: string]: string | undefined }
+        | null
+        | undefined;
+    const currentNote = factorNotes?.[factorKey] ?? '';
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-4">
+                <FactorSelectorChips
+                    nFactors={result.n_factors}
+                    activeFactor={interpret.activeFactor}
+                    onSelect={onFocusChange}
+                />
+                <div className="text-sm text-slate-500">
+                    {t('admin.analysis.interpret.def_sorts', 'Defining sorts: {{n}}', {
+                        n: definingSorts,
+                    })}
+                </div>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-lg font-black text-slate-900">
+                        {t('admin.analysis.interpret.statements_title', 'Statements')}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <ul className="space-y-1 text-sm">
+                        {topStatements.map((s) => (
+                            <li key={s.statement_id} className="flex items-center gap-2">
+                                <span
+                                    className={
+                                        s.z >= 0
+                                            ? 'text-emerald-700 font-mono'
+                                            : 'text-rose-700 font-mono'
+                                    }
+                                >
+                                    {s.z >= 0 ? '+' : ''}
+                                    {s.z.toFixed(2)}
+                                </span>
+                                <span className="font-mono font-bold">{s.code}</span>
+                                <span className="text-slate-700 truncate flex-1">“{s.text}”</span>
+                                {s.isDistinguishing && (
+                                    <span
+                                        className="text-2xs px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200"
+                                        role="img"
+                                        aria-label="distinguishing statement"
+                                    >
+                                        D
+                                    </span>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                </CardContent>
+            </Card>
+
+            <FactorVoicesPanel
+                slug={slug}
+                factorIndex={interpret.activeFactor - 1}
+                participants={interpret.flaggedParticipants}
+                onInsertCommentQuote={handleInsertCommentQuote}
+            />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-lg font-black text-slate-900">
+                        {t('admin.analysis.interpret.narrative_title', 'Narrative — F{{n}}', {
+                            n: interpret.activeFactor,
+                        })}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <FactorNoteEditor
+                        ref={editorRef}
+                        slug={slug}
+                        runId={run.id}
+                        factorIndex={interpret.activeFactor - 1}
+                        currentNote={currentNote}
+                    />
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+type TFn = (key: string, fallback: string, opts?: Record<string, unknown>) => string;
+
+function formatQuote(t: TFn, comment: ParticipantCardComment, participantLabel: string): string {
+    const stmtFull = comment.statement_text ?? '';
+    const stmt = stmtFull.length > QUOTE_TRUNCATE ? stmtFull.slice(0, QUOTE_TRUNCATE) : stmtFull;
+    return t(
+        'admin.analysis.quote_insert_format',
+        '> {{text}}\n> — {{p}}, on statement {{code}}: "{{stmt}}…"',
+        {
+            text: comment.comment,
+            p: participantLabel,
+            code: comment.statement_code,
+            stmt,
+        }
+    );
+}

--- a/frontend/src/components/admin/analysis/FactorCanvas.tsx
+++ b/frontend/src/components/admin/analysis/FactorCanvas.tsx
@@ -20,6 +20,14 @@ interface Props {
     onFocusChange: (factor: number) => void;
 }
 
+/**
+ * Cap on the number of top |z| statements rendered in the canvas.
+ * 12 covers the typical 6-up + 6-down extremes of a 30-statement Q-set;
+ * larger Q-sets (60+ statements) may bury some distinguishing items
+ * outside the cap. The current sort by |z| descending typically surfaces
+ * distinguishing items but doesn't guarantee it; "distinguishing first"
+ * is a future refinement (Phase 5+).
+ */
 const TOP_STATEMENTS_LIMIT = 12;
 const QUOTE_TRUNCATE = 60;
 
@@ -65,9 +73,13 @@ export function FactorCanvas({ slug, interpret, onFocusChange }: Props) {
         (comment: ParticipantCardComment, participantLabel: string) => {
             const snippet = formatQuote(t, comment, participantLabel);
             editorRef.current?.appendQuote(snippet);
-            interpret.appendToNarrative(snippet);
+            // Note: previously also called interpret.appendToNarrative(snippet),
+            // but no current consumer reads the hook's narrativeDraft externally.
+            // The editor's internal draft is the source of truth until save flushes
+            // to factor_notes. Reintroduce the dual-write only if a consumer
+            // materializes (e.g. compare-pin reading drafts).
         },
-        [t, interpret]
+        [t]
     );
 
     if (!run || !result) {
@@ -167,10 +179,11 @@ type TFn = (key: string, fallback: string, opts?: Record<string, unknown>) => st
 
 function formatQuote(t: TFn, comment: ParticipantCardComment, participantLabel: string): string {
     const stmtFull = comment.statement_text ?? '';
-    const stmt = stmtFull.length > QUOTE_TRUNCATE ? stmtFull.slice(0, QUOTE_TRUNCATE) : stmtFull;
+    const stmt =
+        stmtFull.length > QUOTE_TRUNCATE ? `${stmtFull.slice(0, QUOTE_TRUNCATE)}…` : stmtFull;
     return t(
         'admin.analysis.quote_insert_format',
-        '> {{text}}\n> — {{p}}, on statement {{code}}: "{{stmt}}…"',
+        '> {{text}}\n> — {{p}}, on statement {{code}}: "{{stmt}}"',
         {
             text: comment.comment,
             p: participantLabel,

--- a/frontend/src/components/admin/analysis/FactorNoteEditor.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorNoteEditor.test.tsx
@@ -1,6 +1,7 @@
-import { renderWithProviders, screen, fireEvent, waitFor } from '@/test-utils/test-utils';
+import { renderWithProviders, screen, fireEvent, waitFor, act } from '@/test-utils/test-utils';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { FactorNoteEditor } from './FactorNoteEditor';
+import { createRef } from 'react';
+import { FactorNoteEditor, type FactorNoteEditorHandle } from './FactorNoteEditor';
 
 const { mockMutate, mockUpdateHook } = vi.hoisted(() => ({
     mockMutate: vi.fn(),
@@ -105,5 +106,64 @@ describe('FactorNoteEditor', () => {
         rerender(<FactorNoteEditor slug="demo" runId={2} factorIndex={0} currentNote="B" />);
         expect(screen.getByText('B')).toBeInTheDocument();
         expect(screen.queryByText('A')).not.toBeInTheDocument();
+    });
+});
+
+describe('FactorNoteEditor: appendQuote handle (Phase 4)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUpdateHook.mockReturnValue({
+            mutate: mockMutate,
+            isPending: false,
+        });
+    });
+
+    it('appendQuote forces edit mode and appends with double-newline separator', async () => {
+        const ref = createRef<FactorNoteEditorHandle>();
+        renderWithProviders(
+            <FactorNoteEditor
+                ref={ref}
+                slug="test-slug"
+                runId={1}
+                factorIndex={0}
+                currentNote="Existing narrative."
+            />
+        );
+        // Editor starts in display mode (paragraph visible, no textarea).
+        expect(screen.queryByRole('textbox')).toBeNull();
+        // Trigger appendQuote.
+        act(() => ref.current?.appendQuote('> Inserted quote'));
+        // Now the textarea is visible AND contains the appended quote.
+        const textarea = await screen.findByRole('textbox');
+        expect(textarea).toHaveValue('Existing narrative.\n\n> Inserted quote');
+    });
+
+    it('appendQuote on empty draft sets the snippet without leading newlines', () => {
+        const ref = createRef<FactorNoteEditorHandle>();
+        renderWithProviders(
+            <FactorNoteEditor ref={ref} slug="test-slug" runId={1} factorIndex={0} currentNote="" />
+        );
+        act(() => ref.current?.appendQuote('> First quote'));
+        const textarea = screen.getByRole('textbox');
+        expect(textarea).toHaveValue('> First quote');
+    });
+
+    it('appendQuote called twice appends both snippets with separator', () => {
+        const ref = createRef<FactorNoteEditorHandle>();
+        renderWithProviders(
+            <FactorNoteEditor ref={ref} slug="test-slug" runId={1} factorIndex={0} currentNote="" />
+        );
+        act(() => ref.current?.appendQuote('> Quote A'));
+        act(() => ref.current?.appendQuote('> Quote B'));
+        const textarea = screen.getByRole('textbox');
+        expect(textarea).toHaveValue('> Quote A\n\n> Quote B');
+    });
+
+    it('FactorNoteEditor still works WITHOUT a ref (backward compat)', () => {
+        renderWithProviders(
+            <FactorNoteEditor slug="test-slug" runId={1} factorIndex={0} currentNote="Existing." />
+        );
+        // Display mode renders without crash.
+        expect(screen.getByText(/Existing\./)).toBeInTheDocument();
     });
 });

--- a/frontend/src/components/admin/analysis/FactorNoteEditor.tsx
+++ b/frontend/src/components/admin/analysis/FactorNoteEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -7,6 +7,15 @@ import {
     useUpdateAnalysisRunApiAdminStudiesSlugAnalysisRunsRunIdPatch,
     getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey,
 } from '@/api/generated';
+
+export interface FactorNoteEditorHandle {
+    /**
+     * Force the editor into edit mode and append `snippet` to the current
+     * draft with a double-newline separator (or set the draft directly if
+     * the draft is empty).
+     */
+    appendQuote: (snippet: string) => void;
+}
 
 interface FactorNoteEditorProps {
     slug: string;
@@ -19,170 +28,185 @@ interface FactorNoteEditorProps {
 
 const MAX_LENGTH = 4000;
 
-export function FactorNoteEditor({ slug, runId, factorIndex, currentNote }: FactorNoteEditorProps) {
-    const { t } = useTranslation();
-    const queryClient = useQueryClient();
-    const factorKey = String(factorIndex + 1);
+export const FactorNoteEditor = forwardRef<FactorNoteEditorHandle, FactorNoteEditorProps>(
+    function FactorNoteEditor({ slug, runId, factorIndex, currentNote }, ref) {
+        const { t } = useTranslation();
+        const queryClient = useQueryClient();
+        const factorKey = String(factorIndex + 1);
 
-    const [isEditing, setIsEditing] = useState(false);
-    const [draft, setDraft] = useState(currentNote);
+        const [isEditing, setIsEditing] = useState(false);
+        const [draft, setDraft] = useState(currentNote);
 
-    // Reset the draft whenever the source of truth (currentNote) changes —
-    // e.g. when the user navigates between runs.
-    useEffect(() => {
-        setDraft(currentNote);
-    }, [currentNote]);
+        // Reset the draft whenever the source of truth (currentNote) changes —
+        // e.g. when the user navigates between runs.
+        useEffect(() => {
+            setDraft(currentNote);
+        }, [currentNote]);
 
-    const mutation = useUpdateAnalysisRunApiAdminStudiesSlugAnalysisRunsRunIdPatch();
-
-    const handleStart = () => {
-        setDraft(currentNote);
-        setIsEditing(true);
-    };
-
-    const handleCancel = () => {
-        setDraft(currentNote);
-        setIsEditing(false);
-    };
-
-    const handleSave = () => {
-        if (draft.length > MAX_LENGTH) return;
-        mutation.mutate(
-            {
-                slug,
-                runId,
-                data: { factor_notes: { [factorKey]: draft } },
-            },
-            {
-                onSuccess: () => {
-                    queryClient.invalidateQueries({
-                        queryKey:
-                            getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey(slug),
-                    });
-                    setIsEditing(false);
-                    toast.success(t('admin.analysis.factor_note.saved', 'Factor narrative saved.'));
+        useImperativeHandle(
+            ref,
+            () => ({
+                appendQuote: (snippet: string) => {
+                    setIsEditing(true);
+                    setDraft((prev) => (prev ? `${prev}\n\n${snippet}` : snippet));
                 },
-                onError: () => {
-                    toast.error(
-                        t(
-                            'admin.analysis.factor_note.error',
-                            'Failed to save the factor narrative.'
-                        )
-                    );
-                },
-            }
+            }),
+            []
         );
-    };
 
-    const charCount = draft.length;
-    const isOverLimit = charCount > MAX_LENGTH;
+        const mutation = useUpdateAnalysisRunApiAdminStudiesSlugAnalysisRunsRunIdPatch();
 
-    if (isEditing) {
-        return (
-            <div className="mt-2 space-y-1.5">
-                <div className="flex items-center gap-1.5 text-2xs text-slate-500 font-medium">
-                    <NotebookText className="size-3" aria-hidden="true" />
-                    {t('admin.analysis.factor_note.label', 'Factor narrative')}
-                </div>
-                <textarea
-                    value={draft}
-                    onChange={(e) => setDraft(e.target.value)}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Escape') handleCancel();
-                    }}
-                    rows={4}
-                    placeholder={t(
-                        'admin.analysis.factor_note.placeholder',
-                        'Write the interpretive narrative for this factor — the discourse, voices, and tensions it foregrounds.'
-                    )}
-                    className="w-full text-xs border border-slate-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-indigo-400 leading-snug"
-                    aria-label={t(
-                        'admin.analysis.factor_note.aria',
-                        'Edit factor {{n}} narrative',
-                        { n: factorIndex + 1 }
-                    )}
-                    // biome-ignore lint/a11y/noAutofocus: intentional inline-edit UX
-                    autoFocus
-                />
-                <div className="flex items-center justify-between gap-2">
-                    <span
-                        className={`text-2xs ${
-                            isOverLimit ? 'text-rose-600 font-semibold' : 'text-slate-400'
-                        }`}
-                    >
-                        {t('admin.analysis.factor_note.char_count', '{{n}}/{{max}}', {
-                            n: charCount,
-                            max: MAX_LENGTH,
-                        })}
-                    </span>
-                    <div className="flex items-center gap-1">
-                        <button
-                            type="button"
-                            onClick={handleSave}
-                            disabled={mutation.isPending || isOverLimit}
-                            className="text-green-600 hover:text-green-700 disabled:opacity-50 p-1"
-                            aria-label={t(
-                                'admin.analysis.factor_note.save_aria',
-                                'Save factor narrative'
-                            )}
+        const handleStart = () => {
+            setDraft(currentNote);
+            setIsEditing(true);
+        };
+
+        const handleCancel = () => {
+            setDraft(currentNote);
+            setIsEditing(false);
+        };
+
+        const handleSave = () => {
+            if (draft.length > MAX_LENGTH) return;
+            mutation.mutate(
+                {
+                    slug,
+                    runId,
+                    data: { factor_notes: { [factorKey]: draft } },
+                },
+                {
+                    onSuccess: () => {
+                        queryClient.invalidateQueries({
+                            queryKey:
+                                getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey(slug),
+                        });
+                        setIsEditing(false);
+                        toast.success(
+                            t('admin.analysis.factor_note.saved', 'Factor narrative saved.')
+                        );
+                    },
+                    onError: () => {
+                        toast.error(
+                            t(
+                                'admin.analysis.factor_note.error',
+                                'Failed to save the factor narrative.'
+                            )
+                        );
+                    },
+                }
+            );
+        };
+
+        const charCount = draft.length;
+        const isOverLimit = charCount > MAX_LENGTH;
+
+        if (isEditing) {
+            return (
+                <div className="mt-2 space-y-1.5">
+                    <div className="flex items-center gap-1.5 text-2xs text-slate-500 font-medium">
+                        <NotebookText className="size-3" aria-hidden="true" />
+                        {t('admin.analysis.factor_note.label', 'Factor narrative')}
+                    </div>
+                    <textarea
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Escape') handleCancel();
+                        }}
+                        rows={4}
+                        placeholder={t(
+                            'admin.analysis.factor_note.placeholder',
+                            'Write the interpretive narrative for this factor — the discourse, voices, and tensions it foregrounds.'
+                        )}
+                        className="w-full text-xs border border-slate-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-indigo-400 leading-snug"
+                        aria-label={t(
+                            'admin.analysis.factor_note.aria',
+                            'Edit factor {{n}} narrative',
+                            { n: factorIndex + 1 }
+                        )}
+                        // biome-ignore lint/a11y/noAutofocus: intentional inline-edit UX
+                        autoFocus
+                    />
+                    <div className="flex items-center justify-between gap-2">
+                        <span
+                            className={`text-2xs ${
+                                isOverLimit ? 'text-rose-600 font-semibold' : 'text-slate-400'
+                            }`}
                         >
-                            <Check className="size-3.5" />
-                        </button>
-                        <button
-                            type="button"
-                            onClick={handleCancel}
-                            className="text-slate-400 hover:text-slate-600 p-1"
-                            aria-label={t(
-                                'admin.analysis.factor_note.cancel_aria',
-                                'Cancel editing'
-                            )}
-                        >
-                            <X className="size-3.5" />
-                        </button>
+                            {t('admin.analysis.factor_note.char_count', '{{n}}/{{max}}', {
+                                n: charCount,
+                                max: MAX_LENGTH,
+                            })}
+                        </span>
+                        <div className="flex items-center gap-1">
+                            <button
+                                type="button"
+                                onClick={handleSave}
+                                disabled={mutation.isPending || isOverLimit}
+                                className="text-green-600 hover:text-green-700 disabled:opacity-50 p-1"
+                                aria-label={t(
+                                    'admin.analysis.factor_note.save_aria',
+                                    'Save factor narrative'
+                                )}
+                            >
+                                <Check className="size-3.5" />
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleCancel}
+                                className="text-slate-400 hover:text-slate-600 p-1"
+                                aria-label={t(
+                                    'admin.analysis.factor_note.cancel_aria',
+                                    'Cancel editing'
+                                )}
+                            >
+                                <X className="size-3.5" />
+                            </button>
+                        </div>
                     </div>
                 </div>
+            );
+        }
+
+        return (
+            <div className="mt-2">
+                {currentNote ? (
+                    <button
+                        type="button"
+                        onClick={handleStart}
+                        className="group w-full text-left flex items-start gap-2 p-2 -mx-2 rounded hover:bg-slate-50 transition-colors"
+                        aria-label={t(
+                            'admin.analysis.factor_note.edit_aria',
+                            'Edit factor {{n}} narrative',
+                            { n: factorIndex + 1 }
+                        )}
+                    >
+                        <NotebookText
+                            className="size-3 text-slate-400 mt-0.5 shrink-0"
+                            aria-hidden="true"
+                        />
+                        <p className="flex-1 min-w-0 text-xs text-slate-600 leading-snug">
+                            {currentNote}
+                        </p>
+                        <Pencil
+                            className="size-3 text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                            aria-hidden="true"
+                        />
+                    </button>
+                ) : (
+                    <button
+                        type="button"
+                        onClick={handleStart}
+                        className="text-2xs text-slate-400 hover:text-slate-600 italic flex items-center gap-1.5 transition-colors"
+                    >
+                        <NotebookText className="size-3" aria-hidden="true" />
+                        {t(
+                            'admin.analysis.factor_note.empty_hint',
+                            'Add an interpretive narrative for this factor'
+                        )}
+                    </button>
+                )}
             </div>
         );
     }
-
-    return (
-        <div className="mt-2">
-            {currentNote ? (
-                <button
-                    type="button"
-                    onClick={handleStart}
-                    className="group w-full text-left flex items-start gap-2 p-2 -mx-2 rounded hover:bg-slate-50 transition-colors"
-                    aria-label={t(
-                        'admin.analysis.factor_note.edit_aria',
-                        'Edit factor {{n}} narrative',
-                        { n: factorIndex + 1 }
-                    )}
-                >
-                    <NotebookText
-                        className="size-3 text-slate-400 mt-0.5 shrink-0"
-                        aria-hidden="true"
-                    />
-                    <p className="flex-1 min-w-0 text-xs text-slate-600 leading-snug">
-                        {currentNote}
-                    </p>
-                    <Pencil
-                        className="size-3 text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
-                        aria-hidden="true"
-                    />
-                </button>
-            ) : (
-                <button
-                    type="button"
-                    onClick={handleStart}
-                    className="text-2xs text-slate-400 hover:text-slate-600 italic flex items-center gap-1.5 transition-colors"
-                >
-                    <NotebookText className="size-3" aria-hidden="true" />
-                    {t(
-                        'admin.analysis.factor_note.empty_hint',
-                        'Add an interpretive narrative for this factor'
-                    )}
-                </button>
-            )}
-        </div>
-    );
-}
+);

--- a/frontend/src/components/admin/analysis/FactorNoteEditor.tsx
+++ b/frontend/src/components/admin/analysis/FactorNoteEditor.tsx
@@ -51,7 +51,7 @@ export const FactorNoteEditor = forwardRef<FactorNoteEditorHandle, FactorNoteEdi
                     setDraft((prev) => (prev ? `${prev}\n\n${snippet}` : snippet));
                 },
             }),
-            []
+            [] // setters (setIsEditing, setDraft) are stable; the closure stays correct.
         );
 
         const mutation = useUpdateAnalysisRunApiAdminStudiesSlugAnalysisRunsRunIdPatch();

--- a/frontend/src/components/admin/analysis/FactorSelectorChips.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorSelectorChips.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders } from '@/test-utils/test-utils';
+import { FactorSelectorChips } from './FactorSelectorChips';
+
+describe('FactorSelectorChips', () => {
+    it('renders one chip per factor with F-prefixed labels', () => {
+        renderWithProviders(
+            <FactorSelectorChips nFactors={3} activeFactor={1} onSelect={vi.fn()} />
+        );
+        const chips = screen.getAllByRole('tab');
+        expect(chips).toHaveLength(3);
+        expect(chips[0]).toHaveTextContent('F1');
+        expect(chips[1]).toHaveTextContent('F2');
+        expect(chips[2]).toHaveTextContent('F3');
+    });
+
+    it('marks the active chip with aria-selected=true and others false', () => {
+        renderWithProviders(
+            <FactorSelectorChips nFactors={3} activeFactor={2} onSelect={vi.fn()} />
+        );
+        const chips = screen.getAllByRole('tab');
+        expect(chips[0]).toHaveAttribute('aria-selected', 'false');
+        expect(chips[1]).toHaveAttribute('aria-selected', 'true');
+        expect(chips[2]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('calls onSelect with the 1-based factor number when a chip is clicked', () => {
+        const onSelect = vi.fn();
+        renderWithProviders(
+            <FactorSelectorChips nFactors={3} activeFactor={1} onSelect={onSelect} />
+        );
+        fireEvent.click(screen.getAllByRole('tab')[1]!);
+        expect(onSelect).toHaveBeenCalledWith(2);
+    });
+
+    it('renders a tablist wrapper for assistive technology', () => {
+        renderWithProviders(
+            <FactorSelectorChips nFactors={2} activeFactor={1} onSelect={vi.fn()} />
+        );
+        expect(screen.getByRole('tablist')).toBeInTheDocument();
+    });
+
+    it('handles nFactors=1 gracefully (single chip)', () => {
+        renderWithProviders(
+            <FactorSelectorChips nFactors={1} activeFactor={1} onSelect={vi.fn()} />
+        );
+        expect(screen.getAllByRole('tab')).toHaveLength(1);
+    });
+
+    it('renders zero chips when nFactors=0 (defensive)', () => {
+        renderWithProviders(
+            <FactorSelectorChips nFactors={0} activeFactor={1} onSelect={vi.fn()} />
+        );
+        expect(screen.queryAllByRole('tab')).toHaveLength(0);
+    });
+});

--- a/frontend/src/components/admin/analysis/FactorSelectorChips.tsx
+++ b/frontend/src/components/admin/analysis/FactorSelectorChips.tsx
@@ -1,0 +1,41 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { Button } from '@/components/ui/button';
+
+interface Props {
+    /** Total factors in the run (1..N). */
+    nFactors: number;
+    /** 1-based active factor index. */
+    activeFactor: number;
+    /** Called with the 1-based factor number when a chip is clicked. */
+    onSelect: (factor: number) => void;
+}
+
+/**
+ * Tab-like chips for selecting one factor among N. Used inside FactorCanvas
+ * to switch the focused factor without leaving the page. Clicking a chip
+ * fires `onSelect(k)` (1-based), which the parent typically wires to a
+ * URL search-param mutation (`?focus=fk`).
+ */
+export function FactorSelectorChips({ nFactors, activeFactor, onSelect }: Props) {
+    return (
+        <div className="flex gap-2" role="tablist">
+            {Array.from({ length: nFactors }, (_, i) => i + 1).map((f) => (
+                <Button
+                    key={f}
+                    variant={f === activeFactor ? 'default' : 'outline'}
+                    size="sm"
+                    role="tab"
+                    aria-selected={f === activeFactor}
+                    onClick={() => onSelect(f)}
+                >
+                    F{f}
+                </Button>
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
@@ -13,6 +13,14 @@ interface FactorVoicesPanelProps {
     slug: string;
     factorIndex: number;
     participants: ParticipantLoading[];
+    /**
+     * Optional callback fired when the analyst clicks the ▸+ button on a
+     * card comment. The callback receives the full comment + a participant
+     * label so the consumer (FactorCanvas) can format and insert a quote
+     * snippet into the active factor narrative. When undefined, no insert
+     * button is rendered (legacy read-only mode).
+     */
+    onInsertCommentQuote?: (comment: ParticipantCardComment, participantLabel: string) => void;
 }
 
 function scoreBadgeClass(score: number): string {
@@ -42,9 +50,15 @@ interface ParticipantMaterialCardProps {
     label: string;
     recordings: ParticipantAudioRecording[];
     comments: ParticipantCardComment[];
+    onInsertCommentQuote?: (comment: ParticipantCardComment, participantLabel: string) => void;
 }
 
-function ParticipantMaterialCard({ label, recordings, comments }: ParticipantMaterialCardProps) {
+function ParticipantMaterialCard({
+    label,
+    recordings,
+    comments,
+    onInsertCommentQuote,
+}: ParticipantMaterialCardProps) {
     const { t } = useTranslation();
     return (
         <div className="bg-white rounded-lg border border-slate-200 p-3 space-y-3">
@@ -105,6 +119,19 @@ function ParticipantMaterialCard({ label, recordings, comments }: ParticipantMat
                                     >
                                         {formatScore(c.grid_score)}
                                     </span>
+                                    {onInsertCommentQuote !== undefined && (
+                                        <button
+                                            type="button"
+                                            onClick={() => onInsertCommentQuote(c, label)}
+                                            aria-label={t(
+                                                'admin.analysis.interpret.insert_comment_quote',
+                                                'Insert comment as quote'
+                                            )}
+                                            className="ml-auto text-slate-400 hover:text-emerald-700 text-xs"
+                                        >
+                                            ▸+
+                                        </button>
+                                    )}
                                 </div>
                                 <p className="text-slate-700 leading-snug">{c.statement_text}</p>
                                 <p className="mt-1 text-slate-600 italic leading-snug">
@@ -119,7 +146,12 @@ function ParticipantMaterialCard({ label, recordings, comments }: ParticipantMat
     );
 }
 
-export function FactorVoicesPanel({ slug, factorIndex, participants }: FactorVoicesPanelProps) {
+export function FactorVoicesPanel({
+    slug,
+    factorIndex,
+    participants,
+    onInsertCommentQuote,
+}: FactorVoicesPanelProps) {
     const { t } = useTranslation();
     const [tooltipOpen, setTooltipOpen] = useState(false);
 
@@ -231,6 +263,7 @@ export function FactorVoicesPanel({ slug, factorIndex, participants }: FactorVoi
                             label={p.label}
                             recordings={recordingsByParticipant.get(p.db_id) ?? []}
                             comments={commentsByParticipant.get(p.db_id) ?? []}
+                            onInsertCommentQuote={onInsertCommentQuote}
                         />
                     ))}
                 </div>

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -562,6 +562,10 @@ describe('AnalysisPage', () => {
             initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
         });
 
+        // Focus mode is now the default — switch to Overview to see the
+        // four-tab layout where the loadings guidance lives.
+        await userEvent.click(screen.getByRole('button', { name: /overview/i }));
+
         // The loadings tab should show its guidance card (default tab)
         expect(await screen.findByText(/Reading Factor Loadings/i)).toBeInTheDocument();
     });
@@ -690,6 +694,167 @@ describe('AnalysisPage', () => {
             expect(screen.queryByTestId('interpret-phase')).not.toBeInTheDocument();
         });
         expect(screen.getByRole('button', { name: /commit and interpret/i })).toBeInTheDocument();
+    });
+
+    // ── Focus / Overview mode toggle (Task 24) ─────────────────────
+
+    it('Interpret phase renders Focus mode by default', async () => {
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+        mockGetRunHook.mockReturnValue({
+            data: mockRun,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+        });
+
+        renderWithProviders(<AnalysisPage />, {
+            initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+        });
+
+        // FactorCanvas renders the FactorSelectorChips (role="tab"); legacy
+        // Tabs (role="tab", names "Loadings"/"Factor Arrays"/…) are NOT
+        // mounted in Focus mode.
+        await waitFor(() => {
+            expect(screen.getByRole('tab', { name: 'F1' })).toBeInTheDocument();
+        });
+        expect(screen.queryByRole('tab', { name: /loadings/i })).not.toBeInTheDocument();
+    });
+
+    it('clicking Overview switches to the legacy four-tabs layout', async () => {
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+        mockGetRunHook.mockReturnValue({
+            data: mockRun,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+        });
+
+        renderWithProviders(<AnalysisPage />, {
+            initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+        });
+
+        await userEvent.click(screen.getByRole('button', { name: /overview/i }));
+
+        expect(screen.getByRole('tab', { name: /loadings/i })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: /factor arrays/i })).toBeInTheDocument();
+        // FactorCanvas chips are gone in Overview mode.
+        expect(screen.queryByRole('tab', { name: 'F1' })).not.toBeInTheDocument();
+    });
+
+    it('clicking Per-factor focus switches back from Overview', async () => {
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+        mockGetRunHook.mockReturnValue({
+            data: mockRun,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+        });
+
+        renderWithProviders(<AnalysisPage />, {
+            initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+        });
+
+        await userEvent.click(screen.getByRole('button', { name: /overview/i }));
+        expect(screen.getByRole('tab', { name: /loadings/i })).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', { name: /per-factor focus/i }));
+        expect(screen.getByRole('tab', { name: 'F1' })).toBeInTheDocument();
+        expect(screen.queryByRole('tab', { name: /loadings/i })).not.toBeInTheDocument();
+    });
+
+    it('?focus=f2 URL param renders F2 as the active chip', async () => {
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+        mockGetRunHook.mockReturnValue({
+            data: mockRun,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+        });
+
+        renderWithProviders(<AnalysisPage />, {
+            initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42&focus=f2`],
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole('tab', { name: 'F2' })).toBeInTheDocument();
+        });
+        const f2 = screen.getByRole('tab', { name: 'F2' });
+        const f1 = screen.getByRole('tab', { name: 'F1' });
+        expect(f2).toHaveAttribute('aria-selected', 'true');
+        expect(f1).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('clicking F2 chip updates the active chip aria-selected', async () => {
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+        mockGetRunHook.mockReturnValue({
+            data: mockRun,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+        });
+
+        renderWithProviders(<AnalysisPage />, {
+            initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+        });
+
+        // F1 active by default (focus omitted from URL).
+        await waitFor(() => {
+            expect(screen.getByRole('tab', { name: 'F1' })).toHaveAttribute(
+                'aria-selected',
+                'true'
+            );
+        });
+
+        // Click F2 — the URL writer (setFocusFromCanvas) updates ?focus=f2,
+        // the hook re-derives activeFactor=2, and the chip aria flips.
+        await userEvent.click(screen.getByRole('tab', { name: 'F2' }));
+        await waitFor(() => {
+            expect(screen.getByRole('tab', { name: 'F2' })).toHaveAttribute(
+                'aria-selected',
+                'true'
+            );
+        });
+        expect(screen.getByRole('tab', { name: 'F1' })).toHaveAttribute('aria-selected', 'false');
     });
 
     it('navigates to interpret phase after a successful run', async () => {

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -55,6 +55,7 @@ import { StatementsTable } from '@/components/admin/analysis/StatementsTable';
 import { FactorCharacteristicsTable } from '@/components/admin/analysis/FactorCharacteristicsTable';
 import { AnalysisHistoryPanel } from '@/components/admin/analysis/AnalysisHistoryPanel';
 import { FactorVoicesPanel } from '@/components/admin/analysis/FactorVoicesPanel';
+import { FactorCanvas } from '@/components/admin/analysis/FactorCanvas';
 import { useExplorePhase, type ExplorePhaseApi } from '@/hooks/admin/useExplorePhase';
 import { useInterpretPhase, type InterpretPhaseApi } from '@/hooks/admin/useInterpretPhase';
 import type { AnalysisResult, AnalysisRunRead, AnalysisRunSummary } from '@/api/model';
@@ -122,6 +123,20 @@ export default function AnalysisPage() {
         );
     }, [setSearchParams]);
 
+    const setFocusFromCanvas = useCallback(
+        (factor: number) => {
+            setSearchParams(
+                (prev) => {
+                    const p = new URLSearchParams(prev);
+                    p.set('focus', `f${factor}`);
+                    return p;
+                },
+                { replace: true }
+            );
+        },
+        [setSearchParams]
+    );
+
     const explore = useExplorePhase(slug, navigateToInterpret);
     const interpret = useInterpretPhase(slug, runId, focus, compareTo);
 
@@ -177,6 +192,7 @@ export default function AnalysisPage() {
                 t={t}
                 onSelectHistoricalRun={navigateToHistoricalRun}
                 onBackToExplore={navigateToExplore}
+                onFocusChange={setFocusFromCanvas}
             />
         );
     }
@@ -737,6 +753,7 @@ interface InterpretShellProps {
     t: TFunction;
     onSelectHistoricalRun: (runId: number) => void;
     onBackToExplore: () => void;
+    onFocusChange: (factor: number) => void;
 }
 
 function InterpretShell({
@@ -746,6 +763,7 @@ function InterpretShell({
     t,
     onSelectHistoricalRun,
     onBackToExplore,
+    onFocusChange,
 }: InterpretShellProps) {
     const [searchParams, setSearchParams] = useSearchParams();
     const activeTab = searchParams.get('tab') ?? 'loadings';
@@ -766,6 +784,11 @@ function InterpretShell({
         },
         [setSearchParams]
     );
+
+    // ── Mode toggle: Focus (FactorCanvas) is the default; Overview keeps
+    // the legacy four-tab layout as a one-click escape hatch for
+    // cross-factor views (loadings/arrays/statements/summary).
+    const [mode, setMode] = useState<'focus' | 'overview'>('focus');
 
     const run = interpret.run;
     const analysisResult = run ? (run.result as unknown as AnalysisResult) : null;
@@ -1023,168 +1046,207 @@ function InterpretShell({
                 </Button>
             </div>
 
+            {/* Mode toggle — Focus (FactorCanvas) by default, Overview restores
+                the legacy four-tab layout. Sits above the results card. */}
+            <div className="flex justify-end">
+                <div
+                    className="inline-flex rounded-md bg-slate-100 p-1"
+                    role="group"
+                    aria-label={t('admin.analysis.interpret.mode_toggle', 'View mode')}
+                >
+                    <button
+                        type="button"
+                        onClick={() => setMode('focus')}
+                        className={
+                            mode === 'focus'
+                                ? 'px-3 py-1.5 text-xs font-medium rounded bg-white text-slate-900 shadow-sm'
+                                : 'px-3 py-1.5 text-xs font-medium text-slate-600 hover:text-slate-900'
+                        }
+                        aria-pressed={mode === 'focus'}
+                    >
+                        {t('admin.analysis.interpret.focus_mode', 'Per-factor focus')}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setMode('overview')}
+                        className={
+                            mode === 'overview'
+                                ? 'px-3 py-1.5 text-xs font-medium rounded bg-white text-slate-900 shadow-sm'
+                                : 'px-3 py-1.5 text-xs font-medium text-slate-600 hover:text-slate-900'
+                        }
+                        aria-pressed={mode === 'overview'}
+                    >
+                        {t('admin.analysis.interpret.overview_mode', 'Overview')}
+                    </button>
+                </div>
+            </div>
+
             {/* Results */}
-            <Card className="border-none shadow-sm bg-white rounded-2xl relative">
-                <CardContent className="pt-5 pb-5">
-                    <Tabs value={activeTab} onValueChange={setActiveTab}>
-                        <TabsList className="mb-5 flex-wrap h-auto gap-1">
-                            <TabsTrigger value="loadings" className="gap-1.5">
-                                <BarChart3 className="size-3.5" aria-hidden="true" />
-                                {t('admin.analysis.tab_loadings', 'Loadings')}
-                            </TabsTrigger>
-                            <TabsTrigger value="arrays" className="gap-1.5">
-                                <Grid3X3 className="size-3.5" aria-hidden="true" />
-                                {t('admin.analysis.tab_factor_arrays', 'Factor Arrays')}
-                            </TabsTrigger>
-                            <TabsTrigger value="statements" className="gap-1.5">
-                                <List className="size-3.5" aria-hidden="true" />
-                                {t('admin.analysis.tab_statements', 'Statements')}
-                            </TabsTrigger>
-                            <TabsTrigger value="summary" className="gap-1.5">
-                                <Info className="size-3.5" aria-hidden="true" />
-                                {t('admin.analysis.tab_summary', 'Summary')}
-                            </TabsTrigger>
-                        </TabsList>
+            {mode === 'focus' ? (
+                <FactorCanvas slug={slug} interpret={interpret} onFocusChange={onFocusChange} />
+            ) : (
+                <Card className="border-none shadow-sm bg-white rounded-2xl relative">
+                    <CardContent className="pt-5 pb-5">
+                        <Tabs value={activeTab} onValueChange={setActiveTab}>
+                            <TabsList className="mb-5 flex-wrap h-auto gap-1">
+                                <TabsTrigger value="loadings" className="gap-1.5">
+                                    <BarChart3 className="size-3.5" aria-hidden="true" />
+                                    {t('admin.analysis.tab_loadings', 'Loadings')}
+                                </TabsTrigger>
+                                <TabsTrigger value="arrays" className="gap-1.5">
+                                    <Grid3X3 className="size-3.5" aria-hidden="true" />
+                                    {t('admin.analysis.tab_factor_arrays', 'Factor Arrays')}
+                                </TabsTrigger>
+                                <TabsTrigger value="statements" className="gap-1.5">
+                                    <List className="size-3.5" aria-hidden="true" />
+                                    {t('admin.analysis.tab_statements', 'Statements')}
+                                </TabsTrigger>
+                                <TabsTrigger value="summary" className="gap-1.5">
+                                    <Info className="size-3.5" aria-hidden="true" />
+                                    {t('admin.analysis.tab_summary', 'Summary')}
+                                </TabsTrigger>
+                            </TabsList>
 
-                        <TabsContent value="loadings" className="space-y-3">
-                            <GuidanceCard
-                                title={t(
-                                    'admin.analysis.guide_loadings_title',
-                                    'Reading Factor Loadings'
-                                )}
-                                type="info"
-                                collapsible
-                                defaultOpen={false}
-                            >
-                                <ul className="text-xs leading-relaxed space-y-1 list-disc list-inside">
-                                    <li>
-                                        {t(
-                                            'admin.analysis.guide_loadings_1',
-                                            'Each loading is a correlation (-1 to +1) between a participant and a factor (shared viewpoint).'
-                                        )}
-                                    </li>
-                                    <li>
-                                        {t(
-                                            'admin.analysis.guide_loadings_2',
-                                            'Highlighted values exceed the significance threshold shown above the table.'
-                                        )}
-                                    </li>
-                                </ul>
-                            </GuidanceCard>
-                            <FactorLoadingsTable
-                                result={analysisResult}
-                                flaggingMode={flaggingMode}
-                                manualFlags={manualFlags}
-                                onToggleFlag={handleToggleFlag}
-                            />
-                        </TabsContent>
+                            <TabsContent value="loadings" className="space-y-3">
+                                <GuidanceCard
+                                    title={t(
+                                        'admin.analysis.guide_loadings_title',
+                                        'Reading Factor Loadings'
+                                    )}
+                                    type="info"
+                                    collapsible
+                                    defaultOpen={false}
+                                >
+                                    <ul className="text-xs leading-relaxed space-y-1 list-disc list-inside">
+                                        <li>
+                                            {t(
+                                                'admin.analysis.guide_loadings_1',
+                                                'Each loading is a correlation (-1 to +1) between a participant and a factor (shared viewpoint).'
+                                            )}
+                                        </li>
+                                        <li>
+                                            {t(
+                                                'admin.analysis.guide_loadings_2',
+                                                'Highlighted values exceed the significance threshold shown above the table.'
+                                            )}
+                                        </li>
+                                    </ul>
+                                </GuidanceCard>
+                                <FactorLoadingsTable
+                                    result={analysisResult}
+                                    flaggingMode={flaggingMode}
+                                    manualFlags={manualFlags}
+                                    onToggleFlag={handleToggleFlag}
+                                />
+                            </TabsContent>
 
-                        <TabsContent value="arrays" className="space-y-3">
-                            <GuidanceCard
-                                title={t(
-                                    'admin.analysis.guide_arrays_title',
-                                    'Interpreting Factor Arrays'
-                                )}
-                                type="info"
-                                collapsible
-                                defaultOpen={false}
-                            >
-                                <ul className="text-xs leading-relaxed space-y-1 list-disc list-inside">
-                                    <li>
-                                        {t(
-                                            'admin.analysis.guide_arrays_1',
-                                            'Each factor array is the composite Q-sort representing one shared viewpoint.'
-                                        )}
-                                    </li>
-                                    <li>
-                                        {t(
-                                            'admin.analysis.guide_arrays_2',
-                                            'Read left-to-right as most disagreed to most agreed. Extreme positions carry the strongest signal for interpretation.'
-                                        )}
-                                    </li>
-                                </ul>
-                            </GuidanceCard>
-                            <FactorArraysView
-                                result={analysisResult}
-                                currentRun={currentRun}
-                                slug={slug}
-                                showFactorNarratives={showFactorNarratives}
-                                onToggleFactorNarratives={() =>
-                                    setShowFactorNarratives(!showFactorNarratives)
-                                }
-                            />
-                        </TabsContent>
+                            <TabsContent value="arrays" className="space-y-3">
+                                <GuidanceCard
+                                    title={t(
+                                        'admin.analysis.guide_arrays_title',
+                                        'Interpreting Factor Arrays'
+                                    )}
+                                    type="info"
+                                    collapsible
+                                    defaultOpen={false}
+                                >
+                                    <ul className="text-xs leading-relaxed space-y-1 list-disc list-inside">
+                                        <li>
+                                            {t(
+                                                'admin.analysis.guide_arrays_1',
+                                                'Each factor array is the composite Q-sort representing one shared viewpoint.'
+                                            )}
+                                        </li>
+                                        <li>
+                                            {t(
+                                                'admin.analysis.guide_arrays_2',
+                                                'Read left-to-right as most disagreed to most agreed. Extreme positions carry the strongest signal for interpretation.'
+                                            )}
+                                        </li>
+                                    </ul>
+                                </GuidanceCard>
+                                <FactorArraysView
+                                    result={analysisResult}
+                                    currentRun={currentRun}
+                                    slug={slug}
+                                    showFactorNarratives={showFactorNarratives}
+                                    onToggleFactorNarratives={() =>
+                                        setShowFactorNarratives(!showFactorNarratives)
+                                    }
+                                />
+                            </TabsContent>
 
-                        <TabsContent value="statements" className="space-y-3">
-                            <GuidanceCard
-                                title={t(
-                                    'admin.analysis.guide_statements_title',
-                                    'Understanding Statement Scores'
-                                )}
-                                type="info"
-                                collapsible
-                                defaultOpen={false}
-                            >
-                                <ul className="text-xs leading-relaxed space-y-1 list-disc list-inside">
-                                    <li>
-                                        {t(
-                                            'admin.analysis.guide_statements_1',
-                                            'Z-scores show how strongly each factor agrees or disagrees with each statement (0 = neutral).'
-                                        )}
-                                    </li>
-                                    <li>
-                                        {t(
-                                            'admin.analysis.guide_statements_2',
-                                            'D = distinguishing (placed significantly differently across factors). Stars indicate significance level.'
-                                        )}
-                                    </li>
-                                </ul>
-                            </GuidanceCard>
-                            <StatementsTable result={analysisResult} />
-                        </TabsContent>
+                            <TabsContent value="statements" className="space-y-3">
+                                <GuidanceCard
+                                    title={t(
+                                        'admin.analysis.guide_statements_title',
+                                        'Understanding Statement Scores'
+                                    )}
+                                    type="info"
+                                    collapsible
+                                    defaultOpen={false}
+                                >
+                                    <ul className="text-xs leading-relaxed space-y-1 list-disc list-inside">
+                                        <li>
+                                            {t(
+                                                'admin.analysis.guide_statements_1',
+                                                'Z-scores show how strongly each factor agrees or disagrees with each statement (0 = neutral).'
+                                            )}
+                                        </li>
+                                        <li>
+                                            {t(
+                                                'admin.analysis.guide_statements_2',
+                                                'D = distinguishing (placed significantly differently across factors). Stars indicate significance level.'
+                                            )}
+                                        </li>
+                                    </ul>
+                                </GuidanceCard>
+                                <StatementsTable result={analysisResult} />
+                            </TabsContent>
 
-                        <TabsContent value="summary" className="space-y-3">
-                            <GuidanceCard
-                                title={t(
-                                    'admin.analysis.guide_summary_title',
-                                    'Evaluating Your Solution'
-                                )}
-                                type="info"
-                                collapsible
-                                defaultOpen={false}
-                            >
-                                <ul className="text-xs leading-relaxed space-y-1 list-disc list-inside">
-                                    <li>
-                                        {t(
-                                            'admin.analysis.guide_summary_1',
-                                            'Eigenvalues measure how much variance a factor explains. The Kaiser criterion (eigenvalue > 1) is one common heuristic for deciding how many factors to retain.'
-                                        )}
-                                    </li>
-                                    <li>
-                                        {t(
-                                            'admin.analysis.guide_summary_2',
-                                            'Composite reliability reflects how consistently the flagged sorts define each factor. Higher values mean the factor estimate is based on more agreement among its defining sorts.'
-                                        )}
-                                    </li>
-                                </ul>
-                            </GuidanceCard>
-                            <FactorCharacteristicsTable result={analysisResult} />
-                        </TabsContent>
-                    </Tabs>
+                            <TabsContent value="summary" className="space-y-3">
+                                <GuidanceCard
+                                    title={t(
+                                        'admin.analysis.guide_summary_title',
+                                        'Evaluating Your Solution'
+                                    )}
+                                    type="info"
+                                    collapsible
+                                    defaultOpen={false}
+                                >
+                                    <ul className="text-xs leading-relaxed space-y-1 list-disc list-inside">
+                                        <li>
+                                            {t(
+                                                'admin.analysis.guide_summary_1',
+                                                'Eigenvalues measure how much variance a factor explains. The Kaiser criterion (eigenvalue > 1) is one common heuristic for deciding how many factors to retain.'
+                                            )}
+                                        </li>
+                                        <li>
+                                            {t(
+                                                'admin.analysis.guide_summary_2',
+                                                'Composite reliability reflects how consistently the flagged sorts define each factor. Higher values mean the factor estimate is based on more agreement among its defining sorts.'
+                                            )}
+                                        </li>
+                                    </ul>
+                                </GuidanceCard>
+                                <FactorCharacteristicsTable result={analysisResult} />
+                            </TabsContent>
+                        </Tabs>
 
-                    {/* Per-factor voices panels — always rendered below all tabs */}
-                    <div className="mt-4 space-y-2">
-                        {Array.from({ length: analysisResult.n_factors }, (_, f) => (
-                            <FactorVoicesPanel
-                                key={f}
-                                slug={slug}
-                                factorIndex={f}
-                                participants={analysisResult.participants}
-                            />
-                        ))}
-                    </div>
-                </CardContent>
-            </Card>
+                        {/* Per-factor voices panels — always rendered below all tabs */}
+                        <div className="mt-4 space-y-2">
+                            {Array.from({ length: analysisResult.n_factors }, (_, f) => (
+                                <FactorVoicesPanel
+                                    key={f}
+                                    slug={slug}
+                                    factorIndex={f}
+                                    participants={analysisResult.participants}
+                                />
+                            ))}
+                        </div>
+                    </CardContent>
+                </Card>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Phase 4 of the interpretive-workspace plan. Adds the per-factor workspace and the quote picker that integrates participant card comments into the active factor narrative.

- **\`<FactorCanvas>\`** brings together Statements (top/bottom by |z|, distinguishing badge), Voices (audio + comments of flagged participants), and the Narrative editor in one focused view.
- **\`<FactorSelectorChips>\`** — F1/F2/F3 chips with role=tab + aria-selected. URL-synced via \`?focus=fN\`.
- **Quote picker** — clicking ▸+ on a participant comment forces the editor into edit mode and inserts a markdown blockquote with attribution: \`> {comment}\\n> — {participant}, on statement {code}: "{stmt[:60]}…"\`. Ellipsis is conditional on actual truncation.
- **No insert from audios or statements** (spec §5.3) — narrow scope by design.
- **\`<FactorNoteEditor>\`** converted to \`forwardRef\` exposing an imperative \`appendQuote(snippet)\` handle. Backward-compatible: existing call sites without ref still work.
- **Focus / Overview mode toggle** in InterpretShell preserves the legacy four tabs (loadings/arrays/statements/summary) as Overview, so cross-factor views remain one click away. **Focus is the new default.**

Spec: \`docs/superpowers/specs/2026-04-29-analysis-module-improvements-design.md\` §5.
Plan: \`docs/superpowers/plans/2026-04-29-analysis-interpretive-workspace.md\` Phase 4.

## Test plan
- [x] FactorNoteEditor: forwardRef + appendQuote handle (10 → 11 tests)
- [x] FactorSelectorChips: chips render, aria-selected, onSelect (6 tests)
- [x] FactorVoicesPanel: \`onInsertCommentQuote\` optional prop, no audio insert (8 tests, +0 since the change is additive)
- [x] FactorCanvas: 11 tests covering chips, statements panel, D badge, defining-sorts count, narrative title, null-when-no-result, quote insertion (short + long ellipsis paths), audio rows have no insert button
- [x] AnalysisPage: 23 tests (+5 for mode toggle, URL-driven focus)
- [x] Mid-phase code-reviewer: APPROVE_WITH_NITS; both Important findings (false ellipsis on short statements + dual-write source-of-truth ambiguity) addressed in commit \`22c2af3\` before push
- [x] E2E updated to click Overview before asserting on legacy tabs (commit \`a261350\`)
- [x] \`make ci\` green
- [x] All en/fr/fi locales in sync (5 new keys under \`admin.analysis.interpret.*\` + 1 \`quote_insert_format\`)

## Known follow-ups (deferred to PR 5)
- Compare-pin (Tucker's φ alignment + delta strips in Statements/Voices panels) — Tasks 26-29.
- "Distinguishing first" sort in the Statements panel (currently |z| descending; distinguishing items typically surface but no formal guarantee for v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)