### PR TITLE
fix(robustness): eliminate silent-failure paths flagged by CI

### DIFF
--- a/backend/app/routers/admin/memos.py
+++ b/backend/app/routers/admin/memos.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -48,6 +49,8 @@ from app.services.memo_service import MemoService
 # memo/templates — so it carries its own /admin prefix and registers
 # at /api in main.py.
 router = APIRouter(prefix="/admin", tags=["memos"])
+
+logger = logging.getLogger(__name__)
 
 
 # ---------- helpers ---------------------------------------------------------
@@ -483,5 +486,12 @@ async def _dispatch_mention_emails(
                 mentioner_name=mentioner.email,
             )
         except Exception:
-            # Logged inside the helper; don't let one bad address kill the batch.
-            pass
+            # Don't let one bad address kill the batch — but record a stack so a
+            # bug (e.g. malformed template) doesn't hide behind the helper's
+            # log.error. logger.exception preserves the traceback.
+            logger.exception(
+                "Memo mention email failed (recipient=%s, parent_type=%s, parent_id=%s)",
+                u.email,
+                parent_type.value,
+                parent_id,
+            )

--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -1120,16 +1120,22 @@ def compute_bootstrap_stability(
         cols = rng.integers(0, n_participants, size=n_participants)
         boot = dataset[:, cols]
         try:
-            res = run_analysis(
-                boot,
-                n_factors=n_factors,
-                extraction=extraction,
-                rotation=rotation,
-                flagging="auto",
-                manual_flags_matrix=None,
-                manual_rotations=manual_rotations,
-                grid_config=grid_config,
-            )
+            # Pathological resamples (e.g. all-zero columns from a degenerate
+            # dataset) trigger 0/0 inside np.corrcoef. Those iterations are
+            # filtered out below by the LinAlgError/ValueError catch; scope the
+            # divide-by-zero RuntimeWarning here so a future *unexpected* numpy
+            # warning elsewhere stays visible in the test output.
+            with np.errstate(divide="ignore", invalid="ignore"):
+                res = run_analysis(
+                    boot,
+                    n_factors=n_factors,
+                    extraction=extraction,
+                    rotation=rotation,
+                    flagging="auto",
+                    manual_flags_matrix=None,
+                    manual_rotations=manual_rotations,
+                    grid_config=grid_config,
+                )
         except (ValueError, np.linalg.LinAlgError):
             # Skip iterations whose resample is too degenerate to factor —
             # tracked via n_converged so the caller can flag a low-quality

--- a/backend/app/services/concourse_service.py
+++ b/backend/app/services/concourse_service.py
@@ -711,7 +711,10 @@ class ConcourseService:
         stale: list[StaleStatementEntry] = []
         for s in linked_statements:
             source_id = s.source_concourse_item_id
-            assert source_id is not None  # guaranteed by query filter
+            if source_id is None:
+                # SQL filter guarantees non-null at query time; defensive skip if
+                # session state diverges (and survives -O which strips asserts).
+                continue
             item = items_by_id.get(source_id)
             if item is None:
                 # Source was deleted

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -85,8 +85,10 @@ class StorageService:
             ),
         )
         # settings.S3_BUCKET_NAME is str | None; the all() guard above guarantees
-        # it is non-None at this point (raises ValueError otherwise).
-        assert settings.S3_BUCKET_NAME is not None
+        # it is non-None at this point. Use an explicit raise (not assert) so the
+        # narrow holds even if Python is run with -O.
+        if settings.S3_BUCKET_NAME is None:
+            raise RuntimeError("S3_BUCKET_NAME unset after S3 configuration validation")
         self.bucket_name: str = settings.S3_BUCKET_NAME
 
     async def upload_audio(

--- a/backend/tests/unit/test_analysis_service.py
+++ b/backend/tests/unit/test_analysis_service.py
@@ -1231,22 +1231,32 @@ class TestBootstrapStability:
 
     def test_pathological_iterations_handled(self):
         """A degenerate dataset (all-zero columns) should not raise; n_converged
-        records how many iterations produced a usable factor solution."""
+        records how many iterations produced a usable factor solution.
+
+        The expected divide-by-zero warnings from numpy are scoped via
+        ``np.errstate`` inside ``compute_bootstrap_stability``; we promote any
+        leaking RuntimeWarning to an error here so a future numpy warning
+        outside that scope surfaces as a test failure rather than CI noise.
+        """
+        import warnings
+
         dataset = np.zeros((6, 4), dtype=np.float64)
         # Make one column slightly varying so build_sort_matrix-equivalent
         # filtering would normally exclude it; here we feed the matrix
         # directly to the bootstrap, so iterations may fail at the
         # correlation step and be skipped gracefully.
         dataset[0, 0] = 1.0
-        res = compute_bootstrap_stability(
-            dataset,
-            50,
-            n_factors=2,
-            extraction="pca",
-            rotation="varimax",
-            manual_rotations=None,
-            grid_config=None,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            res = compute_bootstrap_stability(
+                dataset,
+                50,
+                n_factors=2,
+                extraction="pca",
+                rotation="varimax",
+                manual_rotations=None,
+                grid_config=None,
+            )
         assert res["n_iterations"] == 50
         # Many or all iterations may fail; the call must not raise.
         assert 0 <= res["n_converged"] <= 50


### PR DESCRIPTION
## Summary

Four backend changes that address the highest-priority items from the CI-warnings audit (group A: silent failures). All four risk a defect that is invisible today but bites under specific conditions (`python -O`, an unexpected numpy state, or a malformed mention email).

- **`concourse_service.check_stale_statements`** — replace `assert source_id is not None` with an explicit `if … is None: continue` guard. Under `python -O` the assert is stripped; the bare path then calls `items_by_id.get(None)` (returns `None`) and **falsely flags the statement as `source_deleted=True`**. The defensive skip survives `-O`.
- **`storage_service.StorageService.__init__`** — replace `assert settings.S3_BUCKET_NAME is not None` with an explicit `RuntimeError` so the type narrow holds even with `-O`. Mypy still narrows because `raise` is `noreturn`.
- **`memos._dispatch_mention_emails`** — swap `except Exception: pass` for `logger.exception(...)` with the failing recipient + `parent_type` + `parent_id`. Preserves batch resilience but adds a stack trace if a future bug (e.g. malformed template) lurks behind the helper's `logger.error` string.
- **`analysis_service.compute_bootstrap_stability`** — scope `np.errstate(divide='ignore', invalid='ignore')` around the `run_analysis` call where pathological resamples are expected to divide by zero. The accompanying test promotes any leaked `RuntimeWarning` to an error, so a future numpy warning **outside** the scoped region surfaces as a test failure rather than CI noise.

Tracker: see `~/.claude/plans/2026-05-01-qualis-ci-warnings.md` (group A).

## Test plan

- [x] `make ci-fast` passes (235 unit tests + 960 frontend tests + lint + types)
- [x] `pytest tests/unit/test_analysis_service.py::TestBootstrapStability` no longer emits 2 `RuntimeWarning: invalid value encountered in divide` (cleanly 235 passed, 0 warnings)
- [x] `bandit -r app/ -ll` count drops from 7 Low → 4 Low (the 3 issues fixed here are gone)
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)