### PR TITLE
feat(analysis): compare pin — Tucker φ alignment + delta columns (phase 5/5)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -982,7 +982,9 @@
                 "pinned": "Comparing with run #{{id}}",
                 "phi": "φ = {{phi}}",
                 "ambiguous": "ambiguous match — interpret deltas with care",
-                "unpin": "Unpin"
+                "unpin": "Unpin",
+                "delta_z_aria": "Δz {{delta}} vs compare run",
+                "delta_loading_aria": "Δloading {{delta}} vs compare run"
             },
             "quote_insert_format": "> {{text}}\n> — {{p}}, on statement {{code}}: \"{{stmt}}\""
         },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -975,6 +975,15 @@
                 "overview_mode": "Overview",
                 "mode_toggle": "View mode"
             },
+            "compare": {
+                "pin_cta": "Pin compare",
+                "no_other_runs": "No other runs available",
+                "run_label": "Run #{{id}} ({{n}} factors)",
+                "pinned": "Comparing with run #{{id}}",
+                "phi": "φ = {{phi}}",
+                "ambiguous": "ambiguous match — interpret deltas with care",
+                "unpin": "Unpin"
+            },
             "quote_insert_format": "> {{text}}\n> — {{p}}, on statement {{code}}: \"{{stmt}}\""
         },
         "project": {

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -927,6 +927,15 @@
                 "overview_mode": "Yleisnäkymä",
                 "mode_toggle": "Näkymätila"
             },
+            "compare": {
+                "pin_cta": "Kiinnitä vertailu",
+                "no_other_runs": "Ei muita vertailtavia ajoja",
+                "run_label": "Ajo #{{id}} ({{n}} tekijää)",
+                "pinned": "Verrataan ajoon #{{id}}",
+                "phi": "φ = {{phi}}",
+                "ambiguous": "epäselvä vastaavuus — tulkitse delta-arvoja varoen",
+                "unpin": "Poista kiinnitys"
+            },
             "quote_insert_format": "> {{text}}\n> — {{p}}, väittämästä {{code}}: \"{{stmt}}\""
         },
         "project": {

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -934,7 +934,9 @@
                 "pinned": "Verrataan ajoon #{{id}}",
                 "phi": "φ = {{phi}}",
                 "ambiguous": "epäselvä vastaavuus — tulkitse delta-arvoja varoen",
-                "unpin": "Poista kiinnitys"
+                "unpin": "Poista kiinnitys",
+                "delta_z_aria": "Δz {{delta}} vs vertailuajo",
+                "delta_loading_aria": "Δlataus {{delta}} vs vertailuajo"
             },
             "quote_insert_format": "> {{text}}\n> — {{p}}, väittämästä {{code}}: \"{{stmt}}\""
         },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -934,7 +934,9 @@
                 "pinned": "Comparaison avec le run #{{id}}",
                 "phi": "φ = {{phi}}",
                 "ambiguous": "appariement ambigu — interpréter les Δ avec précaution",
-                "unpin": "Désépingler"
+                "unpin": "Désépingler",
+                "delta_z_aria": "Δz {{delta}} vs run de comparaison",
+                "delta_loading_aria": "Δsaturation {{delta}} vs run de comparaison"
             },
             "quote_insert_format": "> {{text}}\n> — {{p}}, sur l'énoncé {{code}} : « {{stmt}} »"
         },

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -927,6 +927,15 @@
                 "overview_mode": "Vue d'ensemble",
                 "mode_toggle": "Mode d'affichage"
             },
+            "compare": {
+                "pin_cta": "Épingler une comparaison",
+                "no_other_runs": "Aucun autre run disponible",
+                "run_label": "Run #{{id}} ({{n}} facteurs)",
+                "pinned": "Comparaison avec le run #{{id}}",
+                "phi": "φ = {{phi}}",
+                "ambiguous": "appariement ambigu — interpréter les Δ avec précaution",
+                "unpin": "Désépingler"
+            },
             "quote_insert_format": "> {{text}}\n> — {{p}}, sur l'énoncé {{code}} : « {{stmt}} »"
         },
         "project": {

--- a/frontend/src/components/admin/analysis/CompareBar.test.tsx
+++ b/frontend/src/components/admin/analysis/CompareBar.test.tsx
@@ -1,0 +1,173 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders } from '@/test-utils/test-utils';
+import { CompareBar } from './CompareBar';
+import type { AnalysisRunSummary } from '@/api/model';
+
+const RUNS: AnalysisRunSummary[] = [
+    {
+        id: 38,
+        ran_at: '2026-04-29T10:00:00Z',
+        n_factors: 3,
+        extraction_method: 'pca',
+        rotation_method: 'varimax',
+        flagging_mode: 'auto',
+    } as unknown as AnalysisRunSummary,
+    {
+        id: 42,
+        ran_at: '2026-04-30T10:00:00Z',
+        n_factors: 3,
+        extraction_method: 'pca',
+        rotation_method: 'varimax',
+        flagging_mode: 'auto',
+    } as unknown as AnalysisRunSummary,
+];
+
+describe('CompareBar', () => {
+    it('renders the Pin button when nothing is pinned', () => {
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={null}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+                phi={null}
+            />
+        );
+        expect(screen.getByRole('button', { name: /pin compare/i })).toBeInTheDocument();
+    });
+
+    it('opening the picker lists runs except the current one', async () => {
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={null}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+                phi={null}
+            />
+        );
+        await userEvent.click(screen.getByRole('button', { name: /pin compare/i }));
+        // Run #38 is offered, run #42 (current) is not.
+        const items = await screen.findAllByRole('menuitem');
+        expect(items.length).toBe(1);
+        expect(items[0]).toHaveTextContent(/Run #38/);
+    });
+
+    it('clicking a picker item calls onPin with the chosen run id', async () => {
+        const onPin = vi.fn();
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={null}
+                onPin={onPin}
+                onUnpin={vi.fn()}
+                phi={null}
+            />
+        );
+        await userEvent.click(screen.getByRole('button', { name: /pin compare/i }));
+        const item = await screen.findByRole('menuitem');
+        await userEvent.click(item);
+        expect(onPin).toHaveBeenCalledWith(38);
+    });
+
+    it('shows pinned run id, φ, and Unpin button when compareTo is set', () => {
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+                phi={0.92}
+            />
+        );
+        expect(screen.getByText(/run #38/i)).toBeInTheDocument();
+        expect(screen.getByText(/0\.92/)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /unpin/i })).toBeInTheDocument();
+    });
+
+    it('clicking Unpin calls onUnpin', () => {
+        const onUnpin = vi.fn();
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={onUnpin}
+                phi={0.92}
+            />
+        );
+        fireEvent.click(screen.getByRole('button', { name: /unpin/i }));
+        expect(onUnpin).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns on |φ| < 0.85', () => {
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+                phi={0.78}
+            />
+        );
+        expect(screen.getByText(/ambiguous match/i)).toBeInTheDocument();
+    });
+
+    it('does not warn on |φ| >= 0.85', () => {
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+                phi={0.85}
+            />
+        );
+        expect(screen.queryByText(/ambiguous match/i)).toBeNull();
+    });
+
+    it('warns on negative φ below threshold (sign-flipped weak match)', () => {
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+                phi={-0.5}
+            />
+        );
+        expect(screen.getByText(/ambiguous match/i)).toBeInTheDocument();
+    });
+
+    it('handles phi=null when pinned (still loading) without crashing', () => {
+        renderWithProviders(
+            <CompareBar
+                runs={RUNS}
+                currentRunId={42}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+                phi={null}
+            />
+        );
+        // Pinned label visible but φ display absent.
+        expect(screen.getByText(/run #38/i)).toBeInTheDocument();
+        expect(screen.queryByText(/φ/)).toBeNull();
+    });
+});

--- a/frontend/src/components/admin/analysis/CompareBar.tsx
+++ b/frontend/src/components/admin/analysis/CompareBar.tsx
@@ -1,0 +1,124 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Pin, X, AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { AnalysisRunSummary } from '@/api/model';
+
+interface CompareBarProps {
+    /** Available runs (the run history). Excludes the current run when picking. */
+    runs: AnalysisRunSummary[];
+    /** The run currently displayed in interpret phase. */
+    currentRunId: number;
+    /** The pinned compare-to run id, or null when nothing is pinned. */
+    compareTo: number | null;
+    onPin: (runId: number) => void;
+    onUnpin: () => void;
+    /** Tucker's φ between the active factor of `currentRunId` and its matched
+     *  factor in `compareTo`. Null when nothing is pinned (or no match yet). */
+    phi: number | null;
+}
+
+const AMBIGUOUS_THRESHOLD = 0.85;
+
+/**
+ * Compare-pin UI for the Interpret phase. When `compareTo` is null, shows
+ * a "Pin compare" dropdown listing the run history (excluding the current
+ * run). When pinned, shows the pinned run id, the Tucker's φ matching the
+ * active factor, and an Unpin button. Warns when |φ| < 0.85 (the spec's
+ * ambiguous-match threshold).
+ */
+export function CompareBar({
+    runs,
+    currentRunId,
+    compareTo,
+    onPin,
+    onUnpin,
+    phi,
+}: CompareBarProps) {
+    const { t } = useTranslation();
+
+    if (compareTo === null) {
+        const pickable = runs.filter((r) => r.id !== currentRunId);
+        return (
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button variant="outline" size="sm">
+                        <Pin className="mr-1 h-3 w-3" aria-hidden="true" />
+                        {t('admin.analysis.compare.pin_cta', 'Pin compare')}
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                    {pickable.length === 0 ? (
+                        <DropdownMenuItem disabled>
+                            {t('admin.analysis.compare.no_other_runs', 'No other runs available')}
+                        </DropdownMenuItem>
+                    ) : (
+                        pickable.map((r) => (
+                            <DropdownMenuItem key={r.id} onClick={() => onPin(r.id)}>
+                                {t(
+                                    'admin.analysis.compare.run_label',
+                                    'Run #{{id}} ({{n}} factors)',
+                                    { id: r.id, n: r.n_factors }
+                                )}
+                            </DropdownMenuItem>
+                        ))
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        );
+    }
+
+    const ambiguous = phi !== null && Math.abs(phi) < AMBIGUOUS_THRESHOLD;
+
+    return (
+        <div className="flex items-center gap-2 text-sm">
+            <Pin className="h-3 w-3 text-slate-500" aria-hidden="true" />
+            <span className="font-medium text-slate-700">
+                {t('admin.analysis.compare.pinned', 'Comparing with run #{{id}}', {
+                    id: compareTo,
+                })}
+            </span>
+            {phi !== null && (
+                <span
+                    className={
+                        ambiguous ? 'text-amber-700 flex items-center gap-1' : 'text-slate-600'
+                    }
+                >
+                    {t('admin.analysis.compare.phi', 'φ = {{phi}}', {
+                        phi: phi.toFixed(2),
+                    })}
+                    {ambiguous && (
+                        <>
+                            <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                            <span>
+                                {t(
+                                    'admin.analysis.compare.ambiguous',
+                                    'ambiguous match — interpret deltas with care'
+                                )}
+                            </span>
+                        </>
+                    )}
+                </span>
+            )}
+            <Button
+                variant="ghost"
+                size="sm"
+                onClick={onUnpin}
+                aria-label={t('admin.analysis.compare.unpin', 'Unpin')}
+            >
+                <X className="h-3 w-3" aria-hidden="true" />
+            </Button>
+        </div>
+    );
+}

--- a/frontend/src/components/admin/analysis/FactorCanvas.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorCanvas.test.tsx
@@ -5,11 +5,13 @@
  */
 
 import { renderWithProviders, screen, fireEvent, waitFor } from '@/test-utils/test-utils';
+import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { FactorCanvas } from './FactorCanvas';
 import type { InterpretPhaseApi } from '@/hooks/admin/useInterpretPhase';
 import type { ParticipantAudioRecording } from '@/api/model/participantAudioRecording';
 import type { ParticipantCardComment } from '@/api/model/participantCardComment';
+import type { AnalysisRunSummary } from '@/api/model';
 
 // ── Hoisted mocks for the generated API hooks ─────────────────────────────────
 const { mockAudiosHook, mockCommentsHook, mockUpdateHook, mockListRunsKey } = vi.hoisted(() => ({
@@ -120,8 +122,24 @@ function buildInterpret(overrides: Partial<InterpretPhaseApi> = {}): InterpretPh
         setShowFactorNarratives: vi.fn(),
         compareRun: null,
         deltaByStatement: null,
+        deltaByParticipant: null,
+        activeMatchPhi: null,
+        activeMatchBIndex: null,
+        isAmbiguousMatch: false,
     };
     return { ...base, ...overrides };
+}
+
+// Default compare-pin props for FactorCanvas. Kept as a factory so each render
+// gets fresh vi.fn()s (avoids state leaking between tests when mocks are
+// asserted against).
+function compareDefaults() {
+    return {
+        runs: [] as AnalysisRunSummary[],
+        compareTo: null as number | null,
+        onPin: vi.fn(),
+        onUnpin: vi.fn(),
+    };
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -136,7 +154,12 @@ describe('FactorCanvas', () => {
 
     it('renders factor selector chips with active factor highlighted', () => {
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         const chips = screen.getAllByRole('tab');
         expect(chips).toHaveLength(3);
@@ -146,7 +169,12 @@ describe('FactorCanvas', () => {
     it('calls onFocusChange when a different chip is clicked', () => {
         const onFocusChange = vi.fn();
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={onFocusChange} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={onFocusChange}
+                {...compareDefaults()}
+            />
         );
         const chips = screen.getAllByRole('tab');
         const second = chips[1];
@@ -157,7 +185,12 @@ describe('FactorCanvas', () => {
 
     it('renders Statements panel with top |z| of active factor', () => {
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         expect(screen.getByText(/Local food sovereignty/)).toBeInTheDocument();
         expect(screen.getByText('+2.41')).toBeInTheDocument();
@@ -166,21 +199,36 @@ describe('FactorCanvas', () => {
 
     it('flags distinguishing statements with a D badge', () => {
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         expect(screen.getByLabelText(/distinguishing statement/i)).toBeInTheDocument();
     });
 
     it('shows defining-sorts count from interpret.flaggedParticipants.length', () => {
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         expect(screen.getByText(/Defining sorts:\s*1/i)).toBeInTheDocument();
     });
 
     it('renders the Narrative editor with the active factor in title', () => {
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         expect(screen.getByText(/Narrative.*F1/i)).toBeInTheDocument();
     });
@@ -188,7 +236,12 @@ describe('FactorCanvas', () => {
     it('returns null when run.result is missing', () => {
         const empty = buildInterpret({ run: null });
         const { container } = renderWithProviders(
-            <FactorCanvas slug="s" interpret={empty} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={empty}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         expect(container.firstChild).toBeNull();
     });
@@ -211,7 +264,12 @@ describe('FactorCanvas', () => {
         const appendToNarrative = vi.fn();
         const interpret = buildInterpret({ appendToNarrative });
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={interpret} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={interpret}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
 
         const insertBtn = await screen.findByLabelText(/insert comment as quote/i);
@@ -244,7 +302,12 @@ describe('FactorCanvas', () => {
             ])
         );
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         const insertBtn = await screen.findByLabelText(/insert comment as quote/i);
         fireEvent.click(insertBtn);
@@ -270,7 +333,12 @@ describe('FactorCanvas', () => {
             ])
         );
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         const insertBtn = await screen.findByLabelText(/insert comment as quote/i);
         fireEvent.click(insertBtn);
@@ -297,12 +365,148 @@ describe('FactorCanvas', () => {
         );
         // Comments are empty, so the only voices content is the audio row.
         renderWithProviders(
-            <FactorCanvas slug="s" interpret={buildInterpret()} onFocusChange={vi.fn()} />
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                {...compareDefaults()}
+            />
         );
         await waitFor(() => {
             expect(document.querySelectorAll('audio')).toHaveLength(1);
         });
         expect(screen.queryByLabelText(/insert audio.*quote/i)).toBeNull();
         expect(screen.queryByLabelText(/insert comment as quote/i)).toBeNull();
+    });
+});
+
+describe('FactorCanvas: compare-pin (Phase 5)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockAudiosHook.mockReturnValue(emptyOk<ParticipantAudioRecording>());
+        mockCommentsHook.mockReturnValue(emptyOk<ParticipantCardComment>());
+        mockUpdateHook.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    });
+
+    it('renders CompareBar pinned state when compareTo is set', () => {
+        const interpret = buildInterpret({
+            activeMatchPhi: 0.92,
+            activeMatchBIndex: 0,
+            isAmbiguousMatch: false,
+        });
+        renderWithProviders(
+            <FactorCanvas
+                slug="s"
+                interpret={interpret}
+                onFocusChange={vi.fn()}
+                runs={[
+                    { id: 38, n_factors: 3 } as unknown as AnalysisRunSummary,
+                    { id: 42, n_factors: 3 } as unknown as AnalysisRunSummary,
+                ]}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+            />
+        );
+        expect(screen.getByText(/run #38/i)).toBeInTheDocument();
+        expect(screen.getByText(/0\.92/)).toBeInTheDocument();
+    });
+
+    it('renders Δz next to statement z-scores when deltaByStatement is non-null', () => {
+        const deltaByStatement = new Map<number, number>([[7, 0.55]]);
+        const interpret = buildInterpret({
+            deltaByStatement,
+            activeMatchPhi: 0.91,
+            activeMatchBIndex: 0,
+        });
+        renderWithProviders(
+            <FactorCanvas
+                slug="s"
+                interpret={interpret}
+                onFocusChange={vi.fn()}
+                runs={[]}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+            />
+        );
+        // Δ chip with the formatted value and aria-label including "Δz"
+        expect(screen.getByLabelText(/Δz 0\.55 vs compare run/i)).toBeInTheDocument();
+    });
+
+    it('does NOT render Δz when deltaByStatement is null (no compare)', () => {
+        renderWithProviders(
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                runs={[]}
+                compareTo={null}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+            />
+        );
+        expect(screen.queryByLabelText(/Δz/i)).toBeNull();
+    });
+
+    it('clicking a picker item in CompareBar fires onPin with the chosen run id', async () => {
+        const onPin = vi.fn();
+        renderWithProviders(
+            <FactorCanvas
+                slug="s"
+                interpret={buildInterpret()}
+                onFocusChange={vi.fn()}
+                runs={[
+                    { id: 38, n_factors: 3 } as unknown as AnalysisRunSummary,
+                    { id: 99, n_factors: 3 } as unknown as AnalysisRunSummary,
+                ]}
+                compareTo={null}
+                onPin={onPin}
+                onUnpin={vi.fn()}
+            />
+        );
+        // CompareBar's "Pin compare" trigger opens a Radix dropdown (portaled);
+        // userEvent is required so the menuitem is visible to findByRole.
+        await userEvent.click(screen.getByRole('button', { name: /pin compare/i }));
+        const items = await screen.findAllByRole('menuitem');
+        // run.id is 42 (the active run from buildInterpret), so #38 and #99
+        // are both pickable. Click the first.
+        const target = items.find((el) => /Run #38/.test(el.textContent ?? ''));
+        if (!target) throw new Error('expected a "Run #38" menuitem');
+        await userEvent.click(target);
+        expect(onPin).toHaveBeenCalledWith(38);
+    });
+
+    it('renders Δloading next to participant labels when deltaByParticipant is set', () => {
+        mockCommentsHook.mockReturnValue(
+            dataOk<ParticipantCardComment>([
+                {
+                    participant_db_id: 1,
+                    statement_id: 7,
+                    statement_code: 'S07',
+                    statement_text: 'Local food sovereignty matters',
+                    grid_score: 4,
+                    comment: 'Because food sovereignty matters',
+                },
+            ])
+        );
+        const deltaByParticipant = new Map<number, number>([[1, 0.25]]);
+        const interpret = buildInterpret({
+            deltaByParticipant,
+            activeMatchPhi: 0.9,
+            activeMatchBIndex: 0,
+        });
+        renderWithProviders(
+            <FactorCanvas
+                slug="s"
+                interpret={interpret}
+                onFocusChange={vi.fn()}
+                runs={[]}
+                compareTo={38}
+                onPin={vi.fn()}
+                onUnpin={vi.fn()}
+            />
+        );
+        expect(screen.getByLabelText(/Δloading 0\.25 vs compare run/i)).toBeInTheDocument();
     });
 });

--- a/frontend/src/components/admin/analysis/FactorCanvas.tsx
+++ b/frontend/src/components/admin/analysis/FactorCanvas.tsx
@@ -10,14 +10,25 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { FactorSelectorChips } from './FactorSelectorChips';
 import { FactorNoteEditor, type FactorNoteEditorHandle } from './FactorNoteEditor';
 import { FactorVoicesPanel } from './FactorVoicesPanel';
+import { CompareBar } from './CompareBar';
 import type { ParticipantCardComment } from '@/api/model/participantCardComment';
 import type { AnalysisResult } from '@/api/model/analysisResult';
+import type { AnalysisRunSummary } from '@/api/model';
 import type { InterpretPhaseApi } from '@/hooks/admin/useInterpretPhase';
+
+/** |Δz| threshold above which the chip is visually emphasised. Mirrors spec §5.5. */
+const DELTA_Z_HIGHLIGHT = 0.5;
 
 interface Props {
     slug: string;
     interpret: InterpretPhaseApi;
     onFocusChange: (factor: number) => void;
+    /** Available runs for the compare-pin picker (typically the run history). */
+    runs: AnalysisRunSummary[];
+    /** The pinned compare-to run id, or null when nothing is pinned. */
+    compareTo: number | null;
+    onPin: (runId: number) => void;
+    onUnpin: () => void;
 }
 
 /**
@@ -42,7 +53,15 @@ const QUOTE_TRUNCATE = 60;
  * pipeline). Statement insertion is also out of scope (z-scores are
  * already visible in StatementsTable / Statements panel).
  */
-export function FactorCanvas({ slug, interpret, onFocusChange }: Props) {
+export function FactorCanvas({
+    slug,
+    interpret,
+    onFocusChange,
+    runs,
+    compareTo,
+    onPin,
+    onUnpin,
+}: Props) {
     const { t } = useTranslation();
     const editorRef = useRef<FactorNoteEditorHandle>(null);
     const run = interpret.run;
@@ -107,6 +126,16 @@ export function FactorCanvas({ slug, interpret, onFocusChange }: Props) {
                         n: definingSorts,
                     })}
                 </div>
+                <div className="ml-auto">
+                    <CompareBar
+                        runs={runs}
+                        currentRunId={run.id}
+                        compareTo={compareTo}
+                        onPin={onPin}
+                        onUnpin={onUnpin}
+                        phi={interpret.activeMatchPhi}
+                    />
+                </div>
             </div>
 
             <Card>
@@ -117,31 +146,56 @@ export function FactorCanvas({ slug, interpret, onFocusChange }: Props) {
                 </CardHeader>
                 <CardContent>
                     <ul className="space-y-1 text-sm">
-                        {topStatements.map((s) => (
-                            <li key={s.statement_id} className="flex items-center gap-2">
-                                <span
-                                    className={
-                                        s.z >= 0
-                                            ? 'text-emerald-700 font-mono'
-                                            : 'text-rose-700 font-mono'
-                                    }
-                                >
-                                    {s.z >= 0 ? '+' : ''}
-                                    {s.z.toFixed(2)}
-                                </span>
-                                <span className="font-mono font-bold">{s.code}</span>
-                                <span className="text-slate-700 truncate flex-1">“{s.text}”</span>
-                                {s.isDistinguishing && (
+                        {topStatements.map((s) => {
+                            const delta = interpret.deltaByStatement?.get(s.statement_id);
+                            const isLargeDelta =
+                                delta !== undefined && Math.abs(delta) >= DELTA_Z_HIGHLIGHT;
+                            return (
+                                <li key={s.statement_id} className="flex items-center gap-2">
                                     <span
-                                        className="text-2xs px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200"
-                                        role="img"
-                                        aria-label="distinguishing statement"
+                                        className={
+                                            s.z >= 0
+                                                ? 'text-emerald-700 font-mono'
+                                                : 'text-rose-700 font-mono'
+                                        }
                                     >
-                                        D
+                                        {s.z >= 0 ? '+' : ''}
+                                        {s.z.toFixed(2)}
                                     </span>
-                                )}
-                            </li>
-                        ))}
+                                    {delta !== undefined && (
+                                        <span
+                                            className={
+                                                isLargeDelta
+                                                    ? 'text-2xs px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200 font-mono'
+                                                    : 'text-2xs text-slate-500 font-mono'
+                                            }
+                                            role="img"
+                                            aria-label={t(
+                                                'admin.analysis.compare.delta_z_aria',
+                                                'Δz {{delta}} vs compare run',
+                                                { delta: delta.toFixed(2) }
+                                            )}
+                                        >
+                                            Δ{delta >= 0 ? '+' : ''}
+                                            {delta.toFixed(2)}
+                                        </span>
+                                    )}
+                                    <span className="font-mono font-bold">{s.code}</span>
+                                    <span className="text-slate-700 truncate flex-1">
+                                        “{s.text}”
+                                    </span>
+                                    {s.isDistinguishing && (
+                                        <span
+                                            className="text-2xs px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200"
+                                            role="img"
+                                            aria-label="distinguishing statement"
+                                        >
+                                            D
+                                        </span>
+                                    )}
+                                </li>
+                            );
+                        })}
                     </ul>
                 </CardContent>
             </Card>
@@ -151,6 +205,7 @@ export function FactorCanvas({ slug, interpret, onFocusChange }: Props) {
                 factorIndex={interpret.activeFactor - 1}
                 participants={interpret.flaggedParticipants}
                 onInsertCommentQuote={handleInsertCommentQuote}
+                deltaByParticipant={interpret.deltaByParticipant ?? undefined}
             />
 
             <Card>

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx
@@ -282,6 +282,101 @@ describe('FactorVoicesPanel', () => {
         expect(screen.getByText(/My rationale/)).toBeInTheDocument();
     });
 
+    // ── Δloading display (Phase 5) ────────────────────────────────────────────
+    describe('Δloading display (Phase 5)', () => {
+        it('renders Δloading chip when deltaByParticipant is provided', async () => {
+            const participants = [makeParticipant(60, 'Kira', [1])];
+            const comments = [makeComment(60, 1, 'S1', 'Statement one prose', 3, 'Kira rationale')];
+
+            mockAudiosHook.mockReturnValue(emptyOk<ParticipantAudioRecording>());
+            mockCommentsHook.mockReturnValue(dataOk(comments));
+
+            renderWithProviders(
+                <FactorVoicesPanel
+                    slug="demo-study"
+                    factorIndex={0}
+                    participants={participants}
+                    deltaByParticipant={new Map([[60, 0.3]])}
+                />
+            );
+
+            await waitFor(() => {
+                expect(screen.getByText('Kira')).toBeInTheDocument();
+            });
+
+            // The chip exposes its value through aria-label so screen readers
+            // hear "Δloading 0.30 vs compare run".
+            const chip = screen.getByLabelText(/Δloading 0\.30/i);
+            expect(chip).toBeInTheDocument();
+            // Visible glyph includes the sign for non-negative values.
+            expect(chip.textContent).toMatch(/Δ\+0\.30/);
+        });
+
+        it('highlights large |Δloading| (>= 0.20) with amber styling', async () => {
+            const participants = [
+                makeParticipant(70, 'Liam', [1]),
+                makeParticipant(71, 'Mona', [1]),
+            ];
+            const comments = [
+                makeComment(70, 1, 'S1', 'Statement one prose', 3, 'Liam rationale'),
+                makeComment(71, 2, 'S2', 'Statement two prose', -2, 'Mona rationale'),
+            ];
+
+            mockAudiosHook.mockReturnValue(emptyOk<ParticipantAudioRecording>());
+            mockCommentsHook.mockReturnValue(dataOk(comments));
+
+            renderWithProviders(
+                <FactorVoicesPanel
+                    slug="demo-study"
+                    factorIndex={0}
+                    participants={participants}
+                    deltaByParticipant={
+                        new Map([
+                            [70, 0.25], // above threshold → amber
+                            [71, 0.1], // below threshold → muted slate
+                        ])
+                    }
+                />
+            );
+
+            await waitFor(() => {
+                expect(screen.getByText('Liam')).toBeInTheDocument();
+            });
+
+            const highChip = screen.getByLabelText(/Δloading 0\.25/i);
+            const lowChip = screen.getByLabelText(/Δloading 0\.10/i);
+
+            // High-delta chip has amber background; low-delta chip does not.
+            expect(highChip.className).toMatch(/bg-amber-50/);
+            expect(highChip.className).toMatch(/text-amber-700/);
+            expect(lowChip.className).not.toMatch(/bg-amber-50/);
+            expect(lowChip.className).toMatch(/text-slate-500/);
+        });
+
+        it('does NOT render Δloading chip when deltaByParticipant is undefined', async () => {
+            const participants = [makeParticipant(80, 'Nina', [1])];
+            const comments = [makeComment(80, 1, 'S1', 'Statement one prose', 3, 'Nina rationale')];
+
+            mockAudiosHook.mockReturnValue(emptyOk<ParticipantAudioRecording>());
+            mockCommentsHook.mockReturnValue(dataOk(comments));
+
+            renderWithProviders(
+                <FactorVoicesPanel
+                    slug="demo-study"
+                    factorIndex={0}
+                    participants={participants}
+                    // deltaByParticipant intentionally omitted (Phase 4 callsite).
+                />
+            );
+
+            await waitFor(() => {
+                expect(screen.getByText('Nina')).toBeInTheDocument();
+            });
+
+            expect(screen.queryByLabelText(/Δloading/i)).toBeNull();
+        });
+    });
+
     // ── Test 8: participant with comments but no audio is still listed ────────
     it('lists a participant who has comments but no audio', async () => {
         const participants = [makeParticipant(50, 'Iris', [1]), makeParticipant(51, 'Jamal', [1])];

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
@@ -9,6 +9,9 @@ import {
     useListCommentsForParticipantsApiAdminStudiesSlugAnalysisCommentsGet,
 } from '@/api/generated';
 
+/** |Δloading| threshold above which the chip is visually emphasised. Mirrors spec §5.5. */
+const DELTA_LOADING_HIGHLIGHT = 0.2;
+
 interface FactorVoicesPanelProps {
     slug: string;
     factorIndex: number;
@@ -21,6 +24,13 @@ interface FactorVoicesPanelProps {
      * button is rendered (legacy read-only mode).
      */
     onInsertCommentQuote?: (comment: ParticipantCardComment, participantLabel: string) => void;
+    /**
+     * Optional Δloading on the active factor per participant_db_id, sign-flip
+     * aware (provided by useInterpretPhase compare flow). When defined and a
+     * participant is in the map, render a Δ chip next to the participant
+     * label. Undefined when no compare run is pinned.
+     */
+    deltaByParticipant?: Map<number, number>;
 }
 
 function scoreBadgeClass(score: number): string {
@@ -48,6 +58,7 @@ function groupByParticipant<T extends { participant_db_id: number }>(
 
 interface ParticipantMaterialCardProps {
     label: string;
+    deltaLoading?: number;
     recordings: ParticipantAudioRecording[];
     comments: ParticipantCardComment[];
     onInsertCommentQuote?: (comment: ParticipantCardComment, participantLabel: string) => void;
@@ -55,6 +66,7 @@ interface ParticipantMaterialCardProps {
 
 function ParticipantMaterialCard({
     label,
+    deltaLoading,
     recordings,
     comments,
     onInsertCommentQuote,
@@ -62,7 +74,27 @@ function ParticipantMaterialCard({
     const { t } = useTranslation();
     return (
         <div className="bg-white rounded-lg border border-slate-200 p-3 space-y-3">
-            <p className="text-xs font-semibold text-slate-700">{label}</p>
+            <div className="flex items-center gap-2">
+                <p className="text-xs font-semibold text-slate-700">{label}</p>
+                {deltaLoading !== undefined && (
+                    <span
+                        className={
+                            Math.abs(deltaLoading) >= DELTA_LOADING_HIGHLIGHT
+                                ? 'text-2xs px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200 font-mono'
+                                : 'text-2xs text-slate-500 font-mono'
+                        }
+                        role="img"
+                        aria-label={t(
+                            'admin.analysis.compare.delta_loading_aria',
+                            'Δloading {{delta}} vs compare run',
+                            { delta: deltaLoading.toFixed(2) }
+                        )}
+                    >
+                        Δ{deltaLoading >= 0 ? '+' : ''}
+                        {deltaLoading.toFixed(2)}
+                    </span>
+                )}
+            </div>
 
             {recordings.length > 0 && (
                 <div className="space-y-2">
@@ -151,6 +183,7 @@ export function FactorVoicesPanel({
     factorIndex,
     participants,
     onInsertCommentQuote,
+    deltaByParticipant,
 }: FactorVoicesPanelProps) {
     const { t } = useTranslation();
     const [tooltipOpen, setTooltipOpen] = useState(false);
@@ -261,6 +294,7 @@ export function FactorVoicesPanel({
                         <ParticipantMaterialCard
                             key={p.db_id}
                             label={p.label}
+                            deltaLoading={deltaByParticipant?.get(p.db_id)}
                             recordings={recordingsByParticipant.get(p.db_id) ?? []}
                             comments={commentsByParticipant.get(p.db_id) ?? []}
                             onInsertCommentQuote={onInsertCommentQuote}

--- a/frontend/src/hooks/admin/useInterpretPhase.test.ts
+++ b/frontend/src/hooks/admin/useInterpretPhase.test.ts
@@ -407,6 +407,211 @@ describe('useInterpretPhase', () => {
         expect(result.current.deltaByStatement).toBeNull();
     });
 
+    describe('Tucker φ matching (Phase 5)', () => {
+        it('exposes activeMatchPhi and activeMatchBIndex when both runs are loaded', () => {
+            const baseRun = makeRun({ id: 42 });
+            const compare = makeRun({ id: 7 });
+
+            mockGetAnalysisRunHook.mockImplementation((_slug: string, runId: number) => {
+                if (runId === 42) return makeLoadedRunQuery(baseRun);
+                if (runId === 7) return makeLoadedRunQuery(compare);
+                return makeIdleRunQuery();
+            });
+
+            const { result } = renderHook(() => useInterpretPhase('test-study', 42, 'f1', 7), {
+                wrapper: AllTheProviders,
+            });
+
+            // Identical fixtures → φ = 1.0 for the matched factor.
+            expect(result.current.activeMatchPhi).not.toBeNull();
+            expect(result.current.activeMatchBIndex).toBe(0);
+            expect(result.current.activeMatchPhi).toBeCloseTo(1.0, 6);
+        });
+
+        it('exposes null match fields when compareRun is missing', () => {
+            const run = makeRun();
+            mockGetAnalysisRunHook.mockImplementation((_slug: string, runId: number) =>
+                runId === 42 ? makeLoadedRunQuery(run) : makeIdleRunQuery()
+            );
+
+            const { result } = renderHook(() => useInterpretPhase('test-study', 42, 'f1', null), {
+                wrapper: AllTheProviders,
+            });
+
+            expect(result.current.activeMatchPhi).toBeNull();
+            expect(result.current.activeMatchBIndex).toBeNull();
+            expect(result.current.isAmbiguousMatch).toBe(false);
+        });
+
+        it('isAmbiguousMatch=false when |phi| >= 0.85 (identity match)', () => {
+            const baseRun = makeRun({ id: 42 });
+            const compare = makeRun({ id: 7 });
+
+            mockGetAnalysisRunHook.mockImplementation((_slug: string, runId: number) => {
+                if (runId === 42) return makeLoadedRunQuery(baseRun);
+                if (runId === 7) return makeLoadedRunQuery(compare);
+                return makeIdleRunQuery();
+            });
+
+            const { result } = renderHook(() => useInterpretPhase('test-study', 42, 'f1', 7), {
+                wrapper: AllTheProviders,
+            });
+
+            expect(result.current.isAmbiguousMatch).toBe(false);
+        });
+
+        it('isAmbiguousMatch=true when |phi| < 0.85', () => {
+            const baseRun = makeRun({ id: 42 });
+            // Construct a compare run whose factor 0 z-scores produce a low |φ|
+            // against base factor 0 ([1.5, -1.2]). Using [1.0, 1.0] gives:
+            //   φ = (1.5 - 1.2) / (sqrt(1.5²+1.2²) * sqrt(2)) ≈ 0.111
+            const compare = makeRun({
+                id: 7,
+                result: {
+                    n_participants: 3,
+                    n_statements: 2,
+                    n_factors: 2,
+                    participants: baseRun.result.participants,
+                    statement_scores: [
+                        {
+                            statement_id: 10,
+                            code: 'S10',
+                            text: 'Statement ten',
+                            z_scores: [1.0, 1.0],
+                            factor_arrays: [1, 1],
+                        },
+                        {
+                            statement_id: 11,
+                            code: 'S11',
+                            text: 'Statement eleven',
+                            z_scores: [1.0, 1.0],
+                            factor_arrays: [1, 1],
+                        },
+                    ],
+                },
+            });
+
+            mockGetAnalysisRunHook.mockImplementation((_slug: string, runId: number) => {
+                if (runId === 42) return makeLoadedRunQuery(baseRun);
+                if (runId === 7) return makeLoadedRunQuery(compare);
+                return makeIdleRunQuery();
+            });
+
+            const { result } = renderHook(() => useInterpretPhase('test-study', 42, 'f1', 7), {
+                wrapper: AllTheProviders,
+            });
+
+            expect(result.current.activeMatchPhi).not.toBeNull();
+            expect(Math.abs(result.current.activeMatchPhi ?? 0)).toBeLessThan(0.85);
+            expect(result.current.isAmbiguousMatch).toBe(true);
+        });
+
+        it('deltaByStatement uses sign-flip when matched factor has negative phi', () => {
+            const baseRun = makeRun({ id: 42 });
+            // Construct compare run where factor 0 is exactly the negation of
+            // base factor 0. Tucker φ = -1.0 → sign-flip applied → Δ ≈ 0.
+            const compare = makeRun({
+                id: 7,
+                result: {
+                    n_participants: 3,
+                    n_statements: 2,
+                    n_factors: 2,
+                    participants: baseRun.result.participants,
+                    statement_scores: [
+                        {
+                            statement_id: 10,
+                            code: 'S10',
+                            text: 'Statement ten',
+                            // negation of base [1.5, -0.3] on factor 0
+                            z_scores: [-1.5, 0.3],
+                            factor_arrays: [-3, 1],
+                        },
+                        {
+                            statement_id: 11,
+                            code: 'S11',
+                            text: 'Statement eleven',
+                            // negation of base [-1.2, 0.9] on factor 0
+                            z_scores: [1.2, -0.9],
+                            factor_arrays: [2, -2],
+                        },
+                    ],
+                },
+            });
+
+            mockGetAnalysisRunHook.mockImplementation((_slug: string, runId: number) => {
+                if (runId === 42) return makeLoadedRunQuery(baseRun);
+                if (runId === 7) return makeLoadedRunQuery(compare);
+                return makeIdleRunQuery();
+            });
+
+            const { result } = renderHook(() => useInterpretPhase('test-study', 42, 'f1', 7), {
+                wrapper: AllTheProviders,
+            });
+
+            // Match should pick bIndex=0 with φ ≈ -1.0.
+            expect(result.current.activeMatchBIndex).toBe(0);
+            expect(result.current.activeMatchPhi).toBeCloseTo(-1.0, 6);
+
+            const delta = result.current.deltaByStatement;
+            expect(delta).not.toBeNull();
+            // With sign-flip: za - (zb * -1) = za + zb = 1.5 + (-1.5) = 0.
+            expect(delta?.get(10)).toBeCloseTo(0.0, 6);
+            expect(delta?.get(11)).toBeCloseTo(0.0, 6);
+        });
+
+        it('deltaByParticipant exposes Δloading per participant_db_id', () => {
+            const baseRun = makeRun({ id: 42 });
+            // Compare: same participants by db_id, loadings differ by 0.10 on
+            // factor 0. Statement scores remain identical so the Tucker match
+            // resolves to bIndex=0 with φ=1.0 (no sign-flip).
+            const compare = makeRun({
+                id: 7,
+                result: {
+                    n_participants: 3,
+                    n_statements: 2,
+                    n_factors: 2,
+                    participants: [
+                        { db_id: 1, label: 'P1', loadings: [0.6, 0.1], flagged_factors: [1] },
+                        { db_id: 2, label: 'P2', loadings: [0.1, 0.8], flagged_factors: [2] },
+                        { db_id: 3, label: 'P3', loadings: [0.4, 0.5], flagged_factors: [1, 2] },
+                    ],
+                    statement_scores: baseRun.result.statement_scores,
+                },
+            });
+
+            mockGetAnalysisRunHook.mockImplementation((_slug: string, runId: number) => {
+                if (runId === 42) return makeLoadedRunQuery(baseRun);
+                if (runId === 7) return makeLoadedRunQuery(compare);
+                return makeIdleRunQuery();
+            });
+
+            const { result } = renderHook(() => useInterpretPhase('test-study', 42, 'f1', 7), {
+                wrapper: AllTheProviders,
+            });
+
+            const delta = result.current.deltaByParticipant;
+            expect(delta).not.toBeNull();
+            expect(delta?.size).toBe(3);
+            // base.loadings[0] - compare.loadings[0] for each participant = +0.10
+            expect(delta?.get(1)).toBeCloseTo(0.1, 6);
+            expect(delta?.get(2)).toBeCloseTo(0.1, 6);
+            expect(delta?.get(3)).toBeCloseTo(0.1, 6);
+        });
+
+        it('deltaByParticipant returns null when no compareTo', () => {
+            const run = makeRun();
+            mockGetAnalysisRunHook.mockImplementation((_slug: string, runId: number) =>
+                runId === 42 ? makeLoadedRunQuery(run) : makeIdleRunQuery()
+            );
+
+            const { result } = renderHook(() => useInterpretPhase('test-study', 42, 'f1', null), {
+                wrapper: AllTheProviders,
+            });
+
+            expect(result.current.deltaByParticipant).toBeNull();
+        });
+    });
+
     describe('showFactorNarratives localStorage', () => {
         beforeEach(() => {
             window.localStorage.clear();

--- a/frontend/src/hooks/admin/useInterpretPhase.ts
+++ b/frontend/src/hooks/admin/useInterpretPhase.ts
@@ -14,14 +14,16 @@
  * Visual state stays in the page component (factor selector chips, mode
  * toggle, compare-pin picker open state).
  *
- * Phase 2 limitation: factor matching for compareTo is by-index. Phase 5
- * upgrades it to Tucker's φ alignment with sign-flip and ambiguous-match
- * warnings. The deltaByStatement Map shape stays stable.
+ * Phase 5 (Task 27): factor matching across compareTo runs is now Tucker's
+ * congruence (φ) alignment with sign-flip awareness and ambiguous-match
+ * warnings. The consumer-facing Map shapes (deltaByStatement, the new
+ * deltaByParticipant) stay stable; the upgrade is internal.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useGetAnalysisRunApiAdminStudiesSlugAnalysisRunsRunIdGet } from '@/api/generated';
 import type { AnalysisResult, AnalysisRunRead, ParticipantLoading } from '@/api/model';
+import { matchFactorsByPhi } from '@/utils/tuckerPhi';
 
 // ────────────────────────────────────────────────────────────────
 // Public API surface
@@ -37,7 +39,32 @@ export interface InterpretPhaseApi {
     setNarrativeDraft: (draft: string) => void;
     appendToNarrative: (snippet: string) => void;
     compareRun: AnalysisRunRead | null;
+    /**
+     * Δz on the active factor per statement_id. Sign-flip aware via the
+     * Tucker φ match between active and compare runs. Null when no compare
+     * run is loaded or no match could be computed.
+     */
     deltaByStatement: Map<number, number> | null;
+    /**
+     * Δloading on the active factor per participant_db_id. Sign-flip aware
+     * via the same Tucker φ match. Null when no compare run is loaded.
+     */
+    deltaByParticipant: Map<number, number> | null;
+    /**
+     * Tucker's φ of the active factor's match in the compare run. Null when
+     * no compare run is loaded or the match couldn't be computed.
+     */
+    activeMatchPhi: number | null;
+    /**
+     * 0-based factor index in the compare run that matches the active
+     * factor. Null when no match exists.
+     */
+    activeMatchBIndex: number | null;
+    /**
+     * True when a compare run is loaded AND |activeMatchPhi| < 0.85. The
+     * threshold matches CompareBar's warning trigger.
+     */
+    isAmbiguousMatch: boolean;
     /**
      * Per-analyst, per-study UI preference for showing the per-factor narrative
      * editor in the interpret view. Persisted in localStorage so the choice
@@ -158,24 +185,67 @@ export function useInterpretPhase(
         [narrativesPrefKey]
     );
 
-    // ── deltaByStatement (by-index match — Phase 2) ───────────────
-    // Phase 5 (Task 27) refines this to Tucker's φ alignment with sign-flip
-    // detection and ambiguous-match warnings. Map shape stays stable so the
-    // page component does not need to change.
-    const deltaByStatement = useMemo<Map<number, number> | null>(() => {
+    // ── Tucker φ factor matching (Phase 5) ────────────────────────
+    // Align A and B factors by maximum |φ| over the intersection of
+    // statements present in both runs. Statement-id intersection makes
+    // the matcher robust to concourses that gained/lost statements
+    // between runs (length mismatch would otherwise throw inside
+    // tuckerPhi).
+    const factorMatches = useMemo(() => {
         if (!runResult || !compareResult) return null;
+        const compareById = new Map(compareResult.statement_scores.map((s) => [s.statement_id, s]));
+        const aMatrix: number[][] = [];
+        const bMatrix: number[][] = [];
+        for (const s of runResult.statement_scores) {
+            const matching = compareById.get(s.statement_id);
+            if (!matching) continue;
+            aMatrix.push(s.z_scores);
+            bMatrix.push(matching.z_scores);
+        }
+        if (aMatrix.length === 0) return null;
+        return matchFactorsByPhi(aMatrix, bMatrix);
+    }, [runResult, compareResult]);
+
+    const activeMatch = factorMatches?.find((m) => m.aIndex === activeFactor - 1) ?? null;
+    const activeMatchPhi = activeMatch?.phi ?? null;
+    const activeMatchBIndex = activeMatch?.bIndex ?? null;
+    const isAmbiguousMatch = activeMatchPhi !== null && Math.abs(activeMatchPhi) < 0.85;
+
+    // ── deltaByStatement (Tucker-aligned, sign-flip aware) ────────
+    const deltaByStatement = useMemo<Map<number, number> | null>(() => {
+        if (!runResult || !compareResult || activeMatchBIndex === null) return null;
+        const sign = (activeMatchPhi ?? 0) < 0 ? -1 : 1;
         const factorIdx = activeFactor - 1;
         const compareById = new Map(compareResult.statement_scores.map((s) => [s.statement_id, s]));
         const out = new Map<number, number>();
         for (const s of runResult.statement_scores) {
-            const match = compareById.get(s.statement_id);
-            if (!match) continue;
+            const matching = compareById.get(s.statement_id);
+            if (!matching) continue;
             const za = s.z_scores[factorIdx] ?? 0;
-            const zb = match.z_scores[factorIdx] ?? 0;
+            const zb = (matching.z_scores[activeMatchBIndex] ?? 0) * sign;
             out.set(s.statement_id, za - zb);
         }
         return out;
-    }, [runResult, compareResult, activeFactor]);
+    }, [runResult, compareResult, activeFactor, activeMatchBIndex, activeMatchPhi]);
+
+    // ── deltaByParticipant (Tucker-aligned, sign-flip aware) ──────
+    const deltaByParticipant = useMemo<Map<number, number> | null>(() => {
+        if (!runResult || !compareResult || activeMatchBIndex === null) return null;
+        const sign = (activeMatchPhi ?? 0) < 0 ? -1 : 1;
+        const factorIdx = activeFactor - 1;
+        const compareById = new Map<number, ParticipantLoading>(
+            compareResult.participants.map((p) => [p.db_id, p])
+        );
+        const out = new Map<number, number>();
+        for (const p of runResult.participants) {
+            const matching = compareById.get(p.db_id);
+            if (!matching) continue;
+            const la = p.loadings[factorIdx] ?? 0;
+            const lb = (matching.loadings[activeMatchBIndex] ?? 0) * sign;
+            out.set(p.db_id, la - lb);
+        }
+        return out;
+    }, [runResult, compareResult, activeFactor, activeMatchBIndex, activeMatchPhi]);
 
     return {
         run,
@@ -188,6 +258,10 @@ export function useInterpretPhase(
         appendToNarrative,
         compareRun,
         deltaByStatement,
+        deltaByParticipant,
+        activeMatchPhi,
+        activeMatchBIndex,
+        isAmbiguousMatch,
         showFactorNarratives,
         setShowFactorNarratives,
     };

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -857,6 +857,33 @@ describe('AnalysisPage', () => {
         expect(screen.getByRole('tab', { name: 'F1' })).toHaveAttribute('aria-selected', 'false');
     });
 
+    it('treats malformed runId / compareTo URL params as null (no NaN propagation)', async () => {
+        // Defensive guard for ?runId=invalid&compareTo=garbage. Without
+        // Number.isFinite the page would pass NaN to useInterpretPhase, which
+        // would eventually fire `/runs/NaN`. With the guard, both params fall
+        // back to null, so the interpret hook sees runId=null and the page
+        // lands on Explore (no `interpret-phase` testid).
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+
+        renderWithProviders(<AnalysisPage />, {
+            initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=invalid&compareTo=garbage`],
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('interpret-phase')).toBeNull();
+        });
+        // mockGetRunHook is called by useInterpretPhase; the runId argument
+        // must be null (not NaN). The page falls back to Explore copy.
+        expect(screen.getByRole('button', { name: /commit and interpret/i })).toBeInTheDocument();
+    });
+
     it('navigates to interpret phase after a successful run', async () => {
         mockEigenvaluesHook.mockReturnValue({
             data: mockEigenvalues,

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -58,6 +58,7 @@ import { FactorVoicesPanel } from '@/components/admin/analysis/FactorVoicesPanel
 import { FactorCanvas } from '@/components/admin/analysis/FactorCanvas';
 import { useExplorePhase, type ExplorePhaseApi } from '@/hooks/admin/useExplorePhase';
 import { useInterpretPhase, type InterpretPhaseApi } from '@/hooks/admin/useInterpretPhase';
+import { useListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGet } from '@/api/generated';
 import type { AnalysisResult, AnalysisRunRead, AnalysisRunSummary } from '@/api/model';
 import { downloadBlob, generateLoadingsCsv, generateScoresCsv } from '@/utils/analysisCsvExport';
 import { generateAnalysisXlsx } from '@/utils/analysisXlsxExport';
@@ -137,8 +138,41 @@ export default function AnalysisPage() {
         [setSearchParams]
     );
 
+    const handlePin = useCallback(
+        (id: number) => {
+            setSearchParams(
+                (prev) => {
+                    const p = new URLSearchParams(prev);
+                    p.set('compareTo', String(id));
+                    return p;
+                },
+                { replace: true }
+            );
+        },
+        [setSearchParams]
+    );
+
+    const handleUnpin = useCallback(() => {
+        setSearchParams(
+            (prev) => {
+                const p = new URLSearchParams(prev);
+                p.delete('compareTo');
+                return p;
+            },
+            { replace: true }
+        );
+    }, [setSearchParams]);
+
     const explore = useExplorePhase(slug, navigateToInterpret);
     const interpret = useInterpretPhase(slug, runId, focus, compareTo);
+
+    // Run history for the compare-pin picker. The same query hook backs
+    // AnalysisHistoryPanel; React Query dedupes concurrent fetches so this
+    // is effectively a free read off the cache.
+    const runsQuery = useListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGet(slug, {
+        query: { enabled: !!slug },
+    });
+    const runs = runsQuery.data ?? [];
 
     // ── Empty-state contract: not enough participants for factor analysis ──
     // Wave A — UX progressive-disclosure audit. The configuration card walls
@@ -193,6 +227,10 @@ export default function AnalysisPage() {
                 onSelectHistoricalRun={navigateToHistoricalRun}
                 onBackToExplore={navigateToExplore}
                 onFocusChange={setFocusFromCanvas}
+                runs={runs}
+                compareTo={compareTo}
+                onPin={handlePin}
+                onUnpin={handleUnpin}
             />
         );
     }
@@ -754,6 +792,10 @@ interface InterpretShellProps {
     onSelectHistoricalRun: (runId: number) => void;
     onBackToExplore: () => void;
     onFocusChange: (factor: number) => void;
+    runs: AnalysisRunSummary[];
+    compareTo: number | null;
+    onPin: (runId: number) => void;
+    onUnpin: () => void;
 }
 
 function InterpretShell({
@@ -764,6 +806,10 @@ function InterpretShell({
     onSelectHistoricalRun,
     onBackToExplore,
     onFocusChange,
+    runs,
+    compareTo,
+    onPin,
+    onUnpin,
 }: InterpretShellProps) {
     const [searchParams, setSearchParams] = useSearchParams();
     const activeTab = searchParams.get('tab') ?? 'loadings';
@@ -1083,7 +1129,15 @@ function InterpretShell({
 
             {/* Results */}
             {mode === 'focus' ? (
-                <FactorCanvas slug={slug} interpret={interpret} onFocusChange={onFocusChange} />
+                <FactorCanvas
+                    slug={slug}
+                    interpret={interpret}
+                    onFocusChange={onFocusChange}
+                    runs={runs}
+                    compareTo={compareTo}
+                    onPin={onPin}
+                    onUnpin={onUnpin}
+                />
             ) : (
                 <Card className="border-none shadow-sm bg-white rounded-2xl relative">
                     <CardContent className="pt-5 pb-5">

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -63,6 +63,12 @@ import type { AnalysisResult, AnalysisRunRead, AnalysisRunSummary } from '@/api/
 import { downloadBlob, generateLoadingsCsv, generateScoresCsv } from '@/utils/analysisCsvExport';
 import { generateAnalysisXlsx } from '@/utils/analysisXlsxExport';
 
+function parseRunIdParam(raw: string | null): number | null {
+    if (raw === null) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+}
+
 export default function AnalysisPage() {
     const { studySlug, projectSlug } = useParams();
     const slug = studySlug ?? '';
@@ -70,11 +76,9 @@ export default function AnalysisPage() {
     const [searchParams, setSearchParams] = useSearchParams();
 
     const phase = searchParams.get('phase') ?? 'explore';
-    const runIdParam = searchParams.get('runId');
-    const runId = runIdParam ? Number(runIdParam) : null;
+    const runId = parseRunIdParam(searchParams.get('runId'));
     const focus = searchParams.get('focus') ?? 'f1';
-    const compareToParam = searchParams.get('compareTo');
-    const compareTo = compareToParam ? Number(compareToParam) : null;
+    const compareTo = parseRunIdParam(searchParams.get('compareTo'));
 
     const navigateToInterpret = useCallback(
         (newRunId: number) => {


### PR DESCRIPTION
## Summary

**Final PR of the interpretive-workspace plan.** Closes the brainstorm: any prior run can be pinned alongside the current one, and per-factor deltas surface in the canvas with Tucker's congruence-aware factor matching.

- **\`<CompareBar>\`** — picks a run from history (URL-scoped \`?compareTo=\`), displays the pinned run id + Tucker's φ matching the active factor, warns when |φ| < 0.85, offers an Unpin button.
- **\`useInterpretPhase\`** — factor matching upgraded from Phase-2 by-index to Tucker's φ alignment via the \`matchFactorsByPhi\` utility (Phase 3). New surface: \`activeMatchPhi\`, \`activeMatchBIndex\`, \`isAmbiguousMatch\`, \`deltaByParticipant\`. The existing \`deltaByStatement\` is rewritten to be sign-flip aware.
- **\`<FactorCanvas>\`** — mounts CompareBar in the chips row, renders Δz next to statement z-scores in the Statements panel, threads \`deltaByParticipant\` to FactorVoicesPanel. Δ chips highlighted in amber when |Δz| ≥ 0.5 / |Δloading| ≥ 0.2.
- **\`<FactorVoicesPanel>\`** — accepts optional \`deltaByParticipant\` prop, renders Δloading chip next to each flagged participant.
- **\`AnalysisPage\`** — adds \`handlePin\` / \`handleUnpin\` URL handlers + run-history fetch; threads through InterpretShell to FactorCanvas.

Different \`n_factors\` between runs is supported (Tucker greedy assignment leaves extra B-factors unmatched). Sign-flipped factor pairs (φ ≈ -1) produce near-zero deltas thanks to sign-aware subtraction.

Spec: \`docs/superpowers/specs/2026-04-29-analysis-module-improvements-design.md\` §5.5.
Plan: \`docs/superpowers/plans/2026-04-29-analysis-interpretive-workspace.md\` Phase 5.

## Test plan
- [x] CompareBar (9 tests): pin/unpin states, picker filtering, ambiguous warning above/below threshold (incl. negative φ), null-phi loading state
- [x] useInterpretPhase Phase 5 sub-suite (7 new on top of 17 baseline = 24 total): activeMatchPhi exposed, isAmbiguousMatch threshold both directions, sign-flip in deltaByStatement, deltaByParticipant correctness, null-when-no-compare
- [x] FactorCanvas Phase 5 sub-suite (5 new on top of 11 baseline = 16 total): CompareBar pinned state, Δz chip render, Δz absent without compare, onPin call, no Δ when not pinned
- [x] FactorVoicesPanel Δloading direct coverage (3 new on top of 8 baseline = 11 total): chip render with prop, amber highlight at threshold, absent without prop
- [x] AnalysisPage NaN guard (24 total): malformed runId / compareTo URL params fall back to null instead of propagating NaN to /runs/NaN
- [x] tuckerPhi pure utility (10 tests, unchanged from Phase 3)
- [x] Mid-phase code-reviewer: APPROVE_WITH_NITS; one Important finding (NaN guard) and one Minor (FactorVoicesPanel direct coverage) addressed in commit \`de48e53\` before push
- [x] \`make ci\` green
- [x] All en/fr/fi locales in sync (\`admin.analysis.compare.*\` keys + delta aria labels)

## What this completes

Five PRs ago, the Analysis page was a one-shot calculator. Now it's a two-phase interpretive workspace:
- **Phase 1** — backend diagnostics (Horn's parallel analysis, Velicer's MAP) and a \`/preview-range\` endpoint.
- **Phase 2** — page split into Explore / Interpret phases, addressed by URL.
- **Phase 3** — Explorer panel: diagnostics + clickable preview-range table.
- **Phase 4** — Factor Canvas: per-factor focus mode with statements + voices + narrative editor + quote picker.
- **Phase 5** — Compare pin: any prior run epinglable; Δz / Δloading surfaced in the canvas with Tucker's φ alignment.

The brainstorm's three pain points (deciding n_factors, building factor narratives, comparing runs) are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)