### PR TITLE
refactor(design): polish Condition of Instruction tab

### DIFF
--- a/frontend/src/components/admin/designer/ConditionOfInstructionEditor.tsx
+++ b/frontend/src/components/admin/designer/ConditionOfInstructionEditor.tsx
@@ -3,9 +3,9 @@ import { isRoughSortEnabled } from '@/utils/studyConfig';
 import { useTranslation } from 'react-i18next';
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Target, RotateCcw } from 'lucide-react';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent } from '@/components/ui/card';
+import { Target, RotateCcw, Lightbulb } from 'lucide-react';
 import type React from 'react';
 import { createResetToDefaultHandler } from '@/utils/studyResetHelpers';
 import { MultiLangFieldIcon } from './MultiLangFieldIcon';
@@ -21,6 +21,77 @@ interface ConditionOfInstructionEditorProps {
     roughSortLocked?: boolean;
     roughSortLockedCount?: number;
 }
+
+interface InstructionFieldProps {
+    id: 'pre_instruction' | 'condition_of_instruction';
+    title: string;
+    description: string;
+    placeholder: string;
+    value: string;
+    translations: Record<string, string>;
+    activeLocale: string;
+    readOnly?: boolean;
+    onChange: (value: string) => void;
+    onReset: () => void;
+    resetLabel: string;
+    fieldLabel: string;
+}
+
+const InstructionField = ({
+    id,
+    title,
+    description,
+    placeholder,
+    value,
+    translations,
+    activeLocale,
+    readOnly,
+    onChange,
+    onReset,
+    resetLabel,
+    fieldLabel,
+}: InstructionFieldProps) => (
+    <div className="space-y-3">
+        <div>
+            <h3 className="text-base font-bold text-slate-900 tracking-tight">{title}</h3>
+            <p className="text-sm text-slate-500 italic mt-0.5">{description}</p>
+        </div>
+        <div className="grid gap-2">
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                    <Label
+                        htmlFor={id}
+                        className="text-2xs font-bold uppercase tracking-wide text-slate-500"
+                    >
+                        {fieldLabel}
+                    </Label>
+                    <MultiLangFieldIcon activeLocale={activeLocale} translations={translations} />
+                </div>
+                {!readOnly && (
+                    <button
+                        type="button"
+                        onClick={onReset}
+                        className="flex items-center gap-1.5 px-2 py-1 rounded-md text-2xs
+                                   font-medium text-slate-400
+                                   hover:text-indigo-600 hover:bg-slate-50 transition-colors"
+                    >
+                        <RotateCcw className="size-3" />
+                        {resetLabel}
+                    </button>
+                )}
+            </div>
+            <Textarea
+                id={id}
+                value={value}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
+                placeholder={placeholder}
+                rows={3}
+                className="min-h-[80px] text-base leading-relaxed rounded-xl border-slate-200 bg-slate-50/30 focus:bg-white focus-visible:ring-indigo-500/20 transition-all px-4 py-3 resize-y"
+                disabled={readOnly}
+            />
+        </div>
+    </div>
+);
 
 const ConditionOfInstructionEditor = ({
     readOnly,
@@ -48,8 +119,31 @@ const ConditionOfInstructionEditor = ({
         });
     };
 
+    const preInstructionTranslations =
+        draft.translations?.reduce(
+            (acc, tr) => {
+                if (tr.pre_instruction) acc[tr.language_code] = tr.pre_instruction;
+                return acc;
+            },
+            {} as Record<string, string>
+        ) || {};
+
+    const conditionTranslations =
+        draft.translations?.reduce(
+            (acc, tr) => {
+                if (tr.condition_of_instruction)
+                    acc[tr.language_code] = tr.condition_of_instruction;
+                return acc;
+            },
+            {} as Record<string, string>
+        ) || {};
+
+    const roughSortOn = isRoughSortEnabled(draft);
+    const fieldLabel = t('admin.design.condition.field_label', 'Instruction Text');
+    const resetLabel = t('common.reset_to_default');
+
     return (
-        <div className="space-y-12 min-h-[500px]">
+        <div className="space-y-10 min-h-[500px]">
             <section className="space-y-6">
                 <div className="flex items-center gap-3 text-slate-900 font-bold text-xl tracking-tight">
                     <div className="bg-indigo-50 p-2 rounded-xl border border-indigo-100 shadow-sm">
@@ -59,220 +153,115 @@ const ConditionOfInstructionEditor = ({
                 </div>
 
                 {/*
-                 * Rough-sort toggle. Moved here from the Q-sort tab so the
-                 * admin can decide whether to ask for a preliminary sort and
-                 * write the matching consigne in the same place. The
-                 * Preliminary Sort Instruction card below is gated on
-                 * `isRoughSortEnabled(draft)` so it disappears when the
-                 * toggle is off. Lock policy mirrors backend
+                 * Rough-sort toggle. Demoted from a Card to a plain row: it's
+                 * the gate that decides whether the pre-instruction subsection
+                 * appears below, not a content block of equal weight to the
+                 * instruction fields. Lock policy mirrors backend
                  * study_service.update_study: once any participant has
                  * progressed past consent (last_step_reached > 1) the toggle
                  * is frozen.
                  */}
-                <Card
-                    className="border-none shadow-sm bg-white rounded-2xl overflow-hidden"
-                    data-testid="rough-sort-section"
-                >
-                    <CardContent className="pt-6 space-y-3">
-                        {roughSortLocked && (
-                            <div
-                                data-testid="rough-sort-lock-banner"
-                                className="rounded border-l-4 border-amber-400 bg-amber-50 p-2 text-sm text-amber-900"
-                            >
-                                {t('admin.study_design.rough_sort.lock_banner', {
-                                    count: roughSortLockedCount,
-                                    defaultValue:
-                                        'Toggle locked. {{count}} participant(s) have started the survey; ' +
-                                        'archive or delete those sessions before changing this setting.',
-                                })}
-                            </div>
-                        )}
-                        <label className="flex items-center gap-2">
-                            <input
-                                type="checkbox"
-                                data-testid="rough-sort-toggle"
-                                checked={isRoughSortEnabled(draft)}
-                                disabled={roughSortLocked || readOnly}
-                                onChange={(e) =>
-                                    updateDraft((d) => {
-                                        d.rough_sort_enabled = e.target.checked;
-                                    })
-                                }
-                            />
-                            <span className="text-sm font-bold text-slate-900">
-                                {t(
-                                    'admin.study_design.rough_sort.toggle_label',
-                                    'Enable preliminary sort (3-pile triage)'
-                                )}
-                            </span>
-                        </label>
-                        {!isRoughSortEnabled(draft) && (
-                            <p className="text-xs italic text-slate-500">
-                                {t(
-                                    'admin.study_design.rough_sort.deck_mode_note',
-                                    'Disabled. Participants see the full Q-set as a horizontally-scrollable deck.'
-                                )}
-                            </p>
-                        )}
-                    </CardContent>
-                </Card>
+                <div className="space-y-2" data-testid="rough-sort-section">
+                    {roughSortLocked && (
+                        <div
+                            data-testid="rough-sort-lock-banner"
+                            className="rounded border-l-4 border-amber-400 bg-amber-50 p-2 text-sm text-amber-900"
+                        >
+                            {t('admin.study_design.rough_sort.lock_banner', {
+                                count: roughSortLockedCount,
+                                defaultValue:
+                                    'Toggle locked. {{count}} participant(s) have started the survey; ' +
+                                    'archive or delete those sessions before changing this setting.',
+                            })}
+                        </div>
+                    )}
+                    <label className="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            data-testid="rough-sort-toggle"
+                            checked={roughSortOn}
+                            disabled={roughSortLocked || readOnly}
+                            onChange={(e) =>
+                                updateDraft((d) => {
+                                    d.rough_sort_enabled = e.target.checked;
+                                })
+                            }
+                        />
+                        <span className="text-sm font-semibold text-slate-900">
+                            {t(
+                                'admin.study_design.rough_sort.toggle_label',
+                                'Enable preliminary sort (3-pile triage)'
+                            )}
+                        </span>
+                    </label>
+                    {!roughSortOn && (
+                        <p className="text-xs italic text-slate-500 pl-6">
+                            {t(
+                                'admin.study_design.rough_sort.deck_mode_note',
+                                'Disabled. Participants see the full Q-set as a horizontally-scrollable deck.'
+                            )}
+                        </p>
+                    )}
+                </div>
 
-                {isRoughSortEnabled(draft) && (
-                    <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
-                        <CardHeader className="pb-4">
-                            <CardTitle className="text-base font-black text-slate-900 tracking-tight">
-                                {t(
+                <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
+                    <CardContent className="pt-6 pb-6 divide-y divide-slate-100 [&>*+*]:pt-8">
+                        {roughSortOn && (
+                            <InstructionField
+                                id="pre_instruction"
+                                title={t(
                                     'admin.design.condition.pre_title',
                                     'Preliminary Sort Instruction'
                                 )}
-                            </CardTitle>
-                            <CardDescription className="text-sm font-medium text-slate-500 italic">
-                                {t(
+                                description={t(
                                     'admin.design.condition.pre_desc',
                                     'Instruction given to participants during the initial rough sort.'
                                 )}
-                            </CardDescription>
-                        </CardHeader>
-                        <CardContent className="space-y-6">
-                            <div className="grid gap-3">
-                                <div className="flex items-center justify-between">
-                                    <div className="flex items-center gap-2">
-                                        <Label
-                                            htmlFor="pre_instruction"
-                                            className="text-2xs font-black text-slate-500"
-                                        >
-                                            {t(
-                                                'admin.design.condition.pre_field_label',
-                                                'Instruction Text'
-                                            )}
-                                        </Label>
-                                        <MultiLangFieldIcon
-                                            activeLocale={activeLocale}
-                                            translations={
-                                                draft.translations?.reduce(
-                                                    (acc, tr) => {
-                                                        if (tr.pre_instruction)
-                                                            acc[tr.language_code] =
-                                                                tr.pre_instruction;
-                                                        return acc;
-                                                    },
-                                                    {} as Record<string, string>
-                                                ) || {}
-                                            }
-                                        />
-                                    </div>
-                                    {!readOnly && (
-                                        <button
-                                            type="button"
-                                            onClick={resetPreInstruction}
-                                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-2xs
-                                                 font-black text-slate-500
-                                                 hover:bg-slate-100 hover:text-indigo-600 transition-colors
-                                                 shadow-sm border bg-white"
-                                        >
-                                            <RotateCcw className="size-3" />
-                                            {t('common.reset_to_default')}
-                                        </button>
-                                    )}
-                                </div>
-                                <Input
-                                    id="pre_instruction"
-                                    value={translation?.pre_instruction || ''}
-                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                                        handleChange('pre_instruction', e.target.value)
-                                    }
-                                    placeholder={t(
-                                        'admin.design.condition.pre_placeholder',
-                                        'e.g. Based on your personal point of view...'
-                                    )}
-                                    className="font-bold text-lg h-12 rounded-xl border-slate-200 bg-slate-50/30 focus:bg-white focus:ring-indigo-500/20 transition-all px-4"
-                                    disabled={readOnly}
-                                />
-                            </div>
-                        </CardContent>
-                    </Card>
-                )}
+                                placeholder={t(
+                                    'admin.design.condition.pre_placeholder',
+                                    'e.g. Based on your personal point of view...'
+                                )}
+                                value={translation?.pre_instruction || ''}
+                                translations={preInstructionTranslations}
+                                activeLocale={activeLocale}
+                                readOnly={readOnly}
+                                onChange={(v) => handleChange('pre_instruction', v)}
+                                onReset={resetPreInstruction}
+                                resetLabel={resetLabel}
+                                fieldLabel={fieldLabel}
+                            />
+                        )}
 
-                <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
-                    <CardHeader className="pb-4">
-                        <CardTitle className="text-base font-black text-slate-900 tracking-tight">
-                            {t('admin.design.condition.grid_title', 'Q-Sort Instruction')}
-                        </CardTitle>
-                        <CardDescription className="text-sm font-medium text-slate-500 italic">
-                            {t(
+                        <InstructionField
+                            id="condition_of_instruction"
+                            title={t('admin.design.condition.grid_title', 'Q-Sort Instruction')}
+                            description={t(
                                 'admin.design.condition.grid_desc',
                                 'This is the core instruction guiding participants during the Q-Sort process.'
                             )}
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent className="space-y-6">
-                        <div className="grid gap-3">
-                            <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-2">
-                                    <Label
-                                        htmlFor="condition_of_instruction"
-                                        className="text-2xs font-black text-slate-500"
-                                    >
-                                        {t(
-                                            'admin.design.condition.field_label',
-                                            'Instruction Text'
-                                        )}
-                                    </Label>
-                                    <MultiLangFieldIcon
-                                        activeLocale={activeLocale}
-                                        translations={
-                                            draft.translations?.reduce(
-                                                (acc, tr) => {
-                                                    if (tr.condition_of_instruction)
-                                                        acc[tr.language_code] =
-                                                            tr.condition_of_instruction;
-                                                    return acc;
-                                                },
-                                                {} as Record<string, string>
-                                            ) || {}
-                                        }
-                                    />
-                                </div>
-                                {!readOnly && (
-                                    <button
-                                        type="button"
-                                        onClick={resetInstruction}
-                                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-2xs
-                                                 font-black text-slate-500
-                                                 hover:bg-slate-100 hover:text-indigo-600 transition-colors
-                                                 shadow-sm border bg-white"
-                                    >
-                                        <RotateCcw className="size-3" />
-                                        {t('common.reset_to_default')}
-                                    </button>
-                                )}
-                            </div>
-                            <Input
-                                id="condition_of_instruction"
-                                value={translation?.condition_of_instruction || ''}
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                                    handleChange('condition_of_instruction', e.target.value)
-                                }
-                                placeholder={t(
-                                    'admin.design.condition.placeholder',
-                                    'e.g. Please rank the following statements...'
-                                )}
-                                className="font-bold text-lg h-12 rounded-xl border-slate-200 bg-slate-50/30 focus:bg-white focus:ring-indigo-500/20 transition-all px-4"
-                                disabled={readOnly}
-                            />
-                        </div>
+                            placeholder={t(
+                                'admin.design.condition.placeholder',
+                                'e.g. Please rank the following statements...'
+                            )}
+                            value={translation?.condition_of_instruction || ''}
+                            translations={conditionTranslations}
+                            activeLocale={activeLocale}
+                            readOnly={readOnly}
+                            onChange={(v) => handleChange('condition_of_instruction', v)}
+                            onReset={resetInstruction}
+                            resetLabel={resetLabel}
+                            fieldLabel={fieldLabel}
+                        />
                     </CardContent>
                 </Card>
             </section>
 
-            <section className="bg-amber-50/50 border border-amber-100 rounded-2xl p-8 shadow-sm">
-                <h4 className="text-base font-black text-amber-900 mb-3 flex items-center gap-3 tracking-tight">
-                    <div className="bg-white p-2 rounded-xl border border-amber-200 shadow-sm">
-                        <Target className="h-5 w-5 text-amber-600" />
-                    </div>
+            <section className="bg-amber-50/50 border border-amber-100 rounded-2xl p-6 shadow-sm">
+                <h4 className="text-base font-bold text-amber-900 mb-2 flex items-center gap-2.5 tracking-tight">
+                    <Lightbulb className="h-5 w-5 text-amber-600" />
                     {t('admin.design.condition.tips.title')}
                 </h4>
-                <p className="text-sm font-bold text-amber-800/70 leading-relaxed max-w-2xl">
+                <p className="text-sm text-amber-800/80 leading-relaxed max-w-2xl">
                     {t('admin.design.condition.tips.desc')}
                 </p>
             </section>


### PR DESCRIPTION
## Summary

Tightens the **Condition d'instruction** tab in the study designer so it reads as one focused form rather than three stacked cards of equal weight.

- Single-line `<Input>` (h-12, font-bold text-lg) → multi-line `<Textarea>` (min-h-80px, regular weight, leading-relaxed) for both consignes. Q-method consignes are typically 1–3 sentences, and the bold single-line input made them scroll horizontally and feel shouty.
- Rough-sort toggle demoted from a `Card` to an inline checkbox row at the top of the section. It's the gate that decides whether the pre-instruction subsection appears below, not a content block of equal weight to the instruction fields. Lock banner + helper text preserved.
- Two near-identical instruction cards merged into a single `Card` with two divider-separated subsections, via a shared `InstructionField` subcomponent. Only the Q-Sort subsection renders when rough-sort is off.
- Reset-to-default button: ghost style (`text-slate-400 hover:text-indigo-600 hover:bg-slate-50`) instead of a `border + shadow-sm + bg-white + font-black` chip, so it stops competing with the field label.
- Tips block: `Target` → `Lightbulb` icon (matches the convention in `InterfaceEditor`), padding `p-8` → `p-6` (matches `PostSortConfigEditor`).

All i18n keys preserved (`admin.design.condition.title`, `pre_title`, `grid_title`, `pre_desc`, `grid_desc`, `field_label`, `pre_field_label`, `placeholder`, `pre_placeholder`, `tips.title`, `tips.desc`). Test selectors (`htmlFor`/Label linkage, `data-testid` hooks for the rough-sort row + lock banner + toggle) still match — existing test file passes unchanged.

## Test plan

- [x] `make ci-fast` (lint + types + 235 backend unit + 986 frontend unit tests, 6 skipped)
- [x] `make ci` (full local CI: lint + check + backend mypy + tsc + tests + frontend build)
- [ ] Manual UI check: visit Study Designer → "Condition d'instruction" tab, toggle rough-sort on/off, type in both consignes, verify Reset and MultiLangFieldIcon still work, verify lock banner still shows when participant has progressed past consent
- [ ] Verify in `fr` and `fi` locales (translation keys unchanged but worth confirming visually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)