### PR TITLE
chore(ci): silence bandit false positives + document suppressions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,16 @@ We patch the latest tagged release. Older releases are best-effort.
 
 Dependencies surface CVEs that we have evaluated and chose not to fix because the affected code paths are not reachable in Qualis's usage.
 
+### Bandit suppressions
+
+`bandit -ll` (run by `make check`) flags a small number of patterns where the static heuristic does not match the actual semantics. Each suppression is annotated inline with `# nosec <test-id>` and the rationale lives next to the code:
+
+- `app/routers/auth.py:103` — `# nosec B106`. The string `"bearer"` is the OAuth2 token-type literal returned to the client, not a credential.
+- `app/services/study_service.py` (~line 503) — `# nosec B311`. `random.Random` is used to produce a deterministic per-session statement-shuffle for Q-methodology reproducibility; it is not security-sensitive. The seed is derived from the session token.
+- `app/services/study_service.py` (~line 542) — `# nosec B105`. The dict key `requires_password` is a payload field name; the value is the literal `False`. Bandit pattern-matches the key and flags the entry. The suppression is hoisted to a single-line local assignment to keep the AST attribution scoped.
+
+Last reviewed: 2026-05-01.
+
 ### `xlsx` (SheetJS Community Edition)
 
 [GHSA-4r6h-8v6p-xvw6](https://github.com/advisories/GHSA-4r6h-8v6p-xvw6) (prototype pollution) and [GHSA-5pgg-2g8v-p4x9](https://github.com/advisories/GHSA-5pgg-2g8v-p4x9) (ReDoS) require **attacker-controlled XLSX inputs to be parsed**. Qualis only **writes** XLSX files for export (`frontend/src/utils/analysisXlsxExport.ts`); it never parses untrusted XLSX. The test suite parses XLSX but only data it just wrote.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Sentinel value for unset secrets in dev — production startup checks compare
+# against this constant to detect missing env vars. Not a credential.
+_INSECURE_DEFAULT_SENTINEL = "CHANGEME-insecure-dev-only"
+
 # Sentry — initialised here (before app construction) so the SDK captures
 # import-time and startup errors. No-op when SENTRY_DSN is not configured.
 if settings.SENTRY_DSN:
@@ -87,12 +91,12 @@ async def lifespan(app: FastAPI):
 
     # Production Readiness Checks
     if settings.ENVIRONMENT != "development":
-        if settings.SECRET_KEY == "CHANGEME-insecure-dev-only":
+        if settings.SECRET_KEY == _INSECURE_DEFAULT_SENTINEL:
             logger.critical(
                 "SECRET_KEY is using the insecure default! Set a strong random SECRET_KEY in environment variables."
             )
 
-        if settings.IP_HASH_SALT == "CHANGEME-insecure-dev-only":
+        if settings.IP_HASH_SALT == _INSECURE_DEFAULT_SENTINEL:
             logger.critical(
                 "IP_HASH_SALT is using the insecure default! Set a unique IP_HASH_SALT in environment variables."
             )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -100,7 +100,8 @@ async def login_for_access_token(
         subject=user.email, expires_delta=access_token_expires
     )
 
-    return Token(access_token=access_token, token_type="bearer")
+    # token_type "bearer" is the OAuth2 literal, not a credential.
+    return Token(access_token=access_token, token_type="bearer")  # nosec B106
 
 
 @router.post("/register", response_model=UserRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/services/study_service.py
+++ b/backend/app/services/study_service.py
@@ -498,7 +498,9 @@ class StudyService:
         if study.randomize_statement_order and session_token:
             import random
 
-            local_random = random.Random(
+            # Deterministic per-session shuffle for Q-methodology
+            # reproducibility, not a security-sensitive RNG.
+            local_random = random.Random(  # nosec B311
                 StudyService._generate_session_seed(str(session_token))
             )
             local_random.shuffle(statements_data)
@@ -529,6 +531,11 @@ class StudyService:
                 effective_state = StudyState.paused.value
             elif study.end_date and is_now_after(study.end_date):
                 effective_state = StudyState.closed.value
+
+        # Bound to a local to keep the bandit suppression on a single line and
+        # avoid AST propagation to the dict literal below. The field name
+        # contains "password" but the value is the literal False.
+        requires_password = False  # nosec B105
 
         return {
             "slug": study.slug,
@@ -569,7 +576,7 @@ class StudyService:
             "state": effective_state,
             "step_help": (getattr(translation, "step_help", {}) or {})
             or lang_defaults.get("step_help", {}),
-            "requires_password": False,
+            "requires_password": requires_password,
             "start_date": study.start_date,
             "end_date": study.end_date,
             "branding": study.branding


### PR DESCRIPTION
## Summary

Cleans up the 4 bandit false positives identified in the CI-warnings audit (group C). One was eliminated by refactor (no `# nosec` needed); three are annotated inline and listed in `SECURITY.md`.

- **`main.py`** — hoist the `'CHANGEME-insecure-dev-only'` literal into a module-level constant `_INSECURE_DEFAULT_SENTINEL`. Comparing `settings.SECRET_KEY == _INSECURE_DEFAULT_SENTINEL` (against a name, not a literal) sidesteps B105 entirely. **No `# nosec` needed** — the cleanest outcome.
- **`routers/auth.py`** — `token_type='bearer'` is the OAuth2 literal returned to the client, not a credential. `# nosec B106`.
- **`services/study_service.py`** — `random.Random` for the per-session statement shuffle is intentionally non-cryptographic (Q-methodology reproducibility); the seed is derived from the session token. `# nosec B311`.
- **`services/study_service.py`** — `requires_password` is a payload field name; the value is the literal `False`. Bandit pattern-matches the key. To keep the suppression scoped to a single line (and avoid AST propagation to every entry of the surrounding dict literal), the value is bound to a local `requires_password = False  # nosec B105` first, then referenced by the dict.

`SECURITY.md` gains a **Bandit suppressions** subsection mirroring the existing pip-audit ignored-CVE list, with one bullet per active suppression.

After this change, `bandit -r app/ -ll` reports no issues with no stderr warnings (the 3 remaining Low findings are all targeted by [#PR1](https://github.com/jvastenaekels/qualis/tree/ci-warnings/silent-failure-cleanup)).

Tracker: see `~/.claude/plans/2026-05-01-qualis-ci-warnings.md` (group C).

## Test plan

- [x] `make ci` passes (lint + check + test + build)
- [x] `bandit -r app/ -ll` produces zero stderr WARNING and "No issues identified"
- [x] `bandit -r app/` (no severity filter) confirms only the 3 PR1-territory issues remain
- [ ] CI passes on push

## Implementation notes

Two non-obvious bandit quirks surfaced and shaped the final form:

1. **Trailing rationale on `# nosec` lines is parsed as test IDs.** `# nosec B105 — payload field name` makes bandit emit `Test in comment: the is not a test name or id, ignoring`. Rationale is therefore on a Python comment line *above* the suppressed statement; the suppression itself is the bare `# nosec Bxxx`.
2. **`# nosec` propagates by AST node.** A dict literal spanning many lines receives the suppression on every entry; the workaround is to hoist the value to a local before the dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)