### PR TITLE
refactor: reduce cognitive complexity — Wave 1 utilities & hooks

### DIFF
--- a/frontend/src/api/mutator.ts
+++ b/frontend/src/api/mutator.ts
@@ -68,6 +68,79 @@ function buildRequestHeaders(
     return requestHeaders;
 }
 
+function handle401(_method: string, url: string): void {
+    if (url.includes('/api/token') || url.includes('/api/study/')) return;
+    // biome-ignore lint/suspicious/noExplicitAny: window hack to suppress unsaved-changes dialog
+    (window as any).__isAutoLogout = true;
+
+    // Distinguish "had a token, lost it" (session_expired) from
+    // "never authenticated" (auth_required) — the latter occurs
+    // when a cold visitor opens /admin and is bounced through 401.
+    const hadToken = useAuthStore.getState().token !== null;
+    useAuthStore.getState().logout();
+    useSessionStore.getState().resetSession();
+    useResponseStore.getState().resetResponses();
+    if (!window.location.pathname.includes('/login')) {
+        const reason = hadToken ? 'session_expired' : 'auth_required';
+        window.location.href = `/login?reason=${reason}`;
+    }
+}
+
+function handle403(
+    method: string,
+    url: string,
+    parsedMessage: string,
+    parsedCode: string | undefined
+): void {
+    console.warn('Access Forbidden:', method, url);
+    // Skip toast for GETs — those are background fetches; surfacing a
+    // toast for every read-side 403 is noise (e.g. a viewer landing on
+    // a page that pre-fetches data they're not entitled to). Mutations
+    // are user-triggered, so the toast is informative there.
+    if (method.toUpperCase() === 'GET') return;
+    const { key, fallback } = resolveApiErrorKey({ code: parsedCode, message: parsedMessage });
+    const description = key
+        ? i18n.t(key, fallback)
+        : parsedMessage ||
+          i18n.t(
+              'errors.access_denied_description',
+              'You do not have permission to perform this action.'
+          );
+    toast.error(i18n.t('errors.access_denied_title', 'Access Denied'), {
+        id: `403:${method}:${url}`, // dedupe identical 403s on the same endpoint
+        description,
+    });
+}
+
+function handle409(
+    method: string,
+    url: string,
+    parsedMessage: string,
+    parsedCode: string | undefined
+): void {
+    const { key, fallback } = resolveApiErrorKey({ code: parsedCode, message: parsedMessage });
+    toast.error(i18n.t('errors.conflict_title', 'Conflict'), {
+        id: `409:${method}:${url}`,
+        description: key
+            ? i18n.t(key, fallback)
+            : parsedMessage ||
+              i18n.t(
+                  'errors.conflict_description',
+                  'The resource has been modified or already exists.'
+              ),
+    });
+}
+
+function handle429(url: string): void {
+    toast.error(i18n.t('errors.rate_limited_title', 'Too Many Requests'), {
+        id: `429:${url}`,
+        description: i18n.t(
+            'errors.rate_limited_description',
+            'Please wait a moment before trying again.'
+        ),
+    });
+}
+
 /** Side effects (toasts, redirect, bug-report) for error responses. */
 function handleErrorStatus(
     status: number,
@@ -77,76 +150,12 @@ function handleErrorStatus(
     parsedMessage: string,
     parsedCode: string | undefined
 ): void {
-    if (status === 401 && !url.includes('/api/token') && !url.includes('/api/study/')) {
-        // biome-ignore lint/suspicious/noExplicitAny: window hack to suppress unsaved-changes dialog
-        (window as any).__isAutoLogout = true;
-
-        // Distinguish "had a token, lost it" (session_expired) from
-        // "never authenticated" (auth_required) — the latter occurs
-        // when a cold visitor opens /admin and is bounced through 401.
-        const hadToken = useAuthStore.getState().token !== null;
-        useAuthStore.getState().logout();
-        useSessionStore.getState().resetSession();
-        useResponseStore.getState().resetResponses();
-        if (!window.location.pathname.includes('/login')) {
-            const reason = hadToken ? 'session_expired' : 'auth_required';
-            window.location.href = `/login?reason=${reason}`;
-        }
-    }
-
-    if (status === 403) {
-        console.warn('Access Forbidden:', method, url);
-        // Skip toast for GETs — those are background fetches; surfacing a
-        // toast for every read-side 403 is noise (e.g. a viewer landing on
-        // a page that pre-fetches data they're not entitled to). Mutations
-        // are user-triggered, so the toast is informative there.
-        if (method.toUpperCase() === 'GET') return;
-        const { key, fallback } = resolveApiErrorKey({
-            code: parsedCode,
-            message: parsedMessage,
-        });
-        const description = key
-            ? i18n.t(key, fallback)
-            : parsedMessage ||
-              i18n.t(
-                  'errors.access_denied_description',
-                  'You do not have permission to perform this action.'
-              );
-        toast.error(i18n.t('errors.access_denied_title', 'Access Denied'), {
-            id: `403:${method}:${url}`, // dedupe identical 403s on the same endpoint
-            description,
-        });
-    }
-    if (status === 429) {
-        toast.error(i18n.t('errors.rate_limited_title', 'Too Many Requests'), {
-            id: `429:${url}`,
-            description: i18n.t(
-                'errors.rate_limited_description',
-                'Please wait a moment before trying again.'
-            ),
-        });
-    }
-    if (status === 409) {
-        const { key, fallback } = resolveApiErrorKey({
-            code: parsedCode,
-            message: parsedMessage,
-        });
-        toast.error(i18n.t('errors.conflict_title', 'Conflict'), {
-            id: `409:${method}:${url}`,
-            description: key
-                ? i18n.t(key, fallback)
-                : parsedMessage ||
-                  i18n.t(
-                      'errors.conflict_description',
-                      'The resource has been modified or already exists.'
-                  ),
-        });
-    }
+    if (status === 401) handle401(method, url);
+    else if (status === 403) handle403(method, url, parsedMessage, parsedCode);
+    else if (status === 409) handle409(method, url, parsedMessage, parsedCode);
+    else if (status === 429) handle429(url);
     if (status >= 500) {
-        reportBug(`Server Error ${status} at ${url}: ${errorText}`, {
-            endpoint: url,
-            status,
-        });
+        reportBug(`Server Error ${status} at ${url}: ${errorText}`, { endpoint: url, status });
     }
 }
 

--- a/frontend/src/hooks/admin/useRecruitmentPage.helpers.test.ts
+++ b/frontend/src/hooks/admin/useRecruitmentPage.helpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { buildAccessRulesUpdate } from './useRecruitmentPage.helpers';
+
+describe('buildAccessRulesUpdate', () => {
+    const baseValues = {
+        passwordEnabled: false,
+        accessPassword: '',
+        startDate: null,
+        endDate: null,
+    };
+
+    it('omits password fields when slug is locked', () => {
+        const update = buildAccessRulesUpdate(
+            { ...baseValues, passwordEnabled: true, accessPassword: 'secret' },
+            { isSlugLocked: true }
+        );
+        expect(update).not.toHaveProperty('access_password');
+    });
+
+    it('clears password (null) when password is disabled in unlocked draft', () => {
+        const update = buildAccessRulesUpdate(
+            { ...baseValues, passwordEnabled: false },
+            { isSlugLocked: false }
+        );
+        expect(update.access_password).toBeNull();
+    });
+
+    it('sets password when enabled and value provided in unlocked draft', () => {
+        const update = buildAccessRulesUpdate(
+            { ...baseValues, passwordEnabled: true, accessPassword: 'secret' },
+            { isSlugLocked: false }
+        );
+        expect(update.access_password).toBe('secret');
+    });
+
+    it('omits password field when enabled but empty string in unlocked draft', () => {
+        const update = buildAccessRulesUpdate(
+            { ...baseValues, passwordEnabled: true, accessPassword: '' },
+            { isSlugLocked: false }
+        );
+        expect(update).not.toHaveProperty('access_password');
+    });
+
+    it('serializes dates as ISO strings, null when absent', () => {
+        const update = buildAccessRulesUpdate(
+            {
+                ...baseValues,
+                startDate: '2026-01-01T00:00',
+                endDate: null,
+            },
+            { isSlugLocked: false }
+        );
+        expect(update.start_date).toBe(new Date('2026-01-01T00:00').toISOString());
+        expect(update.end_date).toBeNull();
+    });
+});

--- a/frontend/src/hooks/admin/useRecruitmentPage.helpers.ts
+++ b/frontend/src/hooks/admin/useRecruitmentPage.helpers.ts
@@ -1,0 +1,36 @@
+interface AccessRulesValues {
+    passwordEnabled: boolean;
+    accessPassword?: string | null;
+    startDate?: string | null;
+    endDate?: string | null;
+}
+
+interface BuildOpts {
+    isSlugLocked: boolean;
+}
+
+/**
+ * Build the partial study-update payload for the recruitment "access rules"
+ * form. Password edits are only valid in draft (unlocked) state — outside
+ * draft, the backend whitelist accepts only start_date/end_date, so this
+ * helper omits `access_password` entirely instead of sending a no-op null
+ * that would trigger a 422.
+ */
+export function buildAccessRulesUpdate(
+    data: AccessRulesValues,
+    opts: BuildOpts
+): Record<string, unknown> {
+    const update: Record<string, unknown> = {};
+
+    if (!opts.isSlugLocked) {
+        if (!data.passwordEnabled) {
+            update.access_password = null;
+        } else if (data.accessPassword) {
+            update.access_password = data.accessPassword;
+        }
+    }
+
+    update.start_date = data.startDate ? new Date(data.startDate).toISOString() : null;
+    update.end_date = data.endDate ? new Date(data.endDate).toISOString() : null;
+    return update;
+}

--- a/frontend/src/hooks/admin/useRecruitmentPage.ts
+++ b/frontend/src/hooks/admin/useRecruitmentPage.ts
@@ -52,6 +52,7 @@ import type { RecruitmentLinkRead, RecruitmentLinkType, StudyRead, StudyUpdate }
 import { AdminService } from '@/api/admin';
 import { parseApiErrorSync } from '@/lib/error-utils';
 import { useAdminContext } from '@/hooks/useAdminContext';
+import { buildAccessRulesUpdate } from './useRecruitmentPage.helpers';
 
 // ────────────────────────────────────────────────────────────────
 // Schemas
@@ -350,23 +351,7 @@ export function useRecruitmentPage(): RecruitmentPageApi {
         async (data: AccessRulesValues) => {
             if (!slug) return;
             try {
-                const update: Record<string, unknown> = {};
-
-                // Password edits are only valid in draft state; outside draft
-                // the backend whitelist accepts only start_date / end_date so
-                // we omit the field entirely instead of sending a no-op null
-                // that would trigger a 422.
-                if (!isSlugLocked) {
-                    if (!data.passwordEnabled) {
-                        update.access_password = null;
-                    } else if (data.accessPassword) {
-                        update.access_password = data.accessPassword;
-                    }
-                }
-
-                update.start_date = data.startDate ? new Date(data.startDate).toISOString() : null;
-                update.end_date = data.endDate ? new Date(data.endDate).toISOString() : null;
-
+                const update = buildAccessRulesUpdate(data, { isSlugLocked });
                 await AdminService.updateStudy(slug, update as unknown as StudyUpdate);
 
                 toast.success(

--- a/frontend/src/hooks/useDragAutoInteraction.helpers.test.ts
+++ b/frontend/src/hooks/useDragAutoInteraction.helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { computeNextPanPosition, computeEdgePanSpeed } from './useDragAutoInteraction.helpers';
+
+describe('computeNextPanPosition', () => {
+    const dims = { contentW: 1000, contentH: 800, wrapperW: 500, wrapperH: 400 };
+
+    it('returns null when speed is zero', () => {
+        const r = computeNextPanPosition(
+            { positionX: 0, positionY: 0, scale: 1 },
+            { dx: 0, dy: 0 },
+            { x: 250, y: 200 },
+            dims,
+            null
+        );
+        expect(r).toBeNull();
+    });
+
+    it('moves position by dx/dy at scale 1', () => {
+        const r = computeNextPanPosition(
+            { positionX: 0, positionY: 0, scale: 1 },
+            { dx: 5, dy: 3 },
+            { x: 250, y: 200 },
+            dims,
+            null
+        );
+        expect(r).toEqual({ x: 5, y: 3 });
+    });
+
+    it('clamps to wrapper - content bounds', () => {
+        const r = computeNextPanPosition(
+            { positionX: -10000, positionY: -10000, scale: 1 },
+            { dx: -100, dy: -100 },
+            { x: 250, y: 200 },
+            dims,
+            null
+        );
+        // minX = 500 - 1000*1 - 500*0.2 = -600
+        expect(r?.x).toBeGreaterThanOrEqual(-600);
+        expect(r?.y).toBeGreaterThanOrEqual(-480);
+    });
+
+    it('reduces speed by 0.3 when cursor is outside grid rect', () => {
+        const r = computeNextPanPosition(
+            { positionX: 0, positionY: 0, scale: 1 },
+            { dx: 10, dy: 0 },
+            { x: 1000, y: 200 }, // x > gridRect.right
+            dims,
+            { left: 0, right: 500, top: 0, bottom: 400 }
+        );
+        expect(r?.x).toBeCloseTo(3, 5); // 10 * 0.3
+    });
+});
+
+describe('computeEdgePanSpeed', () => {
+    const rect = { left: 0, right: 500, top: 0, bottom: 400 };
+
+    it('returns zero speed in the center', () => {
+        expect(computeEdgePanSpeed(250, 200, rect)).toEqual({ dx: 0, dy: 0 });
+    });
+
+    it('pans right when near left edge', () => {
+        const { dx } = computeEdgePanSpeed(10, 200, rect);
+        expect(dx).toBeGreaterThan(0);
+    });
+
+    it('pans left when near right edge', () => {
+        const { dx } = computeEdgePanSpeed(495, 200, rect);
+        expect(dx).toBeLessThan(0);
+    });
+
+    it('pans down when near top edge', () => {
+        const { dy } = computeEdgePanSpeed(250, 10, rect);
+        expect(dy).toBeGreaterThan(0);
+    });
+
+    it('pans up when near bottom edge', () => {
+        const { dy } = computeEdgePanSpeed(250, 395, rect);
+        expect(dy).toBeLessThan(0);
+    });
+});

--- a/frontend/src/hooks/useDragAutoInteraction.helpers.ts
+++ b/frontend/src/hooks/useDragAutoInteraction.helpers.ts
@@ -1,0 +1,88 @@
+interface TransformState {
+    positionX: number;
+    positionY: number;
+    scale: number;
+}
+
+interface PanSpeed {
+    dx: number;
+    dy: number;
+}
+
+interface Dimensions {
+    contentW: number;
+    contentH: number;
+    wrapperW: number;
+    wrapperH: number;
+}
+
+interface Rect {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+}
+
+/**
+ * Compute the next clamped position for an auto-pan tick. Returns null when
+ * the resulting position would equal the current one (no movement).
+ *
+ * @param gridRect optional grid bounding box; when the cursor is outside of
+ *   it, speed is reduced to 30% (kinder when the user has moved off-grid).
+ */
+export function computeNextPanPosition(
+    state: TransformState,
+    panSpeed: PanSpeed,
+    cursor: { x: number; y: number },
+    dims: Dimensions,
+    gridRect: Rect | null
+): { x: number; y: number } | null {
+    let speedFactor = 1.0;
+    if (gridRect) {
+        const { x, y } = cursor;
+        if (x < gridRect.left || x > gridRect.right || y < gridRect.top || y > gridRect.bottom) {
+            speedFactor = 0.3;
+        }
+    }
+
+    const effectiveDx = panSpeed.dx * speedFactor;
+    const effectiveDy = panSpeed.dy * speedFactor;
+
+    const contentW = dims.contentW * state.scale;
+    const contentH = dims.contentH * state.scale;
+    const minX = dims.wrapperW - contentW - dims.wrapperW * 0.2;
+    const maxX = dims.wrapperW * 0.2;
+    const minY = dims.wrapperH - contentH - dims.wrapperH * 0.2;
+    const maxY = dims.wrapperH * 0.2;
+
+    const newX = Math.max(minX, Math.min(maxX, state.positionX + effectiveDx));
+    const newY = Math.max(minY, Math.min(maxY, state.positionY + effectiveDy));
+
+    if (newX === state.positionX && newY === state.positionY) return null;
+    return { x: newX, y: newY };
+}
+
+/**
+ * Compute the auto-pan speed when the cursor is near an edge of `rect`.
+ * Returns zero speed when the cursor is in the central zone.
+ */
+export function computeEdgePanSpeed(x: number, y: number, rect: Rect): PanSpeed {
+    const edgeThreshold = 60;
+    const maxPanSpeed = 15;
+    let dx = 0;
+    let dy = 0;
+
+    if (x < rect.left + edgeThreshold) {
+        dx = maxPanSpeed * Math.min((rect.left + edgeThreshold - x) / edgeThreshold, 1);
+    } else if (x > rect.right - edgeThreshold) {
+        dx = -maxPanSpeed * Math.min((x - (rect.right - edgeThreshold)) / edgeThreshold, 1);
+    }
+
+    if (y < rect.top + edgeThreshold) {
+        dy = maxPanSpeed * Math.min((rect.top + edgeThreshold - y) / edgeThreshold, 1);
+    } else if (y > rect.bottom - edgeThreshold) {
+        dy = -maxPanSpeed * Math.min((y - (rect.bottom - edgeThreshold)) / edgeThreshold, 1);
+    }
+
+    return { dx, dy };
+}

--- a/frontend/src/hooks/useDragAutoInteraction.ts
+++ b/frontend/src/hooks/useDragAutoInteraction.ts
@@ -6,6 +6,7 @@
 
 import { useCallback, useRef } from 'react';
 import type { InteractionUtils } from '../types/grid';
+import { computeNextPanPosition, computeEdgePanSpeed } from './useDragAutoInteraction.helpers';
 
 interface UseDragAutoInteractionProps {
     interactionUtils: InteractionUtils | null | undefined;
@@ -41,51 +42,43 @@ export const useDragAutoInteraction = ({
             const content = interactionUtils?.contentRef.current;
             const wrapper = interactionUtils?.wrapperRef.current;
 
-            if (transform && content && wrapper) {
-                const state = transform.instance.transformState;
-                const scale = state.scale;
-                const { dx: currentDx, dy: currentDy } = panSpeed.current;
+            if (!transform || !content || !wrapper) return;
 
-                let speedFactor = 1.0;
-                const gridEl = document.querySelector('[data-testid="grid-container"]');
-                if (gridEl) {
-                    const gridRect = gridEl.getBoundingClientRect();
-                    const { x: curX, y: curY } = lastPos.current;
-                    if (
-                        curX < gridRect.left ||
-                        curX > gridRect.right ||
-                        curY < gridRect.top ||
-                        curY > gridRect.bottom
-                    ) {
-                        speedFactor = 0.3;
-                    }
-                }
+            const state = transform.instance.transformState;
+            const gridEl = document.querySelector('[data-testid="grid-container"]');
+            const gridRect = gridEl ? gridEl.getBoundingClientRect() : null;
 
-                const effectiveDx = currentDx * speedFactor;
-                const effectiveDy = currentDy * speedFactor;
+            const next = computeNextPanPosition(
+                state,
+                panSpeed.current,
+                lastPos.current,
+                {
+                    contentW: content.offsetWidth,
+                    contentH: content.offsetHeight,
+                    wrapperW: wrapper.clientWidth,
+                    wrapperH: wrapper.clientHeight,
+                },
+                gridRect
+            );
 
-                const contentW = content.offsetWidth * scale;
-                const contentH = content.offsetHeight * scale;
-                const wrapperW = wrapper.clientWidth;
-                const wrapperH = wrapper.clientHeight;
-
-                const minX = wrapperW - contentW - wrapperW * 0.2;
-                const maxX = wrapperW * 0.2;
-                const minY = wrapperH - contentH - wrapperH * 0.2;
-                const maxY = wrapperH * 0.2;
-
-                const newX = Math.max(minX, Math.min(maxX, state.positionX + effectiveDx));
-                const newY = Math.max(minY, Math.min(maxY, state.positionY + effectiveDy));
-
-                if (newX !== state.positionX || newY !== state.positionY) {
-                    transform.setTransform(newX, newY, scale, 0);
-                    onPan?.();
-                } else {
-                    stopPan();
-                }
+            if (next) {
+                transform.setTransform(next.x, next.y, state.scale, 0);
+                onPan?.();
+            } else {
+                stopPan();
             }
         }, 16);
     }, [interactionUtils, onPan, stopPan]);
+
+    const schedulePanActivation = useCallback(() => {
+        if (panInterval.current || panActivationTimer.current) return;
+        panActivationTimer.current = setTimeout(() => {
+            panActivationTimer.current = null;
+            if (panSpeed.current.dx !== 0 || panSpeed.current.dy !== 0) {
+                startPanInterval();
+            }
+        }, 500);
+    }, [startPanInterval]);
 
     const updateInteraction = useCallback(
         (x: number, y: number) => {
@@ -107,41 +100,16 @@ export const useDragAutoInteraction = ({
             if (!wrapper) return;
 
             const rect = wrapper.getBoundingClientRect();
-            const edgeThreshold = 60;
-            const maxPanSpeed = 15;
-
-            let dx = 0;
-            let dy = 0;
-
-            if (x < rect.left + edgeThreshold) {
-                dx = maxPanSpeed * Math.min((rect.left + edgeThreshold - x) / edgeThreshold, 1);
-            } else if (x > rect.right - edgeThreshold) {
-                dx = -maxPanSpeed * Math.min((x - (rect.right - edgeThreshold)) / edgeThreshold, 1);
-            }
-
-            if (y < rect.top + edgeThreshold) {
-                dy = maxPanSpeed * Math.min((rect.top + edgeThreshold - y) / edgeThreshold, 1);
-            } else if (y > rect.bottom - edgeThreshold) {
-                dy =
-                    -maxPanSpeed * Math.min((y - (rect.bottom - edgeThreshold)) / edgeThreshold, 1);
-            }
-
+            const { dx, dy } = computeEdgePanSpeed(x, y, rect);
             panSpeed.current = { dx, dy };
 
             if (dx !== 0 || dy !== 0) {
-                if (!panInterval.current && !panActivationTimer.current) {
-                    panActivationTimer.current = setTimeout(() => {
-                        panActivationTimer.current = null;
-                        if (panSpeed.current.dx !== 0 || panSpeed.current.dy !== 0) {
-                            startPanInterval();
-                        }
-                    }, 500);
-                }
+                schedulePanActivation();
             } else {
                 stopPan();
             }
         },
-        [interactionUtils, stopPan, startPanInterval]
+        [interactionUtils, stopPan, schedulePanActivation]
     );
 
     const cleanupInteraction = useCallback(() => {

--- a/frontend/src/hooks/useFineSortDrag.helpers.test.ts
+++ b/frontend/src/hooks/useFineSortDrag.helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDropTarget } from './useFineSortDrag.helpers';
+
+describe('resolveDropTarget', () => {
+    const qsort = [
+        { statementId: 42, col: 3, row: 2 },
+        { statementId: 99, col: 5, row: 1 },
+    ];
+
+    it('decodes a deck drop with category prefix', () => {
+        expect(resolveDropTarget('deck-agree', qsort)).toEqual({
+            kind: 'deck',
+            category: 'agree',
+        });
+    });
+
+    it('decodes a deck-area drop (deck-area-disagree)', () => {
+        expect(resolveDropTarget('deck-area-disagree', qsort)).toEqual({
+            kind: 'deck',
+            category: 'disagree',
+        });
+    });
+
+    it('decodes a slot drop', () => {
+        expect(resolveDropTarget('slot_3_2', qsort)).toEqual({
+            kind: 'slot',
+            col: 3,
+            row: 2,
+        });
+    });
+
+    it('resolves a card-on-card drop to the underlying card slot', () => {
+        expect(resolveDropTarget('42', qsort)).toEqual({
+            kind: 'slot',
+            col: 3,
+            row: 2,
+        });
+    });
+
+    it('returns kind:none for an unrecognized overId with no matching card', () => {
+        expect(resolveDropTarget('1234', qsort)).toEqual({ kind: 'none' });
+    });
+
+    it('returns kind:none for a malformed slot id', () => {
+        expect(resolveDropTarget('slot_x_y', qsort)).toEqual({ kind: 'none' });
+    });
+});

--- a/frontend/src/hooks/useFineSortDrag.helpers.ts
+++ b/frontend/src/hooks/useFineSortDrag.helpers.ts
@@ -1,0 +1,46 @@
+interface PlacedCard {
+    statementId: number;
+    col: number;
+    row: number;
+}
+
+export type DropTarget =
+    | { kind: 'deck'; category: 'agree' | 'neutral' | 'disagree' }
+    | { kind: 'slot'; col: number; row: number }
+    | { kind: 'none' };
+
+/**
+ * Decode a DnD-Kit `over.id` (string) into the participant intent.
+ * - `deck-<cat>` or `deck-area-<cat>` → return-to-pile
+ * - `slot_<col>_<row>` → place at slot
+ * - any other string that matches a placed card's statementId → resolve
+ *   to that card's slot
+ */
+export function resolveDropTarget(overIdRaw: string, qsort: PlacedCard[]): DropTarget {
+    let overId = overIdRaw;
+
+    if (overId.startsWith('deck-')) {
+        let cat = overId.replace('deck-', '');
+        if (cat.startsWith('area-')) cat = cat.replace('area-', '');
+        return { kind: 'deck', category: cat as 'agree' | 'neutral' | 'disagree' };
+    }
+
+    if (!overId.startsWith('slot_')) {
+        const cardId = Number(overId);
+        const placed = !Number.isNaN(cardId)
+            ? qsort.find((c) => c.statementId === cardId)
+            : undefined;
+        if (placed) {
+            overId = `slot_${placed.col}_${placed.row}`;
+        } else {
+            return { kind: 'none' };
+        }
+    }
+
+    const parts = overId.split('_');
+    if (parts.length !== 3 || !parts[1] || !parts[2]) return { kind: 'none' };
+    const col = parseInt(parts[1], 10);
+    const row = parseInt(parts[2], 10);
+    if (Number.isNaN(col) || Number.isNaN(row)) return { kind: 'none' };
+    return { kind: 'slot', col, row };
+}

--- a/frontend/src/hooks/useFineSortDrag.ts
+++ b/frontend/src/hooks/useFineSortDrag.ts
@@ -11,6 +11,7 @@ import { useUIStore } from '../store/useUIStore';
 import type { DragCard, InteractionUtils } from '../types/grid';
 import { useDragAutoInteraction } from './useDragAutoInteraction';
 import { useGridPlacement } from './useGridPlacement';
+import { resolveDropTarget } from './useFineSortDrag.helpers';
 
 // Define minimal types needed for the hook to avoid circular deps or complex mocks
 interface Statement {
@@ -142,45 +143,18 @@ export const useFineSortDrag = ({
     const handleDragEnd = useCallback(
         (event: DragEndEvent) => {
             const { active, over } = event;
-
-            // Ensure we ALWAYS clean up drag state, even if placement fails
             try {
                 if (!over) return;
-
                 const cardId = active.id as number;
-                let overIdString = String(over.id);
+                const target = resolveDropTarget(String(over.id), responses.qsort);
 
-                // 1. Check for Deck Drop (Return to Pile)
-                if (overIdString.startsWith('deck-')) {
-                    let categoryStr = overIdString.replace('deck-', '');
-                    // Handle deck area drop
-                    if (categoryStr.startsWith('area-')) {
-                        categoryStr = categoryStr.replace('area-', '');
-                    }
-
-                    const category = categoryStr as 'agree' | 'neutral' | 'disagree';
+                if (target.kind === 'deck') {
                     actions.unplaceCard(cardId);
-                    actions.categorizeCard(cardId, category);
+                    actions.categorizeCard(cardId, target.category);
                     return;
                 }
-
-                // 2. If dropped on another card, resolve to its slot
-                if (!overIdString.startsWith('slot_')) {
-                    const cardIdAtOver = over.id as number;
-                    const placedCard = responses.qsort.find((c) => c.statementId === cardIdAtOver);
-                    if (placedCard) {
-                        overIdString = `slot_${placedCard.col}_${placedCard.row}`;
-                    }
-                }
-
-                // 3. Slot Placement
-                if (overIdString.startsWith('slot_')) {
-                    const parts = overIdString.split('_');
-                    if (parts.length === 3 && parts[1] && parts[2]) {
-                        const col = parseInt(parts[1], 10);
-                        const row = parseInt(parts[2], 10);
-                        handlePlacement(cardId, col, row);
-                    }
+                if (target.kind === 'slot') {
+                    handlePlacement(cardId, target.col, target.row);
                 }
             } catch (error) {
                 console.error('Drag end error:', error);

--- a/frontend/src/hooks/useGridCalculations.helpers.test.ts
+++ b/frontend/src/hooks/useGridCalculations.helpers.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { computeCardDimensions } from './useGridCalculations.helpers';
+
+describe('computeCardDimensions', () => {
+    it('returns null for zero-size wrapper', () => {
+        expect(computeCardDimensions({ W: 0, H: 100 }, [{ score: 0, capacity: 5 }])).toBeNull();
+        expect(computeCardDimensions({ W: 100, H: 0 }, [{ score: 0, capacity: 5 }])).toBeNull();
+    });
+
+    it('returns null for empty columns', () => {
+        expect(computeCardDimensions({ W: 1000, H: 800 }, [])).toBeNull();
+    });
+
+    it('returns null when max row capacity is 0', () => {
+        expect(computeCardDimensions({ W: 1000, H: 800 }, [{ score: 0, capacity: 0 }])).toBeNull();
+    });
+
+    it('clamps minimum dimensions to 140x90 on tiny screens', () => {
+        const r = computeCardDimensions(
+            { W: 200, H: 200 },
+            Array.from({ length: 10 }, () => ({ score: 0, capacity: 10 }))
+        );
+        expect(r).not.toBeNull();
+        if (!r) return;
+        expect(r.width).toBeGreaterThanOrEqual(140);
+        expect(r.height).toBeGreaterThanOrEqual(90);
+    });
+
+    it('uses clamped aspect ratio (1.2-1.8)', () => {
+        const r = computeCardDimensions({ W: 4000, H: 200 }, [{ score: 0, capacity: 5 }]);
+        if (!r) return;
+        expect(r.width / r.height).toBeLessThanOrEqual(1.8 + 0.001);
+    });
+
+    it('respects vertical bound when content overflows height', () => {
+        const r = computeCardDimensions(
+            { W: 1000, H: 100 },
+            Array.from({ length: 5 }, () => ({ score: 0, capacity: 10 }))
+        );
+        if (!r) return;
+        expect(r.height).toBeGreaterThanOrEqual(90);
+    });
+});

--- a/frontend/src/hooks/useGridCalculations.helpers.ts
+++ b/frontend/src/hooks/useGridCalculations.helpers.ts
@@ -1,0 +1,48 @@
+interface GridColumn {
+    score: number;
+    capacity: number;
+}
+
+const GAP = 8;
+const PADDING_X = 32;
+const PADDING_Y = 32;
+const MIN_W = 140;
+const MIN_H = 90;
+const MIN_RATIO = 1.2;
+const MAX_RATIO = 1.8;
+
+/**
+ * Compute clamped card width/height that fit `gridColumns` within the
+ * wrapper. Returns null on degenerate input (zero size, no columns,
+ * zero-capacity columns).
+ */
+export function computeCardDimensions(
+    wrapper: { W: number; H: number },
+    gridColumns: GridColumn[]
+): { width: number; height: number } | null {
+    const { W, H } = wrapper;
+    if (W === 0 || H === 0) return null;
+    const numCols = gridColumns.length;
+    if (numCols === 0) return null;
+    const maxRows = Math.max(...gridColumns.map((c) => c.capacity || 0));
+    if (maxRows === 0) return null;
+
+    const availableW = W - PADDING_X - (numCols - 1) * GAP;
+    const availableH = H - PADDING_Y - (maxRows - 1) * GAP;
+    if (availableW <= 0 || availableH <= 0) return null;
+
+    const rawW = availableW / numCols;
+    const rawH = availableH / maxRows;
+    const ratio = Math.max(MIN_RATIO, Math.min(rawW / rawH, MAX_RATIO));
+
+    let width = rawW;
+    let height = rawW / ratio;
+    if (height > rawH) {
+        height = rawH;
+        width = height * ratio;
+    }
+
+    width = Math.max(width, MIN_W);
+    height = Math.max(height, MIN_H);
+    return { width, height };
+}

--- a/frontend/src/hooks/useGridCalculations.ts
+++ b/frontend/src/hooks/useGridCalculations.ts
@@ -6,6 +6,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useViewport } from '@/contexts/ViewportContext';
+import { computeCardDimensions } from './useGridCalculations.helpers';
 
 interface GridColumn {
     score: number;
@@ -34,9 +35,6 @@ export const useGridCalculations = ({
     const calculateOptimalSize = useCallback(() => {
         if (!wrapperRef.current) return;
 
-        // Grid Anchoring: Do not resize cards when in Mobile Focus Mode (Deck Collapsed)
-        // This prevents "Layout Thrashing" / Chaos.
-        // Exception: allow recalculation when orientation changes (e.g. portrait→landscape)
         const orientationChanged = isLandscape !== prevLandscapeRef.current;
         if (orientationChanged) {
             prevLandscapeRef.current = isLandscape;
@@ -44,59 +42,17 @@ export const useGridCalculations = ({
         if (selectedCardId && !isDesktop && !orientationChanged) return;
 
         const wrapper = wrapperRef.current;
-        const W = wrapper.clientWidth;
-        const H = wrapper.clientHeight;
-        if (W === 0 || H === 0) return;
-
-        const numCols = gridColumns.length;
-        if (numCols === 0) return;
-
-        const maxRows = Math.max(...gridColumns.map((c) => c.capacity || 0));
-        if (maxRows === 0) return;
-
-        // Calculate max possible dimensions based on available space
-        // We want to maximize card size within the viewport before applying zoom
-        const GAP = 8; // gap-2
-        const PADDING_X = 32; // px-4 * 2
-        const PADDING_Y = 32;
-
-        const availableW = W - PADDING_X - (numCols - 1) * GAP;
-        const availableH = H - PADDING_Y - (maxRows - 1) * GAP;
-
-        if (availableW <= 0 || availableH <= 0) return;
-
-        // Ideal raw dimensions to just fit
-        const rawW = availableW / numCols;
-        const rawH = availableH / maxRows;
-
-        // We want to maintain a reasonable Aspect Ratio (e.g. 3/2 or 4/3)
-        // But also fill space.
-        // Let's deduce an optimal Aspect Ratio that fits the screen shape best
-        // constrained between square (1.0) and wide (2.2)
-        const currentRatio = rawW / rawH; // This is the ratio if we stretch to fill perfectly
-
-        // Clamp ratio to keep cards looking like cards
-        const clampedRatio = Math.max(1.2, Math.min(currentRatio, 1.8));
-
-        // Now calculate dimensions based on this clamped ratio
-        // We fit within rawW and rawH
-        let newWidth = rawW;
-        let newHeight = rawW / clampedRatio;
-
-        if (newHeight > rawH) {
-            newHeight = rawH;
-            newWidth = newHeight * clampedRatio;
-        }
-
-        // Enforce a minimum legible size (e.g. for mobile or small screens)
-        // Zoom will handle downscaling if needed, but for layout calculation we want robust base
-        newWidth = Math.max(newWidth, 140);
-        newHeight = Math.max(newHeight, 90);
+        const next = computeCardDimensions(
+            { W: wrapper.clientWidth, H: wrapper.clientHeight },
+            gridColumns
+        );
+        if (!next) return;
 
         setCardDimensions((prev) => {
-            if (Math.abs(prev.width - newWidth) < 2 && Math.abs(prev.height - newHeight) < 2)
+            if (Math.abs(prev.width - next.width) < 2 && Math.abs(prev.height - next.height) < 2) {
                 return prev;
-            return { width: newWidth, height: newHeight };
+            }
+            return next;
         });
     }, [gridColumns, selectedCardId, isDesktop, isLandscape]);
 

--- a/frontend/src/hooks/useGridZoom.helpers.test.ts
+++ b/frontend/src/hooks/useGridZoom.helpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { computeAutoFitTransform } from './useGridZoom.helpers';
+
+const wrapperDims = { wrapperW: 500, wrapperH: 800, contentW: 1000, contentH: 600 };
+
+describe('computeAutoFitTransform', () => {
+    it('returns null when content has zero size', () => {
+        expect(
+            computeAutoFitTransform(
+                { ...wrapperDims, contentW: 0 },
+                { isDesktop: true, isLandscape: false }
+            )
+        ).toBeNull();
+    });
+
+    it('portrait mobile: anchors bottom with 10px margin', () => {
+        const r = computeAutoFitTransform(wrapperDims, { isDesktop: false, isLandscape: false });
+        expect(r).not.toBeNull();
+        if (!r) return;
+        expect(r.y).toBeCloseTo(800 - 600 * r.scale - 10, 1);
+    });
+
+    it('landscape mobile: centers vertically', () => {
+        const r = computeAutoFitTransform(wrapperDims, { isDesktop: false, isLandscape: true });
+        if (!r) return;
+        expect(r.y).toBeCloseTo((800 - 600 * r.scale) / 2, 1);
+    });
+
+    it('desktop: caps scale at 1.0', () => {
+        const r = computeAutoFitTransform(
+            { wrapperW: 500, wrapperH: 800, contentW: 100, contentH: 60 },
+            { isDesktop: true, isLandscape: false }
+        );
+        expect(r?.scale).toBe(1.0);
+    });
+
+    it('desktop: enforces minimum y of 20', () => {
+        const r = computeAutoFitTransform(
+            { wrapperW: 500, wrapperH: 100, contentW: 100, contentH: 60 },
+            { isDesktop: true, isLandscape: false }
+        );
+        if (!r) return;
+        expect(r.y).toBeGreaterThanOrEqual(20);
+    });
+
+    it('mobile: x is centered horizontally', () => {
+        const r = computeAutoFitTransform(wrapperDims, { isDesktop: false, isLandscape: false });
+        if (!r) return;
+        expect(r.x).toBeCloseTo((500 - 1000 * r.scale) / 2, 1);
+    });
+});

--- a/frontend/src/hooks/useGridZoom.helpers.ts
+++ b/frontend/src/hooks/useGridZoom.helpers.ts
@@ -1,0 +1,61 @@
+interface AutoFitDims {
+    wrapperW: number;
+    wrapperH: number;
+    contentW: number;
+    contentH: number;
+}
+
+interface Viewport {
+    isDesktop: boolean;
+    isLandscape: boolean;
+}
+
+interface AutoFitTransform {
+    scale: number;
+    x: number;
+    y: number;
+}
+
+/**
+ * Compute the (scale, x, y) for centering and fitting the grid content into
+ * the wrapper. Branches on desktop / portrait-mobile / landscape-mobile,
+ * each with empirically-tuned padding and anchoring rules. Returns null
+ * when content dimensions are zero.
+ */
+export function computeAutoFitTransform(
+    dims: AutoFitDims,
+    viewport: Viewport
+): AutoFitTransform | null {
+    if (dims.contentW === 0 || dims.contentH === 0) return null;
+
+    const { wrapperW, wrapperH, contentW, contentH } = dims;
+    const { isDesktop, isLandscape } = viewport;
+    const isMobile = !isDesktop;
+    const isLandscapeMobile = isMobile && isLandscape;
+
+    if (isMobile) {
+        const widthScale = (wrapperW * 0.98) / contentW;
+        const heightScale = (wrapperH * (isLandscapeMobile ? 0.95 : 0.9)) / contentH;
+        const scale = isLandscapeMobile
+            ? Math.min(widthScale, heightScale)
+            : Math.min(widthScale, Math.max(heightScale, widthScale * 0.7));
+
+        const x = (wrapperW - contentW * scale) / 2;
+        const y = isLandscapeMobile
+            ? (wrapperH - contentH * scale) / 2
+            : wrapperH - contentH * scale - 10;
+
+        return { scale, x, y };
+    }
+
+    // Desktop
+    const padding = 70;
+    const bottomLegendBuffer = 60;
+    const availableW = wrapperW - padding;
+    const availableH = wrapperH - padding - bottomLegendBuffer;
+    const scale = Math.min(availableW / contentW, availableH / contentH, 1.0);
+    const x = (wrapperW - contentW * scale) / 2;
+    const yRaw = (wrapperH - contentH * scale) / 2;
+    const y = yRaw < 20 ? 20 : yRaw;
+    return { scale, x, y };
+}

--- a/frontend/src/hooks/useGridZoom.ts
+++ b/frontend/src/hooks/useGridZoom.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { ReactZoomPanPinchRef } from 'react-zoom-pan-pinch';
 import { useViewport } from '@/contexts/ViewportContext';
+import { computeAutoFitTransform } from './useGridZoom.helpers';
 
 interface UseGridZoomProps {
     wrapperRef: React.RefObject<HTMLDivElement | null>;
@@ -30,73 +31,25 @@ export const useGridZoom = ({
         if (!transformRef.current || !wrapperRef.current || !contentRef.current) return;
         const wrapper = wrapperRef.current;
         const content = contentRef.current;
-        const wrapperW = wrapper.clientWidth;
-        const wrapperH = wrapper.clientHeight;
-        const contentW = content.offsetWidth;
-        const contentH = content.offsetHeight;
-        if (contentW === 0 || contentH === 0) return;
 
-        const isMobile = !isDesktop;
-        const isLandscapeMobile = isMobile && isLandscape;
+        const transform = computeAutoFitTransform(
+            {
+                wrapperW: wrapper.clientWidth,
+                wrapperH: wrapper.clientHeight,
+                contentW: content.offsetWidth,
+                contentH: content.offsetHeight,
+            },
+            { isDesktop, isLandscape }
+        );
+        if (!transform) return;
 
-        let scale: number, x: number, y: number;
-
-        if (isMobile) {
-            // Center the grid in the full wrapper width. Portrait mobile used
-            // to subtract ~64px on the right so the rightmost column wouldn't
-            // sit under the floating zoom toolbar (top-right, with
-            // backdrop-blur), but the result was visibly off-center to the
-            // left and the toolbar's blur is enough to keep the underlying
-            // content readable when it does overlap. Landscape mobile already
-            // used the full wrapper width (no toolbar in the same corner);
-            // desktop has its own branch below.
-            // 2% breathing room — empirical margin so the grid doesn't kiss
-            // the wrapper edge; the toolbar's backdrop-blur tolerates the
-            // occasional overlap that the old 64–72px reservation prevented.
-            const widthScale = (wrapperW * 0.98) / contentW;
-            const heightScale = (wrapperH * (isLandscapeMobile ? 0.95 : 0.9)) / contentH;
-
-            if (isLandscapeMobile) {
-                // Landscape mobile: fit both dimensions, center vertically
-                scale = Math.min(widthScale, heightScale);
-            } else {
-                // Portrait mobile: fit width primarily
-                scale = Math.min(widthScale, Math.max(heightScale, widthScale * 0.7));
-            }
-
-            x = (wrapperW - contentW * scale) / 2;
-
-            if (isLandscapeMobile) {
-                // Center vertically in landscape
-                y = (wrapperH - contentH * scale) / 2;
-            } else {
-                // Anchor Bottom in portrait to leave top space for numbers/text
-                y = wrapperH - contentH * scale - 10;
-            }
-        } else {
-            // Desktop: Fit both, with padding to encompass Spectrum Bar
-            const padding = 70; // Reduced to 70px to increase default zoom for better readability
-            const bottomLegendBuffer = 60; // Extra buffer for the bottom legend
-            const availableW = wrapperW - padding;
-            const availableH = wrapperH - padding - bottomLegendBuffer;
-
-            const scaleX = availableW / contentW;
-            const scaleY = availableH / contentH;
-
-            scale = Math.min(scaleX, scaleY, 1.0); // Slight cap to prevent edge-touching
-
-            // Center Horizontally
-            x = (wrapperW - contentW * scale) / 2;
-
-            // Center Vertically, but bias upwards slightly to ensure bottom legend is safe
-            // Or just precise centering based on the calculated scale which now fits height
-            y = (wrapperH - contentH * scale) / 2;
-
-            // Ensure we don't push it off top if we have space
-            if (y < 20) y = 20;
-        }
-
-        transformRef.current.setTransform(x, y, scale, 400, 'easeOutQuad');
+        transformRef.current.setTransform(
+            transform.x,
+            transform.y,
+            transform.scale,
+            400,
+            'easeOutQuad'
+        );
     }, [wrapperRef, contentRef, isDesktop, isLandscape]);
 
     const zoomIn = useCallback(() => {

--- a/frontend/src/hooks/useStudyPersistence.helpers.test.ts
+++ b/frontend/src/hooks/useStudyPersistence.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isDraftInSync } from './useStudyPersistence.helpers';
+import { isDraftInSync, resolveServerConflict } from './useStudyPersistence.helpers';
 
 describe('isDraftInSync', () => {
     it('returns true when draft equals original', () => {
@@ -32,5 +32,43 @@ describe('isDraftInSync', () => {
         const draft = { id: 1, title: 'a' };
         const original = { id: 1, title: 'a' };
         expect(isDraftInSync(draft, original, null)).toBe(true);
+    });
+});
+
+describe('resolveServerConflict', () => {
+    it('returns hard-conflict when merge fails', () => {
+        const result = resolveServerConflict(
+            { id: 1, title: 'local' } as unknown as Parameters<typeof resolveServerConflict>[0],
+            { id: 1, title: 'server' } as unknown as Parameters<typeof resolveServerConflict>[1],
+            null,
+            () => ({ success: false, merged: null, warnings: [] })
+        );
+        expect(result.kind).toBe('hard-conflict');
+    });
+
+    it('returns merged on success', () => {
+        const result = resolveServerConflict(
+            { id: 1, title: 'local' } as unknown as Parameters<typeof resolveServerConflict>[0],
+            { id: 1, title: 'server' } as unknown as Parameters<typeof resolveServerConflict>[1],
+            null,
+            () => ({ success: true, merged: { id: 1, title: 'merged' }, warnings: [] })
+        );
+        expect(result.kind).toBe('merged');
+        if (result.kind === 'merged') {
+            expect(result.merged).toEqual({ id: 1, title: 'merged' });
+            expect(result.warnings).toEqual([]);
+        }
+    });
+
+    it('forwards warnings on partial merge', () => {
+        const result = resolveServerConflict(
+            { id: 1, title: 'local' } as unknown as Parameters<typeof resolveServerConflict>[0],
+            { id: 1, title: 'server' } as unknown as Parameters<typeof resolveServerConflict>[1],
+            null,
+            () => ({ success: true, merged: { id: 1 }, warnings: ['title'] })
+        );
+        if (result.kind === 'merged') {
+            expect(result.warnings).toEqual(['title']);
+        }
     });
 });

--- a/frontend/src/hooks/useStudyPersistence.helpers.test.ts
+++ b/frontend/src/hooks/useStudyPersistence.helpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { isDraftInSync } from './useStudyPersistence.helpers';
+
+describe('isDraftInSync', () => {
+    it('returns true when draft equals original', () => {
+        const draft = { id: 1, title: 'a' };
+        const original = { id: 1, title: 'a' };
+        expect(isDraftInSync(draft, original, null)).toBe(true);
+    });
+
+    it('returns true when draft equals last saved (even if differs from original)', () => {
+        const draft = { id: 1, title: 'b' };
+        const original = { id: 1, title: 'a' };
+        const lastSaved = JSON.stringify({ id: 1, title: 'b' });
+        expect(isDraftInSync(draft, original, lastSaved)).toBe(true);
+    });
+
+    it('returns false when draft differs from both', () => {
+        const draft = { id: 1, title: 'c' };
+        const original = { id: 1, title: 'a' };
+        const lastSaved = JSON.stringify({ id: 1, title: 'b' });
+        expect(isDraftInSync(draft, original, lastSaved)).toBe(false);
+    });
+
+    it('handles null original (no server state yet)', () => {
+        const draft = { id: 1, title: 'a' };
+        const lastSaved = JSON.stringify({ id: 1, title: 'a' });
+        expect(isDraftInSync(draft, null, lastSaved)).toBe(true);
+    });
+
+    it('handles null lastSaved', () => {
+        const draft = { id: 1, title: 'a' };
+        const original = { id: 1, title: 'a' };
+        expect(isDraftInSync(draft, original, null)).toBe(true);
+    });
+});

--- a/frontend/src/hooks/useStudyPersistence.helpers.ts
+++ b/frontend/src/hooks/useStudyPersistence.helpers.ts
@@ -1,0 +1,19 @@
+import { areStudiesEqual } from '@/store/useStudyDesigner';
+import type { StudyUpdate } from '@/api/model';
+
+/**
+ * Returns true when the draft is in sync with either the original server state
+ * (already projected to StudyUpdate by the caller) or the last successfully
+ * saved draft snapshot.
+ */
+export function isDraftInSync(
+    draft: StudyUpdate,
+    original: StudyUpdate | null,
+    lastSavedDraftJson: string | null
+): boolean {
+    if (areStudiesEqual(draft, original)) return true;
+    if (lastSavedDraftJson) {
+        return areStudiesEqual(draft, JSON.parse(lastSavedDraftJson) as StudyUpdate);
+    }
+    return false;
+}

--- a/frontend/src/hooks/useStudyPersistence.helpers.ts
+++ b/frontend/src/hooks/useStudyPersistence.helpers.ts
@@ -1,5 +1,40 @@
 import { areStudiesEqual } from '@/store/useStudyDesigner';
 import type { StudyUpdate } from '@/api/model';
+import { mergeStudyUpdates, type MergeStudyResult } from '@/utils/mergeStudy';
+
+type MergeFn = (
+    local: StudyUpdate,
+    server: StudyUpdate,
+    original: StudyUpdate | null,
+    strategy: 'local-wins'
+) => MergeStudyResult;
+
+export type ConflictResolution =
+    | { kind: 'merged'; merged: StudyUpdate; warnings: string[] }
+    | { kind: 'hard-conflict' };
+
+/**
+ * Resolve a 409 conflict by merging local draft against server state.
+ * Caller must pre-convert serverRead/original to StudyUpdate via
+ * projectStudyToUpdate before calling. Returns 'merged' with the merged
+ * draft (and any warnings) on success, 'hard-conflict' otherwise.
+ */
+export function resolveServerConflict(
+    draft: StudyUpdate,
+    serverUpdate: StudyUpdate,
+    originalUpdate: StudyUpdate | null,
+    merge: MergeFn = mergeStudyUpdates
+): ConflictResolution {
+    const result = merge(draft, serverUpdate, originalUpdate, 'local-wins');
+    if (result.success && result.merged) {
+        return {
+            kind: 'merged',
+            merged: result.merged,
+            warnings: result.warnings ?? [],
+        };
+    }
+    return { kind: 'hard-conflict' };
+}
 
 /**
  * Returns true when the draft is in sync with either the original server state

--- a/frontend/src/hooks/useStudyPersistence.ts
+++ b/frontend/src/hooks/useStudyPersistence.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useStudyDesigner, projectStudyToUpdate, areStudiesEqual } from '@/store/useStudyDesigner';
+import { useStudyDesigner, projectStudyToUpdate } from '@/store/useStudyDesigner';
+import { isDraftInSync } from './useStudyPersistence.helpers';
 import { useUpdateStudyApiAdminStudiesSlugPatch } from '@/api/generated';
 import type { StudyUpdate, StudyRead } from '@/api/model';
 import { useBlocker, useParams } from 'react-router-dom';
@@ -56,34 +57,29 @@ export function useStudyPersistence() {
     // Exposed blocker for UI handling
     // We intentionally removed the window.confirm logic here to let the UI handle it via the blocker object
 
-    // 4. Change Detection Logic
     useEffect(() => {
         if (!draft || !effectiveSlug) return;
 
-        // Detect if something actually changed relative to what's on server or last saved
-        const originalDraft = original ? projectStudyToUpdate(original) : null;
+        const synced = isDraftInSync(
+            draft,
+            original ? projectStudyToUpdate(original) : null,
+            lastSavedDraftRef.current
+        );
 
-        // If draft content matches original content or last saved content
-        const isSyncedWithOriginal = areStudiesEqual(draft, originalDraft);
-        const isSyncedWithLastSave =
-            lastSavedDraftRef.current &&
-            areStudiesEqual(draft, JSON.parse(lastSavedDraftRef.current));
-
-        if (isSyncedWithOriginal || isSyncedWithLastSave) {
+        if (synced) {
             if (syncStatus !== 'synced' && syncStatus !== 'saving') {
                 setSyncStatus('synced');
             }
             return;
         }
 
-        // Mark as modified if not already saving
         if (syncStatus !== 'modified' && syncStatus !== 'saving' && syncStatus !== 'error') {
             setSyncStatus('modified');
         }
 
-        // 5. Local Backup Logic
-        // We keep a local backup in localStorage keyed by slug
-        // This is a safety measure against crashes/refreshes.
+        // 5. Local Backup Logic — keeps a localStorage snapshot keyed by slug
+        // as a safety net against crashes/refreshes. Debounced 1s so we don't
+        // hammer storage on every keystroke.
         const backupTimer = setTimeout(() => {
             if (syncStatus === 'modified' || syncStatus === 'saving') {
                 const backupData = {
@@ -95,10 +91,10 @@ export function useStudyPersistence() {
                     `qualis-draft-backup-${effectiveSlug}`,
                     JSON.stringify(backupData)
                 );
-                // Also update the test draft key so open test tabs can react via 'storage' event
+                // Also update the test-draft key so open test tabs react via 'storage' event.
                 localStorage.setItem(`qualis-test-draft-${effectiveSlug}`, JSON.stringify(draft));
             }
-        }, 1000); // Debounce backup
+        }, 1000);
 
         return () => clearTimeout(backupTimer);
     }, [draft, effectiveSlug, original, setSyncStatus, syncStatus]);

--- a/frontend/src/hooks/useStudyPersistence.ts
+++ b/frontend/src/hooks/useStudyPersistence.ts
@@ -1,12 +1,11 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useStudyDesigner, projectStudyToUpdate } from '@/store/useStudyDesigner';
-import { isDraftInSync } from './useStudyPersistence.helpers';
+import { isDraftInSync, resolveServerConflict } from './useStudyPersistence.helpers';
 import { useUpdateStudyApiAdminStudiesSlugPatch } from '@/api/generated';
 import type { StudyUpdate, StudyRead } from '@/api/model';
 import { useBlocker, useParams } from 'react-router-dom';
 import type { ApiError } from '@/api/client';
-import { mergeStudyUpdates } from '@/utils/mergeStudy';
 import { toast } from 'sonner';
 
 /**
@@ -99,13 +98,82 @@ export function useStudyPersistence() {
         return () => clearTimeout(backupTimer);
     }, [draft, effectiveSlug, original, setSyncStatus, syncStatus]);
 
+    // Applies a resolved 409 conflict to local state.
+    const applyConflict = useCallback(
+        (apiError: ApiError & { details: { server_state: StudyRead } }) => {
+            const serverRead = apiError.details.server_state;
+            const serverUpdate = projectStudyToUpdate(serverRead);
+            const originalUpdate = original ? projectStudyToUpdate(original) : null;
+            const resolution = resolveServerConflict(
+                draft as StudyUpdate,
+                serverUpdate,
+                originalUpdate
+            );
+
+            if (resolution.kind === 'merged') {
+                if (resolution.warnings.length > 0) {
+                    toast.info(
+                        t('admin.study.save.synced_warnings', {
+                            fields: resolution.warnings.join(', '),
+                        })
+                    );
+                } else {
+                    toast.info(t('admin.study.save.synced_concurrent'));
+                }
+                updateOriginal(serverRead);
+                updateDraft((d) => {
+                    Object.keys(d).forEach((k) => {
+                        // @ts-expect-error
+                        if (resolution.merged[k] === undefined) delete d[k];
+                    });
+                    Object.assign(d, resolution.merged);
+                });
+                lastSavedDraftRef.current = null;
+                setSyncStatus('modified');
+                return true;
+            }
+
+            toast.error(
+                t(
+                    'admin.study.save.conflict',
+                    'Conflict detected. Some changes could not be merged.'
+                )
+            );
+            setSyncStatus('error');
+            return false;
+        },
+        [draft, original, updateOriginal, updateDraft, setSyncStatus, t]
+    );
+
+    // Handles errors from the save mutation.
+    const handleSaveError = useCallback(
+        (error: unknown) => {
+            if (error instanceof Error && error.name === 'AbortError') return;
+
+            const apiError = error as ApiError & { details: { server_state: StudyRead } };
+
+            if (apiError?.status === 409 && apiError.details?.server_state) {
+                try {
+                    applyConflict(apiError);
+                } catch (mergeError) {
+                    console.error('Merge failed', mergeError);
+                    setSyncStatus('error');
+                }
+            } else {
+                console.error('Save failed:', error);
+                setSyncStatus('error');
+                toast.error(t('admin.study.save.error', 'Failed to save changes'));
+            }
+        },
+        [applyConflict, setSyncStatus, t]
+    );
+
     // 5. Manual Save Function
     const save = useCallback(async () => {
         if (!draft || !effectiveSlug || syncStatus === 'saving') return;
 
         const draftJson = JSON.stringify(draft);
 
-        // Cancel any in-flight requests
         if (abortControllerRef.current) {
             abortControllerRef.current.abort();
         }
@@ -119,93 +187,14 @@ export function useStudyPersistence() {
                 data: draft as StudyUpdate,
             });
 
-            // Success
             lastSavedDraftRef.current = draftJson;
             setSyncStatus('synced');
             setLastSavedAt(new Date());
-
-            // Sync original and draft immediately to reflect server state
-            // This also ensures last_updated_at matches the server's new timestamp
             setStudy(result);
-
-            // Ensure test draft is synced on successful save
             localStorage.setItem(`qualis-test-draft-${effectiveSlug}`, JSON.stringify(draft));
-
             toast.success(t('admin.study.save.success'));
         } catch (error) {
-            if (error instanceof Error && error.name === 'AbortError') {
-                return;
-            }
-
-            const apiError = error as ApiError & {
-                details: { server_state: StudyRead };
-            };
-
-            // Optimistic Locking: 409 Conflict
-            if (apiError?.status === 409 && apiError.details?.server_state) {
-                try {
-                    const serverRead = apiError.details.server_state;
-                    const serverUpdate = projectStudyToUpdate(serverRead);
-                    const originalUpdate = original ? projectStudyToUpdate(original) : null;
-
-                    const mergeResult = mergeStudyUpdates(
-                        draft,
-                        serverUpdate,
-                        originalUpdate,
-                        'local-wins'
-                    );
-
-                    if (mergeResult.success && mergeResult.merged) {
-                        if (mergeResult.warnings && mergeResult.warnings.length > 0) {
-                            toast.info(
-                                t('admin.study.save.synced_warnings', {
-                                    fields: mergeResult.warnings.join(', '),
-                                })
-                            );
-                        } else {
-                            toast.info(t('admin.study.save.synced_concurrent'));
-                        }
-
-                        // 1. Update Baseline (server state becomes new original)
-                        updateOriginal(serverRead);
-
-                        // 2. Update Draft with Merged Content
-                        updateDraft((d) => {
-                            // Clear existing keys to ensure removal works
-                            Object.keys(d).forEach((k) => {
-                                // @ts-expect-error
-                                if (mergeResult.merged[k] === undefined) delete d[k];
-                            });
-                            Object.assign(d, mergeResult.merged);
-                        });
-
-                        // 3. Mark as modified because the user still hasn't "saved" this merged result
-                        // to the backend, or they might want to review it.
-                        // Actually, in manual mode, maybe we should still be in 'modified' state?
-                        // If we just merged and haven't pushed it back to server, we are definitely NOT synced.
-                        lastSavedDraftRef.current = null; // Forces re-evaluation
-                        setSyncStatus('modified');
-                        return;
-                    } else {
-                        // Hard Conflict
-                        toast.error(
-                            t(
-                                'admin.study.save.conflict',
-                                'Conflict detected. Some changes could not be merged.'
-                            )
-                        );
-                        setSyncStatus('error');
-                        return;
-                    }
-                } catch (mergeError) {
-                    console.error('Merge failed', mergeError);
-                    setSyncStatus('error');
-                }
-            } else {
-                console.error('Save failed:', error);
-                setSyncStatus('error');
-                toast.error(t('admin.study.save.error', 'Failed to save changes'));
-            }
+            handleSaveError(error);
         }
     }, [
         draft,
@@ -215,9 +204,7 @@ export function useStudyPersistence() {
         updateMutation,
         setLastSavedAt,
         setStudy,
-        original,
-        updateDraft,
-        updateOriginal,
+        handleSaveError,
         t,
     ]);
 

--- a/frontend/src/utils/mergeStudy.ts
+++ b/frontend/src/utils/mergeStudy.ts
@@ -2,12 +2,15 @@ import type { StudyUpdate } from '@/api/model';
 
 type ResolutionStrategy = 'manual' | 'local-wins' | 'server-wins';
 
-interface MergeResult {
+export interface MergeStudyResult {
     success: boolean;
-    merged?: StudyUpdate;
+    merged?: StudyUpdate | null;
     conflicts?: string[];
     warnings?: string[];
 }
+
+/** @deprecated Use MergeStudyResult */
+type MergeResult = MergeStudyResult;
 
 /** Track of conflicts/warnings produced while resolving each field. */
 interface MergeAccumulator {

--- a/frontend/src/utils/studyResetHelpers.test.ts
+++ b/frontend/src/utils/studyResetHelpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { applyDefaultsToTranslations } from './studyResetHelpers';
+
+vi.mock('@/constants/studyDefaults', () => ({
+    DEFAULT_STUDY_CONTENT: {
+        en: { instructions: 'Default EN instructions', title: 'Default EN title' },
+        fr: { instructions: 'Default FR instructions', title: 'Default FR title' },
+    },
+}));
+
+describe('applyDefaultsToTranslations', () => {
+    it('returns early when draft has no translations', () => {
+        const draft: { translations?: unknown } = {};
+        applyDefaultsToTranslations(draft, 'instructions');
+        expect(draft).toEqual({});
+    });
+
+    it('applies the EN default to a single EN translation', () => {
+        const draft = { translations: [{ language_code: 'en', instructions: 'old' }] };
+        applyDefaultsToTranslations(draft, 'instructions');
+        expect(draft.translations[0].instructions).toBe('Default EN instructions');
+    });
+
+    it('falls back to EN default when language is not in DEFAULT_STUDY_CONTENT', () => {
+        const draft = { translations: [{ language_code: 'fi', instructions: 'old' }] };
+        applyDefaultsToTranslations(draft, 'instructions');
+        expect(draft.translations[0].instructions).toBe('Default EN instructions');
+    });
+
+    it('applies per-language defaults independently', () => {
+        const draft = {
+            translations: [
+                { language_code: 'en', title: 'old' },
+                { language_code: 'fr', title: 'old' },
+            ],
+        };
+        applyDefaultsToTranslations(draft, 'title');
+        expect(draft.translations[0].title).toBe('Default EN title');
+        expect(draft.translations[1].title).toBe('Default FR title');
+    });
+
+    it('applies the transform when provided', () => {
+        const draft = { translations: [{ language_code: 'en', title: 'old' }] };
+        applyDefaultsToTranslations(draft, 'title', (v: string) => `[${v}]`);
+        expect(draft.translations[0].title).toBe('[Default EN title]');
+    });
+
+    it('skips a field absent from defaults', () => {
+        const draft = { translations: [{ language_code: 'en', missing: 'kept' }] };
+        applyDefaultsToTranslations(draft, 'missing');
+        expect(draft.translations[0].missing).toBe('kept');
+    });
+});

--- a/frontend/src/utils/studyResetHelpers.ts
+++ b/frontend/src/utils/studyResetHelpers.ts
@@ -9,13 +9,31 @@ interface ResetOptions {
 }
 
 /**
- * Creates a reusable handler for resetting study fields to their default localized values.
- *
- * @param updateDraft - The updateDraft function from the study designer store
- * @param t - The translation function
- * @param options - Configuration for confirmations and notifications
- * @returns A function that takes a field name and an optional transform function
+ * Apply the localized default for `field` to every translation on the draft.
+ * Mutates `draft` in place. Falls back to EN defaults when a language is not
+ * in DEFAULT_STUDY_CONTENT. Optionally transforms the default value.
  */
+export function applyDefaultsToTranslations(
+    // biome-ignore lint/suspicious/noExplicitAny: draft requires dynamic property access
+    draft: any,
+    field: string,
+    // biome-ignore lint/suspicious/noExplicitAny: transform handles various value types
+    transform?: (value: any) => any
+): void {
+    if (!draft.translations) return;
+
+    for (const trans of draft.translations) {
+        const lang = trans.language_code;
+        const defaults = DEFAULT_STUDY_CONTENT[lang] || DEFAULT_STUDY_CONTENT.en;
+
+        if (defaults && defaults[field] !== undefined) {
+            const defaultValue = defaults[field];
+            const valueToApply = transform ? transform(defaultValue) : defaultValue;
+            trans[field] = JSON.parse(JSON.stringify(valueToApply));
+        }
+    }
+}
+
 export const createResetToDefaultHandler = (
     // biome-ignore lint/suspicious/noExplicitAny: draft requires dynamic property access
     updateDraft: (fn: (draft: any) => void) => void,
@@ -31,22 +49,7 @@ export const createResetToDefaultHandler = (
         } = options;
 
         const doReset = () => {
-            updateDraft((d) => {
-                if (!d.translations) return;
-
-                for (const trans of d.translations) {
-                    const lang = trans.language_code;
-                    const defaults = DEFAULT_STUDY_CONTENT[lang] || DEFAULT_STUDY_CONTENT.en;
-
-                    if (defaults && defaults[field] !== undefined) {
-                        const defaultValue = defaults[field];
-                        const valueToApply = transform ? transform(defaultValue) : defaultValue;
-
-                        // biome-ignore lint/suspicious/noExplicitAny: dynamic field access
-                        (trans as any)[field] = JSON.parse(JSON.stringify(valueToApply));
-                    }
-                }
-            });
+            updateDraft((d) => applyDefaultsToTranslations(d, field, transform));
             toast.success(successMessage);
         };
 

--- a/frontend/src/utils/tuckerPhi.test.ts
+++ b/frontend/src/utils/tuckerPhi.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { tuckerPhi, matchFactorsByPhi } from './tuckerPhi';
+import { tuckerPhi, matchFactorsByPhi, findBestMatchForFactor } from './tuckerPhi';
 
 describe('tuckerPhi', () => {
     it('returns 1 for identical vectors', () => {
@@ -82,5 +82,49 @@ describe('matchFactorsByPhi', () => {
         const matches = matchFactorsByPhi(a, b);
         expect(matches).toHaveLength(1);
         expect(matches[0]).toMatchObject({ aIndex: 0, bIndex: 0 });
+    });
+});
+
+describe('findBestMatchForFactor', () => {
+    const bMatrix = [
+        [1, 0],
+        [0, 1],
+        [1, 0],
+    ];
+
+    it('picks the highest |φ| from unused columns', () => {
+        const aCol = [1, 0, 1];
+        const used = new Set<number>();
+        const m = findBestMatchForFactor(0, aCol, bMatrix, used);
+        expect(m).not.toBeNull();
+        expect(m?.bIndex).toBe(0);
+        expect(m?.phi).toBeCloseTo(1, 5);
+    });
+
+    it('skips already-used columns', () => {
+        const aCol = [1, 0, 1];
+        const used = new Set([0]);
+        const m = findBestMatchForFactor(0, aCol, bMatrix, used);
+        expect(m?.bIndex).toBe(1);
+    });
+
+    it('returns null when all columns are used', () => {
+        const aCol = [1, 0, 1];
+        const used = new Set([0, 1]);
+        expect(findBestMatchForFactor(0, aCol, bMatrix, used)).toBeNull();
+    });
+
+    it('preserves negative phi for sign-flipped match', () => {
+        const flipped = [
+            [-1, 0],
+            [0, -1],
+            [-1, 0],
+        ];
+        const m = findBestMatchForFactor(0, [1, 0, 1], flipped, new Set());
+        expect(m?.phi).toBeCloseTo(-1, 5);
+    });
+
+    it('returns null for empty bMatrix row width', () => {
+        expect(findBestMatchForFactor(0, [1], [[]], new Set())).toBeNull();
     });
 });

--- a/frontend/src/utils/tuckerPhi.ts
+++ b/frontend/src/utils/tuckerPhi.ts
@@ -34,6 +34,29 @@ export interface FactorMatch {
 }
 
 /**
+ * Find the unused column of bMatrix with the highest |φ| against aCol.
+ * Returns null if all columns are used or bMatrix has no factors.
+ */
+export function findBestMatchForFactor(
+    aIndex: number,
+    aCol: readonly number[],
+    bMatrix: readonly (readonly number[])[],
+    used: ReadonlySet<number>
+): FactorMatch | null {
+    const nFactorsB = bMatrix[0]?.length ?? 0;
+    let best: FactorMatch | null = null;
+    for (let j = 0; j < nFactorsB; j++) {
+        if (used.has(j)) continue;
+        const bCol = bMatrix.map((row) => row[j] ?? 0);
+        const phi = tuckerPhi(aCol, bCol);
+        if (best === null || Math.abs(phi) > Math.abs(best.phi)) {
+            best = { aIndex, bIndex: j, phi };
+        }
+    }
+    return best;
+}
+
+/**
  * Match factors of run A to factors of run B by maximum |φ|.
  * Greedy assignment: for each factor of A in order, pick the unused
  * factor of B with the highest |φ|. Sign of φ is preserved (a flipped
@@ -49,20 +72,11 @@ export function matchFactorsByPhi(
 ): FactorMatch[] {
     if (aMatrix.length === 0 || bMatrix.length === 0) return [];
     const nFactorsA = aMatrix[0]?.length ?? 0;
-    const nFactorsB = bMatrix[0]?.length ?? 0;
     const used = new Set<number>();
     const matches: FactorMatch[] = [];
     for (let i = 0; i < nFactorsA; i++) {
         const aCol = aMatrix.map((row) => row[i] ?? 0);
-        let best: FactorMatch | null = null;
-        for (let j = 0; j < nFactorsB; j++) {
-            if (used.has(j)) continue;
-            const bCol = bMatrix.map((row) => row[j] ?? 0);
-            const phi = tuckerPhi(aCol, bCol);
-            if (best === null || Math.abs(phi) > Math.abs(best.phi)) {
-                best = { aIndex: i, bIndex: j, phi };
-            }
-        }
+        const best = findBestMatchForFactor(i, aCol, bMatrix, used);
         if (best !== null) {
             used.add(best.bIndex);
             matches.push(best);

--- a/frontend/src/utils/uaParser.test.ts
+++ b/frontend/src/utils/uaParser.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { parseUA } from './uaParser';
+
+describe('parseUA', () => {
+    it('returns Unknown defaults for empty input', () => {
+        expect(parseUA()).toEqual({ browser: 'Unknown', os: 'Unknown', device: 'desktop' });
+        expect(parseUA('')).toEqual({ browser: 'Unknown', os: 'Unknown', device: 'desktop' });
+    });
+
+    it('detects iPad as tablet + iOS + Safari', () => {
+        const ua = 'Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit Safari/605.1.15';
+        const r = parseUA(ua);
+        expect(r.device).toBe('tablet');
+        expect(r.os).toBe('iOS');
+        expect(r.browser).toBe('Safari');
+    });
+
+    it('detects iPhone as mobile + iOS', () => {
+        const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0)';
+        expect(parseUA(ua)).toMatchObject({ device: 'mobile', os: 'iOS' });
+    });
+
+    it('detects Android phone as mobile + Android + Chrome', () => {
+        const ua = 'Mozilla/5.0 (Linux; Android 13) AppleWebKit Chrome/120';
+        const r = parseUA(ua);
+        expect(r.device).toBe('mobile');
+        expect(r.os).toBe('Android');
+        expect(r.browser).toBe('Chrome');
+    });
+
+    it('detects Edge over Chrome on Windows', () => {
+        const ua = 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit Chrome/120 Edg/120';
+        const r = parseUA(ua);
+        expect(r.os).toBe('Windows');
+        expect(r.browser).toBe('Edge');
+    });
+
+    it('detects Opera not Chrome', () => {
+        const ua = 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit Chrome/120 OPR/100';
+        expect(parseUA(ua).browser).toBe('Opera');
+    });
+
+    it('detects Firefox', () => {
+        expect(parseUA('Mozilla/5.0 Firefox/120').browser).toBe('Firefox');
+    });
+
+    it('detects macOS desktop Safari', () => {
+        const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit Safari/605';
+        expect(parseUA(ua)).toEqual({ device: 'desktop', os: 'macOS', browser: 'Safari' });
+    });
+
+    it('detects Linux desktop', () => {
+        expect(parseUA('Mozilla/5.0 (X11; Linux x86_64) Firefox/120').os).toBe('Linux');
+    });
+
+    it('falls back to desktop when no mobile/tablet markers present', () => {
+        expect(parseUA('Mozilla/5.0 (Windows NT 10.0)').device).toBe('desktop');
+    });
+});

--- a/frontend/src/utils/uaParser.ts
+++ b/frontend/src/utils/uaParser.ts
@@ -4,52 +4,38 @@ interface UAInfo {
     device: 'mobile' | 'tablet' | 'desktop';
 }
 
-/**
- * Parse user agent string to extract browser, OS, and device type
- */
+function detectDevice(ua: string): UAInfo['device'] {
+    if (/tablet|ipad|playbook|silk/i.test(ua)) return 'tablet';
+    if (/mobile|iphone|ipod|android|blackberry|opera mini|windows phone/i.test(ua)) return 'mobile';
+    return 'desktop';
+}
+
+function detectOS(ua: string): string {
+    if (/windows/i.test(ua)) return 'Windows';
+    if (/android/i.test(ua)) return 'Android';
+    if (/ipad|iphone|ipod/i.test(ua)) return 'iOS';
+    if (/macintosh|mac os x/i.test(ua)) return 'macOS';
+    if (/linux/i.test(ua)) return 'Linux';
+    return 'Unknown';
+}
+
+function detectBrowser(ua: string): string {
+    if (/edg/i.test(ua)) return 'Edge';
+    if (/opr|opios/i.test(ua)) return 'Opera';
+    if (/chrome|crios/i.test(ua)) return 'Chrome';
+    if (/firefox|fxios/i.test(ua)) return 'Firefox';
+    if (/safari/i.test(ua)) return 'Safari';
+    if (/trident|msie/i.test(ua)) return 'Internet Explorer';
+    return 'Unknown';
+}
+
 export function parseUA(userAgent?: string): UAInfo {
-    const info: UAInfo = {
-        browser: 'Unknown',
-        os: 'Unknown',
-        device: 'desktop',
+    if (!userAgent) {
+        return { browser: 'Unknown', os: 'Unknown', device: 'desktop' };
+    }
+    return {
+        device: detectDevice(userAgent),
+        os: detectOS(userAgent),
+        browser: detectBrowser(userAgent),
     };
-
-    if (!userAgent) return info;
-
-    // Device detection
-    if (/tablet|ipad|playbook|silk/i.test(userAgent)) {
-        info.device = 'tablet';
-    } else if (/mobile|iphone|ipod|android|blackberry|opera mini|windows phone/i.test(userAgent)) {
-        info.device = 'mobile';
-    }
-
-    // OS detection
-    if (/windows/i.test(userAgent)) {
-        info.os = 'Windows';
-    } else if (/android/i.test(userAgent)) {
-        info.os = 'Android';
-    } else if (/ipad|iphone|ipod/i.test(userAgent)) {
-        info.os = 'iOS';
-    } else if (/macintosh|mac os x/i.test(userAgent)) {
-        info.os = 'macOS';
-    } else if (/linux/i.test(userAgent)) {
-        info.os = 'Linux';
-    }
-
-    // Browser detection
-    if (/edg/i.test(userAgent)) {
-        info.browser = 'Edge';
-    } else if (/chrome|crios/i.test(userAgent) && !/opr|opios/i.test(userAgent)) {
-        info.browser = 'Chrome';
-    } else if (/firefox|fxios/i.test(userAgent)) {
-        info.browser = 'Firefox';
-    } else if (/safari/i.test(userAgent) && !/chrome|crios|edg|opr|opios/i.test(userAgent)) {
-        info.browser = 'Safari';
-    } else if (/opr|opios/i.test(userAgent)) {
-        info.browser = 'Opera';
-    } else if (/trident|msie/i.test(userAgent)) {
-        info.browser = 'Internet Explorer';
-    }
-
-    return info;
 }


### PR DESCRIPTION
## Summary
- Extract pure helpers from 12 cognitive-complexity sites in W1 scope (utilities + transverse hooks).
- Pin existing behavior with characterization tests before each refactor.
- Reduce frontend complexity warnings from **65 to 53** (-12, -18.5%).

Refactors follow patterns P3 (utility decomposition) and P4 (hook helper extraction) from [`docs/superpowers/specs/2026-05-03-ci-warnings-design.md`](docs/superpowers/specs/2026-05-03-ci-warnings-design.md). Implementation steps in [`docs/superpowers/plans/2026-05-03-ci-warnings-wave1-utilities.md`](docs/superpowers/plans/2026-05-03-ci-warnings-wave1-utilities.md).

Files refactored:
- `utils/uaParser.ts` — split into per-axis detectors
- `utils/tuckerPhi.ts` — extract `findBestMatchForFactor`
- `utils/studyResetHelpers.ts` — extract `applyDefaultsToTranslations`
- `api/mutator.ts` — split `handleErrorStatus` per status code
- `hooks/useStudyPersistence.ts` — extract `isDraftInSync`, `resolveServerConflict` (+ inner `applyConflict`/`handleSaveError` callbacks)
- `hooks/useDragAutoInteraction.ts` — extract `computeNextPanPosition`, `computeEdgePanSpeed` (+ inner `schedulePanActivation` callback)
- `hooks/useGridZoom.ts` — extract `computeAutoFitTransform`
- `hooks/useGridCalculations.ts` — extract `computeCardDimensions`
- `hooks/useFineSortDrag.ts` — extract `resolveDropTarget`
- `hooks/admin/useRecruitmentPage.ts` — extract `buildAccessRulesUpdate`

Sister change: `utils/mergeStudy.ts` exports `MergeStudyResult` (with `MergeResult` kept as a deprecated internal alias).

## Test plan
- [x] \`make ci-fast\` green at every commit (lint + types + unit)
- [x] \`make ci\` green pre-push (lint + check + tests + build)
- [x] Existing hook test files (\`useStudyPersistence.test.ts\`, \`useGridZoom.test.ts\`, \`useFineSortDrag.test.ts\`/\`.deck.test.ts\`, \`mutator.test.ts\`, \`tuckerPhi.test.ts\`) still pass
- [x] **57 new pure-helper tests** added across 9 new \`*.helpers.test.ts\` / \`*.test.ts\` files
- [x] Frontend complexity warning count drops from 65 to 53 (-12)

## Review process
- Spec compliance reviewer (Sonnet) on every commit.
- Code-quality reviewer (Opus, extra-high effort) on every commit.
- Tasks 4 (\`mutator.handleErrorStatus\`) and 6 (\`useStudyPersistence.save\` 409 conflict) — high-risk auth/persistence — got **double Opus review**.
- Codex consulted on T5 (helper signature: \`StudyUpdate\` vs \`StudyRead\` — cleaner narrow contract approved) and T6 (triple-extraction expansion + \`MergeStudyResult\` aliasing — approved with non-blocking follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)