### PR TITLE
feat(admin): warn on inconsistent process_steps entries (rough/profile)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1640,6 +1640,12 @@
                         "consent_description": "Reset consent description",
                         "process_steps": "Reset process steps",
                         "process_steps_confirm": "Are you sure you want to reset all process steps to defaults? This will replace your custom steps."
+                    },
+                    "inconsistent": {
+                        "banner_title": "Inconsistent process steps",
+                        "rough_disabled": "The 'First impressions' (rough sort) step is in this list but the study has rough sort disabled. Participants will not see it.",
+                        "presort_disabled": "The 'Let's meet' (pre-sort survey) step is in this list but the study has the pre-sort survey disabled. Participants will not see it.",
+                        "remove_action": "Remove"
                     }
                 },
                 "consent_title": "Consent form",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -1592,6 +1592,12 @@
                         "consent_description": "Palauta suostumuskuvaus",
                         "process_steps": "Palauta prosessin vaiheet",
                         "process_steps_confirm": "Oletko varma, että haluat palauttaa kaikki prosessivaiheet oletusarvoihin? Tämä korvaa mukautetut vaiheet."
+                    },
+                    "inconsistent": {
+                        "banner_title": "Epäjohdonmukaiset prosessivaiheet",
+                        "rough_disabled": "Vaihe 'Ensivaikutelma' (esilajittelu) on tässä luettelossa, mutta tutkimuksessa esilajittelu on poistettu käytöstä. Osallistujat eivät näe sitä.",
+                        "presort_disabled": "Vaihe 'Tutustutaan' (esilajittelukysely) on tässä luettelossa, mutta tutkimuksessa esilajittelukysely on poistettu käytöstä. Osallistujat eivät näe sitä.",
+                        "remove_action": "Poista"
                     }
                 },
                 "consent_title": "Suostumuslomake",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -1630,6 +1630,12 @@
                         "consent_description": "Réinitialiser la description du consentement",
                         "process_steps": "Réinitialiser les étapes",
                         "process_steps_confirm": "Êtes-vous sûr de vouloir réinitialiser toutes les étapes par défaut ? Cela remplacera vos étapes personnalisées."
+                    },
+                    "inconsistent": {
+                        "banner_title": "Étapes du processus incohérentes",
+                        "rough_disabled": "L'étape « Premières impressions » (pré-tri) est dans cette liste mais l'étude a le pré-tri désactivé. Les participants ne la verront pas.",
+                        "presort_disabled": "L'étape « Faisons connaissance » (questionnaire pré-tri) est dans cette liste mais l'étude a le questionnaire pré-tri désactivé. Les participants ne la verront pas.",
+                        "remove_action": "Supprimer"
                     }
                 },
                 "consent_title": "Formulaire de consentement",

--- a/frontend/src/components/admin/designer/IntroductionEditor.tsx
+++ b/frontend/src/components/admin/designer/IntroductionEditor.tsx
@@ -299,7 +299,19 @@ const IntroductionEditor = ({ readOnly }: { readOnly?: boolean }) => {
                                     readOnly={readOnly}
                                 />
                             </div>
-                            <ProcessStepEditor readOnly={readOnly} />
+                            <ProcessStepEditor
+                                readOnly={readOnly}
+                                roughSortEnabled={draft.rough_sort_enabled !== false}
+                                presortEnabled={(() => {
+                                    const cfg = draft.presort_config as
+                                        | { enabled?: boolean }
+                                        | null
+                                        | undefined;
+                                    if (!cfg) return true;
+                                    if ('enabled' in cfg) return cfg.enabled !== false;
+                                    return true;
+                                })()}
+                            />
                         </CardContent>
                     </AccordionContent>
                 </AccordionItem>

--- a/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
@@ -1,0 +1,144 @@
+import { screen, within } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { renderWithStore } from '@/test-utils/renderWithStore';
+import { ProcessStepEditor } from './ProcessStepEditor';
+import { useStudyDesigner } from '@/store/useStudyDesigner';
+
+// Build a minimal draft with the given list of process steps.
+// biome-ignore lint/suspicious/noExplicitAny: convenient partial mock for the StudyUpdate draft
+const buildDraft = (
+    // biome-ignore lint/suspicious/noExplicitAny: minimal step shape for tests
+    steps: any[],
+    overrides: Record<string, unknown> = {}
+    // biome-ignore lint/suspicious/noExplicitAny: convenient partial mock
+): any => ({
+    slug: 'test-study',
+    state: 'draft',
+    default_language: 'en',
+    rough_sort_enabled: true,
+    presort_config: { enabled: true, fields: {} },
+    translations: [
+        {
+            language_code: 'en',
+            title: 'Test Study',
+            subtitle: '',
+            objective: '',
+            instructions: '',
+            process_steps: steps,
+        },
+    ],
+    ...overrides,
+});
+
+const profileStep = {
+    id: 'profile',
+    title: "Let's meet",
+    description: 'Pre-sort survey',
+    icon: 'Hand',
+};
+
+const roughStep = {
+    id: 'rough',
+    title: 'First impressions',
+    description: 'Rough triage',
+    icon: 'Hand',
+};
+
+const otherStep = {
+    id: 'step_custom_1',
+    title: 'Custom step',
+    description: 'Some custom phase',
+    icon: 'Circle',
+};
+
+describe('ProcessStepEditor — inconsistent feature flags banner', () => {
+    it('renders the banner when rough_sort_enabled is false and a rough step exists', () => {
+        const draft = buildDraft([otherStep, roughStep], { rough_sort_enabled: false });
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        const banner = screen.getByTestId('process-steps-inconsistent-banner');
+        expect(banner).toBeInTheDocument();
+        expect(banner).toHaveTextContent(/rough sort|rough_sort_disabled|First impressions/i);
+    });
+
+    it('renders the banner when presort is disabled and a profile step exists', () => {
+        const draft = buildDraft([profileStep, otherStep], {
+            presort_config: { enabled: false, fields: {} },
+        });
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        const banner = screen.getByTestId('process-steps-inconsistent-banner');
+        expect(banner).toBeInTheDocument();
+        expect(banner).toHaveTextContent(/pre-?sort|Let's meet/i);
+    });
+
+    it('hides the banner when no inconsistencies exist', () => {
+        const draft = buildDraft([profileStep, roughStep, otherStep]);
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        expect(screen.queryByTestId('process-steps-inconsistent-banner')).not.toBeInTheDocument();
+    });
+
+    it('removes the offending entry when Remove is clicked (rough)', async () => {
+        const user = userEvent.setup();
+        const draft = buildDraft([otherStep, roughStep], { rough_sort_enabled: false });
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        const banner = screen.getByTestId('process-steps-inconsistent-banner');
+        const removeBtn = within(banner).getByRole('button', { name: /remove/i });
+        await user.click(removeBtn);
+
+        // Banner should be gone after removal.
+        expect(screen.queryByTestId('process-steps-inconsistent-banner')).not.toBeInTheDocument();
+
+        // Store should no longer contain the rough step.
+        const state = useStudyDesigner.getState();
+        const ids = state.draft?.translations?.[0].process_steps?.map((s) => s.id) ?? [];
+        expect(ids).not.toContain('rough');
+        expect(ids).toContain('step_custom_1');
+    });
+
+    it('removes the offending entry when Remove is clicked (profile)', async () => {
+        const user = userEvent.setup();
+        const draft = buildDraft([profileStep, otherStep], {
+            presort_config: { enabled: false, fields: {} },
+        });
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        const banner = screen.getByTestId('process-steps-inconsistent-banner');
+        const removeBtn = within(banner).getByRole('button', { name: /remove/i });
+        await user.click(removeBtn);
+
+        expect(screen.queryByTestId('process-steps-inconsistent-banner')).not.toBeInTheDocument();
+
+        const state = useStudyDesigner.getState();
+        const ids = state.draft?.translations?.[0].process_steps?.map((s) => s.id) ?? [];
+        expect(ids).not.toContain('profile');
+        expect(ids).toContain('step_custom_1');
+    });
+
+    it('shows two banner items when both inconsistencies exist simultaneously', () => {
+        const draft = buildDraft([profileStep, roughStep, otherStep], {
+            rough_sort_enabled: false,
+            presort_config: { enabled: false, fields: {} },
+        });
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        const banner = screen.getByTestId('process-steps-inconsistent-banner');
+        const items = within(banner).getAllByTestId('process-steps-inconsistent-item');
+        expect(items).toHaveLength(2);
+    });
+});

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
     DndContext,
     closestCenter,
@@ -230,7 +230,27 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
     );
 };
 
-export function ProcessStepEditor({ readOnly }: { readOnly?: boolean }) {
+interface ProcessStepEditorProps {
+    readOnly?: boolean;
+    /**
+     * Override for the rough-sort feature flag. When omitted, the value is
+     * derived from the current draft (`draft.rough_sort_enabled !== false`).
+     * Mirrors {@link isRoughSortEnabled} in `utils/studyConfig.ts`.
+     */
+    roughSortEnabled?: boolean;
+    /**
+     * Override for the presort feature flag. When omitted, the value is
+     * derived from the current draft (`draft.presort_config.enabled !== false`).
+     * Mirrors {@link isPresortEnabled} in `utils/studyConfig.ts`.
+     */
+    presortEnabled?: boolean;
+}
+
+export function ProcessStepEditor({
+    readOnly,
+    roughSortEnabled: roughSortEnabledProp,
+    presortEnabled: presortEnabledProp,
+}: ProcessStepEditorProps) {
     const { t } = useTranslation();
     const {
         draft,
@@ -302,10 +322,61 @@ export function ProcessStepEditor({ readOnly }: { readOnly?: boolean }) {
         }
     }, [draft?.translations]);
 
-    if (!draft) return null;
-
-    const translation = draft.translations?.find((t) => t.language_code === activeLocale);
+    const translation = draft?.translations?.find((t) => t.language_code === activeLocale);
     const steps = translation?.process_steps || [];
+
+    // Derive feature flags from the draft when no explicit override is passed.
+    // Mirrors `isRoughSortEnabled` / `isPresortEnabled` in `utils/studyConfig.ts`
+    // and the participant-side filter in `WelcomePage.tsx`.
+    const roughSortEnabled = roughSortEnabledProp ?? draft?.rough_sort_enabled !== false;
+    const presortEnabled =
+        presortEnabledProp ??
+        (() => {
+            const cfg = draft?.presort_config as { enabled?: boolean } | null | undefined;
+            if (!cfg) return true;
+            if ('enabled' in cfg) return cfg.enabled !== false;
+            return true;
+        })();
+
+    // Detect process_steps entries that contradict the study's enabled features.
+    // The participant-side filter in WelcomePage drops these silently — we surface
+    // them here so the admin notices and can clean up their step list.
+    const inconsistentEntries = useMemo<
+        {
+            index: number;
+            id: string;
+            title: string;
+            reason: 'rough_disabled' | 'presort_disabled';
+        }[]
+    >(() => {
+        const issues: {
+            index: number;
+            id: string;
+            title: string;
+            reason: 'rough_disabled' | 'presort_disabled';
+        }[] = [];
+        steps.forEach((step, index) => {
+            if (step.id === 'rough' && !roughSortEnabled) {
+                issues.push({
+                    index,
+                    id: step.id,
+                    title: step.title || step.id,
+                    reason: 'rough_disabled',
+                });
+            }
+            if (step.id === 'profile' && !presortEnabled) {
+                issues.push({
+                    index,
+                    id: step.id,
+                    title: step.title || step.id,
+                    reason: 'presort_disabled',
+                });
+            }
+        });
+        return issues;
+    }, [steps, roughSortEnabled, presortEnabled]);
+
+    if (!draft) return null;
 
     const handleDragEnd = (event: DragEndEvent) => {
         const { active, over } = event;
@@ -382,6 +453,51 @@ export function ProcessStepEditor({ readOnly }: { readOnly?: boolean }) {
 
     return (
         <div className="space-y-6">
+            {!readOnly && inconsistentEntries.length > 0 && (
+                <div
+                    data-testid="process-steps-inconsistent-banner"
+                    className="rounded border-l-4 border-amber-400 bg-amber-50 p-3 text-sm text-amber-900 space-y-2"
+                >
+                    <p className="font-bold">
+                        {t(
+                            'admin.design.intro.process_steps.inconsistent.banner_title',
+                            'Inconsistent process steps'
+                        )}
+                    </p>
+                    <ul className="space-y-2">
+                        {inconsistentEntries.map((entry) => (
+                            <li
+                                key={entry.id}
+                                data-testid="process-steps-inconsistent-item"
+                                className="flex items-start justify-between gap-3"
+                            >
+                                <span className="flex-1">
+                                    {entry.reason === 'rough_disabled'
+                                        ? t(
+                                              'admin.design.intro.process_steps.inconsistent.rough_disabled',
+                                              "The 'First impressions' (rough sort) step is in this list but the study has rough sort disabled. Participants will not see it."
+                                          )
+                                        : t(
+                                              'admin.design.intro.process_steps.inconsistent.presort_disabled',
+                                              "The 'Let's meet' (pre-sort survey) step is in this list but the study has the pre-sort survey disabled. Participants will not see it."
+                                          )}
+                                </span>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => deleteStep(entry.index)}
+                                    className="h-8 rounded-lg border-amber-300 bg-white px-3 text-xs font-bold text-amber-800 hover:bg-amber-100 hover:text-amber-900"
+                                >
+                                    {t(
+                                        'admin.design.intro.process_steps.inconsistent.remove_action',
+                                        'Remove'
+                                    )}
+                                </Button>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
             {!readOnly && (
                 <div className="flex items-center justify-end gap-3">
                     <Button


### PR DESCRIPTION
## Summary
Closes #75.

`ProcessStepEditor` now surfaces an amber warning banner when the study's `process_steps` array contains entries that the participant-side `WelcomePage` filter would silently strip:

- `study.rough_sort_enabled === false` AND a step with `id === 'rough'`
- presort disabled (`study.presort_config.enabled === false`) AND a step with `id === 'profile'`

Each inconsistent entry has a per-entry **Remove** button that calls the existing `deleteStep` handler — no new state machine. The banner stays non-blocking; the participant-side filter (PR #72) remains the safety net and is untouched.

## Behaviour
- New optional props `roughSortEnabled?` / `presortEnabled?` (default to values derived from the draft).
- `IntroductionEditor` (the only call site) wires them from `draft.rough_sort_enabled` and `draft.presort_config.enabled` so the boundary is explicit.
- Banner uses the same amber visual the rough-sort lock banner ships with in `StudyDesignPage` (`border-l-4 border-amber-400 bg-amber-50`).
- Banner only renders in editable mode (`!readOnly`).

## i18n
Adds `admin.design.intro.process_steps.inconsistent.{banner_title,rough_disabled,presort_disabled,remove_action}` in en/fr/fi. `npm run i18n-check` is green.

## Test plan
- [x] `npx vitest run src/components/admin/designer/ProcessStepEditor.test.tsx` → 6 new tests pass
- [x] Gate: `ProcessStepEditor` + `StudyDesignPage` + `useStudyDesignPage` + `IntroductionEditor` → 30 passed / 1 skipped (was 24 / 1)
- [x] `npx biome check` on touched files → no new findings (one pre-existing complexity warning on the unrelated translation-sync `useEffect`)
- [x] `npx tsc --noEmit` → clean
- [x] `npm run i18n-check` → perfect sync (en/fr/fi)

## Out of scope
- The "Edit study settings" CTA mentioned in the issue is omitted; the existing `Remove` CTA matches the requested two-CTA fallback ("if not, just the Remove CTA").
- `WelcomePage.tsx` is intentionally untouched per task constraints.