### PR TITLE
docs: fix 4 broken links from squash-merge conflict resolution

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -21,8 +21,10 @@ For the page-by-page catalog of the admin UI, see [`../reference/admin-dashboard
 
 ## For Contributors
 
+Contributor docs have moved to [`../contributing/`](../contributing/). Highlights:
+
 | Guide | Description |
 |-------|-------------|
-| [Development Setup](contributing/development.md) | Clone, install, run locally, and daily workflow tools |
-| [Testing](contributing/testing.md) | Test stack, writing tests, CI pipeline |
-| [Style Guide](contributing/style-guide.md) | Documentation style conventions |
+| [Development Workflow](../contributing/development.md) | First-time setup (clone, install, DB, dev servers) plus daily Make targets, API client sync, and releases |
+| [Testing](../contributing/testing.md) | Test stack, writing tests, CI pipeline |
+| [Style Guide](../contributing/style-guide.md) | Documentation style conventions |

--- a/docs/tutorials/collecting-responses.md
+++ b/docs/tutorials/collecting-responses.md
@@ -141,4 +141,4 @@ You now know how to create public, individual, and limited recruitment links; sh
 
 ## Next Steps
 
-Once you have collected enough responses (typically 15-40+ for Q methodology), continue to **[Analyzing Results](analyzing-results.md)**.
+Once you have collected enough responses (typically 15-40+ for Q methodology), continue to **[Analyzing Results — Foundations](analyzing-results-foundations.md)**.


### PR DESCRIPTION
## Summary
Two doc-tree links broke during the 5-PR doc cleanup that landed earlier today:

1. \`docs/tutorials/collecting-responses.md\` "Next Steps" linked to \`analyzing-results.md\`. The file was renamed to \`analyzing-results-foundations.md\` in PR #93. The conflict resolution on #93 took \`--theirs\` for \`collecting-responses.md\` to preserve the B1 humanizer pass on the funnel description, which dropped the link rename done in B3.

2. \`docs/guides/README.md\` "For Contributors" section pointed to relative paths \`contributing/development.md\` etc. from a \`docs/guides/\` base, which resolved to \`docs/guides/contributing/\` — deleted in PR #90 when the contributing folder was consolidated to \`docs/contributing/\`.

Verified: zero broken internal markdown links across \`docs/\`, \`README.md\`, \`CONTRIBUTING.md\`.

## Test plan
- [x] All internal \`.md\` links resolve.
- [x] No conflict markers leftover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)