### PR TITLE
docs: drift B1 — reference docs + collecting-responses patches

### DIFF
--- a/docs/reference/admin-dashboard.md
+++ b/docs/reference/admin-dashboard.md
@@ -17,7 +17,10 @@ The dashboard is scoped to a single study at a time. The active study is selecte
 | Recruitment | `/admin/studies/{slug}/recruitment` | Access links, conversion funnel |
 | Data | `/admin/studies/{slug}/data` | Participant table, charts, individual sessions, exports |
 | Analysis | `/admin/studies/{slug}/analysis` | Factor analysis runs, scree plot, results tabs |
+| Members | `/admin/projects/{slug}/members` | Project-level: invitations, roles, removal |
 | Profile | `/admin/profile` | Account settings, 2FA |
+
+A **Memos** drawer is available on every study and concourse page via a toolbar icon (see [Memos](#memos)).
 
 ---
 
@@ -166,6 +169,14 @@ Eigenvalues with a Kaiser reference line at `λ = 1`. Source: `GET /api/admin/st
 | Rotation | Varimax / None | Varimax uses Kaiser normalization. |
 | Flagging | Auto / Manual | Auto-flag threshold: significance at `1.96 / sqrt(n_statements)`, plus dominance (highest loading on a single factor). |
 
+### Explorer panel
+
+Diagnostic block surfaced at the top of the Analysis page. Source: `POST /api/admin/studies/{slug}/analysis/preview-range`.
+
+- **Eigenvalue / variance preview** for a configurable factor-count range (typically 1–10), so you can scan how variance breaks down without committing to a full run per candidate.
+- **Cumulative variance** and **scree-line context** alongside the Kaiser λ = 1 reference.
+- **Recommended factor count** based on the Kaiser criterion, with a manual override that drives the next run.
+
 ### Results tabs
 
 | Tab | Content |
@@ -175,9 +186,65 @@ Eigenvalues with a Kaiser reference line at `λ = 1`. Source: `GET /api/admin/st
 | Statements | Z-scores, factor positions, distinguishing/consensus classifications at p < 0.05, 0.01, 0.001 (Standard Error of Differences). |
 | Characteristics | Eigenvalues, variance explained, composite reliability (Spearman-Brown), factor correlation matrix. |
 
+### Compare
+
+When two analysis runs exist, the Compare bar aligns them via Tucker φ congruence (computed client-side; see `frontend/src/utils/tuckerPhi.ts`).
+
+- **φ matrix**: pairwise congruence between factors of the two runs.
+- **Aligned arrays**: factors of the second run reordered + sign-flipped to maximise congruence with the first.
+- **Delta columns**: per-statement difference between aligned arrays.
+
+Used to verify that minor changes (different N, different rotation, different flagging) produce equivalent factor structures. Threshold rule of thumb: φ ≥ 0.95 = identical, 0.90 ≤ φ < 0.95 = equivalent, φ < 0.90 = the perturbation mattered.
+
+### Factor canvas
+
+A focus-mode view for one factor at a time. The factor array sits on the left; a **voices panel** on the right pulls participant material for the highest-loading flagged participants — post-sort comments, audio playback, distinguishing statements at the column extremes — that you can pin onto the canvas to anchor interpretive claims in specific participant voices. Per-factor researcher notes save back to the run.
+
 Each run is persisted to the audit trail (`AnalysisRun`); past runs are accessible from the history panel and can be reloaded or deleted. Notes on a run are editable; results are immutable.
 
 Discarded participants are excluded automatically. Minimum: 2 non-discarded participants.
+
+---
+
+## Memos
+
+A drawer of structured notes attached to a parent (study or concourse). Surfaced on all admin pages of that parent via a toolbar icon. Source: `GET /api/admin/{studies|concourses}/{id}/memo` and related endpoints.
+
+### Entries
+
+A memo is a list of titled entries, each with a markdown body (up to 10 000 chars). Entries are reorderable and may be added or deleted by any project member with edit rights. The drawer remembers position and read state per user.
+
+### Threaded comments
+
+Each entry has a comment thread. Comments support `@user` mentions stored as a `mentions: int[]` array on the comment; mentioned users see an unread badge on the toolbar icon until they open the drawer. Comments can be marked **resolved** (resolution is reversible) or soft-deleted.
+
+### Templates
+
+The **Methodology memo** template surfaces as a dedicated entry on the Study Designer toolbar — a one-click way to log design decisions next to the controls that produced them. Source: `GET /api/admin/memo/templates`.
+
+### Export
+
+Memos are included in the Research Package export. See [Data Export](../guides/data-export.md).
+
+---
+
+## Members
+
+Project-scoped page (path: `/admin/projects/{slug}/members`). Lists project members with their role and supports invitations and removals. Source: `GET /api/admin/projects/{slug}/members`.
+
+### Member table
+
+| Column | Notes |
+| ------ | ----- |
+| Member | Name + email; current user marked. |
+| Role | `Owner` / `Editor` / `Viewer` (see [API roles](api.md#roles)). Editable inline by Owners via a select. |
+| Actions | Remove member (Owners only; cannot self-remove). |
+
+### Invitations
+
+The **Invite member** dialog accepts an email and role. If SMTP is configured, an email is sent; otherwise a shareable invitation link is shown in a confirmation dialog. Pending invitations are listed alongside the member table.
+
+This page replaces the previous embedded members list inside Project Settings.
 
 ---
 

--- a/docs/reference/admin-dashboard.md
+++ b/docs/reference/admin-dashboard.md
@@ -194,11 +194,11 @@ When two analysis runs exist, the Compare bar aligns them via Tucker φ congruen
 - **Aligned arrays**: factors of the second run reordered + sign-flipped to maximise congruence with the first.
 - **Delta columns**: per-statement difference between aligned arrays.
 
-Used to verify that minor changes (different N, different rotation, different flagging) produce equivalent factor structures. Threshold rule of thumb: φ ≥ 0.95 = identical, 0.90 ≤ φ < 0.95 = equivalent, φ < 0.90 = the perturbation mattered.
+Use it to check that two runs produce the same factor structure after a perturbation: a different N, a switch in rotation, or a manual flag override. Threshold rule of thumb: φ ≥ 0.95 = identical, 0.90 ≤ φ < 0.95 = equivalent, φ < 0.90 = the perturbation mattered.
 
 ### Factor canvas
 
-A focus-mode view for one factor at a time. The factor array sits on the left; a **voices panel** on the right pulls participant material for the highest-loading flagged participants — post-sort comments, audio playback, distinguishing statements at the column extremes — that you can pin onto the canvas to anchor interpretive claims in specific participant voices. Per-factor researcher notes save back to the run.
+A focus-mode view for one factor at a time. The factor array sits on the left; a **voices panel** on the right pulls participant material for the highest-loading flagged participants — post-sort comments, audio playback, distinguishing statements at the column extremes — that you can pin onto the canvas to ground each interpretive claim in specific participant voices. Per-factor researcher notes save back to the run.
 
 Each run is persisted to the audit trail (`AnalysisRun`); past runs are accessible from the history panel and can be reloaded or deleted. Notes on a run are editable; results are immutable.
 
@@ -208,7 +208,7 @@ Discarded participants are excluded automatically. Minimum: 2 non-discarded part
 
 ## Memos
 
-A drawer of structured notes attached to a parent (study or concourse). Surfaced on all admin pages of that parent via a toolbar icon. Source: `GET /api/admin/{studies|concourses}/{id}/memo` and related endpoints.
+A drawer of structured notes attached to a parent (study or concourse), available on every admin page of that parent via a toolbar icon. Source: `GET /api/admin/{studies|concourses}/{id}/memo` and related endpoints.
 
 ### Entries
 
@@ -220,7 +220,7 @@ Each entry has a comment thread. Comments support `@user` mentions stored as a `
 
 ### Templates
 
-The **Methodology memo** template surfaces as a dedicated entry on the Study Designer toolbar — a one-click way to log design decisions next to the controls that produced them. Source: `GET /api/admin/memo/templates`.
+The **Methodology memo** template appears as a dedicated entry on the Study Designer toolbar, so you can log design decisions next to the controls that produced them. Source: `GET /api/admin/memo/templates`.
 
 ### Export
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -150,6 +150,27 @@ Wired only when `ENVIRONMENT in ("development", "test")`. The router is not regi
 | DELETE | `.../runs/{run_id}` | Editor | — | Delete a persisted run |
 | GET | `.../audios` | Viewer | — | Audio recordings for flagged participants, with presigned playback URLs |
 | GET | `.../comments` | Viewer | — | Card comments from flagged participants on each factor |
+| POST | `.../preview-range` | Viewer | 10/min | Eigenvalue + variance preview for a configurable factor-count range (Explorer panel) |
+
+### Admin — memos (`/api/admin/{studies\|concourses}/{id}/memo`)
+
+Polymorphic memo subsystem attached to either a study or a concourse.
+
+| Method | Path | Min role | Rate limit | Purpose |
+| --- | --- | --- | --- | --- |
+| GET | `/api/admin/{parent}/{id}/memo` | Viewer | — | Full memo (entries with comment threads) for a study or concourse |
+| GET | `/api/admin/{parent}/{id}/memo/entries` | Viewer | — | List entries only (no comment payloads) |
+| POST | `/api/admin/{parent}/{id}/memo/entries` | Editor | 30/min | Create a new memo entry |
+| GET | `/api/admin/{parent}/{id}/memo/unread` | Viewer | — | Unread-mention count for the current user |
+| PATCH | `/api/admin/memo-entries/{eid}` | Editor | 30/min | Update entry title, body, or position |
+| DELETE | `/api/admin/memo-entries/{eid}` | Editor | 30/min | Delete an entry (cascades to comments) |
+| GET | `/api/admin/memo-entries/{eid}/comments` | Viewer | — | List comments on an entry |
+| POST | `/api/admin/memo-entries/{eid}/comments` | Editor | 60/min | Post a comment with optional `mentions: int[]` |
+| PATCH | `/api/admin/memo-comments/{cid}` | author | 30/min | Edit a comment body |
+| DELETE | `/api/admin/memo-comments/{cid}` | author | 30/min | Soft-delete a comment |
+| POST | `/api/admin/memo-comments/{cid}/resolve` | Editor | 30/min | Mark a comment as resolved |
+| POST | `/api/admin/memo-comments/{cid}/unresolve` | Editor | 30/min | Reopen a resolved comment |
+| GET | `/api/admin/memo/templates` | Viewer | — | Preconfigured templates (e.g. methodology memo) |
 
 ### Admin — lifecycle (`/api/admin/studies/{slug}`)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -34,7 +34,21 @@ The shape of the Q-sort table. An array of column objects.
 | `score` | integer | Column value. |
 | `capacity` | integer | Number of cards that fit in the column. |
 
-The sum of all `capacity` values must equal the number of statements.
+The relationship between `sum(capacity)` and the statement count depends on `distribution_mode` (see below).
+
+### `distribution_mode`
+
+How strictly the grid enforces per-column capacities. Default `"forced"`.
+
+| Value | Activation rule | Submission rule | Notes |
+| ----- | --------------- | --------------- | ----- |
+| `"forced"` | `sum(capacity) == len(statements)` | Each column holds exactly its declared capacity. | Classical Brown-school default (Brown 1980; Watts & Stenner 2012). |
+| `"free"` | `sum(capacity) >= len(statements)` (the grid must fit every statement) | Total submitted count must equal the Q-set size; per-column capacities are not enforced — columns may absorb overflow at sort time. | Used when the slot constraint is itself viewed as an analytical artefact (Brown et al. 2015). |
+| `"flexible"` | `sum(capacity) == len(statements)` | Total enforced; per-column capacities are soft hints (designer warnings only). | Qualis-specific compromise between forced and free. |
+
+### `rough_sort_enabled`
+
+Boolean. When true (default), participants go through a 3-pile triage (agree / neutral / disagree) before the fine-sort grid. When false, participants go directly from pre-sort to the fine-sort grid and place items from a single horizontally-scrollable deck. Only ~38% of published Q studies use rough-sorting (Dieteren et al. 2023).
 
 ### `presort_config`
 

--- a/docs/reference/study-configuration-format.md
+++ b/docs/reference/study-configuration-format.md
@@ -23,6 +23,8 @@ For runtime configuration of a study (the same fields as they appear in the data
     "show_statement_codes": true,
     "randomize_statement_order": true,
     "symmetry_lock": true,
+    "rough_sort_enabled": true,
+    "distribution_mode": "forced",
     "access_password": null,
     "grid_config": [
       { "score": -2, "capacity": 2 },
@@ -101,6 +103,8 @@ For runtime configuration of a study (the same fields as they appear in the data
 | `show_statement_codes` | boolean | If true, statement codes (`S1`, `S2`) are visible to participants. Default `false`. |
 | `randomize_statement_order` | boolean | If true, statement display order is shuffled deterministically per session. Default `false`. |
 | `symmetry_lock` | boolean | If true, the designer enforces symmetric column capacities. Default `true`. |
+| `rough_sort_enabled` | boolean | If true (default), participants go through a 3-pile triage before the fine-sort grid. See [`configuration.md`](configuration.md#rough_sort_enabled). |
+| `distribution_mode` | string | One of `"forced"` (default), `"free"`, `"flexible"`. Controls how strictly per-column capacities are enforced at activation and submission. See [`configuration.md`](configuration.md#distribution_mode). |
 | `access_password` | string \| null | Bcrypt-hashed password gating access. `null` = publicly accessible. |
 | `grid_config` | array | Pyramid columns. See below. |
 | `statements` | array | Statement objects. |
@@ -118,7 +122,10 @@ Each item in `grid_config` represents a column.
 | `score` | integer | Column value (e.g. `-3`, `0`, `+3`). |
 | `capacity` | integer | Number of cards that fit in the column. |
 
-The sum of `capacity` across all columns must equal the number of statements.
+The relationship between `sum(capacity)` and the statement count depends on `distribution_mode`:
+
+- `"forced"` and `"flexible"`: `sum(capacity) == len(statements)`.
+- `"free"`: `sum(capacity) >= len(statements)`.
 
 ### Statement object
 

--- a/docs/tutorials/collecting-responses.md
+++ b/docs/tutorials/collecting-responses.md
@@ -92,7 +92,7 @@ This is the single best way to spot rough edges in instructions, statement wordi
 
 1. Click **Overview** in the left sidebar.
 
-The page shows: study status, the recruitment funnel (sent → started → submitted), completion rate, and recent submissions. The funnel counts come from recruitment-link usage (sent), participant session starts (started), and final submissions (submitted) — gaps between stages are usually where dropout happens.
+The page shows: study status, the recruitment funnel (sent → started → submitted), completion rate, and recent submissions. The funnel counts come from link usage, session starts, and final submissions; gaps between stages are usually where dropout happens.
 
 ---
 

--- a/docs/tutorials/collecting-responses.md
+++ b/docs/tutorials/collecting-responses.md
@@ -92,7 +92,7 @@ This is the single best way to spot rough edges in instructions, statement wordi
 
 1. Click **Overview** in the left sidebar.
 
-The page shows: study status, participant statistics, completion rate, and recent submissions.
+The page shows: study status, the recruitment funnel (sent → started → submitted), completion rate, and recent submissions. The funnel counts come from recruitment-link usage (sent), participant session starts (started), and final submissions (submitted) — gaps between stages are usually where dropout happens.
 
 ---
 
@@ -101,7 +101,7 @@ The page shows: study status, participant statistics, completion rate, and recen
 1. Click **Data** in the left sidebar.
 
 The Data page provides:
-- **Participant Table**: Searchable, sortable table with status, duration, device type, test run flag, and discard status
+- **Participant Table**: Searchable, sortable table with status, duration, device type, and discard status
 - **Timeline Chart**: Submission trends over time
 - **Device Breakdown**: Desktop vs. mobile vs. tablet distribution
 
@@ -130,6 +130,8 @@ If you identify a response that should be excluded:
 Discarded participants are excluded from exports and analysis by default, but the data is preserved for audit. To restore, open the same menu and click **Restore**.
 
 For the full set of state transitions a study goes through (Active → Paused → Closed → Archived), see [`../reference/admin-dashboard.md#general`](../reference/admin-dashboard.md#general). For now, leave your tutorial study Active.
+
+> **Sharing access with team members.** To give a colleague access to monitor responses, invite them via the project Members page (`/admin/projects/<slug>/members`). Roles: `Viewer` (read-only), `Editor` (run analyses, manage recruitment), `Owner` (full access including member management). See [Admin Dashboard — Members](../reference/admin-dashboard.md#members).
 
 ---
 


### PR DESCRIPTION
## Summary
Closes the doc-vs-code drift on the **reference layer** plus mechanical patches in the collecting-responses tutorial.

- `configuration.md`: documents `distribution_mode` (forced / free / flexible — three values, not two; the plan said two, source of truth says three) and `rough_sort_enabled` (default `true`).
- `admin-dashboard.md`: new **Memos** and **Members** top-level sections; **Explorer panel**, **Compare**, **Factor canvas** subsections under Analysis. The Members page replaces the previous embedded list inside Project Settings.
- `study-configuration-format.md`: example JSON + Study object table updated for the two new fields.
- `api.md`: memo subsystem (entries + threaded comments + templates) and `preview-range` endpoint documented. Memos attach to either `studies` or `concourses` (polymorphic on `parent_type`).
- `collecting-responses.md`: drop the dead `is_test_run` mention, expand the recruitment funnel description, link to the `/members` page.

Spec: [`docs/superpowers/specs/2026-05-02-doc-improvement-design.md`](../blob/main/docs/superpowers/specs/2026-05-02-doc-improvement-design.md)

**Wave 2 of 5.** Stacked on PR #90 (Vague 1 hygiène) — base branch is \`docs/hygiene\`. Once #90 merges, retarget this PR to \`main\`.

## Test plan
- [x] \`grep -r "is_test_run\\|test run flag" docs/\` returns 0 in live docs.
- [x] \`admin-dashboard.md\` ToC includes Memos, Members, Compare, Explorer, Factor canvas.
- [x] \`configuration.md\` covers \`distribution_mode\` and \`rough_sort_enabled\`.
- [x] \`make ci-fast\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)