### PR TITLE
refactor(participant): extract useResumeSession hook + pure helpers

### DIFF
--- a/frontend/src/hooks/participant/useResumeSession.test.ts
+++ b/frontend/src/hooks/participant/useResumeSession.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Pure-helper tests for the resume session module.
+ *
+ * Hook integration is covered by `pages/ResumePage.test.tsx`; here we lock the
+ * behaviour of the two pure helpers (`parseResumeError`, `validateDraftResponses`)
+ * so a future regression in the error → state mapping or the per-key draft
+ * fallback fails immediately, without rendering.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { initialResponses } from '../../store/useResponseStore';
+import { parseResumeError, validateDraftResponses } from './useResumeSession';
+
+describe('parseResumeError', () => {
+    it('maps 404 to not_found', () => {
+        expect(parseResumeError({ status: 404 })).toEqual({ kind: 'error', code: 'not_found' });
+    });
+
+    it('maps 410 to redirect-completed (already submitted)', () => {
+        expect(parseResumeError({ status: 410 })).toEqual({ kind: 'redirect-completed' });
+    });
+
+    it('maps 403 to study_closed', () => {
+        expect(parseResumeError({ status: 403 })).toEqual({ kind: 'error', code: 'study_closed' });
+    });
+
+    it('maps 429 to rate_limited', () => {
+        expect(parseResumeError({ status: 429 })).toEqual({ kind: 'error', code: 'rate_limited' });
+    });
+
+    it('falls back to generic error for unknown status', () => {
+        expect(parseResumeError({ status: 500 })).toEqual({ kind: 'error', code: 'error' });
+    });
+
+    it('falls back to generic error when no status field is present', () => {
+        expect(parseResumeError(new Error('network'))).toEqual({ kind: 'error', code: 'error' });
+        expect(parseResumeError(undefined)).toEqual({ kind: 'error', code: 'error' });
+        expect(parseResumeError(null)).toEqual({ kind: 'error', code: 'error' });
+        expect(parseResumeError('string-error')).toEqual({ kind: 'error', code: 'error' });
+    });
+});
+
+describe('validateDraftResponses', () => {
+    it('returns null for empty / missing drafts', () => {
+        expect(validateDraftResponses(undefined)).toBeNull();
+        expect(validateDraftResponses(null)).toBeNull();
+        expect(validateDraftResponses({})).toBeNull();
+    });
+
+    it('returns null when draft is not a plain object', () => {
+        expect(validateDraftResponses([1, 2, 3])).toBeNull();
+        expect(validateDraftResponses('not-an-object')).toBeNull();
+    });
+
+    it('passes through a fully valid draft unchanged', () => {
+        const draft = {
+            presort: { q1: 'yes' },
+            rough: { agree: [1], disagree: [2], neutral: [3], history: ['drag-1'] },
+            qsort: [[1], [2]],
+            postsort: { feedback: 'good' },
+        };
+        const result = validateDraftResponses(draft);
+        expect(result).toEqual(draft);
+    });
+
+    it('falls back per-key when one key is malformed without poisoning others', () => {
+        const draft = {
+            presort: { q1: 'yes' }, // valid
+            rough: { agree: 'not-an-array' }, // invalid
+            qsort: [[1]], // valid
+            postsort: 'not-an-object', // invalid
+        };
+        const result = validateDraftResponses(draft);
+        expect(result).toEqual({
+            presort: { q1: 'yes' },
+            rough: initialResponses.rough,
+            qsort: [[1]],
+            postsort: initialResponses.postsort,
+        });
+    });
+
+    it('falls back to initialResponses on every malformed slice', () => {
+        const draft = {
+            presort: 'bad',
+            rough: { agree: 'bad' },
+            qsort: 'bad',
+            postsort: [1, 2, 3],
+        };
+        const result = validateDraftResponses(draft);
+        // The hydration writes only the subset the resume payload covers
+        // (presort/rough/qsort/postsort); `deck` is intentionally not part of
+        // the validated shape.
+        expect(result).toEqual({
+            presort: initialResponses.presort,
+            rough: initialResponses.rough,
+            qsort: initialResponses.qsort,
+            postsort: initialResponses.postsort,
+        });
+    });
+
+    it('rejects a rough slice with the wrong array shape on any subkey', () => {
+        const draft = {
+            presort: {},
+            rough: {
+                agree: [1],
+                disagree: [2],
+                neutral: [3],
+                history: 'not-an-array', // breaks the shape
+            },
+            qsort: [],
+            postsort: {},
+        };
+        const result = validateDraftResponses(draft);
+        expect(result?.rough).toEqual(initialResponses.rough);
+    });
+});

--- a/frontend/src/hooks/participant/useResumeSession.ts
+++ b/frontend/src/hooks/participant/useResumeSession.ts
@@ -1,0 +1,208 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Resume session hook + pure helpers.
+ *
+ * Restores a participant session from a resume token: API call → store
+ * hydration → navigation. The pure helpers (parseResumeError,
+ * validateDraftResponses) are unit-tested without rendering; the hook
+ * orchestrates side effects.
+ */
+
+import { useEffect, useState } from 'react';
+import type { i18n as I18nType } from 'i18next';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, type NavigateFunction } from 'react-router-dom';
+import { toast } from 'sonner';
+import type { ResumeResponse } from '../../api/model';
+import { customInstance } from '../../api/mutator';
+import { STEP_ROUTES } from '../../constants/stepRoutes';
+import { initialResponses, useResponseStore } from '../../store/useResponseStore';
+import { useSessionStore } from '../../store/useSessionStore';
+import { resetAllStores } from '../../utils/sessionReset';
+
+export type ResumeError = 'not_found' | 'study_closed' | 'rate_limited' | 'error';
+
+/**
+ * Outcome of inspecting a thrown API error. `error` maps to a user-facing
+ * screen; `redirect-completed` is the special case where the backend says the
+ * session was already submitted (HTTP 410) and we route to the confirmation
+ * screen instead of showing an error.
+ */
+export type ParsedResumeError =
+    | { kind: 'error'; code: ResumeError }
+    | { kind: 'redirect-completed' };
+
+export function parseResumeError(err: unknown): ParsedResumeError {
+    const status =
+        err && typeof err === 'object' && 'status' in err ? (err as { status: number }).status : 0;
+
+    if (status === 404) return { kind: 'error', code: 'not_found' };
+    if (status === 410) return { kind: 'redirect-completed' };
+    if (status === 403) return { kind: 'error', code: 'study_closed' };
+    if (status === 429) return { kind: 'error', code: 'rate_limited' };
+    return { kind: 'error', code: 'error' };
+}
+
+type DraftLike = Record<string, unknown>;
+
+interface ValidatedDraft {
+    presort: typeof initialResponses.presort;
+    rough: typeof initialResponses.rough;
+    qsort: typeof initialResponses.qsort;
+    postsort: typeof initialResponses.postsort;
+}
+
+/**
+ * Per-key shape validation of a `draft_responses` payload. Each key falls
+ * back to `initialResponses.<key>` independently when its shape is wrong, so
+ * a corrupted slice cannot poison neighbouring slices.
+ *
+ * Returns `null` when the draft is empty / missing — caller skips hydration.
+ */
+export function validateDraftResponses(draft: unknown): ValidatedDraft | null {
+    if (!draft || typeof draft !== 'object' || Array.isArray(draft)) return null;
+    const d = draft as DraftLike;
+    if (Object.keys(d).length === 0) return null;
+
+    const isPresortShape = d.presort && typeof d.presort === 'object' && !Array.isArray(d.presort);
+
+    const roughObj = d.rough as Record<string, unknown> | undefined;
+    const isRoughShape =
+        roughObj &&
+        typeof roughObj === 'object' &&
+        Array.isArray(roughObj.agree) &&
+        Array.isArray(roughObj.disagree) &&
+        Array.isArray(roughObj.neutral) &&
+        Array.isArray(roughObj.history);
+
+    const isQsortShape = Array.isArray(d.qsort);
+
+    const isPostsortShape =
+        d.postsort && typeof d.postsort === 'object' && !Array.isArray(d.postsort);
+
+    return {
+        presort: isPresortShape
+            ? (d.presort as typeof initialResponses.presort)
+            : initialResponses.presort,
+        rough: isRoughShape ? (d.rough as typeof initialResponses.rough) : initialResponses.rough,
+        qsort: isQsortShape ? (d.qsort as typeof initialResponses.qsort) : initialResponses.qsort,
+        postsort: isPostsortShape
+            ? (d.postsort as typeof initialResponses.postsort)
+            : initialResponses.postsort,
+    };
+}
+
+function safeSessionStorage(action: 'set' | 'remove', key: string, value?: string): void {
+    try {
+        if (action === 'set' && value !== undefined) {
+            sessionStorage.setItem(key, value);
+        } else if (action === 'remove') {
+            sessionStorage.removeItem(key);
+        }
+    } catch {
+        // Ignore storage errors (private mode, full quota, …).
+    }
+}
+
+async function applyResumeSuccess(
+    data: ResumeResponse & { draft_responses: Record<string, unknown> },
+    slug: string,
+    navigate: NavigateFunction,
+    i18n: I18nType
+): Promise<void> {
+    safeSessionStorage('remove', 'qualis-pilot-mode');
+
+    // Reset all stores — including configStore — so the slug guard in
+    // useStudyConfig does not wipe our hydrated session when StudyLayout mounts.
+    resetAllStores();
+
+    const session = useSessionStore.getState();
+    session.setToken(data.session_token);
+    session.setStudySlug(slug);
+    session.setConsent(true);
+    session.setStep(data.last_step_reached);
+    session.setLanguage(data.language);
+    if (data.language) {
+        await i18n.changeLanguage(data.language);
+    }
+    if (data.resume_code) {
+        session.setResumeCode(data.resume_code);
+    }
+
+    const validatedDraft = validateDraftResponses(data.draft_responses);
+    if (validatedDraft !== null) {
+        useResponseStore.setState(validatedDraft);
+    }
+
+    safeSessionStorage('set', 'qualis-resumed-via-link', '1');
+
+    const route = STEP_ROUTES[data.last_step_reached] || 'welcome';
+    navigate(`/study/${slug}/${route}`, { replace: true });
+
+    if (STEP_ROUTES[data.last_step_reached]) {
+        toast.success(i18n.t('resume.restored', 'Welcome back! Your progress has been restored.'));
+    }
+}
+
+function handleAlreadyCompleted(slug: string, navigate: NavigateFunction): void {
+    const state = useSessionStore.getState();
+    state.setStudySlug(slug);
+    state.setConsent(true);
+    state.completeSession('');
+    navigate(`/study/${slug}/post-sort`, { replace: true });
+}
+
+export interface UseResumeSessionResult {
+    error: ResumeError | null;
+}
+
+export function useResumeSession(
+    slug: string | undefined,
+    token: string | undefined
+): UseResumeSessionResult {
+    const { i18n } = useTranslation();
+    const navigate = useNavigate();
+    const [error, setError] = useState<ResumeError | null>(null);
+
+    useEffect(() => {
+        if (!slug || !token) {
+            setError('not_found');
+            return;
+        }
+
+        let cancelled = false;
+
+        const run = async () => {
+            try {
+                const data = await customInstance<
+                    ResumeResponse & { draft_responses: Record<string, unknown> }
+                >({
+                    url: `/api/study/${slug}/resume/${token}`,
+                    method: 'GET',
+                });
+                if (cancelled) return;
+                await applyResumeSuccess(data, slug, navigate, i18n);
+            } catch (err: unknown) {
+                if (cancelled) return;
+                const parsed = parseResumeError(err);
+                if (parsed.kind === 'redirect-completed') {
+                    handleAlreadyCompleted(slug, navigate);
+                    return;
+                }
+                setError(parsed.code);
+            }
+        };
+
+        run();
+        return () => {
+            cancelled = true;
+        };
+    }, [slug, token, navigate, i18n]);
+
+    return { error };
+}

--- a/frontend/src/pages/ResumePage.tsx
+++ b/frontend/src/pages/ResumePage.tsx
@@ -4,206 +4,72 @@
  * Standalone route that restores a participant session from the backend
  * and redirects to the correct study step. Not wrapped in StudyLayout
  * to avoid consent guards and loader dependencies.
+ *
+ * State and side effects live in `useResumeSession`; this component is a
+ * thin renderer.
  */
 
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
-import type { ResumeResponse } from '../api/model';
-import { customInstance } from '../api/mutator';
-import { STEP_ROUTES } from '../constants/stepRoutes';
-import { useSessionStore } from '../store/useSessionStore';
-import { initialResponses, useResponseStore } from '../store/useResponseStore';
-import { resetAllStores } from '../utils/sessionReset';
+import { Link, useParams } from 'react-router-dom';
+import { type ResumeError, useResumeSession } from '../hooks/participant/useResumeSession';
 
-type ResumeError = 'not_found' | 'study_closed' | 'rate_limited' | 'error';
+interface ErrorScreen {
+    message: string;
+    showStudyLink: boolean;
+    showRetry: boolean;
+}
+
+function useErrorScreens(): Record<ResumeError, ErrorScreen> {
+    const { t } = useTranslation();
+    return {
+        not_found: {
+            message: t(
+                'resume.not_found',
+                "This link is no longer valid. If you haven't completed the study, please contact the researcher for a new link."
+            ),
+            showStudyLink: true,
+            showRetry: false,
+        },
+        study_closed: {
+            message: t(
+                'resume.study_closed',
+                'This study is no longer accepting responses. Please contact the researcher if you have questions.'
+            ),
+            showStudyLink: false,
+            showRetry: false,
+        },
+        rate_limited: {
+            message: t(
+                'resume.rate_limited',
+                'Too many attempts. Please wait a moment and try again.'
+            ),
+            showStudyLink: false,
+            showRetry: true,
+        },
+        error: {
+            message: t(
+                'resume.error',
+                'Something went wrong while restoring your session. Please try again.'
+            ),
+            showStudyLink: true,
+            showRetry: true,
+        },
+    };
+}
 
 export default function ResumePage() {
-    const { t, i18n } = useTranslation();
-    const navigate = useNavigate();
+    const { t } = useTranslation();
     const { slug, token } = useParams<{ slug: string; token: string }>();
-    const [error, setError] = useState<ResumeError | null>(null);
-
-    useEffect(() => {
-        if (!slug || !token) {
-            setError('not_found');
-            return;
-        }
-
-        let cancelled = false;
-
-        const restore = async () => {
-            try {
-                const data = await customInstance<
-                    ResumeResponse & { draft_responses: Record<string, unknown> }
-                >({
-                    url: `/api/study/${slug}/resume/${token}`,
-                    method: 'GET',
-                });
-
-                if (cancelled) return;
-
-                // Clear pilot-mode flag so stores use normal persistence keys
-                try {
-                    sessionStorage.removeItem('qualis-pilot-mode');
-                } catch {
-                    // Ignore storage errors
-                }
-
-                // Reset all stores — including configStore to prevent the slug guard
-                // in useStudyConfig from wiping our hydrated session when StudyLayout mounts
-                resetAllStores();
-
-                // Hydrate session store
-                const session = useSessionStore.getState();
-                session.setToken(data.session_token);
-                session.setStudySlug(slug || '');
-                session.setConsent(true);
-                session.setStep(data.last_step_reached);
-                session.setLanguage(data.language);
-                if (data.language) {
-                    await i18n.changeLanguage(data.language);
-                }
-                if (data.resume_code) {
-                    session.setResumeCode(data.resume_code);
-                }
-
-                // Hydrate response store from draft (with runtime shape validation)
-                const draft = data.draft_responses;
-                if (draft && typeof draft === 'object' && Object.keys(draft).length > 0) {
-                    const isValidPresort =
-                        draft.presort &&
-                        typeof draft.presort === 'object' &&
-                        !Array.isArray(draft.presort);
-                    const roughObj = draft.rough as Record<string, unknown> | undefined;
-                    const isValidRough =
-                        roughObj &&
-                        typeof roughObj === 'object' &&
-                        Array.isArray(roughObj.agree) &&
-                        Array.isArray(roughObj.disagree) &&
-                        Array.isArray(roughObj.neutral) &&
-                        Array.isArray(roughObj.history);
-                    const isValidQsort = Array.isArray(draft.qsort);
-                    const isValidPostsort =
-                        draft.postsort &&
-                        typeof draft.postsort === 'object' &&
-                        !Array.isArray(draft.postsort);
-
-                    useResponseStore.setState({
-                        presort: isValidPresort
-                            ? (draft.presort as typeof initialResponses.presort)
-                            : initialResponses.presort,
-                        rough: isValidRough
-                            ? (draft.rough as typeof initialResponses.rough)
-                            : initialResponses.rough,
-                        qsort: isValidQsort
-                            ? (draft.qsort as typeof initialResponses.qsort)
-                            : initialResponses.qsort,
-                        postsort: isValidPostsort
-                            ? (draft.postsort as typeof initialResponses.postsort)
-                            : initialResponses.postsort,
-                    });
-                }
-
-                // Flag so StudyLayout skips its welcome-back toast (we show our own)
-                try {
-                    sessionStorage.setItem('qualis-resumed-via-link', '1');
-                } catch {
-                    // Ignore storage errors
-                }
-
-                // Navigate to the correct step
-                const route = STEP_ROUTES[data.last_step_reached] || 'welcome';
-                navigate(`/study/${slug}/${route}`, { replace: true });
-
-                // Show welcome-back toast after navigation
-                const stepName = STEP_ROUTES[data.last_step_reached];
-                if (stepName) {
-                    toast.success(
-                        i18n.t('resume.restored', 'Welcome back! Your progress has been restored.')
-                    );
-                }
-            } catch (err: unknown) {
-                if (cancelled) return;
-
-                const status =
-                    err && typeof err === 'object' && 'status' in err
-                        ? (err as { status: number }).status
-                        : 0;
-
-                if (status === 404) {
-                    setError('not_found');
-                } else if (status === 410) {
-                    // Session already submitted — show the confirmation screen
-                    const state = useSessionStore.getState();
-                    state.setStudySlug(slug || '');
-                    state.setConsent(true);
-                    state.completeSession('');
-                    navigate(`/study/${slug}/post-sort`, { replace: true });
-                    return;
-                } else if (status === 403) {
-                    setError('study_closed');
-                } else if (status === 429) {
-                    setError('rate_limited');
-                } else {
-                    setError('error');
-                }
-            }
-        };
-
-        restore();
-        return () => {
-            cancelled = true;
-        };
-    }, [slug, token, navigate, i18n.changeLanguage, i18n.t]);
+    const { error } = useResumeSession(slug, token);
+    const screens = useErrorScreens();
 
     if (error) {
-        const config: Record<
-            ResumeError,
-            { message: string; showStudyLink: boolean; showRetry: boolean }
-        > = {
-            not_found: {
-                message: t(
-                    'resume.not_found',
-                    "This link is no longer valid. If you haven't completed the study, please contact the researcher for a new link."
-                ),
-                showStudyLink: true,
-                showRetry: false,
-            },
-            study_closed: {
-                message: t(
-                    'resume.study_closed',
-                    'This study is no longer accepting responses. Please contact the researcher if you have questions.'
-                ),
-                showStudyLink: false,
-                showRetry: false,
-            },
-            rate_limited: {
-                message: t(
-                    'resume.rate_limited',
-                    'Too many attempts. Please wait a moment and try again.'
-                ),
-                showStudyLink: false,
-                showRetry: true,
-            },
-            error: {
-                message: t(
-                    'resume.error',
-                    'Something went wrong while restoring your session. Please try again.'
-                ),
-                showStudyLink: true,
-                showRetry: true,
-            },
-        };
-
-        const errorConfig = config[error];
-
+        const screen = screens[error];
         return (
             <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center p-8 space-y-6">
                 <div className="max-w-md text-center space-y-4">
-                    <p className="text-slate-600 text-lg">{errorConfig.message}</p>
-                    {errorConfig.showStudyLink && slug && (
+                    <p className="text-slate-600 text-lg">{screen.message}</p>
+                    {screen.showStudyLink && slug && (
                         <Link
                             to={`/study/${slug}/welcome`}
                             className="inline-block px-6 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
@@ -211,7 +77,7 @@ export default function ResumePage() {
                             {t('resume.go_to_study', 'Start a new session')}
                         </Link>
                     )}
-                    {errorConfig.showRetry && (
+                    {screen.showRetry && (
                         <button
                             type="button"
                             onClick={() => window.location.reload()}
@@ -225,7 +91,6 @@ export default function ResumePage() {
         );
     }
 
-    // Loading state
     return (
         <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center p-8 space-y-6">
             <div className="w-16 h-16 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />


### PR DESCRIPTION
## Summary

Implements PR 4 of the CI-warnings audit (group B2.2 — frontend ResumePage hook).

Resume from a saved session is the riskiest single path in the participant flow: a bug between API response and store hydration silently restores the **wrong cards, language, or step**. Cognitive complexity 73 on the inline `restore()` function made every change a coin flip.

### Decomposition

The 200-line inline restore is split into three pure helpers + the hook:

- **`parseResumeError(err)`** — pure mapper from a thrown API error to `{kind: 'error', code: ResumeError} | {kind: 'redirect-completed'}`. Deterministically handles 404, 410, 403, 429, and unknown / shapeless errors.
- **`validateDraftResponses(draft)`** — pure per-key shape validator. Each of `presort` / `rough` / `qsort` / `postsort` falls back to `initialResponses.<key>` **independently** when its slice is malformed, so a corrupted slice cannot poison neighbouring slices.
- **`applyResumeSuccess(data, slug, navigate, i18n)`** — orchestrates store hydration + navigation + welcome-back toast.
- **`safeSessionStorage('set'|'remove', key, value?)`** — wraps the duplicated `sessionStorage` try/catch noise into one helper.
- **`useResumeSession(slug, token)`** — the public hook; thin try/catch around `customInstance`, dispatching to `applyResumeSuccess` / `handleAlreadyCompleted` / `setError(code)`.

`ResumePage.tsx` is now a thin renderer: reads slug/token from `useParams`, calls `useResumeSession`, and switches between error screen and loading spinner. The error-screen lookup is a small `useErrorScreens()` hook that returns the i18n-resolved messages.

### Why this is bug-robustness, not just cleanup

- **One source of truth for the error → state mapping.** Today every status code is checked inline; tomorrow when the backend adds a 423 or a 451, the change happens in one switch.
- **Per-key draft validation.** A future API change that breaks one slice cannot silently corrupt another. Each slice independently falls back to `initialResponses.<key>`.
- **Cancellation guard intact.** The `cancelled` closure pattern is preserved end-to-end so an unmount during a slow restore never writes to a dead component.
- **Pure helpers are unit-testable without rendering.** Every status branch + every fallback path is locked by a fast unit test, not an integration test that mocks 7 modules.

## Test plan

- [x] `make ci` passes (lint + check + test + build)
- [x] **12 new helper tests** in `useResumeSession.test.ts` (all branches of `parseResumeError` + all per-key fallback paths of `validateDraftResponses`)
- [x] **10 existing integration tests** in `ResumePage.test.tsx` still pass without modification — confirms observable behaviour is unchanged
- [x] Biome warning count: 70 → 69 (the `noExcessiveCognitiveComplexity` warning on `ResumePage::restore` cc 73 is gone; no new warnings on the hook)
- [ ] CI passes on push

Net: −190 / +55 in the page; +new hook + helper tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)