### PR TITLE
refactor(concourse): apply biome-ignore precedent on item row callback (cc 63)

### DIFF
--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -650,6 +650,7 @@ export default function ConcourseDetailPage() {
                                     </span>
                                 </div>
                             )}
+                            {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: row rendering — many cooperating visual states (selection, edit mode, status, missing translation, mobile/desktop layouts, hover-only actions). Same shell-suppression precedent as the page-level biome-ignore on line 78 (CLAUDE.md). */}
                             {filteredItems.map((item) => {
                                 const activeTranslation = item.translations?.find(
                                     (tr) => tr.language_code === activeLocale


### PR DESCRIPTION
## Summary

Implements PR 10 (final entry of the CI-warnings audit, group B2.4).

### What this is

The `filteredItems.map` callback in `ConcourseDetailPage` renders rows with many cooperating visual states — selection, edit mode, status, missing-translation, mobile vs desktop layouts, hover-only actions. The complexity is genuinely JSX-driven; biome scores it **cc 63**.

The project already documents an exception for JSX shells with this shape (`CLAUDE.md` "JSX shell complexity" section), and the page-level component carries the same suppression on line 78. This PR extends the same pattern to the row-rendering callback with a one-line rationale citing the precedent.

### Decision: biome-ignore vs full sub-component extraction

The plan's original B2.4 entry recommended extracting `<ConcourseItemRow item=… />`. Today's choice is to ship the documented exception (consistent with the `AnalysisPage` / `StudyDesignPage` / `RecruitmentPage` / `ConcourseDetailPage` shell precedent established in earlier PRs) rather than risk regressions across a 497-line render block with 15+ prop dependencies.

A future PR can still do the extraction if the row is needed elsewhere — at that point the prop interface will be motivated by an actual reuse case rather than a complexity score.

### Result

Frontend complexity warning count: **65 → 64**. ConcourseDetailPage's two cc warnings (cc 36 on the page shell, suppressed earlier; cc 63 on the row callback, this PR) are both now annotated.

## Test plan

- [x] `make ci-fast` passes (lint + check + test)
- [x] All 985 frontend tests pass without modification
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)