### PR TITLE
fix(viewer): hide create-study CTAs and stop concourse auto-create for viewers

### DIFF
--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -22,6 +22,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthStore } from '@/store/useAuthStore';
+import { usePermission } from '@/hooks/usePermission';
 import { CreateStudyDialog } from '@/components/admin/CreateStudyDialog';
 import { ImportStudyDialog } from '@/components/admin/ImportStudyDialog';
 import { useTranslation } from 'react-i18next';
@@ -72,6 +73,8 @@ export function AdminDashboard() {
     const { currentProject } = useAuthStore();
     const navigate = useNavigate();
     const { t } = useTranslation();
+    const { can } = usePermission();
+    const canCreateStudy = can('study:create'); // viewers don't see Create-study CTAs
     const {
         isLoading,
         hasStudies,
@@ -175,18 +178,26 @@ export function AdminDashboard() {
                                     'admin.dashboard.step_study_desc',
                                     'Define the sorting grid for your Q-sort.'
                                 )}
-                                action={() => setShowCreateDialog(true)}
-                                actionLabel={t('admin.dashboard.create_study', 'Create study')}
+                                action={
+                                    canCreateStudy ? () => setShowCreateDialog(true) : undefined
+                                }
+                                actionLabel={
+                                    canCreateStudy
+                                        ? t('admin.dashboard.create_study', 'Create study')
+                                        : undefined
+                                }
                             />
                         </ol>
                     </CardContent>
                 </Card>
 
-                <CreateStudyDialog
-                    open={showCreateDialog}
-                    onOpenChange={setShowCreateDialog}
-                    projectSlug={projectSlug}
-                />
+                {canCreateStudy && (
+                    <CreateStudyDialog
+                        open={showCreateDialog}
+                        onOpenChange={setShowCreateDialog}
+                        projectSlug={projectSlug}
+                    />
+                )}
             </div>
         );
     }
@@ -203,16 +214,18 @@ export function AdminDashboard() {
                         </h1>
                     </div>
                 </div>
-                <div className="flex items-center gap-2 shrink-0">
-                    <Button onClick={() => setShowCreateDialog(true)} size="sm">
-                        <Plus className="mr-2 h-3.5 w-3.5" />
-                        {t('admin.dashboard.create_study', 'Create study')}
-                    </Button>
-                    <Button onClick={() => setShowImportDialog(true)} variant="ghost" size="sm">
-                        <Upload className="mr-2 h-3.5 w-3.5" />
-                        {t('admin.dashboard.import_study', 'Import')}
-                    </Button>
-                </div>
+                {canCreateStudy && (
+                    <div className="flex items-center gap-2 shrink-0">
+                        <Button onClick={() => setShowCreateDialog(true)} size="sm">
+                            <Plus className="mr-2 h-3.5 w-3.5" />
+                            {t('admin.dashboard.create_study', 'Create study')}
+                        </Button>
+                        <Button onClick={() => setShowImportDialog(true)} variant="ghost" size="sm">
+                            <Upload className="mr-2 h-3.5 w-3.5" />
+                            {t('admin.dashboard.import_study', 'Import')}
+                        </Button>
+                    </div>
+                )}
             </div>
 
             {/* Alerts */}
@@ -267,7 +280,7 @@ export function AdminDashboard() {
                     projectSlug={projectSlug}
                     locale={currentLocale}
                     t={t}
-                    onCreateStudy={() => setShowCreateDialog(true)}
+                    onCreateStudy={canCreateStudy ? () => setShowCreateDialog(true) : undefined}
                 />
             ) : (
                 <StudyGroups
@@ -282,16 +295,20 @@ export function AdminDashboard() {
                 />
             )}
 
-            <CreateStudyDialog
-                open={showCreateDialog}
-                onOpenChange={setShowCreateDialog}
-                projectSlug={projectSlug}
-            />
-            <ImportStudyDialog
-                open={showImportDialog}
-                onOpenChange={setShowImportDialog}
-                projectSlug={projectSlug}
-            />
+            {canCreateStudy && (
+                <>
+                    <CreateStudyDialog
+                        open={showCreateDialog}
+                        onOpenChange={setShowCreateDialog}
+                        projectSlug={projectSlug}
+                    />
+                    <ImportStudyDialog
+                        open={showImportDialog}
+                        onOpenChange={setShowImportDialog}
+                        projectSlug={projectSlug}
+                    />
+                </>
+            )}
         </div>
     );
 }
@@ -412,7 +429,7 @@ function SingleStudyCard({
     // biome-ignore lint/suspicious/noExplicitAny: date-fns locale type
     locale: any;
     t: TranslateFn;
-    onCreateStudy: () => void;
+    onCreateStudy?: () => void; // omitted for viewers — Add-study CTA hides
 }) {
     const navigate = useNavigate();
     const participants = study.participant_count ?? 0;
@@ -429,15 +446,17 @@ function SingleStudyCard({
                         {t('admin.dashboard.studies', 'Studies')}
                     </h2>
                 </div>
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-xs text-muted-foreground"
-                    onClick={onCreateStudy}
-                >
-                    <Plus className="h-3 w-3 mr-1" />
-                    {t('admin.dashboard.add_study', 'Add study')}
-                </Button>
+                {onCreateStudy && (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-xs text-muted-foreground"
+                        onClick={onCreateStudy}
+                    >
+                        <Plus className="h-3 w-3 mr-1" />
+                        {t('admin.dashboard.add_study', 'Add study')}
+                    </Button>
+                )}
             </div>
 
             <Card

--- a/frontend/src/pages/admin/ConcourseListPage.tsx
+++ b/frontend/src/pages/admin/ConcourseListPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAdminContext } from '@/hooks/useAdminContext';
+import { usePermission } from '@/hooks/usePermission';
 import {
     useListConcoursesApiAdminConcoursesGet,
     useCreateConcourseApiAdminConcoursesPost,
@@ -18,8 +19,15 @@ export default function ConcourseListPage() {
     const { t } = useTranslation();
     const navigate = useNavigate();
     const { project: workspace } = useAdminContext();
+    const { can } = usePermission();
+    const canCreate = can('study:create'); // owner/member only — viewers can't auto-create
 
-    const { data, isLoading } = useListConcoursesApiAdminConcoursesGet();
+    // Gate the GET on having the project context hydrated, otherwise the
+    // request fires without an X-Project-ID header and the backend returns
+    // a spurious 403 → "Access Denied" toast on first paint.
+    const { data, isLoading } = useListConcoursesApiAdminConcoursesGet(undefined, {
+        query: { enabled: !!workspace?.slug },
+    });
     const concourses = data?.items ?? [];
 
     const createMutation = useCreateConcourseApiAdminConcoursesPost();
@@ -27,7 +35,8 @@ export default function ConcourseListPage() {
     const [error, setError] = useState<string | null>(null);
 
     const attemptCreate = useCallback(() => {
-        if (creatingRef.current || createMutation.isPending || !workspace?.slug) return;
+        if (creatingRef.current || createMutation.isPending || !workspace?.slug || !canCreate)
+            return;
         creatingRef.current = true;
         setError(null);
 
@@ -59,7 +68,7 @@ export default function ConcourseListPage() {
                     )
                 );
             });
-    }, [workspace?.slug, workspace?.title, createMutation, t, navigate]);
+    }, [workspace?.slug, workspace?.title, createMutation, t, navigate, canCreate]);
 
     useEffect(() => {
         if (isLoading || !workspace?.slug) return;
@@ -70,8 +79,10 @@ export default function ConcourseListPage() {
             return;
         }
 
-        attemptCreate();
-    }, [isLoading, concourses, workspace?.slug, navigate, attemptCreate]);
+        // Viewers cannot create — show the empty-state message instead of
+        // attempting a POST that the backend will reject with 403.
+        if (canCreate) attemptCreate();
+    }, [isLoading, concourses, workspace?.slug, navigate, attemptCreate, canCreate]);
 
     if (error) {
         return (
@@ -90,6 +101,21 @@ export default function ConcourseListPage() {
                     )}
                     {t('common.retry', 'Retry')}
                 </Button>
+            </div>
+        );
+    }
+
+    // Viewer landed on the page but no concourse exists yet and they can't
+    // create one — show a clear empty state instead of an infinite spinner.
+    if (!isLoading && concourses.length === 0 && !canCreate) {
+        return (
+            <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center px-4">
+                <p className="text-sm text-slate-600">
+                    {t(
+                        'admin.concourse.viewer_empty_state',
+                        'No concourse yet. Ask the project owner or a member to create one.'
+                    )}
+                </p>
             </div>
         );
     }


### PR DESCRIPTION
## Summary

Two pre-existing UX bugs surfaced during the manual verification of PR #100 (project-roles-refactor). The role contract is correct end-to-end (viewers get clean 403 from every mutation endpoint), but the UI was confusing them with controls that always failed.

## The bugs

### 1. \`ConcourseListPage\` — spurious "Access Denied" toast on first paint

Fired the initial \`GET /api/admin/concourses\` immediately on mount, before \`useAuthStore.currentProject\` had hydrated. The \`mutator.ts\` injects \`X-Project-ID\` from the auth store, so a missing \`currentProject\` produced a request without that header → backend returns 403 → mutator's universal "Access Denied" toast fires.

The same component then auto-tried \`POST /api/admin/concourses\` on entry. Fine for owners/members; a **viewer** got a second 403 toast and no usable state.

### 2. \`AdminDashboard\` — Create-study CTAs visible to viewers

"Create study" / "Add study" / "Import" buttons rendered for everyone. Backend rejected the call with 403 anyway, but viewers saw clickable controls that always failed — misleading.

## Fixes

\`ConcourseListPage.tsx\`:
- Gate \`useListConcoursesApiAdminConcoursesGet\` on \`workspace?.slug\` via Orval's \`query.enabled\` so the request waits for the project context.
- Skip \`attemptCreate()\` when \`usePermission().can('study:create')\` is false.
- Render an explicit empty-state message for viewers when no concourse exists (\`admin.concourse.viewer_empty_state\`) instead of spinning forever.

\`AdminDashboard.tsx\`:
- Read \`canCreateStudy = usePermission().can('study:create')\`.
- Hide the top-right Create/Import button group for viewers.
- Drop the \`action\` callback on the onboarding step 4 ("Create a study") for viewers.
- Mount \`CreateStudyDialog\` and \`ImportStudyDialog\` only when \`canCreateStudy\`.
- \`SingleStudyCard.onCreateStudy\` becomes optional; the "Add study" button hides when undefined.

## Verification

Manual Playwright pass against a fresh stack with seeded owner/member/viewer:

- ✅ Viewer on \`/app/.../members\`: list visible, every mutation control disabled (combobox, Retirer, Inviter).
- ✅ Viewer on \`/app/.../settings\`: title/slug textboxes disabled.
- ✅ Viewer on \`/app/.../concourses\`: now shows the empty-state message instead of "Access Denied" toast.
- ✅ Viewer on \`/app/.../dashboard\`: no Create/Add/Import CTAs.
- ✅ DevTools forge as viewer: every mutation rejected with proper 403 envelope (\`POST/PATCH/DELETE projects\`, \`PATCH/DELETE members\`, \`POST invitations\`, \`POST concourses\`, \`POST/DELETE studies/{slug}\`, \`POST anonymise-bulk\`).
- ✅ Member also tested: project-level destruction blocked (DELETE project, manage team, DELETE concourse, DELETE study, POST reset all 403); editor-tier ops allowed per spec (PATCH study 200, anonymise-bulk 200, clear-all-participants 204).

## Test plan
- [x] \`make ci-fast\` GREEN locally.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)