### PR TITLE
audit(wave-3): multi-tenant isolation deep dive

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,11 +16,11 @@ load_dotenv(Path(__file__).resolve().parents[2] / ".env")
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 # Set testing environment variable BEFORE app modules are imported
 os.environ["TESTING"] = "true"
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import selectinload
 
 from app.database import Base, get_db
@@ -63,18 +63,44 @@ async def db_engine():
     await engine.dispose()
 
 
+_ENUM_TYPES = (
+    "studystate",
+    "participantstatus",
+    "recruitmentlinktype",
+    "concourseitemstatus",
+    "distributionmode",
+    "projectrole",
+    "memoparenttype",
+)
+
+
+async def _reset_schema(conn: AsyncConnection) -> None:
+    """Drop all tables then all custom ENUM types, then recreate.
+
+    SQLAlchemy's ``drop_all`` drops tables but silently skips PostgreSQL ENUM
+    types when those types are not referenced by any surviving table (e.g.
+    after a previous test left a dirty DB).  The stale ENUMs then make the
+    next ``create_all`` fail with ``duplicate key value violates unique
+    constraint "pg_type_typname_nsp_index"``.  We drop them explicitly with
+    ``IF EXISTS … CASCADE`` between the two DDL phases.
+    """
+    await conn.run_sync(Base.metadata.drop_all)
+    for type_name in _ENUM_TYPES:
+        await conn.execute(text(f"DROP TYPE IF EXISTS {type_name} CASCADE"))
+    await conn.run_sync(lambda sync_conn: Base.metadata.create_all(sync_conn, checkfirst=True))
+
+
 @pytest_asyncio.fixture
 async def db(db_engine):
     """Create a fresh database session for each test."""
     # Drop any leftover schema from previous tests (especially Alembic-driven
     # tests like test_memo_migration that bypass this fixture and leave the
     # studies/users/etc tables in their migration-frozen state — without
-    # the latest model columns). drop_all is a no-op when nothing exists.
+    # the latest model columns). Also explicitly drops ENUM types which
+    # ``drop_all`` skips, to avoid duplicate-type errors on the next
+    # ``create_all`` (see ``_reset_schema`` for details).
     async with db_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-    # Create tables
-    async with db_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+        await _reset_schema(conn)
 
     # Create session factory bound to this engine
     TestingSessionLocal = async_sessionmaker(
@@ -88,9 +114,12 @@ async def db(db_engine):
     async with TestingSessionLocal() as session:
         yield session
 
-    # Drop tables (optional for in-memory, but good practice)
+    # Drop tables and ENUM types — symmetric with setup so the next test
+    # starts from a truly clean slate.
     async with db_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
+        for type_name in _ENUM_TYPES:
+            await conn.execute(text(f"DROP TYPE IF EXISTS {type_name} CASCADE"))
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/security/wave_3/conftest.py
+++ b/backend/tests/security/wave_3/conftest.py
@@ -1,0 +1,452 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Multi-tenant fixtures for the Wave 3 cross-tenant IDOR harness.
+
+Seeds two parallel projects (A, B) each with the full menagerie of admin-
+visible objects (study, participant, concourse, concourse item, concourse
+tag, recruitment link, memo entry, memo comment, audio recording, analysis
+run). The harness in `test_admin_idor_harness.py` then sends a request as
+a project-A member that targets a project-B object id (or X-Project-ID
+header) and asserts the response is a denial (403 or 404).
+
+Audio recordings are seeded as DB rows only — no actual S3 object exists.
+The presigned-URL generation in admin endpoints will surface a benign
+warning during the test run; the harness never asserts on the URL itself
+(only on the response status code).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    AnalysisRun,
+    AudioRecording,
+    Concourse,
+    ConcourseItem,
+    ConcourseItemTranslation,
+    ConcourseTag,
+    MemoComment,
+    MemoEntry,
+    MemoParentType,
+    Participant,
+    Project,
+    ProjectMember,
+    ProjectRole,
+    RecruitmentLink,
+    RecruitmentLinkType,
+    Study,
+    StudyState,
+    StudyTranslation,
+    User,
+)
+from app.utils.security import create_access_token, get_password_hash
+
+
+# -----------------------------------------------------------------------------
+# Data container
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class TenancyFixtures:
+    """Bundle of seeded objects for the two-project tenancy harness.
+
+    Attribute names match the placeholder suffixes used in path templates:
+    `{project_b_id}` resolves to `project_b.id`, `{study_in_b_slug}` to
+    `study_in_b.slug`, etc. The `path_substitutions_*` dicts flatten this
+    into the str-keyed dict that `route.path_template.format(**subs)` consumes.
+    """
+
+    # Projects
+    project_a: Project
+    project_b: Project
+
+    # Users (six total: each project has owner/member/viewer)
+    alice: User
+    bob: User
+    charlie: User
+    dan: User
+    eve: User
+    frank: User
+
+    # Domain objects in project A (tested-against-A reference; harness uses _b)
+    study_in_a: Study
+    participant_in_a: Participant
+    concourse_in_a: Concourse
+    concourse_item_in_a: ConcourseItem
+    concourse_tag_in_a: ConcourseTag
+    recruitment_link_in_a: RecruitmentLink
+    memo_entry_in_a: MemoEntry
+    memo_comment_in_a: MemoComment
+    audio_in_a: AudioRecording
+    analysis_run_in_a: AnalysisRun
+
+    # Domain objects in project B (the cross-tenant targets)
+    study_in_b: Study
+    participant_in_b: Participant
+    concourse_in_b: Concourse
+    concourse_item_in_b: ConcourseItem
+    concourse_tag_in_b: ConcourseTag
+    recruitment_link_in_b: RecruitmentLink
+    memo_entry_in_b: MemoEntry
+    memo_comment_in_b: MemoComment
+    audio_in_b: AudioRecording
+    analysis_run_in_b: AnalysisRun
+
+    # JWT bearer headers per user (authoring identity is project-A roles
+    # for the harness; project-B identities exist for symmetric tests).
+    token_a_owner: str = ""
+    token_a_member: str = ""
+    token_a_viewer: str = ""
+    token_b_owner: str = ""
+    token_b_member: str = ""
+    token_b_viewer: str = ""
+
+    # Map of placeholder -> str(value) used in path-template substitution.
+    path_substitutions_b: dict[str, str] = field(default_factory=dict)
+
+    def header_a(
+        self, role: str = "member", with_project_a: bool = False
+    ) -> dict[str, str]:
+        """Bearer header for project A's owner/member/viewer.
+
+        If ``with_project_a`` is True, also sets X-Project-ID to project A's id
+        — for endpoints that legitimately need a header to satisfy the dependency
+        but where we still want to see what happens with a path id from B.
+        Default is False (we want the cross-tenant case: token from A but
+        header (or path) targeting B).
+        """
+        token_map = {
+            "owner": self.token_a_owner,
+            "member": self.token_a_member,
+            "viewer": self.token_a_viewer,
+        }
+        headers = {"Authorization": f"Bearer {token_map[role]}"}
+        if with_project_a:
+            headers["X-Project-ID"] = str(self.project_a.id)
+        return headers
+
+
+# -----------------------------------------------------------------------------
+# Seeding helpers
+# -----------------------------------------------------------------------------
+
+
+async def _make_user(db: AsyncSession, label: str) -> User:
+    user = User(
+        email=f"{label}-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password=get_password_hash("pw"),
+        email_verified_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_project(
+    db: AsyncSession, suffix: str, owner: User, member: User, viewer: User
+) -> Project:
+    proj = Project(
+        title=f"Project {suffix}", slug=f"project-{suffix}-{uuid.uuid4().hex[:6]}"
+    )
+    db.add(proj)
+    await db.flush()
+    db.add_all(
+        [
+            ProjectMember(project_id=proj.id, user_id=owner.id, role=ProjectRole.owner),
+            ProjectMember(
+                project_id=proj.id, user_id=member.id, role=ProjectRole.member
+            ),
+            ProjectMember(
+                project_id=proj.id, user_id=viewer.id, role=ProjectRole.viewer
+            ),
+        ]
+    )
+    await db.flush()
+    return proj
+
+
+async def _make_study(db: AsyncSession, project: Project, suffix: str) -> Study:
+    study = Study(
+        slug=f"study-{suffix}-{uuid.uuid4().hex[:6]}",
+        project_id=project.id,
+        state=StudyState.draft,
+        grid_config=[{"score": 0, "capacity": 1}],
+        presort_config={},
+        postsort_config={},
+    )
+    db.add(study)
+    await db.flush()
+    db.add(
+        StudyTranslation(
+            study_id=study.id,
+            language_code="en",
+            title=f"Study {suffix}",
+            description="d",
+            instructions="i",
+            consent_title="c",
+            consent_description="cd",
+        )
+    )
+    await db.flush()
+    return study
+
+
+async def _make_participant(db: AsyncSession, study: Study) -> Participant:
+    p = Participant(
+        study_id=study.id,
+        language_used="en",
+    )
+    db.add(p)
+    await db.flush()
+    return p
+
+
+async def _make_concourse(db: AsyncSession, project: Project, owner: User) -> Concourse:
+    c = Concourse(
+        project_id=project.id,
+        title=f"Concourse {uuid.uuid4().hex[:6]}",
+        description="d",
+        created_by=owner.id,
+    )
+    db.add(c)
+    await db.flush()
+    return c
+
+
+async def _make_concourse_item(
+    db: AsyncSession, concourse: Concourse, owner: User
+) -> ConcourseItem:
+    item = ConcourseItem(
+        concourse_id=concourse.id,
+        code=f"C{uuid.uuid4().hex[:4]}",
+        created_by=owner.id,
+    )
+    db.add(item)
+    await db.flush()
+    db.add(ConcourseItemTranslation(item_id=item.id, language_code="en", text="text"))
+    await db.flush()
+    return item
+
+
+async def _make_concourse_tag(db: AsyncSession, project: Project) -> ConcourseTag:
+    tag = ConcourseTag(
+        project_id=project.id,
+        name=f"tag-{uuid.uuid4().hex[:6]}",
+    )
+    db.add(tag)
+    await db.flush()
+    return tag
+
+
+async def _make_recruitment_link(db: AsyncSession, study: Study) -> RecruitmentLink:
+    link = RecruitmentLink(
+        study_id=study.id,
+        type=RecruitmentLinkType.public,
+        token=uuid.uuid4().hex,
+        name="link",
+        is_active=True,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=90),
+    )
+    db.add(link)
+    await db.flush()
+    return link
+
+
+async def _make_memo_entry(
+    db: AsyncSession, parent_type: MemoParentType, parent_id: int, owner: User
+) -> MemoEntry:
+    entry = MemoEntry(
+        parent_type=parent_type,
+        parent_id=parent_id,
+        title="entry",
+        body="body",
+        position=0,
+        created_by=owner.id,
+        last_edited_by=owner.id,
+    )
+    db.add(entry)
+    await db.flush()
+    return entry
+
+
+async def _make_memo_comment(
+    db: AsyncSession, entry: MemoEntry, owner: User
+) -> MemoComment:
+    comment = MemoComment(
+        entry_id=entry.id,
+        user_id=owner.id,
+        body="cmt",
+        mentions=[],
+    )
+    db.add(comment)
+    await db.flush()
+    return comment
+
+
+async def _make_audio(db: AsyncSession, participant: Participant) -> AudioRecording:
+    """Insert an AudioRecording row. No real S3 object — the harness
+    only checks the auth/scope decision, not the presigned URL.
+    """
+    audio = AudioRecording(
+        participant_id=participant.id,
+        question_key=f"q_{uuid.uuid4().hex[:6]}",
+        s3_bucket="test-bucket",
+        s3_key=f"audio/{uuid.uuid4().hex}.webm",
+        file_size_bytes=1024,
+        duration_seconds=1.0,
+        mime_type="audio/webm",
+    )
+    db.add(audio)
+    await db.flush()
+    return audio
+
+
+async def _make_analysis_run(
+    db: AsyncSession, study: Study, owner: User
+) -> AnalysisRun:
+    run = AnalysisRun(
+        study_id=study.id,
+        ran_by_user_id=owner.id,
+        extraction_method="pca",
+        n_factors=2,
+        rotation_method="varimax",
+        flagging_mode="auto",
+        notes=None,
+        factor_notes={},
+        result={"placeholder": True},
+    )
+    db.add(run)
+    await db.flush()
+    return run
+
+
+def _token_for(user: User) -> str:
+    return create_access_token(subject=user.email, expires_delta=timedelta(minutes=30))
+
+
+# -----------------------------------------------------------------------------
+# Fixture
+# -----------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def tenancy(db: AsyncSession) -> TenancyFixtures:
+    """Seed a two-project tenancy and return the bundle.
+
+    Function-scoped to match the existing `db` fixture (which drops and
+    re-creates the schema each test). With 89 parametrised cases this is
+    ~89× the seeding cost, which is acceptable for a one-shot security
+    harness; the harness can be re-run on demand and is not a hot-path
+    suite. If we later want to amortise seeding cost, we'd promote `db`
+    to module scope and tear down per-test rows manually.
+    """
+    # Users — one owner / member / viewer per project.
+    alice = await _make_user(db, "alice")
+    bob = await _make_user(db, "bob")
+    charlie = await _make_user(db, "charlie")
+    dan = await _make_user(db, "dan")
+    eve = await _make_user(db, "eve")
+    frank = await _make_user(db, "frank")
+
+    project_a = await _make_project(db, "a", owner=alice, member=bob, viewer=charlie)
+    project_b = await _make_project(db, "b", owner=dan, member=eve, viewer=frank)
+
+    # Project A objects.
+    study_in_a = await _make_study(db, project_a, "a")
+    participant_in_a = await _make_participant(db, study_in_a)
+    concourse_in_a = await _make_concourse(db, project_a, alice)
+    concourse_item_in_a = await _make_concourse_item(db, concourse_in_a, alice)
+    concourse_tag_in_a = await _make_concourse_tag(db, project_a)
+    recruitment_link_in_a = await _make_recruitment_link(db, study_in_a)
+    memo_entry_in_a = await _make_memo_entry(
+        db, MemoParentType.concourse, concourse_in_a.id, alice
+    )
+    memo_comment_in_a = await _make_memo_comment(db, memo_entry_in_a, alice)
+    audio_in_a = await _make_audio(db, participant_in_a)
+    analysis_run_in_a = await _make_analysis_run(db, study_in_a, alice)
+
+    # Project B objects (cross-tenant targets).
+    study_in_b = await _make_study(db, project_b, "b")
+    participant_in_b = await _make_participant(db, study_in_b)
+    concourse_in_b = await _make_concourse(db, project_b, dan)
+    concourse_item_in_b = await _make_concourse_item(db, concourse_in_b, dan)
+    concourse_tag_in_b = await _make_concourse_tag(db, project_b)
+    recruitment_link_in_b = await _make_recruitment_link(db, study_in_b)
+    memo_entry_in_b = await _make_memo_entry(
+        db, MemoParentType.concourse, concourse_in_b.id, dan
+    )
+    memo_comment_in_b = await _make_memo_comment(db, memo_entry_in_b, dan)
+    audio_in_b = await _make_audio(db, participant_in_b)
+    analysis_run_in_b = await _make_analysis_run(db, study_in_b, dan)
+
+    await db.commit()
+
+    fx = TenancyFixtures(
+        project_a=project_a,
+        project_b=project_b,
+        alice=alice,
+        bob=bob,
+        charlie=charlie,
+        dan=dan,
+        eve=eve,
+        frank=frank,
+        study_in_a=study_in_a,
+        participant_in_a=participant_in_a,
+        concourse_in_a=concourse_in_a,
+        concourse_item_in_a=concourse_item_in_a,
+        concourse_tag_in_a=concourse_tag_in_a,
+        recruitment_link_in_a=recruitment_link_in_a,
+        memo_entry_in_a=memo_entry_in_a,
+        memo_comment_in_a=memo_comment_in_a,
+        audio_in_a=audio_in_a,
+        analysis_run_in_a=analysis_run_in_a,
+        study_in_b=study_in_b,
+        participant_in_b=participant_in_b,
+        concourse_in_b=concourse_in_b,
+        concourse_item_in_b=concourse_item_in_b,
+        concourse_tag_in_b=concourse_tag_in_b,
+        recruitment_link_in_b=recruitment_link_in_b,
+        memo_entry_in_b=memo_entry_in_b,
+        memo_comment_in_b=memo_comment_in_b,
+        audio_in_b=audio_in_b,
+        analysis_run_in_b=analysis_run_in_b,
+        token_a_owner=_token_for(alice),
+        token_a_member=_token_for(bob),
+        token_a_viewer=_token_for(charlie),
+        token_b_owner=_token_for(dan),
+        token_b_member=_token_for(eve),
+        token_b_viewer=_token_for(frank),
+    )
+
+    fx.path_substitutions_b = {
+        # Project-B identifiers (path placeholders the harness uses).
+        "project_b_id": str(project_b.id),
+        "project_b_slug": project_b.slug,
+        "study_in_b_id": str(study_in_b.id),
+        "study_in_b_slug": study_in_b.slug,
+        "participant_in_b_id": str(participant_in_b.id),
+        "concourse_in_b_id": str(concourse_in_b.id),
+        "concourse_item_in_b_id": str(concourse_item_in_b.id),
+        "concourse_tag_in_b_id": str(concourse_tag_in_b.id),
+        "recruitment_link_in_b_id": str(recruitment_link_in_b.id),
+        "memo_entry_in_b_id": str(memo_entry_in_b.id),
+        "memo_comment_in_b_id": str(memo_comment_in_b.id),
+        "audio_in_b_id": str(audio_in_b.id),
+        "analysis_run_in_b_id": str(analysis_run_in_b.id),
+        # User-id targets for endpoints like /projects/{slug}/members/{user_id}.
+        "user_in_b_id": str(dan.id),
+        # Statement id placeholder (we don't seed a statement; the route
+        # only matters for cross-tenant denial which fires before id lookup).
+        "statement_id": "999999",
+    }
+
+    return fx

--- a/backend/tests/security/wave_3/test_admin_idor_harness.py
+++ b/backend/tests/security/wave_3/test_admin_idor_harness.py
@@ -1,0 +1,819 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Wave 3 Task 3 — Cross-tenant IDOR harness over the 89 admin endpoints.
+
+For each admin route, we send the request as a project-A member while
+targeting a project-B object (either via the path id/slug or via the
+``X-Project-ID`` header). The expected behaviour is a denial — 403 (header-
+based ``require_project_role``) or 404 (slug-based ``check_*_permission``,
+which collapses existence-disclosure with permission denial).
+
+Routes that don't fit the cross-tenant model are skipped explicitly:
+
+- Top-level **enumeration** routes (``GET /api/admin/projects``,
+  ``POST /api/admin/projects``, ``GET /api/admin/users``,
+  ``POST /api/admin/users``, ``GET /api/admin/invitations/verify``,
+  ``POST /api/admin/invitations/accept``, ``GET /api/admin/memo/templates``)
+  have no cross-tenant target id; their isolation is asserted by other
+  test classes (filter by membership / superuser gate).
+- Routes for which we don't seed an object (e.g. statement_id paths)
+  still fire — the dependency runs before the id lookup, so the denial
+  is asserted before any 404 from the missing object would surface.
+
+Routes are encoded as :class:`Route` rows. Each row carries the HTTP
+method, the path template, an isolation pattern enum, an optional minimal
+body that satisfies request validation, and the set of denial status
+codes the route may legitimately return. A status code outside the set
+is a candidate finding for Task 4 — the harness records it but does not
+fix anything.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import TenancyFixtures
+
+
+Pattern = Literal["A_HEADER", "A_SLUG", "B"]
+
+
+@dataclass(frozen=True)
+class Route:
+    """One row in the cross-tenant denial harness.
+
+    Attributes
+    ----------
+    method
+        HTTP verb in upper case.
+    path_template
+        URL with placeholder names from
+        :attr:`TenancyFixtures.path_substitutions_b`.
+    pattern
+        Isolation mechanism the route uses:
+        - ``A_HEADER``: header dependency (``X-Project-ID``); harness sends
+          B's id in the header along with A's bearer.
+        - ``A_SLUG``: ``check_project_permission`` / ``check_study_permission``
+          on a slug in the path; harness sends B's slug with A's bearer.
+        - ``B``: bespoke inline check on an opaque object id in the path;
+          harness sends B's object id with A's bearer.
+    body
+        Minimal JSON body satisfying request validation. ``None`` for
+        GET / DELETE without a body.
+    expected
+        Acceptable denial status codes. The harness asserts the response
+        is in this set. Differs across routes because some return 403,
+        some return 404 by design.
+    """
+
+    method: str
+    path_template: str
+    pattern: Pattern
+    body: dict | None
+    expected: frozenset[int]
+
+
+# --- Minimal bodies that satisfy schema validation ---------------------------
+#
+# These bodies are designed to PASS the schema validator so that the request
+# reaches the auth/scope check. They MUST NOT mutate state — denial fires
+# first, before the body's content matters. If a body fails schema validation,
+# we'd see 422 and the harness would never observe the auth decision.
+
+_STUDY_CREATE_BODY = {
+    "translations": [
+        {
+            "language_code": "en",
+            "title": "x",
+            "description": "x",
+            "instructions": "x",
+            "consent_title": "x",
+            "consent_description": "x",
+        }
+    ],
+    "statements": [],
+}
+
+_STUDY_UPDATE_BODY = {"slug": "ignored-slug-cross-tenant"}
+_STUDY_STATE_BODY = "active"  # POST /state takes a state via query/body
+_TAG_CREATE_BODY = {"name": "x"}
+_CONCOURSE_CREATE_BODY = {"title": "x"}
+_CONCOURSE_UPDATE_BODY = {"title": "y"}
+_CONCOURSE_ITEM_CREATE_BODY = {
+    "code": "C1",
+    "translations": [{"language_code": "en", "text": "t"}],
+}
+_CONCOURSE_ITEM_BULK_BODY = {"items": [_CONCOURSE_ITEM_CREATE_BODY]}
+_CONCOURSE_ITEM_IMPORT_BODY = {
+    "text_block": "line\n",
+    "language_code": "en",
+}
+_CONCOURSE_ITEM_UPDATE_BODY = {"version": 1}
+_CONCOURSE_ITEM_COMMENT_BODY = {"body": "x"}
+_PROJECT_CREATE_BODY = {"title": "x", "slug": "x-project-cross"}
+_PROJECT_UPDATE_BODY = {"title": "y"}
+_PROJECT_MEMBER_UPDATE_BODY = {"role": "member"}
+_PROJECT_INVITE_BODY = {"email": "stranger@example.com", "role": "member"}
+_INVITATION_ACCEPT_BODY = {"token": "irrelevant.cross.tenant"}
+_USER_CREATE_BODY = {"email": "u@example.com", "password": "pw1234"}
+_RECRUITMENT_LINK_BODY = {"name": "x", "type": "public"}
+_MEMO_ENTRY_BODY = {"title": "x", "body": "y"}
+_MEMO_ENTRY_UPDATE_BODY = {"title": "x"}
+_MEMO_COMMENT_BODY = {"body": "x"}
+_MEMO_COMMENT_UPDATE_BODY = {"body": "x"}
+_ANALYSIS_RUN_BODY = {"n_factors": 2}
+_ANALYSIS_PREVIEW_BODY = {"n_factors_range": [2, 3]}
+_ANALYSIS_RUN_PATCH_BODY = {"notes": "x"}
+_BULK_ANONYMISE_BODY = {"submitted_before": "2030-01-01T00:00:00Z"}
+_PARTICIPANT_DISCARD_BODY = {"is_discarded": True, "discard_reason": "x"}
+_IMPORT_CONCOURSE_BODY = {
+    "concourse_id": 999_999,
+    "item_ids": [1],
+    "code_prefix": "",
+    "replace_existing": False,
+}
+_STUDY_IMPORT_BODY = {"config": {"version": "1.0"}, "new_slug": "x-imported-cross"}
+
+
+# --- The 89 routes ----------------------------------------------------------
+#
+# Mirrors the inventory in
+# ``docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md``.
+# Routes flagged with ``CROSS_TENANT_NOT_APPLICABLE`` in
+# :data:`SKIPPED_ROUTES` below are top-level enumerations or unauth endpoints
+# whose isolation is not a cross-tenant IDOR (they have no project-B target).
+
+ROUTES: list[Route] = [
+    # -- projects.py (10 routes; 2 are top-level, skipped) -----------------------
+    Route(
+        "GET",
+        "/api/admin/projects/{project_b_slug}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/projects/{project_b_slug}",
+        "A_SLUG",
+        _PROJECT_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/projects/{project_b_slug}/members",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/projects/{project_b_slug}/members/{user_in_b_id}",
+        "A_SLUG",
+        _PROJECT_MEMBER_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/projects/{project_b_slug}/members/{user_in_b_id}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/projects/{project_b_slug}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/projects/{project_b_slug}/invitations",
+        "A_SLUG",
+        _PROJECT_INVITE_BODY,
+        frozenset({403, 404}),
+    ),
+    # -- recruitment.py (3 routes) --------------------------------------------
+    Route(
+        "GET",
+        "/api/admin/recruitment/{study_in_b_slug}/links",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/recruitment/{study_in_b_slug}/links",
+        "A_SLUG",
+        _RECRUITMENT_LINK_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/recruitment/links/{recruitment_link_in_b_id}",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    # -- memos.py (13 cross-tenant routes; templates skipped) -----------------
+    Route(
+        "GET",
+        "/api/admin/concourses/{concourse_in_b_id}/memo",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_id}/memo",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/concourses/{concourse_in_b_id}/memo/unread?since=2030-01-01T00:00:00Z",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_id}/memo/unread?since=2030-01-01T00:00:00Z",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/memo/entries",
+        "B",
+        _MEMO_ENTRY_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_id}/memo/entries",
+        "B",
+        _MEMO_ENTRY_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/memo-entries/{memo_entry_in_b_id}",
+        "B",
+        _MEMO_ENTRY_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/memo-entries/{memo_entry_in_b_id}",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/memo-entries/{memo_entry_in_b_id}/comments",
+        "B",
+        _MEMO_COMMENT_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/memo-comments/{memo_comment_in_b_id}",
+        "B",
+        _MEMO_COMMENT_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/memo-comments/{memo_comment_in_b_id}",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/memo-comments/{memo_comment_in_b_id}/resolve",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/memo-comments/{memo_comment_in_b_id}/unresolve",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    # -- studies_participants.py (5 routes) -----------------------------------
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/participants",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/participants/{participant_in_b_id}",
+        "B",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/studies/participants/{participant_in_b_id}/discard",
+        "B",
+        _PARTICIPANT_DISCARD_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/studies/{study_in_b_slug}/participants",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/studies/{study_in_b_slug}/participants/{participant_in_b_id}/personal-data",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    # -- exports.py (8 routes) ------------------------------------------------
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/export/csv",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/export/pqmethod",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/export/r-kit",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/dump",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/participants/{participant_in_b_id}/export/csv",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/participants/{participant_in_b_id}/export/json",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/participants/{participant_in_b_id}/export/audio",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/export/package",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    # -- lifecycle.py (3 routes) ----------------------------------------------
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/data-inventory",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/anonymise-preview?cutoff=2030-01-01T00:00:00Z",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/anonymise-bulk",
+        "A_SLUG",
+        _BULK_ANONYMISE_BODY,
+        frozenset({403, 404}),
+    ),
+    # -- studies.py main (12 routes; the GET / and POST / are header-scoped) --
+    Route(
+        "POST",
+        "/api/admin/studies",
+        "A_HEADER",
+        _STUDY_CREATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies",
+        "A_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/studies/{study_in_b_slug}",
+        "A_SLUG",
+        _STUDY_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/validate",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/state?new_state=active",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/reset",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/studies/{study_in_b_slug}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/import-concourse",
+        "A_SLUG",
+        _IMPORT_CONCOURSE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/stale-statements",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/sync-statement/{statement_id}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/sync-all-stale",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    # -- analysis.py (10 routes) ----------------------------------------------
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/analysis/eigenvalues",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/analysis/run",
+        "A_SLUG",
+        _ANALYSIS_RUN_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/{study_in_b_slug}/analysis/preview-range",
+        "A_SLUG",
+        _ANALYSIS_PREVIEW_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/analysis/runs",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/analysis/runs/{analysis_run_in_b_id}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/studies/{study_in_b_slug}/analysis/runs/{analysis_run_in_b_id}",
+        "A_SLUG",
+        _ANALYSIS_RUN_PATCH_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/studies/{study_in_b_slug}/analysis/runs/{analysis_run_in_b_id}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/analysis/audios?participant_ids={participant_in_b_id}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/analysis/comments?participant_ids={participant_in_b_id}",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    # -- studies_import_export.py (4 routes; 2 top-level skipped) -------------
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/stats",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/export/config",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/studies/{study_in_b_slug}/storage-usage",
+        "A_SLUG",
+        None,
+        frozenset({403, 404}),
+    ),
+    # -- concourses.py (15 routes) --------------------------------------------
+    Route("GET", "/api/admin/concourses/tags", "A_HEADER", None, frozenset({403, 404})),
+    Route(
+        "POST",
+        "/api/admin/concourses/tags",
+        "A_HEADER",
+        _TAG_CREATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/concourses/tags/{concourse_tag_in_b_id}",
+        "A_HEADER",  # require_project_role(member); B's tag id with A's header
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/concourses",
+        "A_HEADER",
+        _CONCOURSE_CREATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route("GET", "/api/admin/concourses", "A_HEADER", None, frozenset({403, 404})),
+    Route(
+        "GET",
+        "/api/admin/concourses/{concourse_in_b_id}",
+        "A_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/concourses/{concourse_in_b_id}",
+        "A_HEADER",
+        _CONCOURSE_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/concourses/{concourse_in_b_id}",
+        "A_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/items",
+        "A_HEADER",
+        _CONCOURSE_ITEM_CREATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/items/bulk",
+        "A_HEADER",
+        _CONCOURSE_ITEM_BULK_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/items/import",
+        "A_HEADER",
+        _CONCOURSE_ITEM_IMPORT_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "PATCH",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}",
+        "A_HEADER",
+        _CONCOURSE_ITEM_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "DELETE",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}",
+        "A_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}/versions",
+        "A_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "GET",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}/comments",
+        "A_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}/comments",
+        "A_HEADER",
+        _CONCOURSE_ITEM_COMMENT_BODY,
+        frozenset({403, 404}),
+    ),
+    # -- users.py (3 routes; superuser-gated) ---------------------------------
+    Route(
+        "DELETE",
+        "/api/admin/users/{user_in_b_id}",
+        "A_HEADER",  # not really header-based but project-A bearer must be 403 (not superuser)
+        None,
+        frozenset({403, 404}),
+    ),
+    # -- studies_import_export.py top-level (require_project_role(member)) ---
+    Route(
+        "POST",
+        "/api/admin/studies/import",
+        "A_HEADER",
+        _STUDY_IMPORT_BODY,
+        frozenset({403, 404}),
+    ),
+    Route(
+        "POST",
+        "/api/admin/studies/validate-import",
+        "A_HEADER",
+        {"config": {"version": "1.0"}},
+        frozenset({403, 404}),
+    ),
+]
+
+
+# Routes excluded from the cross-tenant harness — see :mod:`docs/audits/...`.
+# Either they have no project-B target (top-level enumeration / superuser /
+# unauth) or their isolation is verified by another harness.
+SKIPPED_ROUTES: list[tuple[str, str, str]] = [
+    ("GET", "/api/admin/projects", "list filtered to caller's memberships"),
+    ("POST", "/api/admin/projects", "creates new project; no B target"),
+    (
+        "GET",
+        "/api/admin/invitations/verify",
+        "unauthenticated; harness for token tampering lives elsewhere",
+    ),
+    (
+        "POST",
+        "/api/admin/invitations/accept",
+        "auth-only token consumption; cross-tenant N/A",
+    ),
+    ("GET", "/api/admin/users", "superuser-gated; cross-project N/A"),
+    ("POST", "/api/admin/users", "superuser-gated; cross-project N/A"),
+    ("GET", "/api/admin/memo/templates", "static templates; no project scope"),
+]
+
+
+def _format_path(template: str, fx: TenancyFixtures) -> str:
+    """Substitute placeholder names with project-B identifiers."""
+    return template.format(**fx.path_substitutions_b)
+
+
+@pytest.mark.asyncio
+class TestProjectAMemberCannotAccessProjectBResource:
+    """Cross-tenant denial harness over the 89 admin endpoints."""
+
+    @pytest.mark.parametrize(
+        "route",
+        ROUTES,
+        ids=lambda r: f"{r.method}_{r.path_template}",
+    )
+    async def test_cross_tenant_denial(
+        self,
+        route: Route,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+    ) -> None:
+        """Bob (project-A member) targets project-B resources — must be denied.
+
+        Pattern legend (also documented on :class:`Route`):
+
+        - **A_HEADER**: harness sends ``X-Project-ID = project_b.id`` along
+          with Bob's bearer. ``require_project_role`` checks if Bob is a
+          member of project B; he is not → 403.
+        - **A_SLUG**: harness puts B's slug in the path. ``check_*_permission``
+          tries to find a row where Bob is a member of the slug-named
+          project; finds none → 404.
+        - **B**: harness puts B's object id in the path. The route's
+          bespoke inline check resolves the object's parent project, then
+          looks up Bob's membership; finds none → 403 or 404.
+
+        The expected denial set is therefore ``{403, 404}`` for all routes;
+        the harness records the actual code so Task 4 can spot any 200/500
+        leakage or unexpected status.
+        """
+        path = _format_path(route.path_template, tenancy)
+        headers = {"Authorization": f"Bearer {tenancy.token_a_member}"}
+        if route.pattern == "A_HEADER":
+            headers["X-Project-ID"] = str(tenancy.project_b.id)
+
+        response = await client.request(
+            route.method,
+            path,
+            headers=headers,
+            json=route.body,
+        )
+
+        assert response.status_code in route.expected, (
+            f"Cross-tenant leak candidate: {route.method} {path} "
+            f"(pattern={route.pattern}) returned {response.status_code} — "
+            f"expected one of {sorted(route.expected)}. "
+            f"Body preview: {response.text[:200]}"
+        )
+
+
+# Coverage assertion — keeps the harness honest about how many of the 89
+# inventory routes are actually exercised.
+def test_harness_coverage_matches_inventory() -> None:
+    """The harness must cover (encoded + skipped) routes ≥ inventory size."""
+    encoded = len(ROUTES)
+    skipped = len(SKIPPED_ROUTES)
+    assert encoded + skipped >= 89, (
+        f"Harness covers {encoded} routes + {skipped} skipped = "
+        f"{encoded + skipped}; inventory is 89. Update ROUTES or SKIPPED_ROUTES."
+    )

--- a/backend/tests/security/wave_3/test_admin_idor_harness.py
+++ b/backend/tests/security/wave_3/test_admin_idor_harness.py
@@ -28,6 +28,27 @@ body that satisfies request validation, and the set of denial status
 codes the route may legitimately return. A status code outside the set
 is a candidate finding for Task 4 — the harness records it but does not
 fix anything.
+
+Pattern legend
+--------------
+- **A_HEADER**: Bob sends ``X-Project-ID = project_b.id``. The dep layer
+  (``require_project_role``) rejects because Bob is not a member of B.
+  Tests the *dependency layer* only.
+- **A_SLUG**: harness puts B's slug in the path. ``check_*_permission``
+  finds no membership row for Bob in B's slug-named project → 404.
+- **B**: harness puts B's object id in the path with Bob's bearer. A
+  bespoke inline check resolves the object's parent project and finds no
+  Bob membership → 403/404.
+- **B_VALID_HEADER**: the canonical Pattern-B attack. Bob sends a *valid*
+  ``X-Project-ID = project_a.id`` (he IS a member of A, so the dep layer
+  accepts the request) but supplies a foreign object id from project B in
+  the path (e.g. ``concourse_in_b.id``). Whether the cross-tenant object
+  leaks depends entirely on **inline service guards** (e.g.
+  ``concourses.py:170`` checks ``concourse.project_id != project.id``).
+  These are *pin-down tests* — the inline guards already exist in
+  production; the cases ensure a future refactor that drops a guard while
+  keeping the dependency will surface here before merge.
+  Expected: ``{403, 404}``.
 """
 
 from __future__ import annotations
@@ -41,7 +62,7 @@ from httpx import AsyncClient
 from .conftest import TenancyFixtures
 
 
-Pattern = Literal["A_HEADER", "A_SLUG", "B"]
+Pattern = Literal["A_HEADER", "A_SLUG", "B", "B_VALID_HEADER"]
 
 
 @dataclass(frozen=True)
@@ -63,6 +84,10 @@ class Route:
           on a slug in the path; harness sends B's slug with A's bearer.
         - ``B``: bespoke inline check on an opaque object id in the path;
           harness sends B's object id with A's bearer.
+        - ``B_VALID_HEADER``: pin-down for inline service guards. Harness
+          sends A's id in the ``X-Project-ID`` header (dep layer accepts)
+          but puts B's object id in the path. The inline guard (e.g.
+          ``concourse.project_id != project.id``) must produce 403/404.
     body
         Minimal JSON body satisfying request validation. ``None`` for
         GET / DELETE without a body.
@@ -754,6 +779,118 @@ def _format_path(template: str, fx: TenancyFixtures) -> str:
     return template.format(**fx.path_substitutions_b)
 
 
+# --- B_VALID_HEADER routes — pin-down tests for inline service guards --------
+#
+# These are the canonical Pattern-B attack: Bob sends a *valid*
+# X-Project-ID = project_a.id (dep layer accepts; Bob IS a member of A) but
+# supplies a foreign object id from project B in the path. The inline service
+# guard must catch it and return 403 or 404.
+#
+# Only A_HEADER routes whose path contains a project-scoped object id appear
+# here. Routes with no path id (POST /concourses, GET /concourses, etc.),
+# body-only id routes (studies/import), or superuser-gated routes (users/{id})
+# are not applicable and are omitted.
+
+ROUTES_B_VALID_HEADER: list[Route] = [
+    # concourses.py — tag delete: service filters tag by project.id
+    Route(
+        "DELETE",
+        "/api/admin/concourses/tags/{concourse_tag_in_b_id}",
+        "B_VALID_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — GET concourse: concourse.project_id != project.id → 404
+    Route(
+        "GET",
+        "/api/admin/concourses/{concourse_in_b_id}",
+        "B_VALID_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — PATCH concourse: service update_concourse checks project.id
+    Route(
+        "PATCH",
+        "/api/admin/concourses/{concourse_in_b_id}",
+        "B_VALID_HEADER",
+        _CONCOURSE_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — DELETE concourse: concourse.project_id != project.id → 404
+    Route(
+        "DELETE",
+        "/api/admin/concourses/{concourse_in_b_id}",
+        "B_VALID_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — POST items: _verify_concourse_ownership(concourse_id, project.id)
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/items",
+        "B_VALID_HEADER",
+        _CONCOURSE_ITEM_CREATE_BODY,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — POST items/bulk: same ownership guard
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/items/bulk",
+        "B_VALID_HEADER",
+        _CONCOURSE_ITEM_BULK_BODY,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — POST items/import: same ownership guard
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/items/import",
+        "B_VALID_HEADER",
+        _CONCOURSE_ITEM_IMPORT_BODY,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — PATCH item: _verify_concourse_ownership + _verify_item_ownership
+    Route(
+        "PATCH",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}",
+        "B_VALID_HEADER",
+        _CONCOURSE_ITEM_UPDATE_BODY,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — DELETE item: same dual ownership guard
+    Route(
+        "DELETE",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}",
+        "B_VALID_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — GET item versions: _verify_concourse_ownership + _verify_item_ownership
+    Route(
+        "GET",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}/versions",
+        "B_VALID_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — GET item comments: same dual ownership guard
+    Route(
+        "GET",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}/comments",
+        "B_VALID_HEADER",
+        None,
+        frozenset({403, 404}),
+    ),
+    # concourses.py — POST item comment: same dual ownership guard
+    Route(
+        "POST",
+        "/api/admin/concourses/{concourse_in_b_id}/items/{concourse_item_in_b_id}/comments",
+        "B_VALID_HEADER",
+        _CONCOURSE_ITEM_COMMENT_BODY,
+        frozenset({403, 404}),
+    ),
+]
+
+
 @pytest.mark.asyncio
 class TestProjectAMemberCannotAccessProjectBResource:
     """Cross-tenant denial harness over the 89 admin endpoints."""
@@ -803,6 +940,49 @@ class TestProjectAMemberCannotAccessProjectBResource:
             f"Cross-tenant leak candidate: {route.method} {path} "
             f"(pattern={route.pattern}) returned {response.status_code} — "
             f"expected one of {sorted(route.expected)}. "
+            f"Body preview: {response.text[:200]}"
+        )
+
+    @pytest.mark.parametrize(
+        "route",
+        ROUTES_B_VALID_HEADER,
+        ids=lambda r: f"{r.method}_{r.path_template}",
+    )
+    async def test_inline_guard_with_valid_header(
+        self,
+        route: Route,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+    ) -> None:
+        """Bob sends a *valid* X-Project-ID (project A) but a foreign path id.
+
+        Pattern: **B_VALID_HEADER** — the dep layer (``require_project_role``)
+        accepts the request because Bob is legitimately a member of A and the
+        ``X-Project-ID`` header names A. The denial must therefore come from
+        the **inline service guard** (e.g. ``concourse.project_id != project.id``
+        or ``_verify_concourse_ownership``). These are pin-down tests: the
+        guards already exist; the cases ensure a future refactor cannot
+        silently remove a guard while keeping the dependency layer intact.
+        """
+        path = _format_path(route.path_template, tenancy)
+        headers = {
+            "Authorization": f"Bearer {tenancy.token_a_member}",
+            "X-Project-ID": str(tenancy.project_a.id),
+        }
+
+        response = await client.request(
+            route.method,
+            path,
+            headers=headers,
+            json=route.body,
+        )
+
+        assert response.status_code in route.expected, (
+            f"Inline-guard leak candidate: {route.method} {path} "
+            f"(pattern={route.pattern}) returned {response.status_code} — "
+            f"expected one of {sorted(route.expected)}. "
+            f"A valid X-Project-ID header was sent; denial must come from "
+            f"the inline service guard, not the dep layer. "
             f"Body preview: {response.text[:200]}"
         )
 

--- a/backend/tests/security/wave_3/test_audio_upload_ownership.py
+++ b/backend/tests/security/wave_3/test_audio_upload_ownership.py
@@ -1,0 +1,122 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Wave 3 Task 6 — Audio-upload ownership claim integrity.
+
+The audio upload endpoint (``POST /api/audio/upload``) does not accept a
+``participant_id`` from the request body or query string. The
+participant identity is derived from the form-supplied ``session_token``
+(a 128-bit UUID) which is looked up against
+``Participant.session_token`` — same opaque credential that gates every
+participant-facing endpoint. There is no body-supplied identifier the
+attacker could tamper with to claim ownership of a different
+participant row.
+
+Similarly, ``DELETE /api/audio/{recording_id}`` and
+``GET /api/audio/{recording_id}/url`` require the caller's
+``session_token`` to match the participant who owns the recording —
+fetched via the ``recording → participant`` join — before any S3 key
+is exposed.
+
+This regression guard pins three behaviours:
+
+1. ``DELETE /api/audio/{recording_id}`` rejects a wrong session_token
+   with 403 even when the caller knows the recording id.
+2. ``GET /api/audio/{recording_id}/url`` rejects a wrong session_token
+   with 403 (would otherwise leak a presigned URL).
+3. The upload endpoint has no ``participant_id`` parameter — verified
+   by reading the route signature.
+
+Status: filed as F-04-003 (observation — body has no trusted participant
+claim, all participant-id derivation is session-token-based).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from httpx import AsyncClient
+
+from app.routers.audio import (
+    delete_audio_recording,
+    get_audio_url,
+    upload_audio,
+)
+
+from .conftest import TenancyFixtures
+
+
+class TestAudioUploadOwnership:
+    """Audio endpoints derive participant identity from session_token only."""
+
+    def test_upload_signature_has_no_participant_id_parameter(self) -> None:
+        """The upload route must not accept a body-supplied participant_id.
+
+        If such a parameter were ever added, ownership-claim tampering
+        becomes possible — an attacker could upload audio as another
+        participant by spoofing the id. The regression test pins that
+        the parameter list is session_token-only.
+        """
+        sig = inspect.signature(upload_audio)
+        param_names = set(sig.parameters)
+        assert "participant_id" not in param_names, (
+            "upload_audio must not accept a participant_id parameter — "
+            "ownership must be derived from session_token. Parameters: "
+            f"{sorted(param_names)}"
+        )
+        # session_token is the trusted credential.
+        assert "session_token" in param_names, (
+            f"upload_audio must accept session_token. Parameters: {sorted(param_names)}"
+        )
+
+    def test_delete_and_get_url_signatures_use_session_token(self) -> None:
+        """The delete + get-url routes must gate on session_token."""
+        for fn in (delete_audio_recording, get_audio_url):
+            sig = inspect.signature(fn)
+            assert "session_token" in sig.parameters, (
+                f"{fn.__name__} must gate on session_token; "
+                f"parameters: {sorted(sig.parameters)}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_wrong_session_token(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+    ) -> None:
+        """DELETE /api/audio/{rec_id} with wrong session_token must 403."""
+        # Both audio_in_a and audio_in_b are seeded; an attacker who knows
+        # audio_in_b.id but presents participant_in_a's session_token must
+        # be denied.
+        wrong_session = tenancy.participant_in_a.session_token
+        response = await client.delete(
+            f"/api/audio/{tenancy.audio_in_b.id}",
+            params={"session_token": str(wrong_session)},
+        )
+        assert response.status_code == 403, (
+            "Cross-participant delete must be rejected with 403; "
+            f"got {response.status_code} body={response.text!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_url_rejects_wrong_session_token(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+    ) -> None:
+        """GET /api/audio/{rec_id}/url with wrong session_token must 403.
+
+        Critical because this endpoint returns a presigned S3 URL — a
+        successful response would be a direct data leak.
+        """
+        wrong_session = tenancy.participant_in_a.session_token
+        response = await client.get(
+            f"/api/audio/{tenancy.audio_in_b.id}/url",
+            params={"session_token": str(wrong_session)},
+        )
+        assert response.status_code == 403, (
+            "Cross-participant presigned-URL fetch must be rejected with 403; "
+            f"got {response.status_code} body={response.text!r}"
+        )

--- a/backend/tests/security/wave_3/test_export_filter.py
+++ b/backend/tests/security/wave_3/test_export_filter.py
@@ -1,0 +1,196 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Wave 3 Task 8 — Bulk-export filter correctness.
+
+The cross-tenant IDOR harness (Task 3) already covered every export
+endpoint at the **path** level (Bob targeting study-B's slug → 404).
+This task widens that to ask: does the export query *itself* trust any
+non-path input — body, header, or query string — that an attacker could
+manipulate to widen the result set beyond their own study?
+
+Read of ``backend/app/routers/admin/exports.py`` and
+``backend/app/routers/admin/studies_import_export.py``:
+
+- All eight export endpoints derive ``study.id`` from
+  ``check_study_permission(StudyRole.editor)`` (path-bound).
+- All ``Participant`` queries filter ``Participant.study_id == study.id``
+  at the SQL level. The ``participant_id`` route also adds
+  ``Participant.id == participant_id`` as a defence-in-depth path
+  scope.
+- The single in-Python filter is in
+  ``GET /studies/{slug}/participants/{participant_id}/export/json``
+  (``exports.py:240-248``): it calls ``get_study_full_dump(db, study.id)``
+  and then ``next(p for p in dump['participants'] if p['db_id'] == participant_id)``.
+  Because the upstream dump is already SQL-scoped to ``study.id``, the
+  in-Python filter cannot return a participant from a different study.
+
+No body or header is read by any export endpoint. The only non-path
+parameter is ``include_discussion: bool`` on
+``GET /export/package`` — a boolean toggle, not a tenant identifier.
+
+This regression guard pins three behaviours:
+
+1. ``GET /studies/{slug}/participants/{participant_id}/export/json``
+   returns 404 when ``participant_id`` belongs to a different study,
+   even when the caller has full editor permission on the slug-named
+   study.
+2. The CSV/PQMethod/R-Kit/audio export endpoints ignore extraneous body
+   or header data — they do not honour any tenant filter from the body.
+3. ``StudyDataService.get_study_full_dump`` only returns participants
+   for the queried study (verified via in-process call).
+
+Status: filed as F-04-005 (observation — all exports membership-scoped
+at SQL level; no body/header-trusted filters exist).
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Study, StudyState
+from app.services.study_data_service import StudyDataService
+
+from .conftest import TenancyFixtures
+
+
+async def _set_studies_active(db: AsyncSession, *studies: Study) -> None:
+    """Some export endpoints accept any state; others gate on it. We make
+    both studies active so endpoint-level state checks don't preempt the
+    cross-tenant assertion."""
+    for s in studies:
+        s.state = StudyState.active
+        db.add(s)
+    await db.commit()
+
+
+@pytest.mark.asyncio
+class TestExportFilterCorrectness:
+    """Bulk export queries scope by study_id and ignore body/header tenant claims."""
+
+    async def test_participant_json_export_rejects_cross_study_id(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+        db: AsyncSession,
+    ) -> None:
+        """Passing study_in_a's slug + participant_in_b's id must 404.
+
+        This is the in-Python-filter case (exports.py:229-256). Even
+        though the caller has editor permission on study_in_a, the
+        underlying dump is already SQL-scoped to study_in_a, so
+        ``participant_in_b.id`` cannot be found in the dump.
+        """
+        await _set_studies_active(db, tenancy.study_in_a, tenancy.study_in_b)
+
+        response = await client.get(
+            f"/api/admin/studies/{tenancy.study_in_a.slug}/participants/"
+            f"{tenancy.participant_in_b.id}/export/json",
+            headers={"Authorization": f"Bearer {tenancy.token_a_owner}"},
+        )
+        assert response.status_code == 404, (
+            "Cross-study participant_id on legitimate study slug must 404; "
+            f"got {response.status_code} body={response.text!r}"
+        )
+
+    async def test_participant_csv_export_rejects_cross_study_id(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+        db: AsyncSession,
+    ) -> None:
+        """SQL-level defence-in-depth: participant_csv has
+        ``WHERE Participant.id == participant_id AND Participant.study_id == study.id``."""
+        await _set_studies_active(db, tenancy.study_in_a, tenancy.study_in_b)
+
+        response = await client.get(
+            f"/api/admin/studies/{tenancy.study_in_a.slug}/participants/"
+            f"{tenancy.participant_in_b.id}/export/csv",
+            headers={"Authorization": f"Bearer {tenancy.token_a_owner}"},
+        )
+        assert response.status_code == 404, (
+            f"Cross-study participant CSV must 404; got {response.status_code}"
+        )
+
+    async def test_participant_audio_export_rejects_cross_study_id(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+        db: AsyncSession,
+    ) -> None:
+        """Audio export is the highest-impact leak (raw audio files)."""
+        await _set_studies_active(db, tenancy.study_in_a, tenancy.study_in_b)
+
+        response = await client.get(
+            f"/api/admin/studies/{tenancy.study_in_a.slug}/participants/"
+            f"{tenancy.participant_in_b.id}/export/audio",
+            headers={"Authorization": f"Bearer {tenancy.token_a_owner}"},
+        )
+        assert response.status_code == 404, (
+            f"Cross-study participant audio must 404; got {response.status_code}"
+        )
+
+    async def test_full_dump_service_only_returns_target_study_participants(
+        self,
+        tenancy: TenancyFixtures,
+        db: AsyncSession,
+    ) -> None:
+        """Direct service-level check: ``get_study_full_dump(study_a.id)``
+        contains no participant from study_b.
+
+        This is the foundation the in-Python participant_json filter
+        relies on. If the service ever returns participants from other
+        studies, every consumer leaks.
+        """
+        dump_a = await StudyDataService.get_study_full_dump(db, tenancy.study_in_a.id)
+        ids_in_dump = {p["db_id"] for p in dump_a["participants"]}
+        assert tenancy.participant_in_b.id not in ids_in_dump, (
+            "get_study_full_dump leaks participants across studies — "
+            f"got {ids_in_dump}, study_b participant id is {tenancy.participant_in_b.id}"
+        )
+
+        # Symmetric check.
+        dump_b = await StudyDataService.get_study_full_dump(db, tenancy.study_in_b.id)
+        ids_in_dump_b = {p["db_id"] for p in dump_b["participants"]}
+        assert tenancy.participant_in_a.id not in ids_in_dump_b
+
+    async def test_csv_export_ignores_unknown_query_params(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+        db: AsyncSession,
+    ) -> None:
+        """Extra query params (e.g. ``?study_id=X``, ``?project_id=Y``)
+        must not influence the result — FastAPI ignores unknown params,
+        but we pin the behaviour to catch a future signature change that
+        adds a tenant-claim parameter to the route.
+        """
+        await _set_studies_active(db, tenancy.study_in_a, tenancy.study_in_b)
+
+        response = await client.get(
+            f"/api/admin/studies/{tenancy.study_in_a.slug}/export/csv",
+            params={
+                "study_id": tenancy.study_in_b.id,
+                "project_id": tenancy.project_b.id,
+            },
+            headers={"Authorization": f"Bearer {tenancy.token_a_owner}"},
+        )
+        # Either 200 (got study_a's CSV) or 404 (slug not found / no
+        # data) — but never an A-export containing study_b's data. We
+        # also assert the filename in the Content-Disposition is for
+        # study_a, not study_b.
+        assert response.status_code == 200, (
+            f"CSV export of own study must succeed; got {response.status_code}"
+        )
+        cd = response.headers.get("content-disposition", "")
+        assert tenancy.study_in_a.slug in cd, (
+            "CSV filename must reflect the path-derived study slug; "
+            f"got Content-Disposition: {cd!r}"
+        )
+        assert tenancy.study_in_b.slug not in cd, (
+            "Body-supplied study_id must not influence the export filename — "
+            f"got Content-Disposition: {cd!r}"
+        )

--- a/backend/tests/security/wave_3/test_quota_concurrency.py
+++ b/backend/tests/security/wave_3/test_quota_concurrency.py
@@ -1,0 +1,177 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Wave 3 Task 9 — Quota state under concurrent member-add.
+
+The member quota check at
+``app.services.quotas.assert_can_add_member`` (and the symmetric
+``assert_can_create_owned_project``) follows the canonical
+check-then-insert pattern:
+
+1. ``SELECT COUNT(*) FROM project_members WHERE project_id = X``
+2. If count >= limit: raise QuotaExceeded.
+3. Caller inserts a new ProjectMember row.
+
+There is **no row-level lock** between steps 1 and 3:
+
+- No ``with_for_update()`` on the count query.
+- No advisory lock (``pg_advisory_xact_lock``) on the project id.
+- No serialisable isolation level escalation.
+
+Two concurrent invitation-accepts on the same project, both running
+when ``count = limit - 1``, both observe ``count - 1`` in step 1 and
+both pass step 2; both inserts then commit and the project lands at
+``count = limit + 1``. This is a classic TOCTOU race.
+
+**Severity: minor.** The quota cap on Qualis is configured per-deployment
+(``MAX_MEMBERS_PER_PROJECT`` defaults to ``0`` which means unlimited)
+and is not billing- or licensing-relevant for the open-source
+deployment. The race over-fills by 1 per concurrent burst, which is
+recoverable (the operator can remove the extra member). The fix —
+either ``SELECT … FOR UPDATE`` on a project-level lock row, or a partial
+unique index that caps the row count — is out of scope for Wave 3 and
+deferred to the backlog (Task 10).
+
+**Concurrency simulation note.** The in-process httpx test client
+serialises through a single ``AsyncSession`` (the ``db`` fixture); we
+cannot simulate true PostgreSQL concurrency from inside one test. We
+therefore document the TOCTOU pattern via static-analysis assertions
+and an *interleaved-count* simulation that demonstrates the race
+window without actually firing concurrent connections.
+
+Status: filed as F-04-006 (minor — quota TOCTOU, no row-level lock).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ProjectMember, ProjectRole
+from app.services import quotas
+
+from .conftest import TenancyFixtures
+
+
+class TestQuotaTOCTOU:
+    """Static + behavioural evidence for the quota TOCTOU race."""
+
+    def test_count_helper_does_not_lock_rows(self) -> None:
+        """``_count_members`` must NOT use ``with_for_update`` today.
+
+        This is a deliberately negative pin: it documents the *current*
+        behaviour. When the race is fixed (e.g. by moving the check
+        into a SELECT … FOR UPDATE on a sentinel row), this test must
+        be flipped to assert the new locking semantics — that's the
+        signal the fix landed.
+        """
+        source = inspect.getsource(quotas._count_members)
+        assert "with_for_update" not in source, (
+            "If with_for_update has been added to _count_members, the TOCTOU "
+            "fix has landed — flip this assertion and update F-04-006."
+        )
+        assert "advisory" not in source.lower(), (
+            "If an advisory lock has been added, flip this assertion."
+        )
+
+    def test_assert_can_add_member_uses_unguarded_count(self) -> None:
+        """Source of ``assert_can_add_member`` must call ``_count_members``
+        without surrounding lock acquisition. Pinned to catch any
+        accidental rewrite that only changes a comment but leaves the
+        race in place.
+        """
+        source = inspect.getsource(quotas.assert_can_add_member)
+        assert "_count_members" in source
+        assert "with_for_update" not in source
+        assert "advisory" not in source.lower()
+
+    @pytest.mark.asyncio
+    async def test_interleaved_counts_demonstrate_race_window(
+        self,
+        tenancy: TenancyFixtures,
+        db: AsyncSession,
+    ) -> None:
+        """Demonstrate the race window without firing concurrent connections.
+
+        We seed the project to exactly ``limit - 1`` members (3 already
+        from the fixture; we set the in-test limit to 4). Two
+        sequential calls to ``_count_members`` in quick succession both
+        observe ``count = 3``, which would let two adds slip through
+        in the real concurrent case. The point of this test is not to
+        fail (it asserts the unsafe behaviour holds) but to make the
+        race visible and to break loud if a future commit accidentally
+        introduces a side effect.
+        """
+        # Capture the count twice without an intervening insert.
+        count_1 = await quotas._count_members(db, tenancy.project_a.id)
+        count_2 = await quotas._count_members(db, tenancy.project_a.id)
+        assert count_1 == count_2 == 3, (
+            f"Fixture seeds 3 project_a members; saw {count_1}, {count_2}"
+        )
+
+        # Now insert a fourth member directly via the ORM (mimicking the
+        # second leg of one of the racing requests).
+        from app.models import User
+
+        # Create an extra user we can add to the project.
+        from datetime import datetime, timezone
+        from app.utils.security import get_password_hash
+
+        extra_user = User(
+            email="extra-quota-test@example.com",
+            hashed_password=get_password_hash("pw"),
+            email_verified_at=datetime.now(timezone.utc),
+        )
+        db.add(extra_user)
+        await db.flush()
+        db.add(
+            ProjectMember(
+                project_id=tenancy.project_a.id,
+                user_id=extra_user.id,
+                role=ProjectRole.member,
+            )
+        )
+        await db.commit()
+
+        # Now an immediate re-count sees 4 — but the *cached* count_1/count_2
+        # from before the insert was 3. In a real concurrent race, both
+        # branches would have already passed the check on count_1 = 3
+        # against limit = 4 and would both insert, ending at 5.
+        count_after = await quotas._count_members(db, tenancy.project_a.id)
+        assert count_after == 4
+
+        # The race-window demonstration: the gap between count_1 and
+        # count_after is the window in which a second concurrent
+        # request would also see ``count_1`` and pass the check.
+        # No DB-level constraint stops a 5th insert.
+
+    def test_db_has_no_uniqueness_constraint_capping_member_count(self) -> None:
+        """Belt-and-suspenders: ProjectMember has only a (project_id, user_id)
+        unique constraint — no row-count cap at the DB layer.
+
+        If a future schema change adds a partial-unique-index quota cap,
+        flip this assertion.
+        """
+        from app.models import ProjectMember as PM
+
+        constraints = {c.name for c in PM.__table__.constraints}
+        # The (project_id, user_id) uniqueness is fine — that's what
+        # prevents double-membership. A row-count cap would have to be
+        # implemented as a CHECK or trigger or an external counter.
+        assert not any("count" in (c or "").lower() for c in constraints), (
+            "If a count-capping constraint has been added, the TOCTOU race "
+            "has been fixed at the DB layer. Update F-04-006."
+        )
+
+    def test_owned_project_quota_uses_same_unguarded_pattern(self) -> None:
+        """Symmetric finding: ``assert_can_create_owned_project`` has the
+        same race shape (per-user owned-project count). Pinned so the
+        finding stays comprehensive.
+        """
+        source = inspect.getsource(quotas.assert_can_create_owned_project)
+        assert "_count_owned_projects" in source
+        assert "with_for_update" not in source
+        assert "advisory" not in source.lower()

--- a/backend/tests/security/wave_3/test_recruitment_token_replay.py
+++ b/backend/tests/security/wave_3/test_recruitment_token_replay.py
@@ -1,0 +1,80 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Wave 3 Task 5 — Recruitment-token replay across studies.
+
+A recruitment token issued for Study A must not be replayable against
+Study B, even when both studies live under the same tenant or different
+tenants. The token-validation chain in
+:func:`app.services.recruitment_service.RecruitmentService.validate_link_token`
+explicitly checks ``link.study_id != study_id`` and returns ``None`` on
+mismatch, so the participant-facing handler raises 403.
+
+This regression guard pins that behaviour: it issues a real link for
+Study A, then attempts to use it on Study B's ``GET /api/study/{slug}``
+endpoint and asserts a 403 denial.
+
+Status: filed as F-04-002 (observation — the cross-study check exists
+and is correct).
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import TenancyFixtures
+
+
+@pytest.mark.asyncio
+class TestRecruitmentTokenReplay:
+    """Recruitment tokens are scoped to the issuing study."""
+
+    async def test_token_for_study_a_rejected_on_study_b(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+    ) -> None:
+        """Token issued for study_in_a must be rejected on study_in_b's URL."""
+        token = tenancy.recruitment_link_in_a.token
+
+        # Sanity: the token works against its own study (study_in_a).
+        # The handler returns 200 even if the link is valid, regardless of
+        # study state — the link-token branch only rejects with 403 on
+        # invalid/mismatched/expired tokens.
+        own_response = await client.get(
+            f"/api/study/{tenancy.study_in_a.slug}",
+            params={"link_token": token},
+        )
+        assert own_response.status_code == 200, (
+            f"Token must be accepted on its own study; got {own_response.status_code}"
+        )
+
+        # Cross-study replay: same token, study_in_b's slug.
+        replay_response = await client.get(
+            f"/api/study/{tenancy.study_in_b.slug}",
+            params={"link_token": token},
+        )
+        assert replay_response.status_code == 403, (
+            "Cross-study token replay must be rejected with 403; "
+            f"got {replay_response.status_code} body={replay_response.text!r}"
+        )
+        assert "recruitment link" in replay_response.text.lower()
+
+    async def test_token_for_study_b_rejected_on_study_a(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+    ) -> None:
+        """Symmetric guard: token issued for study_in_b rejected on study_in_a."""
+        token = tenancy.recruitment_link_in_b.token
+
+        replay_response = await client.get(
+            f"/api/study/{tenancy.study_in_a.slug}",
+            params={"link_token": token},
+        )
+        assert replay_response.status_code == 403, (
+            "Cross-study token replay (B→A) must be rejected with 403; "
+            f"got {replay_response.status_code} body={replay_response.text!r}"
+        )

--- a/backend/tests/security/wave_3/test_resume_code_scoping.py
+++ b/backend/tests/security/wave_3/test_resume_code_scoping.py
@@ -1,0 +1,161 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Wave 3 Task 7 — Resume-code lookup scoping.
+
+Resume codes are short, memorable strings (~9M combinations of
+``adjective-noun-NNN`` per language). They are generated globally
+unique in the DB (``app.resume_codes.generate_unique_resume_code``
+checks ``Participant.resume_code == code`` without a study filter).
+
+The risk would be if the *lookup* — at
+``GET /api/study/{slug}/resume/{code}`` — also ran a study-agnostic
+``WHERE resume_code = :code`` query. An attacker who controlled a
+study could harvest resume codes from participants of unrelated
+studies.
+
+The actual lookup
+(``backend/app/routers/participants.py:152-189``) joins
+``Participant`` to ``Study`` and filters
+``Participant.resume_code == code AND Study.slug == slug``. The
+study-scoping makes cross-study harvesting impossible: even if Bob
+guesses a valid code that belongs to a participant in study B, hitting
+``GET /api/study/study-a-slug/resume/CODE`` joins on the wrong study
+slug and returns 404.
+
+Status: filed as F-04-004 (observation — lookup is study-scoped).
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+from .conftest import TenancyFixtures
+
+
+@pytest.mark.asyncio
+class TestResumeCodeScoping:
+    """Resume-code lookup must filter by study, not just by code."""
+
+    async def test_code_for_study_a_not_resolvable_via_study_b_url(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+        db: AsyncSession,
+    ) -> None:
+        """A resume code for participant_in_a, looked up via study_b's URL, must 404."""
+        # Set a known resume code on participant_in_a so we can query it.
+        # The fixture creates the participant without a code; that's the
+        # normal path (codes are minted on first save_draft / submit).
+        known_code = "brave-tiger-427"
+        tenancy.participant_in_a.resume_code = known_code
+        db.add(tenancy.participant_in_a)
+        await db.commit()
+
+        # Sanity: the code resolves on its own study URL.
+        own_study_response = await client.get(
+            f"/api/study/{tenancy.study_in_a.slug}/resume/{known_code}"
+        )
+        # Could be 200 (active) or 403 (draft state) — but never 404.
+        assert own_study_response.status_code != 404, (
+            f"Code must resolve on its own study; got {own_study_response.status_code}"
+        )
+
+        # Cross-study lookup: same code on study_b's URL must 404.
+        cross_response = await client.get(
+            f"/api/study/{tenancy.study_in_b.slug}/resume/{known_code}"
+        )
+        assert cross_response.status_code == 404, (
+            "Cross-study resume-code lookup must 404 (study slug filter); "
+            f"got {cross_response.status_code} body={cross_response.text!r}"
+        )
+
+    async def test_codes_unique_globally_but_lookup_is_scoped(
+        self,
+        tenancy: TenancyFixtures,
+        client: AsyncClient,
+        db: AsyncSession,
+    ) -> None:
+        """Even if two participants in different studies *somehow* shared a code
+        (current generator prevents it, but DB constraints don't), the lookup
+        would still scope by study slug — so each study would only ever see
+        its own participant.
+
+        We don't actually share a code (DB has a unique constraint on
+        Participant.resume_code), but we verify the symmetric direction:
+        a code on participant_in_b is not resolvable via study_a's URL.
+        """
+        known_code = "wise-owl-123"
+        tenancy.participant_in_b.resume_code = known_code
+        db.add(tenancy.participant_in_b)
+        await db.commit()
+
+        cross_response = await client.get(
+            f"/api/study/{tenancy.study_in_a.slug}/resume/{known_code}"
+        )
+        assert cross_response.status_code == 404, (
+            "Symmetric cross-study lookup (B→A) must 404; "
+            f"got {cross_response.status_code} body={cross_response.text!r}"
+        )
+
+        # Sanity: still resolves on its own study.
+        own_response = await client.get(
+            f"/api/study/{tenancy.study_in_b.slug}/resume/{known_code}"
+        )
+        assert own_response.status_code != 404, (
+            f"Code must resolve on its own study; got {own_response.status_code}"
+        )
+
+    async def test_lookup_query_filters_on_study_slug(self) -> None:
+        """Static check: the resume_session handler's query must include
+        ``Study.slug == slug`` in its WHERE clause. We verify by reading
+        the source — this is the canonical guard against a future refactor
+        that drops the study filter."""
+        import inspect
+
+        from app.routers.participants import resume_session
+
+        source = inspect.getsource(resume_session)
+        assert "Study.slug == slug" in source, (
+            "resume_session handler must filter on Study.slug == slug; "
+            "without it, resume codes become a global enumeration oracle. "
+            "Source preview:\n" + source[:500]
+        )
+
+    async def test_unrelated_participant_table_lookups_remain_scoped(
+        self, db: AsyncSession
+    ) -> None:
+        """Belt-and-suspenders: the only ORM places that look up by
+        ``resume_code`` are the resume handler (study-scoped) and the
+        uniqueness probe in ``generate_unique_resume_code``. Pin that
+        no other code path does ``Participant.resume_code == X`` without
+        a join.
+
+        We can't enforce this with a runtime test, so we read the source
+        in the relevant modules and assert no rogue patterns exist.
+        """
+        import inspect
+
+        from app.services import study_data_service, submission_service
+
+        # Pattern is fine in:
+        #   - resume_codes.generate_unique_resume_code (uniqueness probe; not a lookup)
+        #   - participants.resume_session (joined to Study)
+        #
+        # Forbidden anywhere else.
+        for module in (study_data_service, submission_service):
+            source = inspect.getsource(module)
+            # We accept ``participant.resume_code = ...`` (assignment) but
+            # reject ``Participant.resume_code ==`` (filter) without a
+            # study join.
+            if "Participant.resume_code ==" in source:
+                # Verify the filter is in a query that also joins Study.
+                # If not, that's a finding.
+                assert "Study" in source, (
+                    f"{module.__name__} filters on Participant.resume_code "
+                    "without a Study join — potential cross-study leak"
+                )

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -279,7 +279,7 @@ mechanism. Filed as **F-04-001** below.
 | blocker | 0 |
 | major | 0 |
 | minor | 0 |
-| observation | 2 |
+| observation | 3 |
 
 ## Findings
 
@@ -326,6 +326,35 @@ slug. A cross-study replay therefore fails token validation and the handler
 raises 403 "Invalid, expired, or full recruitment link". The regression test
 exercises both directions (A→B and B→A) and pins the 403 denial, plus a
 sanity 200 on the legitimate own-study path.
+
+### F-04-003 — Audio upload ownership claim integrity (observation)
+
+**Severity:** observation
+**Status:** safe — participant identity is session-token-derived; no body claim
+**Files:** `backend/app/routers/audio.py:89-231`,
+          `backend/app/services/storage_service.py:94-175`,
+          `backend/tests/security/wave_3/test_audio_upload_ownership.py`
+**Disposition:** false positive — the upload endpoint accepts no
+`participant_id` parameter; ownership is bound to the form-supplied
+`session_token` UUID.
+
+Concern: if `participant_id` were body-derived (or otherwise
+attacker-controllable), an upload could be smuggled into another
+participant's row.
+
+Reality: `POST /api/audio/upload` accepts `(file, session_token,
+question_key, duration_seconds)` only. The `participant` object is
+fetched via `Participant.session_token == session_token` join (audio.py:124),
+which is itself the participant's authentication credential. The companion
+endpoints (`DELETE /api/audio/{id}` and `GET /api/audio/{id}/url`) verify
+`participant.session_token == session_token` after a join from the
+`recording → participant` row; mismatched tokens get 403. The S3 key format
+(`audio/{study_slug}/{participant_token}/...`) leaks no cross-tenant
+information because the participant_token is itself a 128-bit UUID and the
+key is never exposed without auth (presigned URLs are minted in-handler
+after the session-token check). The regression test pins the no-`participant_id`
+signature plus the 403 behaviour on cross-participant delete and presigned-URL
+fetch.
 
 ## Resolved since prior
 

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -279,7 +279,7 @@ mechanism. Filed as **F-04-001** below.
 | blocker | 0 |
 | major | 0 |
 | minor | 0 |
-| observation | 3 |
+| observation | 4 |
 
 ## Findings
 
@@ -355,6 +355,34 @@ key is never exposed without auth (presigned URLs are minted in-handler
 after the session-token check). The regression test pins the no-`participant_id`
 signature plus the 403 behaviour on cross-participant delete and presigned-URL
 fetch.
+
+### F-04-004 — Resume-code lookup is study-scoped (observation)
+
+**Severity:** observation
+**Status:** safe — lookup query joins on `Study.slug == slug`
+**Files:** `backend/app/routers/participants.py:152-189`,
+          `backend/app/resume_codes.py:649-680`,
+          `backend/tests/security/wave_3/test_resume_code_scoping.py`
+**Disposition:** false positive — even though codes are globally unique
+in the DB, the lookup at `GET /api/study/{slug}/resume/{code}` filters
+on both code AND study slug.
+
+Concern: resume codes are short (~9M `adjective-noun-NNN` combinations
+per language). A globally unguarded lookup
+(`WHERE resume_code = :code`) would let an attacker harvest codes
+belonging to participants of arbitrary studies — short codes plus a
+rate-limited brute-force become realistic over a few thousand requests.
+
+Reality: the resume handler joins `Participant` to `Study` and filters
+`Participant.resume_code == code AND Study.slug == slug`. Cross-study
+lookups return 404 even when the code is valid in some other study —
+the URL contributes the slug, and there is no global enumeration oracle.
+The uniqueness probe in `generate_unique_resume_code` is global by
+necessity (it has to pick a DB-unique code), but it's not a lookup oracle:
+it tells the *caller* whether the code is taken, never the participant.
+The regression test exercises both directions plus a static check that the
+handler source still contains `Study.slug == slug` — a future refactor that
+drops the join would break the test.
 
 ## Resolved since prior
 

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -156,7 +156,121 @@ Prior bug it patched. The `researcher`/`member` rename is mostly cosmetic — wh
 
 ### Cross-tenant access matrix
 
-_Filled by Task 3 after running the parametrised IDOR harness._
+**Harness:** `backend/tests/security/wave_3/test_admin_idor_harness.py`
+**Run at commit:** `76aa9804`
+**Wall-clock:** 210s (3m 30s) for 82 parametrised cases + 1 coverage assertion.
+**Result:** 82 passed / 0 failed (out of 89 inventory routes; 7 not applicable, see below).
+
+Each row sends a request as Bob (project-A member) targeting a project-B object id (or
+`X-Project-ID` header). The expected response is a 403 (header-based dependency) or
+404 (slug-based dependency, existence-disclosure-collapsed). The harness records the
+actual status; any value outside the expected set is a finding for Task 4.
+
+| # | Method | Path template | Pattern | Result | Status set |
+|---|---|---|---|---|---|
+| 1 | GET | /api/admin/projects/{slug} | A_SLUG | passed | 403/404 |
+| 2 | PATCH | /api/admin/projects/{slug} | A_SLUG | passed | 403/404 |
+| 3 | GET | /api/admin/projects/{slug}/members | A_SLUG | passed | 403/404 |
+| 4 | PATCH | /api/admin/projects/{slug}/members/{user_id} | A_SLUG | passed | 403/404 |
+| 5 | DELETE | /api/admin/projects/{slug}/members/{user_id} | A_SLUG | passed | 403/404 |
+| 6 | DELETE | /api/admin/projects/{slug} | A_SLUG | passed | 403/404 |
+| 7 | POST | /api/admin/projects/{slug}/invitations | A_SLUG | passed | 403/404 |
+| 8 | GET | /api/admin/recruitment/{slug}/links | A_SLUG | passed | 403/404 |
+| 9 | POST | /api/admin/recruitment/{slug}/links | A_SLUG | passed | 403/404 |
+| 10 | DELETE | /api/admin/recruitment/links/{link_id} | B | passed | 403/404 |
+| 11 | GET | /api/admin/concourses/{cid}/memo | B | passed | 403/404 |
+| 12 | GET | /api/admin/studies/{sid}/memo | B | passed | 403/404 |
+| 13 | GET | /api/admin/concourses/{cid}/memo/unread | B | passed | 403/404 |
+| 14 | GET | /api/admin/studies/{sid}/memo/unread | B | passed | 403/404 |
+| 15 | POST | /api/admin/concourses/{cid}/memo/entries | B | passed | 403/404 |
+| 16 | POST | /api/admin/studies/{sid}/memo/entries | B | passed | 403/404 |
+| 17 | PATCH | /api/admin/memo-entries/{eid} | B | passed | 403/404 |
+| 18 | DELETE | /api/admin/memo-entries/{eid} | B | passed | 403/404 |
+| 19 | POST | /api/admin/memo-entries/{eid}/comments | B | passed | 403/404 |
+| 20 | PATCH | /api/admin/memo-comments/{cid} | B | passed | 403/404 |
+| 21 | DELETE | /api/admin/memo-comments/{cid} | B | passed | 403/404 |
+| 22 | POST | /api/admin/memo-comments/{cid}/resolve | B | passed | 403/404 |
+| 23 | POST | /api/admin/memo-comments/{cid}/unresolve | B | passed | 403/404 |
+| 24 | GET | /api/admin/studies/{slug}/participants | A_SLUG | passed | 403/404 |
+| 25 | GET | /api/admin/studies/participants/{participant_id} | B | passed | 403/404 |
+| 26 | PATCH | /api/admin/studies/participants/{participant_id}/discard | B | passed | 403/404 |
+| 27 | DELETE | /api/admin/studies/{slug}/participants | A_SLUG | passed | 403/404 |
+| 28 | DELETE | /api/admin/studies/{slug}/participants/{participant_id}/personal-data | A_SLUG | passed | 403/404 |
+| 29 | GET | /api/admin/studies/{slug}/export/csv | A_SLUG | passed | 403/404 |
+| 30 | GET | /api/admin/studies/{slug}/export/pqmethod | A_SLUG | passed | 403/404 |
+| 31 | GET | /api/admin/studies/{slug}/export/r-kit | A_SLUG | passed | 403/404 |
+| 32 | GET | /api/admin/studies/{slug}/dump | A_SLUG | passed | 403/404 |
+| 33 | GET | /api/admin/studies/{slug}/participants/{participant_id}/export/csv | A_SLUG | passed | 403/404 |
+| 34 | GET | /api/admin/studies/{slug}/participants/{participant_id}/export/json | A_SLUG | passed | 403/404 |
+| 35 | GET | /api/admin/studies/{slug}/participants/{participant_id}/export/audio | A_SLUG | passed | 403/404 |
+| 36 | GET | /api/admin/studies/{slug}/export/package | A_SLUG | passed | 403/404 |
+| 37 | GET | /api/admin/studies/{slug}/data-inventory | A_SLUG | passed | 403/404 |
+| 38 | GET | /api/admin/studies/{slug}/anonymise-preview | A_SLUG | passed | 403/404 |
+| 39 | POST | /api/admin/studies/{slug}/anonymise-bulk | A_SLUG | passed | 403/404 |
+| 40 | POST | /api/admin/studies | A_HEADER | passed | 403/404 |
+| 41 | GET | /api/admin/studies | A_HEADER | passed | 403/404 |
+| 42 | GET | /api/admin/studies/{slug} | A_SLUG | passed | 403/404 |
+| 43 | PATCH | /api/admin/studies/{slug} | A_SLUG | passed | 403/404 |
+| 44 | POST | /api/admin/studies/{slug}/validate | A_SLUG | passed | 403/404 |
+| 45 | POST | /api/admin/studies/{slug}/state | A_SLUG | passed | 403/404 |
+| 46 | POST | /api/admin/studies/{slug}/reset | A_SLUG | passed | 403/404 |
+| 47 | DELETE | /api/admin/studies/{slug} | A_SLUG | passed | 403/404 |
+| 48 | POST | /api/admin/studies/{slug}/import-concourse | A_SLUG | passed | 403/404 |
+| 49 | GET | /api/admin/studies/{slug}/stale-statements | A_SLUG | passed | 403/404 |
+| 50 | POST | /api/admin/studies/{slug}/sync-statement/{statement_id} | A_SLUG | passed | 403/404 |
+| 51 | POST | /api/admin/studies/{slug}/sync-all-stale | A_SLUG | passed | 403/404 |
+| 52 | GET | /api/admin/studies/{slug}/analysis/eigenvalues | A_SLUG | passed | 403/404 |
+| 53 | POST | /api/admin/studies/{slug}/analysis/run | A_SLUG | passed | 403/404 |
+| 54 | POST | /api/admin/studies/{slug}/analysis/preview-range | A_SLUG | passed | 403/404 |
+| 55 | GET | /api/admin/studies/{slug}/analysis/runs | A_SLUG | passed | 403/404 |
+| 56 | GET | /api/admin/studies/{slug}/analysis/runs/{run_id} | A_SLUG | passed | 403/404 |
+| 57 | PATCH | /api/admin/studies/{slug}/analysis/runs/{run_id} | A_SLUG | passed | 403/404 |
+| 58 | DELETE | /api/admin/studies/{slug}/analysis/runs/{run_id} | A_SLUG | passed | 403/404 |
+| 59 | GET | /api/admin/studies/{slug}/analysis/audios | A_SLUG | passed | 403/404 |
+| 60 | GET | /api/admin/studies/{slug}/analysis/comments | A_SLUG | passed | 403/404 |
+| 61 | GET | /api/admin/studies/{slug}/stats | A_SLUG | passed | 403/404 |
+| 62 | GET | /api/admin/studies/{slug}/export/config | A_SLUG | passed | 403/404 |
+| 63 | GET | /api/admin/studies/{slug}/storage-usage | A_SLUG | passed | 403/404 |
+| 64 | GET | /api/admin/concourses/tags | A_HEADER | passed | 403/404 |
+| 65 | POST | /api/admin/concourses/tags | A_HEADER | passed | 403/404 |
+| 66 | DELETE | /api/admin/concourses/tags/{tag_id} | A_HEADER | passed | 403/404 |
+| 67 | POST | /api/admin/concourses | A_HEADER | passed | 403/404 |
+| 68 | GET | /api/admin/concourses | A_HEADER | passed | 403/404 |
+| 69 | GET | /api/admin/concourses/{concourse_id} | A_HEADER | passed | 403/404 |
+| 70 | PATCH | /api/admin/concourses/{concourse_id} | A_HEADER | passed | 403/404 |
+| 71 | DELETE | /api/admin/concourses/{concourse_id} | A_HEADER | passed | 403/404 |
+| 72 | POST | /api/admin/concourses/{concourse_id}/items | A_HEADER | passed | 403/404 |
+| 73 | POST | /api/admin/concourses/{concourse_id}/items/bulk | A_HEADER | passed | 403/404 |
+| 74 | POST | /api/admin/concourses/{concourse_id}/items/import | A_HEADER | passed | 403/404 |
+| 75 | PATCH | /api/admin/concourses/{concourse_id}/items/{item_id} | A_HEADER | passed | 403/404 |
+| 76 | DELETE | /api/admin/concourses/{concourse_id}/items/{item_id} | A_HEADER | passed | 403/404 |
+| 77 | GET | /api/admin/concourses/{concourse_id}/items/{item_id}/versions | A_HEADER | passed | 403/404 |
+| 78 | GET | /api/admin/concourses/{concourse_id}/items/{item_id}/comments | A_HEADER | passed | 403/404 |
+| 79 | POST | /api/admin/concourses/{concourse_id}/items/{item_id}/comments | A_HEADER | passed | 403/404 |
+| 80 | DELETE | /api/admin/users/{user_id} | A_HEADER | passed | 403/404 |
+| 81 | POST | /api/admin/studies/import | A_HEADER | passed | 403/404 |
+| 82 | POST | /api/admin/studies/validate-import | A_HEADER | passed | 403/404 |
+
+**Routes excluded from the cross-tenant harness (7 of 89).** No project-B target id
+exists for these routes; their isolation is asserted elsewhere (filter-by-membership
+clause, superuser gate, or anti-enum semantics).
+
+| Method | Path | Reason |
+|---|---|---|
+| GET | /api/admin/projects | enumeration scoped to caller's memberships (in-handler filter) |
+| POST | /api/admin/projects | creates a new project; no cross-tenant target |
+| GET | /api/admin/invitations/verify | unauthenticated; token-tampering coverage lives in Wave 1 |
+| POST | /api/admin/invitations/accept | auth-only token consumption; token must match caller's email |
+| GET | /api/admin/users | superuser-gated; cross-project N/A |
+| POST | /api/admin/users | superuser-gated; cross-project N/A |
+| GET | /api/admin/memo/templates | static templates; no project scope |
+
+**Outcome.** No cross-tenant leakage detected. The two membership mechanisms
+(`require_project_role` over `X-Project-ID`, and `check_*_permission` over slug) are
+behaving symmetrically and the bespoke inline checks (memos, recruitment-link delete,
+participant-id routes) match the dependency-factory contract. The harness is retained
+as a CI regression guard against future refactors that might silently bypass either
+mechanism. Filed as **F-04-001** below.
 
 ## Summary
 
@@ -165,11 +279,28 @@ _Filled by Task 3 after running the parametrised IDOR harness._
 | blocker | 0 |
 | major | 0 |
 | minor | 0 |
-| observation | 0 |
+| observation | 1 |
 
 ## Findings
 
-_Populated as findings are filed by Tasks 4-9. F-04-NNN ID space._
+### F-04-001 — Cross-tenant IDOR harness clean (observation)
+
+**Severity:** observation
+**Status:** passing (regression guard)
+**Files:** `backend/tests/security/wave_3/test_admin_idor_harness.py`,
+          `backend/tests/security/wave_3/conftest.py`
+
+A parametrised harness over the 89 admin endpoints (82 cross-tenant-applicable + 7
+top-level/superuser/unauth excluded) was implemented and run at commit `76aa9804`.
+All 82 cases asserted that a project-A member, when targeting a project-B object id
+or `X-Project-ID` header, receives a 403 or 404 denial. The harness is now a CI
+regression guard: any future change that breaks one of the two membership
+mechanisms (header-based `require_project_role` or slug-based `check_*_permission`)
+or the bespoke inline checks (memos, recruitment-link delete, participant-id
+routes) will surface here before merge.
+
+This is filed as an observation — not a finding — because nothing is broken; the
+harness's value is preventing future regressions, not fixing an existing leak.
 
 ## Resolved since prior
 

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -18,7 +18,145 @@ No carry-overs from Wave 1 or Wave 2 — fresh ground.
 
 ## Inventory
 
-_Filled by Task 2 (admin endpoint table) and Task 3 (cross-tenant access matrix)._
+### Admin endpoint inventory
+
+89 endpoints across 12 router modules (counted by `grep -cE '@router\.(get|post|put|patch|delete)' backend/app/routers/admin/*.py`).
+
+**Pattern legend:**
+
+- **A — Project-scoped via path or header.** Project membership is verified by a single dependency (`check_project_permission(slug)`, `check_study_permission(slug)`, `require_project_role(role)`, or `get_current_project`). The dependency joins `ProjectMember` against the URL's project/study slug or the `X-Project-ID` header. Cross-tenant leakage is only possible if the dependency itself is broken.
+- **B — Object-scoped via path** (path carries an opaque object id like `{participant_id}`, `{eid}`, `{cid}`, `{tag_id}`, `{link_id}`, `{user_id}` without a co-located project/study slug, or carries `{cid}`/`{sid}` for memos). Handler must look up the object's parent project, then check membership. **Highest-risk pattern.** Each of these warrants per-route harness coverage.
+- **C — Top-level enumeration / global** (`/api/admin/projects` list, `/api/admin/users`, invitation accept/verify, `/admin/memo/templates`, `/api/admin/studies/validate-import`, `/api/admin/studies/import`). Filtering or auth must happen in-handler.
+
+`role_dep` notation: `member+` = member-or-higher (member, owner). `editor+` = StudyRole editor or above (mapped from project member/owner). `superuser` = `check_superuser` only. `auth` = only `get_current_user` runs (membership check is inline).
+
+| Method | Path | Source file:line | Pattern | role_dep | Project-scoping mechanism | Notes |
+|---|---|---|---|---|---|---|
+| GET | /api/admin/projects | projects.py:41 | C | auth | filter `WHERE ProjectMember.user_id = current_user.id` | enumeration scoped to caller's memberships |
+| POST | /api/admin/projects | projects.py:85 | C | auth | new project, owner-quota gated via `assert_can_create_owned_project` | |
+| GET | /api/admin/projects/{slug} | projects.py:159 | A | auth | inline join `Project.slug + ProjectMember.user_id` (404 if no membership) | role used only for response payload |
+| PATCH | /api/admin/projects/{slug} | projects.py:195 | A | owner | `check_project_permission(owner)` | |
+| GET | /api/admin/projects/{slug}/members | projects.py:253 | A | viewer+ | `check_project_permission(viewer)` | |
+| PATCH | /api/admin/projects/{slug}/members/{user_id} | projects.py:286 | A | owner | `check_project_permission(owner)`; rejects `role=owner` (`OWNER_ROLE_IMMUTABLE`) | |
+| DELETE | /api/admin/projects/{slug}/members/{user_id} | projects.py:347 | A | owner | `check_project_permission(owner)` + self-removal guard | |
+| DELETE | /api/admin/projects/{slug} | projects.py:399 | A | owner | `check_project_permission(owner)`; refuses if studies remain | |
+| POST | /api/admin/projects/{slug}/invitations | projects.py:449 | A | owner | `check_project_permission(owner)`; quota-gated (`assert_can_add_member`); rejects `role=owner` | |
+| GET | /api/admin/invitations/verify | invitations.py:18 | C | none | unauthenticated; decodes JWT-ish invitation token | leaks `project_name` if token valid; expected behaviour |
+| POST | /api/admin/invitations/accept | invitations.py:53 | C | auth | token email must equal `current_user.email`; quota-gated | adds caller as member |
+| GET | /api/admin/recruitment/{slug}/links | recruitment.py:22 | A | viewer+ | `check_study_permission(viewer)` | |
+| POST | /api/admin/recruitment/{slug}/links | recruitment.py:31 | A | editor+ | `check_study_permission(editor)` | |
+| DELETE | /api/admin/recruitment/links/{link_id} | recruitment.py:58 | B | editor+ (inline) | inline join `RecruitmentLink → Study → ProjectMember` + ROLE_MAP/STUDY hierarchy check | bespoke inline check; review carefully |
+| GET | /api/concourses/{cid}/memo | memos.py:118 | B | viewer+ | `db.get(Concourse, cid)` then `_check_member(c.project_id, viewer)` | path is `/api/admin/concourses/{cid}/memo` (memos router carries its own `/admin` prefix and is mounted at `/api`) |
+| GET | /api/admin/studies/{sid}/memo | memos.py:136 | B | viewer+ | `db.get(Study, sid)` then `_check_member(s.project_id, viewer)` | sid is **integer id**, not slug — distinct from other studies/{slug} routes |
+| GET | /api/admin/concourses/{cid}/memo/unread | memos.py:154 | B | viewer+ | same as above, plus ISO-8601 cutoff | |
+| GET | /api/admin/studies/{sid}/memo/unread | memos.py:181 | B | viewer+ | same | sid integer id |
+| GET | /api/admin/memo/templates | memos.py:208 | C | auth | none — returns static template list | parent_type query arg only |
+| POST | /api/admin/concourses/{cid}/memo/entries | memos.py:219 | B | member+ | `db.get(Concourse, cid)` then `_check_member(c.project_id, member)` | |
+| POST | /api/admin/studies/{sid}/memo/entries | memos.py:248 | B | member+ | `db.get(Study, sid)` then `_check_member(s.project_id, member)` | sid integer id |
+| PATCH | /api/admin/memo-entries/{eid} | memos.py:277 | B | member+ | `_resolve_entry_parent` walks back to project_id, then `_check_member(member)` | |
+| DELETE | /api/admin/memo-entries/{eid} | memos.py:299 | B | member+ | same | |
+| POST | /api/admin/memo-entries/{eid}/comments | memos.py:315 | B | viewer+ | resolve parent project; `validate_mentions` guards mentioned ids | |
+| PATCH | /api/admin/memo-comments/{cid} | memos.py:352 | B | viewer+ if author else owner | resolve via comment → entry → project | author-vs-moderator branching |
+| DELETE | /api/admin/memo-comments/{cid} | memos.py:371 | B | viewer+ if author else owner | same | soft delete |
+| POST | /api/admin/memo-comments/{cid}/resolve | memos.py:392 | B | member+ if entry author else owner | author-aware role gate | |
+| POST | /api/admin/memo-comments/{cid}/unresolve | memos.py:411 | B | member+ if entry author else owner | same | |
+| GET | /api/admin/studies/{slug}/participants | studies_participants.py:33 | A | viewer+ | `check_study_permission(viewer)` | |
+| GET | /api/admin/studies/participants/{participant_id} | studies_participants.py:62 | B | member+ (inline) | inline join `Participant → Study → ProjectMember` with `role.in_([owner, member])` | mode=mediated; viewer-role members are excluded |
+| PATCH | /api/admin/studies/participants/{participant_id}/discard | studies_participants.py:113 | B | member+ (inline) | inline join, same shape | |
+| DELETE | /api/admin/studies/{slug}/participants | studies_participants.py:158 | A | editor+ | `check_study_permission(editor)`; gated to `state=draft` | |
+| DELETE | /api/admin/studies/{slug}/participants/{participant_id}/personal-data | studies_participants.py:179 | A | editor+ | `check_study_permission(editor)`; verifies `participant.study_id == study.id` | GDPR Art. 17 admin-mediated |
+| GET | /api/admin/studies/{slug}/export/csv | exports.py:34 | A | editor+ | `check_study_permission(editor)` | streams CSV |
+| GET | /api/admin/studies/{slug}/export/pqmethod | exports.py:75 | A | editor+ | `check_study_permission(editor)` | streams ZIP |
+| GET | /api/admin/studies/{slug}/export/r-kit | exports.py:118 | A | editor+ | `check_study_permission(editor)` | |
+| GET | /api/admin/studies/{slug}/dump | exports.py:161 | A | editor+ | `check_study_permission(editor)` | full study JSON dump |
+| GET | /api/admin/studies/{slug}/participants/{participant_id}/export/csv | exports.py:175 | A | editor+ | `check_study_permission(editor)` + `participant.study_id == study.id` | |
+| GET | /api/admin/studies/{slug}/participants/{participant_id}/export/json | exports.py:224 | A | editor+ | full dump filtered by `participant_id`; 404 if not found | filter is in-Python (memory) — confirm |
+| GET | /api/admin/studies/{slug}/participants/{participant_id}/export/audio | exports.py:259 | A | editor+ | `check_study_permission(editor)` + `participant.study_id == study.id`; presigned ZIP | |
+| GET | /api/admin/studies/{slug}/export/package | exports.py:350 | A | editor+ | `check_study_permission(editor)` | full research package ZIP |
+| GET | /api/admin/studies/{slug}/data-inventory | lifecycle.py:121 | A | viewer+ | `check_study_permission(viewer)` | |
+| GET | /api/admin/studies/{slug}/anonymise-preview | lifecycle.py:225 | A | viewer+ | `check_study_permission(viewer)` | |
+| POST | /api/admin/studies/{slug}/anonymise-bulk | lifecycle.py:253 | A | editor+ | `check_study_permission(editor)` | mutates participant PII |
+| POST | /api/admin/studies | studies.py:46 | A | member+ | `require_project_role(member)` (X-Project-ID header) | creates study in active project |
+| GET | /api/admin/studies | studies.py:64 | A | auth (header) | `get_current_project` (X-Project-ID); filter `Study.project_id = project.id` | |
+| GET | /api/admin/studies/{slug} | studies.py:97 | A | viewer+ | `check_study_permission(viewer)` | |
+| PATCH | /api/admin/studies/{slug} | studies.py:116 | A | editor+ | `check_study_permission(editor)` | |
+| POST | /api/admin/studies/{slug}/validate | studies.py:148 | A | editor+ | `check_study_permission(editor)` | |
+| POST | /api/admin/studies/{slug}/state | studies.py:163 | A | editor+ | `check_study_permission(editor)` | |
+| POST | /api/admin/studies/{slug}/reset | studies.py:218 | A | owner | `check_study_permission(owner)` | wipes participants |
+| DELETE | /api/admin/studies/{slug} | studies.py:240 | A | owner + superuser | `check_study_permission(owner)` AND `current_user.is_superuser` | requires archived state |
+| POST | /api/admin/studies/{slug}/import-concourse | studies.py:282 | A | editor+ | `check_study_permission(editor)` | |
+| GET | /api/admin/studies/{slug}/stale-statements | studies.py:297 | A | editor+ | `check_study_permission(editor)` | |
+| POST | /api/admin/studies/{slug}/sync-statement/{statement_id} | studies.py:309 | A | editor+ | `check_study_permission(editor)` | concourse-sourced text sync |
+| POST | /api/admin/studies/{slug}/sync-all-stale | studies.py:337 | A | editor+ | `check_study_permission(editor)` | |
+| GET | /api/admin/studies/{slug}/analysis/eigenvalues | analysis.py:98 | A | viewer+ | `check_study_permission(viewer)` | |
+| POST | /api/admin/studies/{slug}/analysis/run | analysis.py:137 | A | editor+ | `check_study_permission(editor)` | persists AnalysisRun |
+| POST | /api/admin/studies/{slug}/analysis/preview-range | analysis.py:403 | A | viewer+ | `check_study_permission(viewer)` | |
+| GET | /api/admin/studies/{slug}/analysis/runs | analysis.py:509 | A | viewer+ | `check_study_permission(viewer)`; filter `AnalysisRun.study_id == study.id` | |
+| GET | /api/admin/studies/{slug}/analysis/runs/{run_id} | analysis.py:526 | A | viewer+ | `_load_run` filters `AnalysisRun.study_id == study.id` | path carries study slug, not just run_id |
+| PATCH | /api/admin/studies/{slug}/analysis/runs/{run_id} | analysis.py:551 | A | editor+ | same | |
+| DELETE | /api/admin/studies/{slug}/analysis/runs/{run_id} | analysis.py:597 | A | editor+ | same | |
+| GET | /api/admin/studies/{slug}/analysis/audios | analysis.py:622 | A | viewer+ | `check_study_permission(viewer)` + `Participant.study_id == study.id` filter on input ids | participant-id stuffing defended-in-depth |
+| GET | /api/admin/studies/{slug}/analysis/comments | analysis.py:723 | A | viewer+ | same | |
+| GET | /api/admin/studies/{slug}/stats | studies_import_export.py:52 | A | viewer+ | `check_study_permission(viewer)` | |
+| GET | /api/admin/studies/{slug}/export/config | studies_import_export.py:69 | A | viewer+ | `check_study_permission(viewer)` | study JSON config (no participant data) |
+| POST | /api/admin/studies/validate-import | studies_import_export.py:388 | C | auth (header) | `get_current_project` (membership only); pure validation, no DB write | |
+| POST | /api/admin/studies/import | studies_import_export.py:479 | C | member+ | `require_project_role(member)` (X-Project-ID); creates study in caller's project | new study lands in header-named project |
+| GET | /api/admin/studies/{slug}/storage-usage | studies_import_export.py:601 | A | viewer+ | `check_study_permission(viewer)` | |
+| GET | /api/admin/concourses/tags | concourses.py:56 | A | auth (header) | `get_current_project` filter by `project.id` | |
+| POST | /api/admin/concourses/tags | concourses.py:65 | A | member+ | `require_project_role(member)` | |
+| DELETE | /api/admin/concourses/tags/{tag_id} | concourses.py:83 | B | member+ | `require_project_role(member)` + service does `project_id` filter on the tag | tag_id is opaque; service guards |
+| POST | /api/admin/concourses | concourses.py:103 | A | member+ | `require_project_role(member)` (creates concourse in header project) | |
+| GET | /api/admin/concourses | concourses.py:130 | A | auth (header) | `get_current_project`; filter `Concourse.project_id = project.id` | |
+| GET | /api/admin/concourses/{concourse_id} | concourses.py:161 | B | auth (header) | `get_current_project` + explicit `if concourse.project_id != project.id: 404` | guard-after-fetch shape |
+| PATCH | /api/admin/concourses/{concourse_id} | concourses.py:183 | B | member+ | `require_project_role(member)` + service `update_concourse(project.id, concourse_id, ...)` | service is responsible for the cross-check |
+| DELETE | /api/admin/concourses/{concourse_id} | concourses.py:198 | B | owner | `require_project_role(owner)` + explicit `if concourse.project_id != project.id: 404` | |
+| POST | /api/admin/concourses/{concourse_id}/items | concourses.py:223 | B | member+ | `require_project_role(member)` + `_verify_concourse_ownership` | |
+| POST | /api/admin/concourses/{concourse_id}/items/bulk | concourses.py:244 | B | member+ | same | |
+| POST | /api/admin/concourses/{concourse_id}/items/import | concourses.py:267 | B | member+ | same | |
+| PATCH | /api/admin/concourses/{concourse_id}/items/{item_id} | concourses.py:290 | B | member+ | `require_project_role(member)` + `_verify_concourse_ownership` | |
+| DELETE | /api/admin/concourses/{concourse_id}/items/{item_id} | concourses.py:313 | B | member+ | same | |
+| GET | /api/admin/concourses/{concourse_id}/items/{item_id}/versions | concourses.py:338 | B | auth (header) | `get_current_project` + `_verify_concourse_ownership` + `_verify_item_ownership` | |
+| GET | /api/admin/concourses/{concourse_id}/items/{item_id}/comments | concourses.py:357 | B | auth (header) | same | |
+| POST | /api/admin/concourses/{concourse_id}/items/{item_id}/comments | concourses.py:376 | B | member+ | `require_project_role(member)` + ownership verifies | |
+| GET | /api/admin/users | users.py:21 | C | superuser | `check_superuser` only; lists all users | superuser-gated; no project scope |
+| POST | /api/admin/users | users.py:45 | C | superuser | `check_superuser` only | superuser-gated |
+| DELETE | /api/admin/users/{user_id} | users.py:82 | C | superuser | `check_superuser` + self-deletion guard | |
+
+**Pattern totals:** 51 type-A, 28 type-B, 10 type-C. Total: 89. No endpoints flagged as unfit.
+
+### Membership machinery
+
+`require_project_role(role)` (`backend/app/dependencies.py:170-193`) is a dependency factory that delegates to `get_current_project` (lines 94-133). `get_current_project` reads the **`X-Project-ID` header**, parses it as an integer, and queries `(Project, ProjectMember)` joined where `Project.id = X-Project-ID AND ProjectMember.user_id = current_user.id`. Missing header → 400; non-integer → 400; no membership row → 403 "Access to this project is denied". The returned `(Project, ProjectMember)` tuple is then handed to `require_project_role`, which compares the member's role against `PROJECT_ROLE_HIERARCHY` and rejects with 403 "Insufficient permissions" if below threshold.
+
+`check_project_permission(role)` (lines 196-239) and `check_study_permission(role)` (lines 242-293) take a different path: they read the **`{slug}`** path parameter directly (project slug or study slug) and run a single inline join against `ProjectMember` keyed on `current_user.id`. Missing row → **404** (not 403) "Project/Study not found or access denied", deliberately collapsing existence-disclosure with permission denial. Role check happens after the row is found, returning 403. `check_study_permission` additionally maps `ProjectRole → StudyRole` via the constant `ROLE_MAP` (`owner→owner, member→editor, viewer→viewer`) and uses `STUDY_ROLE_HIERARCHY` (numeric weights `30/20/10`).
+
+Role hierarchies (`dependencies.py:138-155`):
+
+- `PROJECT_ROLE_HIERARCHY = {owner: 40, member: 20, viewer: 10}`
+- `STUDY_ROLE_HIERARCHY = {owner: 30, editor: 20, viewer: 10}`
+- `ROLE_MAP = {ProjectRole.owner: StudyRole.owner, ProjectRole.member: StudyRole.editor, ProjectRole.viewer: StudyRole.viewer}`
+
+**Short-circuits.** No global super-admin bypass for project/study membership: `is_superuser` is checked only in `check_superuser` (`/api/admin/users` and `DELETE /api/admin/studies/{slug}` overlay) and in the import-export verifier. A superuser **without** project membership cannot reach project/study admin endpoints — confirmed by reading every dependency.
+
+**`password_changed_at` check (F-03-010 from Wave 2).** Lives in `get_current_user` (`dependencies.py:74-78`): every request decodes the JWT, fetches the user, and compares `int(token_iat) < int(user.password_changed_at.timestamp())`. Tokens minted before the user's last password rotation are rejected with 401. Equality is allowed (false-rejection guard for one-second-resolution clock collisions). This runs for **every** admin endpoint by virtue of being the root dependency of every other dependency in the chain.
+
+**Inline-join routes (Pattern B without a slug).** Five admin endpoints check membership inline rather than via a dependency factory: `GET /participants/{participant_id}`, `PATCH /participants/{participant_id}/discard`, `DELETE /recruitment/links/{link_id}`, the memo endpoints (`/concourses/{cid}/memo*`, `/studies/{sid}/memo*`, `/memo-entries/{eid}*`, `/memo-comments/{cid}*`), and the concourse-id routes that explicitly compare `concourse.project_id != project.id`. Each of these is a Task-3 harness target: harness must verify the bespoke check matches the dependency-factory contract and rejects cross-tenant ids with 403/404.
+
+### Migration cb2c7f6f0cfe
+
+`backend/db_migrations/versions/cb2c7f6f0cfe_rename_researcher_to_member_and_owner_.py` (revision `cb2c7f6f0cfe`, down-revision `fd88287d3f9b`).
+
+What it does:
+
+1. **Pre-flight guard.** Refuses to run if any project has more than one `owner` row in `project_members` — raises `RuntimeError` with the offending `project_id`s. Defence-in-depth in case a bug elsewhere created multiple owners.
+2. **Enum rename.** Recreates the `projectrole` Postgres enum as `{owner, member, viewer}` (dropping `researcher`). Recasts both `project_members.role` and `invitations.role` with `CASE WHEN role = 'researcher' THEN 'member' ELSE role END`. Drops the old enum and renames the new one back to `projectrole`.
+3. **Owner-uniqueness partial unique index.** `CREATE UNIQUE INDEX project_members_one_owner_per_project ON project_members (project_id) WHERE role = 'owner'`. DB-level guarantee that no project ever has two owners.
+
+Prior bug it patched. The `researcher`/`member` rename is mostly cosmetic — what matters is the **owner-uniqueness invariant**. Before the migration, the API enforced "Owner is set at creation, never reassigned" only at the application layer (`OWNER_ROLE_IMMUTABLE` rejection in PATCH/invite endpoints). There was no DB-level safeguard, so a race condition (two simultaneous PATCH requests, or a manual SQL fix-up) could in principle create a project with two owners — duplicating the highest-privilege role. The partial unique index closes that gap. (The design doc — `docs/superpowers/specs/2026-05-02-project-roles-refactor-design.md` §9 — frames this explicitly as defence-in-depth.)
+
+### Cross-tenant access matrix
+
+_Filled by Task 3 after running the parametrised IDOR harness._
 
 ## Summary
 

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -278,7 +278,7 @@ mechanism. Filed as **F-04-001** below.
 |----------|-------|
 | blocker | 0 |
 | major | 0 |
-| minor | 0 |
+| minor | 1 |
 | observation | 5 |
 
 ## Findings
@@ -424,6 +424,57 @@ on JSON / CSV / audio export → 404; `get_study_full_dump` only returns
 target-study participants; extraneous `?study_id=X&project_id=Y` query
 params do not influence CSV export filename or content (verified via
 Content-Disposition).
+
+### F-04-006 — Quota check has TOCTOU race against concurrent member-add (minor)
+
+**Severity:** minor
+**Status:** open — no row-level lock between count and insert
+**Files:** `backend/app/services/quotas.py:32-104`,
+          `backend/app/routers/admin/invitations.py:98-110`,
+          `backend/app/routers/admin/projects.py:105, 449-468`,
+          `backend/tests/security/wave_3/test_quota_concurrency.py`
+
+`assert_can_add_member` and `assert_can_create_owned_project` follow a
+classic check-then-insert pattern with no concurrency guard:
+
+1. `SELECT COUNT(*) FROM project_members WHERE project_id = X` (or
+   `WHERE user_id = U AND role = owner` for owner-quota).
+2. If `count >= limit`: `raise QuotaExceeded`.
+3. Caller inserts the new `ProjectMember` row.
+
+There is no `with_for_update()` on the count query, no advisory lock
+(`pg_advisory_xact_lock`), and no isolation-level escalation. Two
+concurrent invitation-accepts on the same project, both running when
+`count = limit - 1`, both observe `count - 1` in step 1 and both pass
+step 2; both inserts then commit and the project lands at
+`count = limit + 1`.
+
+**Severity rationale.** Configured `MAX_MEMBERS_PER_PROJECT` defaults to
+`0` (unlimited) in `app.core.config`, so deployments that don't set the
+cap are unaffected. For deployments that *do* set the cap, the over-fill
+is bounded by the burst size of concurrent accepts, recoverable
+post-hoc, and not billing-relevant for the open-source codebase. Hence
+**minor**.
+
+**Recommended fix** (deferred to backlog):
+- Either acquire `SELECT … FOR UPDATE` on a project-level sentinel row
+  (e.g. `SELECT id FROM projects WHERE id = X FOR UPDATE` before the
+  count), serialising adds; or
+- Move the cap into a DB-level constraint (a CHECK + computed column,
+  or a trigger), removing the application-layer race entirely.
+
+**Concurrency-simulation caveat.** The in-process httpx test client
+serialises through one shared `AsyncSession` (the `db` fixture); we
+cannot fire true concurrent connections from inside one pytest. The
+finding is therefore based on **static analysis** (the SQL pattern is
+self-evidence) plus an *interleaved-count* in-process simulation that
+makes the race window visible: two consecutive `_count_members` calls
+without an intervening insert both observe the pre-insert count, which
+is the same observation each leg of the real race would make. The
+regression test pins the unguarded source pattern with negative
+assertions (`with_for_update` not in source, `advisory` not in source);
+when the fix lands, those assertions flip to confirm the lock is in
+place.
 
 ## Resolved since prior
 

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -279,7 +279,7 @@ mechanism. Filed as **F-04-001** below.
 | blocker | 0 |
 | major | 0 |
 | minor | 0 |
-| observation | 4 |
+| observation | 5 |
 
 ## Findings
 
@@ -383,6 +383,47 @@ it tells the *caller* whether the code is taken, never the participant.
 The regression test exercises both directions plus a static check that the
 handler source still contains `Study.slug == slug` — a future refactor that
 drops the join would break the test.
+
+### F-04-005 — Bulk-export filter correctness (observation)
+
+**Severity:** observation
+**Status:** safe — every export filters by `study_id` at the SQL level;
+no body- or header-trusted tenant claims accepted
+**Files:** `backend/app/routers/admin/exports.py`,
+          `backend/app/routers/admin/studies_import_export.py`,
+          `backend/app/services/study_data_service.py:214-355`,
+          `backend/tests/security/wave_3/test_export_filter.py`
+**Disposition:** false positive — the cross-tenant IDOR harness already
+covered the path-derived case (Task 3); this task widened the inspection
+to body/header inputs and the in-Python participant-JSON filter.
+
+Concern: an export endpoint that accepts a tenant identifier from the
+body, header, or query string would let a member of one study widen the
+result set to siblings or other tenants entirely, exfiltrating raw
+participant payloads at scale.
+
+Reality:
+- All eight admin export endpoints (CSV, PQMethod, R-Kit, dump,
+  participant CSV/JSON/audio, research package) derive `study.id` from
+  `check_study_permission(StudyRole.editor)` (path-bound). No alternate
+  source of `study_id` is read.
+- All `Participant` queries filter `Participant.study_id == study.id`
+  at the SQL level. The participant-id endpoints additionally pin
+  `Participant.id == participant_id` as defence-in-depth.
+- The single in-Python filter — `export_participant_json` (exports.py:240)
+  — calls `StudyDataService.get_study_full_dump(db, study.id)` and then
+  picks the requested `participant_id` from the returned list. Because
+  the upstream dump is already SQL-scoped to `study.id`, the in-Python
+  filter cannot return a participant from another study. The regression
+  test verifies this directly via service-level call.
+- The only non-path query parameter is `include_discussion: bool` on
+  the research-package endpoint — a boolean toggle, not a tenant claim.
+
+The regression test pins five behaviours: cross-study `participant_id`
+on JSON / CSV / audio export → 404; `get_study_full_dump` only returns
+target-study participants; extraneous `?study_id=X&project_id=Y` query
+params do not influence CSV export filename or content (verified via
+Content-Disposition).
 
 ## Resolved since prior
 

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -157,9 +157,19 @@ Prior bug it patched. The `researcher`/`member` rename is mostly cosmetic — wh
 ### Cross-tenant access matrix
 
 **Harness:** `backend/tests/security/wave_3/test_admin_idor_harness.py`
-**Run at commit:** `76aa9804`
-**Wall-clock:** 210s (3m 30s) for 82 parametrised cases + 1 coverage assertion.
-**Result:** 82 passed / 0 failed (out of 89 inventory routes; 7 not applicable, see below).
+**Run at commit:** `76aa9804` (initial); updated after review feedback #1.
+**Wall-clock:** ~141s for 95 parametrised cases + 1 coverage assertion.
+**Result:** 95 passed / 0 failed (82 original A_HEADER/A_SLUG/B cases + 12 new
+B_VALID_HEADER pin-down cases + 1 coverage assertion; 7 routes not applicable, see below).
+
+**B_VALID_HEADER pattern (added in review feedback #1).** For each `A_HEADER` route
+whose path contains a project-scoped object id (concourse id, item id, or tag id), the
+harness adds a second case that sends a *valid* ``X-Project-ID = project_a.id`` header
+(Bob IS a member of A — dep layer accepts) while putting the foreign B-object id in the
+path. The denial must come from the **inline service guard** (e.g.
+``concourse.project_id != project.id``, ``_verify_concourse_ownership``,
+``ConcourseService.delete_tag`` project filter). 12 routes covered; all 12 pass, pinning
+the guards against future refactors that might silently remove them while keeping the dep.
 
 Each row sends a request as Bob (project-A member) targeting a project-B object id (or
 `X-Project-ID` header). The expected response is a 403 (header-based dependency) or
@@ -298,6 +308,15 @@ regression guard: any future change that breaks one of the two membership
 mechanisms (header-based `require_project_role` or slug-based `check_*_permission`)
 or the bespoke inline checks (memos, recruitment-link delete, participant-id
 routes) will surface here before merge.
+
+**B_VALID_HEADER pattern (added after review feedback #1).** 12 additional pin-down
+cases cover the canonical Pattern-B attack vector: Bob sends a valid
+``X-Project-ID = project_a.id`` (dep layer accepts) but a foreign concourse/item/tag
+id from project B in the path. All 12 cases pass, confirming that the inline service
+guards (`concourse.project_id != project.id`, `_verify_concourse_ownership`,
+`ConcourseService.delete_tag` project filter) provide the second line of defence
+independent of the dep layer. Total harness: 82 original + 12 B_VALID_HEADER = 94
+parametrised cases + 1 coverage assertion = 95 tests.
 
 This is filed as an observation — not a finding — because nothing is broken; the
 harness's value is preventing future regressions, not fixing an existing leak.

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -1,0 +1,40 @@
+# Wave 3 — Multi-Tenant Isolation
+
+**Date:** 2026-05-03
+**Auditor:** Claude Opus 4.7
+**Codebase ref:** commit `a56a95bf` of `audit/3-multi-tenant-isolation`
+
+## Scope
+
+Files audited:
+- `backend/app/routers/admin/` (12 modules, ~89 endpoints)
+- `backend/app/services/quotas.py`
+- `backend/app/dependencies.py` (`require_project_role`, `get_current_user`)
+- `backend/db_migrations/versions/cb2c7f6f0cfe_rename_researcher_to_member_and_owner_*.py`
+- Adjacent business-logic flows: `app.routers.audio`, `app.routers.participants`,
+  `app.services.export_service`, `app.routers.recruitment` (if exists).
+
+No carry-overs from Wave 1 or Wave 2 — fresh ground.
+
+## Inventory
+
+_Filled by Task 2 (admin endpoint table) and Task 3 (cross-tenant access matrix)._
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| blocker | 0 |
+| major | 0 |
+| minor | 0 |
+| observation | 0 |
+
+## Findings
+
+_Populated as findings are filed by Tasks 4-9. F-04-NNN ID space._
+
+## Resolved since prior
+
+_Listed by Task 10 if any prior multi-tenant findings were closed by intervening commits._
+
+## False positives — not filed

--- a/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/04-multi-tenant-isolation.md
@@ -279,7 +279,7 @@ mechanism. Filed as **F-04-001** below.
 | blocker | 0 |
 | major | 0 |
 | minor | 0 |
-| observation | 1 |
+| observation | 2 |
 
 ## Findings
 
@@ -301,6 +301,31 @@ routes) will surface here before merge.
 
 This is filed as an observation — not a finding — because nothing is broken; the
 harness's value is preventing future regressions, not fixing an existing leak.
+
+### F-04-002 — Recruitment-token cross-study replay rejected (observation)
+
+**Severity:** observation
+**Status:** safe — explicit study-id check in token validator
+**Files:** `backend/app/services/recruitment_service.py:126-146`,
+          `backend/app/routers/submissions.py:96-103`,
+          `backend/app/services/submission_service.py:514-521`,
+          `backend/tests/security/wave_3/test_recruitment_token_replay.py`
+**Disposition:** false positive — the token validator already pins
+`link.study_id == study_id`.
+
+Concern: a recruitment token issued for Study A could be replayed against
+Study B's `/api/study/{slug}` or submission endpoint, granting unauthorised
+access to a study the holder shouldn't enter.
+
+Reality: `RecruitmentService.validate_link_token(db, study_id, token)` looks
+up the link by token then explicitly returns `None` when
+`link.study_id != study_id`. Both call sites
+(`GET /api/study/{slug}` in `submissions.py:98` and the participant-submit
+flow in `submission_service.py:517`) pass `study.id` derived from the URL
+slug. A cross-study replay therefore fails token validation and the handler
+raises 403 "Invalid, expired, or full recruitment link". The regression test
+exercises both directions (A→B and B→A) and pins the 403 denial, plus a
+sanity 200 on the legitimate own-study path.
 
 ## Resolved since prior
 

--- a/docs/audits/2026-05-03-comprehensive-security-audit/99-action-backlog.md
+++ b/docs/audits/2026-05-03-comprehensive-security-audit/99-action-backlog.md
@@ -183,7 +183,19 @@ Cumulative across all seven waves. Items move through:
   Source: `01-prior-findings-status.md#f-01-010`, `03-auth-email-flows.md#f-01-010`.
 
 ## Wave 3 — Multi-tenant isolation
-_pending Wave 3 plan._
+
+- F-04-001 (severity=observation) — Cross-tenant IDOR harness over 89 admin routes finds 0 leakage.
+  **closed** — harness retained as CI regression guard at `backend/tests/security/wave_3/test_admin_idor_harness.py`.
+- F-04-002 (severity=observation) — Recruitment-token cross-study replay rejected by `RecruitmentService.validate_link_token`.
+  **closed** — verified in commit `eb01aa93`; regression test pins.
+- F-04-003 (severity=observation) — Audio upload ownership session-token-bound; S3 keys carry study_slug + participant_token.
+  **closed** — verified in commit `55dbe262`; regression test pins.
+- F-04-004 (severity=observation) — Resume-code lookup joins `Study.slug == slug AND resume_code == code`; cross-study returns 404.
+  **closed** — verified in commit `ea662c95`; regression test pins.
+- F-04-005 (severity=observation) — Bulk-export queries derive `study.id` from path-bound `check_study_permission`; no body/header-trusted tenant claims.
+  **closed** — verified in commit `7e9433d4`; regression test pins.
+- F-04-006 (severity=minor) — Quota check has TOCTOU race in `quotas.assert_can_add_member` and `assert_can_create_owned_project`.
+  **deferred to backlog** — `MAX_MEMBERS_PER_PROJECT` defaults to 0 (unlimited) in OSS; over-fill is recoverable post-hoc and not billing-relevant. Recommended fix when revisited: `SELECT … FOR UPDATE` on the project sentinel row, or DB-level cap constraint. Source: `04-multi-tenant-isolation.md#f-04-006`. Filed in commit `14058c16`.
 
 ## Wave 4 — Consent & anonymisation pipeline
 _pending Wave 4 plan._
@@ -238,3 +250,4 @@ Items deferred indefinitely (no target wave scheduled yet, or no upstream fix av
 - F-02-005 (xlsx Prototype Pollution/ReDoS) — accepted-risk per `SECURITY.md:25-31`; see Wave 1 entry.
 - F-02-008 (semgrep test-router false positive) — false positive, env-gated; see Wave 1 entry.
 - F-02-009 (semgrep migration-script false positive) — false positive, no untrusted input; see Wave 1 entry.
+- F-04-006 (quota TOCTOU race) — deferred until billing/licensing activates the cap; see Wave 3 entry.


### PR DESCRIPTION
## Summary

Wave 3 of the 2026-05-03 comprehensive security audit. Per the design at
\`docs/superpowers/specs/2026-05-03-comprehensive-security-audit-design.md\`
and the plan at \`docs/superpowers/plans/2026-05-03-audit-wave-3-multi-tenant-isolation.md\`.

**Headline result: the multi-tenant architecture is sound.** A parametrised
cross-tenant IDOR harness over 82 of 89 admin endpoints found **zero leakage**.
The remaining 7 endpoints (top-level enumeration / superuser / unauthenticated)
are skipped with documented rationale. The harness ships as
\`backend/tests/security/wave_3/test_admin_idor_harness.py\` and serves as a
CI regression guard.

## Findings

| ID | Severity | Title | Status |
|---|---|---|---|
| F-04-001 | observation | IDOR harness over 89 admin routes finds 0 leakage | closed (harness as CI guard) |
| F-04-002 | observation | Recruitment-token cross-study replay rejected | closed (regression test pins) |
| F-04-003 | observation | Audio-upload ownership session-token-bound | closed (regression test pins) |
| F-04-004 | observation | Resume-code lookup study-scoped | closed (regression test pins) |
| F-04-005 | observation | Bulk-export filter correctness | closed (regression test pins) |
| F-04-006 | minor | Quota check has TOCTOU race | **deferred to backlog** (OSS unlimited default) |

## Notable

- **89-route harness, 0 leakage:** the existing membership architecture
  (\`require_project_role\` over \`X-Project-ID\` header + \`check_*_permission\`
  over URL slug + bespoke inline checks for memo / recruitment-link-delete /
  participant-id paths) is doing its job.
- **F-04-006 (quota TOCTOU):** filed but not fixed. \`MAX_MEMBERS_PER_PROJECT\`
  defaults to 0 (unlimited) so practical impact is zero today; deferred until
  a billing/licensing scenario activates the cap. Recommended fix
  (\`SELECT … FOR UPDATE\` on project sentinel row, or DB-level cap
  constraint) documented in the finding.
- **Wave 3 is the smallest wave by code-change footprint** — most findings
  are observations that document existing safe behaviour and pin it via
  regression tests.
- One conftest helper added (\`_reset_schema\`) to handle PostgreSQL ENUM
  drop ordering for the Wave 3 multi-tenant fixtures.

## Test plan

- [ ] \`make ci\` green (verified locally).
- [ ] \`pytest backend/tests/security/wave_3/ -v\` shows ~90+ passing
  (82 harness + per-flow tests).
- [ ] No regression in \`make e2e\`.

## Out of scope

- Quota TOCTOU fix (deferred — OSS default is unlimited).
- Memo cross-tenancy (covered by harness; no special-case task needed).
- Wave 4-7 axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)