### PR TITLE
ci(lychee): bump per-request timeout to 60s, retry wait to 5s

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -16,7 +16,12 @@ exclude_path = []
 
 # Retry transient failures (GitHub frequently returns 502 on automated badge URL fetches).
 max_retries = 3
-retry_wait_time = 2
+retry_wait_time = 5
+
+# Per-request timeout — default 20s leaves no room for slow DOI/Zenodo redirect chains.
+# Two consecutive flaky failures (doi.org/10.32614/rj-2014-032,
+# zenodo.org/account/settings/github/) in PR #100 (2026-05-02) prompted the bump.
+timeout = 60
 
 # Treat these HTTP statuses as success (transient gateway errors that resolve on retry but
 # occasionally exhaust the retry budget on busy github.com endpoints).


### PR DESCRIPTION
## Summary

Stops the Documentation Links job from flapping red on slow external DOI/Zenodo lookups.

## Context

PR #100 (project-roles-refactor, merged 2026-05-02) saw two consecutive doc-links failures on different external links each time:
- Run 1: \`doi.org/10.32614/rj-2014-032\` timeout
- Run 2 (rerun): \`zenodo.org/account/settings/github/\` timeout

Both links are valid in browsers and resolve eventually — they just exceed Lychee's default 20s per-request budget when the upstream is slow.

## Change

\`lychee.toml\`:
- \`timeout = 60\` (new) — gives slow redirect chains room to complete.
- \`retry_wait_time = 5\` (was 2) — back off more politely between retries.
- \`max_retries = 3\` (unchanged).
- \`accept = ["200", "429", "502", "503"]\` (unchanged).

## Why this and not a more aggressive fix

- **Exclude doi.org / zenodo.org entirely?** Loses signal — broken DOIs and dead Zenodo refs would pass silently.
- **Make the job non-blocking?** Same problem — degrades the gate from "all links work" to "we tried."
- **Bump timeout only?** Done here. Plus the retry-wait bump so a transient slow-period doesn't burn all 3 retries in 6 seconds.

## Test plan
- [ ] CI run on this PR passes the Documentation Links job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)