### PR TITLE
refactor(study): split get_resolved_study_config (radon E→C)

### DIFF
--- a/backend/app/services/study_service.py
+++ b/backend/app/services/study_service.py
@@ -441,6 +441,90 @@ class StudyService:
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _resolve_statement_data(
+        study: Study,
+        resolved_lang: str,
+        session_token: UUID | None,
+    ) -> list[dict[str, Any]]:
+        """Resolve each statement's translation chain (resolved_lang → en →
+        first available) and optionally apply a deterministic per-session
+        shuffle when ``randomize_statement_order`` is enabled.
+        """
+        statements_data: list[dict[str, Any]] = []
+        for s in study.statements:
+            s_trans = next(
+                (t for t in s.translations if t.language_code == resolved_lang), None
+            )
+            if not s_trans:
+                s_trans = next(
+                    (t for t in s.translations if t.language_code == "en"), None
+                )
+            if not s_trans and s.translations:
+                s_trans = s.translations[0]
+            text = s_trans.text if s_trans else s.code
+            statements_data.append({"id": s.id, "text": text, "code": s.code})
+
+        if study.randomize_statement_order and session_token:
+            import random
+
+            # Deterministic per-session shuffle for Q-methodology
+            # reproducibility, not a security-sensitive RNG.
+            local_random = random.Random(  # nosec B311
+                StudyService._generate_session_seed(str(session_token))
+            )
+            local_random.shuffle(statements_data)
+        return statements_data
+
+    @staticmethod
+    def _compute_effective_state(study: Study) -> str:
+        """Compute the public-facing state of a study, accounting for
+        date-based transitions (DB state stays ``active`` past the
+        scheduled window). Returns the state's wire value."""
+        from datetime import datetime, timezone
+
+        if study.state != StudyState.active:
+            return cast(str, study.state.value)
+
+        now = datetime.now(timezone.utc)
+
+        def is_now_before(target_dt: datetime) -> bool:
+            if target_dt.tzinfo is None:
+                return now.replace(tzinfo=None) < target_dt
+            return now < target_dt
+
+        def is_now_after(target_dt: datetime) -> bool:
+            if target_dt.tzinfo is None:
+                return now.replace(tzinfo=None) > target_dt
+            return now > target_dt
+
+        if study.start_date and is_now_before(study.start_date):
+            return cast(str, StudyState.paused.value)
+        if study.end_date and is_now_after(study.end_date):
+            return cast(str, StudyState.closed.value)
+        return cast(str, study.state.value)
+
+    @staticmethod
+    def _resolve_process_steps(
+        translation: Any, resolved_lang: str, base_lang: str
+    ) -> list[Any]:
+        """Process-steps fallback chain: translation → defaults[resolved_lang]
+        → defaults[base_lang] → defaults['en']."""
+        return (
+            (getattr(translation, "process_steps", []) or [])
+            or DEFAULT_PROCESS_STEPS.get(resolved_lang)
+            or DEFAULT_PROCESS_STEPS.get(base_lang)
+            or DEFAULT_PROCESS_STEPS.get("en", [])
+        )
+
+    @staticmethod
+    def _resolve_distribution_mode(study: Study) -> Any:
+        """Return the distribution mode wire value, tolerating either a
+        DistributionMode enum or a raw string (e.g. when a test fixture
+        bypasses the ORM)."""
+        mode = study.distribution_mode
+        return mode.value if hasattr(mode, "value") else mode
+
+    @staticmethod
     async def get_resolved_study_config(
         study: Study,
         lang: str | None = None,
@@ -478,59 +562,15 @@ class StudyService:
             "objective", None
         )
 
-        statements_data = []
-        for s in study.statements:
-            # Resolve statement translation
-            s_trans = next(
-                (t for t in s.translations if t.language_code == resolved_lang), None
-            )
-            if not s_trans:
-                s_trans = next(
-                    (t for t in s.translations if t.language_code == "en"), None
-                )
-            if not s_trans and s.translations:
-                s_trans = s.translations[0]
-
-            text = s_trans.text if s_trans else s.code
-            statements_data.append({"id": s.id, "text": text, "code": s.code})
-
-        # Q Methodology: Randomize statement order if configured
-        if study.randomize_statement_order and session_token:
-            import random
-
-            # Deterministic per-session shuffle for Q-methodology
-            # reproducibility, not a security-sensitive RNG.
-            local_random = random.Random(  # nosec B311
-                StudyService._generate_session_seed(str(session_token))
-            )
-            local_random.shuffle(statements_data)
+        statements_data = StudyService._resolve_statement_data(
+            study, resolved_lang, session_token
+        )
 
         # Helper for translation attributes
         def get_t_attr(attr: str, default: Any = None) -> Any:
             return getattr(translation, attr, default) if translation else default
 
-        # Calculate effective state based on dates
-        from datetime import datetime, timezone
-
-        now = datetime.now(timezone.utc)
-        effective_state = study.state.value
-
-        if study.state == StudyState.active:
-
-            def is_now_before(target_dt: datetime) -> bool:
-                if target_dt.tzinfo is None:
-                    return now.replace(tzinfo=None) < target_dt
-                return now < target_dt
-
-            def is_now_after(target_dt: datetime) -> bool:
-                if target_dt.tzinfo is None:
-                    return now.replace(tzinfo=None) > target_dt
-                return now > target_dt
-
-            if study.start_date and is_now_before(study.start_date):
-                effective_state = StudyState.paused.value
-            elif study.end_date and is_now_after(study.end_date):
-                effective_state = StudyState.closed.value
+        effective_state = StudyService._compute_effective_state(study)
 
         # Bound to a local to keep the bandit suppression on a single line and
         # avoid AST propagation to the dict literal below. The field name
@@ -548,10 +588,9 @@ class StudyService:
             "postsort_config": study.postsort_config,
             "grid_config": study.grid_config,
             "statements": statements_data,
-            "process_steps": (getattr(translation, "process_steps", []) or [])
-            or DEFAULT_PROCESS_STEPS.get(resolved_lang)
-            or DEFAULT_PROCESS_STEPS.get(base_lang)
-            or DEFAULT_PROCESS_STEPS.get("en", []),
+            "process_steps": StudyService._resolve_process_steps(
+                translation, resolved_lang, base_lang
+            ),
             "consent": {
                 "title": get_t_attr("consent_title")
                 or lang_defaults.get("consent_title"),
@@ -567,9 +606,7 @@ class StudyService:
             "show_statement_codes": study.show_statement_codes,
             "randomize_statement_order": study.randomize_statement_order,
             "rough_sort_enabled": study.rough_sort_enabled,
-            "distribution_mode": study.distribution_mode.value
-            if hasattr(study.distribution_mode, "value")
-            else study.distribution_mode,
+            "distribution_mode": StudyService._resolve_distribution_mode(study),
             "ui_labels": get_t_attr("ui_labels", {}) or {},
             "methodology_tips": (getattr(translation, "methodology_tips", []) or [])
             or lang_defaults.get("methodology_tips", []),


### PR DESCRIPTION
## Summary

Implements PR 7 of the CI-warnings audit (group B1.4 — backend `get_resolved_study_config` split).

This payload is sent to every participant on every study load: **a bug here means the wrong language, the wrong consent text, the wrong grid, or the wrong start/end gating — silently**. Cyclomatic complexity 31 (E) on the inline implementation made the surface too large to reason about.

### Decomposition

Four private static helpers; the public method stays at cc 10 (C):

- **`_resolve_statement_data(study, resolved_lang, session_token)`** — Per-statement translation chain (`resolved_lang → en → first available`) plus the optional deterministic per-session shuffle (Q-methodology reproducibility, not security-sensitive RNG).
- **`_compute_effective_state(study)`** — Public-facing state, accounting for date-based transitions (DB state stays `active` past `end_date` until reaped). Returns the wire string. The two inner closures (`is_now_before` / `is_now_after`) move with it; tz-naive vs tz-aware comparison is preserved.
- **`_resolve_process_steps(translation, resolved_lang, base_lang)`** — Three-deep fallback (`translation → DEFAULT_PROCESS_STEPS[resolved_lang] → DEFAULT_PROCESS_STEPS[base_lang] → DEFAULT_PROCESS_STEPS['en']`). Was a four-line `or` chain inline.
- **`_resolve_distribution_mode(study)`** — Returns the wire value, tolerating either a `DistributionMode` enum or a raw string (test fixtures sometimes bypass the ORM).

### Radon results on `study_service.py`

| Block | Before | After |
|---|---|---|
| `get_resolved_study_config` | **E** (cc 31) | **C** (cc 10) |
| `_resolve_statement_data` | n/a | C |
| `_compute_effective_state` | n/a | B |
| `_resolve_process_steps` / `_resolve_distribution_mode` | n/a | A (not listed at --min B) |
| File average | 14.1 | 11.6 |

### Why this is bug-robustness, not just cleanup

- **The shuffle and the state computation are now independently mockable.** A future test that checks "what does the participant see when start_date is in the future?" can target `_compute_effective_state` directly.
- **The translation-fallback chains are explicit.** `_resolve_process_steps` makes the four-step fallback testable in isolation; today the same fallback was an inline `or` chain in the dict literal.
- **No payload key changes, no fallback-order changes.** Every dict key keeps its position and resolution rule.

## Test plan

- [x] `make ci` passes (lint + check + test + build)
- [x] Participant-flow integration tests in `test_participation.py` exercise this path on every consent + submission — all still pass
- [x] `radon cc study_service.py` confirms `get_resolved_study_config` drops from E to C
- [x] `mypy` clean — `study_service.py` is in the relaxed-strict overrides
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)