### PR TITLE
fix(footer): single centered row, drop GitHub icon, AGPLv3 visible on mobile

### DIFF
--- a/frontend/src/components/Footer.test.tsx
+++ b/frontend/src/components/Footer.test.tsx
@@ -21,27 +21,29 @@ describe('Footer', () => {
         expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
-    it('renders the AGPLv3 link to the LICENSE file, hidden on small screens', () => {
+    it('renders the AGPLv3 link to the LICENSE file, visible on all screen sizes', () => {
         renderWithProviders(<Footer />);
         const link = screen.getByRole('link', { name: 'AGPLv3' });
         expect(link).toHaveAttribute('href', LICENSE_URL);
         expect(link).toHaveAttribute('target', '_blank');
         expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-        expect(link.className).toContain('hidden');
-        expect(link.className).toContain('sm:inline');
-    });
-
-    it('renders the GitHub icon link with aria-label', () => {
-        renderWithProviders(<Footer />);
-        const link = screen.getByRole('link', { name: /View source on GitHub/i });
-        expect(link).toHaveAttribute('href', REPO_URL);
-        expect(link).toHaveAttribute('target', '_blank');
-        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        // Mobile must keep the LICENSE link reachable — no `hidden` class.
+        expect(link.className).not.toContain('hidden');
     });
 
     it('renders the mini Qualis logo as a decorative image', () => {
         renderWithProviders(<Footer />);
         const img = screen.getByAltText('');
         expect(img).toHaveAttribute('src', '/qualis-logo.svg');
+    });
+
+    it('does NOT render a separate GitHub icon link', () => {
+        renderWithProviders(<Footer />);
+        // Only two links remain: the Powered-by attribution and the LICENSE link.
+        // The previous redundant GitHub icon link has been removed.
+        const links = screen.getAllByRole('link');
+        expect(links).toHaveLength(2);
+        // No link is labelled "View source on GitHub" anymore.
+        expect(screen.queryByRole('link', { name: /GitHub/i })).toBeNull();
     });
 });

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -4,7 +4,6 @@
  * Licensed under the GNU Affero General Public License v3.0 or later.
  */
 
-import { FaGithub } from 'react-icons/fa6';
 import { useTranslation } from 'react-i18next';
 
 const REPO_URL = 'https://github.com/jvastenaekels/qualis';
@@ -15,37 +14,24 @@ export const Footer = () => {
 
     return (
         <footer className="border-t border-slate-100 bg-white/70 backdrop-blur">
-            <div className="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between text-xs text-slate-400">
-                <div className="flex items-center gap-2">
-                    <a
-                        href={REPO_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1.5 hover:text-slate-600 transition-colors"
-                    >
-                        <img src="/qualis-logo.svg" alt="" className="h-4 w-4" />
-                        <span>{t('footer.powered_by', 'Powered by Qualis')}</span>
-                    </a>
-                    <span className="hidden sm:inline" aria-hidden="true">
-                        ·
-                    </span>
-                    <a
-                        href={LICENSE_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hidden sm:inline hover:text-slate-600 transition-colors"
-                    >
-                        {t('footer.license', 'AGPLv3')}
-                    </a>
-                </div>
+            <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 py-3 text-center text-xs text-slate-400">
                 <a
                     href={REPO_URL}
                     target="_blank"
                     rel="noopener noreferrer"
-                    aria-label={t('footer.github_aria', 'View source on GitHub')}
+                    className="inline-flex items-center gap-1.5 hover:text-slate-600 transition-colors"
+                >
+                    <img src="/qualis-logo.svg" alt="" className="h-4 w-4" />
+                    <span>{t('footer.powered_by', 'Powered by Qualis')}</span>
+                </a>
+                <span aria-hidden="true">·</span>
+                <a
+                    href={LICENSE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="hover:text-slate-600 transition-colors"
                 >
-                    <FaGithub className="h-4 w-4" />
+                    {t('footer.license', 'AGPLv3')}
                 </a>
             </div>
         </footer>

--- a/frontend/src/layouts/PublicPageLayout.test.tsx
+++ b/frontend/src/layouts/PublicPageLayout.test.tsx
@@ -17,7 +17,7 @@ describe('PublicPageLayout', () => {
             </PublicPageLayout>
         );
         expect(screen.getByTestId('page-content')).toBeInTheDocument();
-        // Footer signature: the GitHub icon link with its aria-label
-        expect(screen.getByRole('link', { name: /View source on GitHub/i })).toBeInTheDocument();
+        // Footer signature: the "Powered by Qualis" attribution link to the repo.
+        expect(screen.getByRole('link', { name: /Powered by Qualis/i })).toBeInTheDocument();
     });
 });

--- a/frontend/src/layouts/StudyLayout.test.tsx
+++ b/frontend/src/layouts/StudyLayout.test.tsx
@@ -630,7 +630,9 @@ describe('Layout Global Footer', () => {
             </Routes>,
             { initialEntries: ['/study/slug/welcome'] }
         );
-        expect(screen.getByRole('link', { name: 'footer.github_aria' })).toBeInTheDocument();
+        expect(
+            screen.getByRole('link', { name: /Powered by Qualis|footer.powered_by/i })
+        ).toBeInTheDocument();
     });
 
     it('hides the global Footer on /fine-sort', () => {
@@ -640,7 +642,9 @@ describe('Layout Global Footer', () => {
             </Routes>,
             { initialEntries: ['/study/slug/fine-sort'] }
         );
-        expect(screen.queryByRole('link', { name: 'footer.github_aria' })).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('link', { name: /Powered by Qualis|footer.powered_by/i })
+        ).not.toBeInTheDocument();
     });
 
     it('hides the global Footer on /rough-sort', () => {
@@ -650,6 +654,8 @@ describe('Layout Global Footer', () => {
             </Routes>,
             { initialEntries: ['/study/slug/rough-sort'] }
         );
-        expect(screen.queryByRole('link', { name: 'footer.github_aria' })).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('link', { name: /Powered by Qualis|footer.powered_by/i })
+        ).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Why

Mobile footer issues spotted on a real device:
- "Powered by Qualis" pushed left, GitHub icon pushed right edge (hard to tap).
- AGPLv3 link hidden below \`sm:\` breakpoint — LICENSE unreachable on phones.
- Redundant GitHub icon: the attribution link already points to the repo.

## What

Collapse the footer to a single centered row that wraps on narrow viewports:

\`\`\`
[logo] Powered by Qualis · AGPLv3
\`\`\`

- "Powered by Qualis" (with mini logo) links to the repo — works as the GitHub entry-point.
- Separator dot stays.
- AGPLv3 links to LICENSE on **every** screen size (no \`hidden sm:inline\`).
- GitHub icon and its \`react-icons/fa6\` import removed.

## Test plan

- [x] \`make ci-fast\` GREEN locally (1035 passing, 6 skipped).
- Updated \`Footer.test.tsx\`: asserts exactly 2 links, no GitHub-aria link, no \`hidden\` class on AGPLv3.
- Updated \`PublicPageLayout.test.tsx\` and \`StudyLayout.test.tsx\` (3 cases): probe the footer via the "Powered by Qualis" link instead of the (now removed) GitHub icon aria-label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)