### PR TITLE
fix(mutator): contextualize and translate Access Denied / 4xx toasts

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2616,6 +2616,12 @@
     "errors": {
         "member_limit_reached": "Project member limit reached.",
         "owner_project_limit_reached": "You can't own any more projects.",
-        "owner_role_immutable": "The Owner role can only be assigned at project creation."
+        "owner_role_immutable": "The Owner role can only be assigned at project creation.",
+        "access_denied_title": "Access denied",
+        "access_denied_description": "You do not have permission to perform this action.",
+        "rate_limited_title": "Too many requests",
+        "rate_limited_description": "Please wait a moment before trying again.",
+        "conflict_title": "Conflict",
+        "conflict_description": "The resource has been modified or already exists."
     }
 }

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -2616,6 +2616,12 @@
     "errors": {
         "member_limit_reached": "Projektin jäsenraja saavutettu.",
         "owner_project_limit_reached": "Et voi omistaa enempää projekteja.",
-        "owner_role_immutable": "Omistajarooli voidaan määrittää vain projektin luonnin yhteydessä."
+        "owner_role_immutable": "Omistajarooli voidaan määrittää vain projektin luonnin yhteydessä.",
+        "access_denied_title": "Käyttö estetty",
+        "access_denied_description": "Sinulla ei ole oikeutta suorittaa tätä toimintoa.",
+        "rate_limited_title": "Liikaa pyyntöjä",
+        "rate_limited_description": "Odota hetki ja yritä uudelleen.",
+        "conflict_title": "Ristiriita",
+        "conflict_description": "Resurssi on muokattu tai se on jo olemassa."
     }
 }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -2616,6 +2616,12 @@
     "errors": {
         "member_limit_reached": "Limite de membres du projet atteinte.",
         "owner_project_limit_reached": "Vous ne pouvez pas posséder davantage de projets.",
-        "owner_role_immutable": "Le rôle Propriétaire ne peut être attribué qu'à la création du projet."
+        "owner_role_immutable": "Le rôle Propriétaire ne peut être attribué qu'à la création du projet.",
+        "access_denied_title": "Accès refusé",
+        "access_denied_description": "Vous n'avez pas l'autorisation d'effectuer cette action.",
+        "rate_limited_title": "Trop de requêtes",
+        "rate_limited_description": "Veuillez patienter un instant avant de réessayer.",
+        "conflict_title": "Conflit",
+        "conflict_description": "La ressource a été modifiée ou existe déjà."
     }
 }

--- a/frontend/src/api/mutator.test.ts
+++ b/frontend/src/api/mutator.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
 import { customInstance } from './mutator';
 
 // No mock for ./client here, we will verify reportBug via its fetch calls
@@ -203,5 +204,86 @@ describe('customInstance: 401 redirect reason', () => {
         }
 
         expect(setHrefSpy).toHaveBeenCalledWith(expect.stringContaining('reason=session_expired'));
+    });
+});
+
+describe('customInstance: 403 toast behaviour', () => {
+    let toastSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        toastSpy = vi.spyOn(toast, 'error').mockImplementation(() => 'id');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        toastSpy.mockRestore();
+    });
+
+    it('does NOT toast on a 403 GET (background read, noise)', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: false,
+                status: 403,
+                text: async () => '{"code":"forbidden","message":"Insufficient permissions"}',
+            })
+        );
+        try {
+            await customInstance({ url: '/api/admin/concourses', method: 'GET' });
+        } catch (_e) {
+            // Expected
+        }
+        expect(toastSpy).not.toHaveBeenCalled();
+    });
+
+    it('DOES toast on a 403 mutation, with the backend message as description', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: false,
+                status: 403,
+                text: async () =>
+                    '{"code":"forbidden","message":"Insufficient permissions. Required: owner"}',
+            })
+        );
+        try {
+            await customInstance({ url: '/api/admin/projects/x', method: 'PATCH', data: {} });
+        } catch (_e) {
+            // Expected
+        }
+        expect(toastSpy).toHaveBeenCalledTimes(1);
+        const [title, opts] = toastSpy.mock.calls[0] as [string, Record<string, unknown>];
+        expect(title).toBeTruthy();
+        expect((opts.description as string) || '').toContain('owner');
+        expect((opts.id as string) || '').toContain('PATCH');
+    });
+
+    it('translates known stable error codes (OWNER_ROLE_IMMUTABLE)', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: false,
+                status: 403,
+                text: async () => '{"code":"error","message":"OWNER_ROLE_IMMUTABLE"}',
+            })
+        );
+        try {
+            await customInstance({
+                url: '/api/admin/projects/x/members/1',
+                method: 'PATCH',
+                data: { role: 'owner' },
+            });
+        } catch (_e) {
+            // Expected
+        }
+        expect(toastSpy).toHaveBeenCalledTimes(1);
+        const [, opts] = toastSpy.mock.calls[0] as [string, Record<string, unknown>];
+        const description = (opts.description as string) || '';
+        // Either the EN translation, the i18n key (when locale not loaded in tests), or the raw code.
+        expect(
+            description === 'The Owner role can only be assigned at project creation.' ||
+                description === 'errors.owner_role_immutable' ||
+                description.includes('OWNER_ROLE_IMMUTABLE')
+        ).toBe(true);
     });
 });

--- a/frontend/src/api/mutator.ts
+++ b/frontend/src/api/mutator.ts
@@ -1,5 +1,7 @@
 import { toast } from 'sonner';
 import { ApiError, reportBug } from './client';
+import i18n from '../i18n';
+import { resolveApiErrorKey } from '../lib/error-utils';
 import { useAuthStore } from '../store/useAuthStore';
 import { useSessionStore } from '../store/useSessionStore';
 import { useResponseStore } from '../store/useResponseStore';
@@ -69,9 +71,11 @@ function buildRequestHeaders(
 /** Side effects (toasts, redirect, bug-report) for error responses. */
 function handleErrorStatus(
     status: number,
+    method: string,
     url: string,
     errorText: string,
-    parsedMessage: string
+    parsedMessage: string,
+    parsedCode: string | undefined
 ): void {
     if (status === 401 && !url.includes('/api/token') && !url.includes('/api/study/')) {
         // biome-ignore lint/suspicious/noExplicitAny: window hack to suppress unsaved-changes dialog
@@ -91,19 +95,51 @@ function handleErrorStatus(
     }
 
     if (status === 403) {
-        console.warn('Access Forbidden:', url);
-        toast.error('Access Denied', {
-            description: 'You do not have permission to perform this action.',
+        console.warn('Access Forbidden:', method, url);
+        // Skip toast for GETs — those are background fetches; surfacing a
+        // toast for every read-side 403 is noise (e.g. a viewer landing on
+        // a page that pre-fetches data they're not entitled to). Mutations
+        // are user-triggered, so the toast is informative there.
+        if (method.toUpperCase() === 'GET') return;
+        const { key, fallback } = resolveApiErrorKey({
+            code: parsedCode,
+            message: parsedMessage,
+        });
+        const description = key
+            ? i18n.t(key, fallback)
+            : parsedMessage ||
+              i18n.t(
+                  'errors.access_denied_description',
+                  'You do not have permission to perform this action.'
+              );
+        toast.error(i18n.t('errors.access_denied_title', 'Access Denied'), {
+            id: `403:${method}:${url}`, // dedupe identical 403s on the same endpoint
+            description,
         });
     }
     if (status === 429) {
-        toast.error('Too Many Requests', {
-            description: 'Please wait a moment before trying again.',
+        toast.error(i18n.t('errors.rate_limited_title', 'Too Many Requests'), {
+            id: `429:${url}`,
+            description: i18n.t(
+                'errors.rate_limited_description',
+                'Please wait a moment before trying again.'
+            ),
         });
     }
     if (status === 409) {
-        toast.error('Conflict', {
-            description: parsedMessage || 'The resource has been modified or already exists.',
+        const { key, fallback } = resolveApiErrorKey({
+            code: parsedCode,
+            message: parsedMessage,
+        });
+        toast.error(i18n.t('errors.conflict_title', 'Conflict'), {
+            id: `409:${method}:${url}`,
+            description: key
+                ? i18n.t(key, fallback)
+                : parsedMessage ||
+                  i18n.t(
+                      'errors.conflict_description',
+                      'The resource has been modified or already exists.'
+                  ),
         });
     }
     if (status >= 500) {
@@ -119,11 +155,11 @@ function buildRequestBody(data: unknown, isFormData: boolean): BodyInit | undefi
     return isFormData ? (data as BodyInit) : JSON.stringify(data);
 }
 
-async function processResponse<T>(response: Response, url: string): Promise<T> {
+async function processResponse<T>(response: Response, method: string, url: string): Promise<T> {
     if (!response.ok) {
         const errorText = await response.text();
         const { message, code, details } = parseErrorBody(errorText);
-        handleErrorStatus(response.status, url, errorText, message);
+        handleErrorStatus(response.status, method, url, errorText, message, code);
         throw new ApiError(response.status, message, code, details);
     }
     if (response.status === 204) {
@@ -179,7 +215,7 @@ export const customInstance = async <T>({
         });
 
         clearTimeout(timeoutId);
-        return await processResponse<T>(response, url);
+        return await processResponse<T>(response, method, url);
     } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
             // External-signal abort vs our own timeout


### PR DESCRIPTION
## Why

The follow-up bug noted at the end of the PR #102 review: the universal \`Access Denied\` toast in \`mutator.ts\` fired on every 403 regardless of context — hardcoded English, no use of the backend's StandardError envelope, surfaced even on background GETs that pre-fetch data the user isn't entitled to (where the toast is noise, not signal).

## What

- **Skip 403 toast for GETs entirely.** Background reads return 403 routinely (e.g. a viewer landing on a page whose pre-fetch they're not authorised for); a \`console.warn\` is enough for diagnostics. Mutations (POST/PATCH/PUT/DELETE) keep the toast since they're user-triggered.
- **Use the backend message.** For mutation 403s, the toast description is now the StandardError \`message\` ("Insufficient permissions. Required: owner") instead of a generic string.
- **Translate stable error codes.** \`resolveApiErrorKey\` maps \`MEMBER_LIMIT_REACHED\` / \`OWNER_PROJECT_LIMIT_REACHED\` / \`OWNER_ROLE_IMMUTABLE\` to localized strings; backend message falls back when no key matches.
- **i18n the titles too.** \`errors.access_denied_title\` / \`access_denied_description\` / \`rate_limited_title\` / \`rate_limited_description\` / \`conflict_title\` / \`conflict_description\` added to en/fr/fi.
- **Dedupe via sonner \`id\`.** \`403:METHOD:URL\` (and equivalents for 409/429) prevents a flurry of failing requests from stacking identical toasts.

## Test plan

3 new mutator tests cover:
- GET 403 → no toast.
- Mutation 403 → toast fires with backend message in description and a dedup id.
- OWNER_ROLE_IMMUTABLE forge → translated description (or i18n key in the unit-test env where the locale isn't loaded).

\`make ci-fast\` GREEN locally (1038 passing, 6 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)