### PR TITLE
refactor: W3a — designer micro-utilities (cognitive complexity)

### DIFF
--- a/frontend/src/components/admin/designer/LanguageManagerModal.helpers.test.ts
+++ b/frontend/src/components/admin/designer/LanguageManagerModal.helpers.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { applyLanguageRestore, applyLanguageInit } from './LanguageManagerModal.helpers';
+
+describe('applyLanguageRestore', () => {
+    it('does nothing when the language is not in original.translations', () => {
+        const draft = { translations: [], statements: [] };
+        const original = { translations: [], statements: [] };
+        applyLanguageRestore(draft, 'fr', original);
+        expect(draft.translations).toEqual([]);
+    });
+
+    it('copies the original study translation with _is_copy=false', () => {
+        const draft = { translations: [], statements: [] };
+        const original = {
+            translations: [{ language_code: 'fr', title: 'Titre', _is_copy: true }],
+            statements: [],
+        };
+        applyLanguageRestore(draft, 'fr', original);
+        expect(draft.translations).toHaveLength(1);
+        const t = draft.translations[0] as {
+            language_code: string;
+            title: string;
+            _is_copy: boolean;
+        };
+        expect(t.language_code).toBe('fr');
+        expect(t.title).toBe('Titre');
+        expect(t._is_copy).toBe(false);
+    });
+
+    it('copies original statement translations matching by code', () => {
+        const draft = {
+            translations: [],
+            statements: [{ code: 'S1', translations: [] }],
+        };
+        const original = {
+            translations: [{ language_code: 'fr', title: 'Titre' }],
+            statements: [{ code: 'S1', translations: [{ language_code: 'fr', text: 'Énoncé 1' }] }],
+        };
+        applyLanguageRestore(draft, 'fr', original);
+        const stmt = draft.statements[0] as {
+            translations: { language_code: string; text: string }[];
+        };
+        expect(stmt.translations).toHaveLength(1);
+        expect(stmt.translations[0]).toEqual({ language_code: 'fr', text: 'Énoncé 1' });
+    });
+
+    it('seeds empty text when statement is new (no original by that code)', () => {
+        const draft = {
+            translations: [],
+            statements: [{ code: 'S_NEW', translations: [] }],
+        };
+        const original = {
+            translations: [{ language_code: 'fr', title: 'Titre' }],
+            statements: [{ code: 'S1', translations: [{ language_code: 'fr', text: 'X' }] }],
+        };
+        applyLanguageRestore(draft, 'fr', original);
+        const stmt = draft.statements[0] as { translations: { text: string }[] };
+        expect(stmt.translations[0]?.text).toBe('');
+    });
+
+    it('seeds empty text when statement matches but has no translation in lang', () => {
+        const draft = {
+            translations: [],
+            statements: [{ code: 'S1', translations: [] }],
+        };
+        const original = {
+            translations: [{ language_code: 'fr', title: 'Titre' }],
+            statements: [{ code: 'S1', translations: [{ language_code: 'en', text: 'X' }] }],
+        };
+        applyLanguageRestore(draft, 'fr', original);
+        const stmt = draft.statements[0] as { translations: { text: string }[] };
+        expect(stmt.translations[0]?.text).toBe('');
+    });
+
+    it('initialises stmt.translations array when missing', () => {
+        const draft = {
+            translations: [],
+            statements: [{ code: 'S1' }],
+        };
+        const original = {
+            translations: [{ language_code: 'fr' }],
+            statements: [{ code: 'S1', translations: [{ language_code: 'fr', text: 'X' }] }],
+        };
+        applyLanguageRestore(draft, 'fr', original);
+        const stmt = draft.statements[0] as { translations: unknown[] };
+        expect(Array.isArray(stmt.translations)).toBe(true);
+        expect(stmt.translations).toHaveLength(1);
+    });
+});
+
+describe('applyLanguageInit', () => {
+    it('adds the language with empty fields when not present', () => {
+        const draft = { translations: [], statements: [] };
+        applyLanguageInit(draft, 'fr');
+        expect(draft.translations).toHaveLength(1);
+        const t = draft.translations[0] as { language_code: string; title: string };
+        expect(t.language_code).toBe('fr');
+        expect(t.title).toBe('');
+    });
+
+    it('is idempotent on study translations (skips if exists)', () => {
+        const draft = {
+            translations: [{ language_code: 'fr', title: 'Existing' }],
+            statements: [],
+        };
+        applyLanguageInit(draft, 'fr');
+        expect(draft.translations).toHaveLength(1);
+        const t = draft.translations[0] as { title: string };
+        expect(t.title).toBe('Existing');
+    });
+
+    it('seeds empty text on every statement', () => {
+        const draft = {
+            translations: [],
+            statements: [
+                { code: 'S1', translations: [] },
+                { code: 'S2', translations: [{ language_code: 'en', text: 'X' }] },
+            ],
+        };
+        applyLanguageInit(draft, 'fr');
+        const s1 = draft.statements[0] as {
+            translations: { language_code: string; text: string }[];
+        };
+        const s2 = draft.statements[1] as {
+            translations: { language_code: string; text: string }[];
+        };
+        expect(s1.translations).toHaveLength(1);
+        expect(s1.translations[0]?.language_code).toBe('fr');
+        expect(s2.translations).toHaveLength(2);
+    });
+
+    it('skips per-statement push when already present', () => {
+        const draft = {
+            translations: [],
+            statements: [{ code: 'S1', translations: [{ language_code: 'fr', text: 'Already' }] }],
+        };
+        applyLanguageInit(draft, 'fr');
+        const s = draft.statements[0] as { translations: { text: string }[] };
+        expect(s.translations).toHaveLength(1);
+        expect(s.translations[0]?.text).toBe('Already');
+    });
+
+    it('initialises stmt.translations array when missing', () => {
+        const draft = {
+            translations: [],
+            statements: [{ code: 'S1' }],
+        };
+        applyLanguageInit(draft, 'fr');
+        const s = draft.statements[0] as { translations: unknown[] };
+        expect(Array.isArray(s.translations)).toBe(true);
+    });
+});

--- a/frontend/src/components/admin/designer/LanguageManagerModal.helpers.ts
+++ b/frontend/src/components/admin/designer/LanguageManagerModal.helpers.ts
@@ -1,0 +1,97 @@
+/**
+ * Helpers for activating a language on a study draft. Two strategies:
+ * - `applyLanguageRestore`: re-add a previously-saved language by copying
+ *   translation objects (study + statements) from the saved `original`.
+ * - `applyLanguageInit`: add a brand-new language with empty fields and
+ *   empty statement translations.
+ *
+ * Both helpers mutate `draft` in place. The signatures use `any` because the
+ * Zustand store's `updateDraft` is typed `(d: any) => void` (load-bearing
+ * dynamic JSON shapes — see CLAUDE.md project conventions).
+ */
+
+// biome-ignore lint/suspicious/noExplicitAny: load-bearing dynamic study draft shape
+type Draft = any;
+// biome-ignore lint/suspicious/noExplicitAny: load-bearing dynamic study read shape
+type Original = any;
+
+function ensureTranslationsArray(draft: Draft): void {
+    if (!Array.isArray(draft.translations)) {
+        draft.translations = [];
+    }
+}
+
+function ensureStatementsArray(draft: Draft): void {
+    if (!Array.isArray(draft.statements)) {
+        draft.statements = [];
+    }
+}
+
+/**
+ * Restore a previously-saved language: copy the saved study translation
+ * (clearing any `_is_copy` flag), then for each statement copy the matching
+ * saved statement translation; if the statement is new (no original), seed
+ * an empty translation entry.
+ */
+export function applyLanguageRestore(draft: Draft, langCode: string, original: Original): void {
+    const existingStudyTrans = original?.translations?.find(
+        // biome-ignore lint/suspicious/noExplicitAny: dynamic translation shape
+        (t: any) => t.language_code === langCode
+    );
+    if (!existingStudyTrans) return;
+
+    ensureTranslationsArray(draft);
+    draft.translations.push({ ...existingStudyTrans, _is_copy: false });
+
+    ensureStatementsArray(draft);
+    for (const stmt of draft.statements) {
+        if (!Array.isArray(stmt.translations)) stmt.translations = [];
+        const originalStmt = original?.statements?.find(
+            // biome-ignore lint/suspicious/noExplicitAny: dynamic statement shape
+            (os: any) => os.code === stmt.code
+        );
+        const originalStmtTrans = originalStmt?.translations?.find(
+            // biome-ignore lint/suspicious/noExplicitAny: dynamic statement-translation shape
+            (st: any) => st.language_code === langCode
+        );
+        stmt.translations.push({
+            language_code: langCode,
+            text: originalStmtTrans?.text ?? '',
+        });
+    }
+}
+
+/**
+ * Add a new language to the draft with empty study fields and empty
+ * per-statement translations. Idempotent: skips if the language already
+ * exists on the study or on a given statement.
+ */
+export function applyLanguageInit(draft: Draft, langCode: string): void {
+    ensureTranslationsArray(draft);
+    const exists = draft.translations.some(
+        // biome-ignore lint/suspicious/noExplicitAny: dynamic translation shape
+        (t: any) => t.language_code === langCode
+    );
+    if (!exists) {
+        draft.translations.push({
+            language_code: langCode,
+            title: '',
+            subtitle: '',
+            description: '',
+            instructions: '',
+            condition_of_instruction: '',
+        });
+    }
+
+    ensureStatementsArray(draft);
+    for (const stmt of draft.statements) {
+        if (!Array.isArray(stmt.translations)) stmt.translations = [];
+        const hasTrans = stmt.translations.some(
+            // biome-ignore lint/suspicious/noExplicitAny: dynamic statement-translation shape
+            (st: any) => st.language_code === langCode
+        );
+        if (!hasTrans) {
+            stmt.translations.push({ language_code: langCode, text: '' });
+        }
+    }
+}

--- a/frontend/src/components/admin/designer/LanguageManagerModal.tsx
+++ b/frontend/src/components/admin/designer/LanguageManagerModal.tsx
@@ -13,6 +13,7 @@ import { Badge } from '@/components/ui/badge';
 import { Check, Plus, Languages } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { SUPPORTED_LANGUAGES, type Language } from '@/constants/languages';
+import { applyLanguageRestore, applyLanguageInit } from './LanguageManagerModal.helpers';
 
 interface LanguageManagerModalProps {
     isOpen: boolean;
@@ -29,86 +30,17 @@ const LanguageManagerModal = ({ isOpen, onClose }: LanguageManagerModalProps) =>
 
     const handleActivate = (langCode: string) => {
         // Check if this language exists in the original (saved) study
-        // If so, restore it instead of copying from source
+        // If so, restore it instead of copying from source.
         const existingTranslation = original?.translations?.find(
             (t) => t.language_code === langCode
         );
 
         if (existingTranslation) {
-            updateDraft((d) => {
-                // 1. Restore translation object
-                // 1. Restore translation object
-                d.translations?.push({
-                    ...existingTranslation,
-                    // Ensure we reset any copy flag if it existed
-                    _is_copy: false,
-                    // biome-ignore lint/suspicious/noExplicitAny: explicit bypass for draft update
-                } as any);
-
-                // 2. Restore statement translations
-                if (d.statements) {
-                    for (const s of d.statements) {
-                        // Find the original statement to get its translation
-                        // We match by code, assuming code is stable.
-                        // If statement was added in draft (no original), it won't have an original translation.
-                        const originalStmt = original?.statements?.find((os) => os.code === s.code);
-
-                        const originalStmtTrans = originalStmt?.translations?.find(
-                            (st) => st.language_code === langCode
-                        );
-
-                        if (originalStmtTrans) {
-                            s.translations?.push({
-                                language_code: langCode,
-                                text: originalStmtTrans.text,
-                            });
-                        } else {
-                            // If no original translation (e.g. statement is new),
-                            // we might want to copy from source?
-                            // But here we are "restoring" the language.
-                            // If the statement is new, it has no translation in this restored language.
-                            // Default to empty string.
-                            s.translations?.push({
-                                language_code: langCode,
-                                text: '',
-                            });
-                        }
-                    }
-                }
-            });
+            updateDraft((d) => applyLanguageRestore(d, langCode, original));
             return;
         }
 
-        updateDraft((d) => {
-            // 1. Create a minimal translation object if it doesn't exist
-            // (Note: updateDraft already runs normalizeStudyData which ensures translations exist)
-            // But we want to explicitly add it here if it's missing from the array
-            const exists = d.translations?.some((t) => t.language_code === langCode);
-            if (!exists) {
-                d.translations?.push({
-                    language_code: langCode,
-                    title: '',
-                    subtitle: '',
-                    description: '',
-                    instructions: '',
-                    condition_of_instruction: '',
-                    // biome-ignore lint/suspicious/noExplicitAny: explicit bypass for draft update
-                } as any);
-            }
-
-            // 2. Initialize statement translations if missing
-            if (d.statements) {
-                for (const s of d.statements) {
-                    const hasTrans = s.translations?.some((st) => st.language_code === langCode);
-                    if (!hasTrans) {
-                        s.translations?.push({
-                            language_code: langCode,
-                            text: '',
-                        });
-                    }
-                }
-            }
-        });
+        updateDraft((d) => applyLanguageInit(d, langCode));
     };
 
     const handleDeactivate = (langCode: string) => {

--- a/frontend/src/components/admin/designer/MultiLangFieldIcon.helpers.test.ts
+++ b/frontend/src/components/admin/designer/MultiLangFieldIcon.helpers.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { buildOtherTranslations } from './MultiLangFieldIcon.helpers';
+
+describe('buildOtherTranslations', () => {
+    describe('record-map input', () => {
+        it('returns empty when only the active locale has a value', () => {
+            expect(buildOtherTranslations({ en: 'Hello' }, 'en')).toEqual([]);
+        });
+
+        it('skips the active locale and returns other languages', () => {
+            const r = buildOtherTranslations({ en: 'Hello', fr: 'Bonjour', fi: 'Hei' }, 'en');
+            expect(r).toHaveLength(2);
+            expect(r.map((e) => e.code).sort()).toEqual(['fi', 'fr']);
+            expect(r.find((e) => e.code === 'fr')?.value).toBe('Bonjour');
+        });
+
+        it('skips empty and whitespace-only values', () => {
+            const r = buildOtherTranslations({ en: 'Hello', fr: '', fi: '   ' }, 'en');
+            expect(r).toEqual([]);
+        });
+
+        it('falls back to fallback flag/label for unknown language codes', () => {
+            const r = buildOtherTranslations({ en: 'Hello', xx: 'Foo' }, 'en');
+            expect(r).toHaveLength(1);
+            expect(r[0]?.flag).toBe('🌐');
+            expect(r[0]?.label).toBe('xx');
+        });
+    });
+
+    describe('array input', () => {
+        it('reads `text` field then `value` field', () => {
+            const r = buildOtherTranslations(
+                [
+                    { language_code: 'en', text: 'Hello' },
+                    { language_code: 'fr', value: 'Bonjour' },
+                ],
+                'en'
+            );
+            expect(r).toHaveLength(1);
+            expect(r[0]?.code).toBe('fr');
+            expect(r[0]?.value).toBe('Bonjour');
+        });
+
+        it('skips the active locale', () => {
+            const r = buildOtherTranslations(
+                [
+                    { language_code: 'en', text: 'Hello' },
+                    { language_code: 'fr', text: 'Bonjour' },
+                ],
+                'fr'
+            );
+            expect(r).toHaveLength(1);
+            expect(r[0]?.code).toBe('en');
+        });
+
+        it('skips entries with no text/value or whitespace', () => {
+            const r = buildOtherTranslations(
+                [
+                    { language_code: 'en', text: 'Hello' },
+                    { language_code: 'fr' },
+                    { language_code: 'fi', text: '   ' },
+                ],
+                'en'
+            );
+            expect(r).toEqual([]);
+        });
+    });
+});

--- a/frontend/src/components/admin/designer/MultiLangFieldIcon.helpers.ts
+++ b/frontend/src/components/admin/designer/MultiLangFieldIcon.helpers.ts
@@ -1,0 +1,42 @@
+import { SUPPORTED_LANGUAGES } from '@/constants/languages';
+
+export interface OtherTranslationEntry {
+    code: string;
+    value: string;
+    label: string;
+    flag: string;
+}
+
+type TranslationsInput =
+    | Record<string, string>
+    | { language_code: string; value?: string; text?: string }[];
+
+function getLangInfo(code: string): { label: string; flag: string } {
+    const lang = SUPPORTED_LANGUAGES.find((l) => l.code === code);
+    return {
+        label: lang?.label || code,
+        flag: lang?.flag || '🌐',
+    };
+}
+
+/** Normalise the two supported input shapes into a uniform `[code, value][]`. */
+function normaliseToEntries(input: TranslationsInput): [string, string][] {
+    if (Array.isArray(input)) {
+        return input.map((item) => [item.language_code, item.text ?? item.value ?? '']);
+    }
+    return Object.entries(input);
+}
+
+/**
+ * Build the list of non-active-locale translations with non-empty values,
+ * normalising the two possible input shapes (array of translation objects
+ * or record map) to a uniform `OtherTranslationEntry[]`.
+ */
+export function buildOtherTranslations(
+    translations: TranslationsInput,
+    activeLocale: string
+): OtherTranslationEntry[] {
+    return normaliseToEntries(translations)
+        .filter(([code, value]) => code !== activeLocale && !!value && value.trim() !== '')
+        .map(([code, value]) => ({ code, value, ...getLangInfo(code) }));
+}

--- a/frontend/src/components/admin/designer/MultiLangFieldIcon.tsx
+++ b/frontend/src/components/admin/designer/MultiLangFieldIcon.tsx
@@ -9,9 +9,9 @@ import {
     DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { SUPPORTED_LANGUAGES } from '@/constants/languages';
 import { cn } from '@/lib/utils';
 import { SafeMarkdown } from '@/components/SafeMarkdown';
+import { buildOtherTranslations } from './MultiLangFieldIcon.helpers';
 
 interface MultiLangFieldIconProps {
     /** Map of language code to string value or a list of translation objects */
@@ -32,46 +32,10 @@ export const MultiLangFieldIcon = ({
 }: MultiLangFieldIconProps) => {
     const { t } = useTranslation();
 
-    const otherTranslations = useMemo(() => {
-        const result: { code: string; value: string; label: string; flag: string }[] = [];
-
-        const getLangInfo = (code: string) => {
-            const lang = SUPPORTED_LANGUAGES.find((l) => l.code === code);
-            return {
-                label: lang?.label || code,
-                flag: lang?.flag || '🌐',
-            };
-        };
-
-        if (Array.isArray(translations)) {
-            for (const item of translations) {
-                if (item.language_code === activeLocale) continue;
-                const value = item.text ?? item.value ?? '';
-                if (!value.trim()) continue;
-
-                const info = getLangInfo(item.language_code);
-                result.push({
-                    code: item.language_code,
-                    value,
-                    ...info,
-                });
-            }
-        } else {
-            for (const [code, value] of Object.entries(translations)) {
-                if (code === activeLocale) continue;
-                if (!value || !value.trim()) continue;
-
-                const info = getLangInfo(code);
-                result.push({
-                    code,
-                    value,
-                    ...info,
-                });
-            }
-        }
-
-        return result;
-    }, [translations, activeLocale]);
+    const otherTranslations = useMemo(
+        () => buildOtherTranslations(translations, activeLocale),
+        [translations, activeLocale]
+    );
 
     if (otherTranslations.length === 0) return null;
 

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -286,6 +286,7 @@ export function ProcessStepEditor({
         });
 
         if (someMismatch) {
+            // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — translation-array sync useEffect bound by missing process_steps schema typing on StudyTranslation; the (t as any).process_steps casts (8 sites in this block) make extraction unsafe until the typing gap is fixed (see W2-end backlog review)
             updateDraft((d) => {
                 // We use the first translation that has steps as the master order
                 const masterTranslation = d.translations?.find(

--- a/frontend/src/components/admin/designer/QuestionBuilder.helpers.test.ts
+++ b/frontend/src/components/admin/designer/QuestionBuilder.helpers.test.ts
@@ -8,11 +8,7 @@ describe('copyMultilangField', () => {
     });
 
     it('overwrites the existing activeLocale value when present', () => {
-        const out = copyMultilangField(
-            { en: 'Hello', fr: 'Bonjour', fi: 'OldFi' },
-            'fr',
-            'fi'
-        );
+        const out = copyMultilangField({ en: 'Hello', fr: 'Bonjour', fi: 'OldFi' }, 'fr', 'fi');
         expect(out.fi).toBe('Bonjour');
     });
 
@@ -42,38 +38,22 @@ describe('copyOptions', () => {
     });
 
     it('copies sourceLang label into activeLocale on object options', () => {
-        const out = copyOptions(
-            [{ label: { en: 'Yes', fr: 'Oui' }, value: 'y' }],
-            'fr',
-            'fi'
-        );
+        const out = copyOptions([{ label: { en: 'Yes', fr: 'Oui' }, value: 'y' }], 'fr', 'fi');
         expect(out[0]?.label).toEqual({ en: 'Yes', fr: 'Oui', fi: 'Oui' });
     });
 
     it('preserves the value field when object option', () => {
-        const out = copyOptions(
-            [{ label: { en: 'Yes' }, value: 'y' }],
-            'en',
-            'fr'
-        );
+        const out = copyOptions([{ label: { en: 'Yes' }, value: 'y' }], 'en', 'fr');
         expect(out[0]?.value).toBe('y');
     });
 
     it('uses empty string when sourceLang label is missing', () => {
-        const out = copyOptions(
-            [{ label: { en: 'Yes' }, value: 'y' }],
-            'fr',
-            'fi'
-        );
+        const out = copyOptions([{ label: { en: 'Yes' }, value: 'y' }], 'fr', 'fi');
         expect(out[0]?.label.fi).toBe('');
     });
 
     it('mixes string and object options correctly', () => {
-        const out = copyOptions(
-            ['One', { label: { en: 'Two' }, value: '2' }],
-            'en',
-            'fr'
-        );
+        const out = copyOptions(['One', { label: { en: 'Two' }, value: '2' }], 'en', 'fr');
         expect(out[0]).toEqual({ label: { en: 'One', fr: 'One' }, value: 'One' });
         expect(out[1]?.label).toEqual({ en: 'Two', fr: 'Two' });
     });

--- a/frontend/src/components/admin/designer/QuestionBuilder.helpers.test.ts
+++ b/frontend/src/components/admin/designer/QuestionBuilder.helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { copyMultilangField, copyOptions } from './QuestionBuilder.helpers';
+
+describe('copyMultilangField', () => {
+    it('copies sourceLang value into activeLocale on a record input', () => {
+        const out = copyMultilangField({ en: 'Hello', fr: 'Bonjour' }, 'fr', 'fi');
+        expect(out).toEqual({ en: 'Hello', fr: 'Bonjour', fi: 'Bonjour' });
+    });
+
+    it('overwrites the existing activeLocale value when present', () => {
+        const out = copyMultilangField(
+            { en: 'Hello', fr: 'Bonjour', fi: 'OldFi' },
+            'fr',
+            'fi'
+        );
+        expect(out.fi).toBe('Bonjour');
+    });
+
+    it('uses empty string when sourceLang is absent in record', () => {
+        const out = copyMultilangField({ en: 'Hello' }, 'fr', 'fi');
+        expect(out).toEqual({ en: 'Hello', fi: '' });
+    });
+
+    it('migrates a legacy string to multilang record (en + activeLocale = legacy)', () => {
+        const out = copyMultilangField('Hello', 'fr', 'fi');
+        expect(out).toEqual({ en: 'Hello', fi: 'Hello' });
+    });
+
+    it('migrates undefined to empty multilang record', () => {
+        const out = copyMultilangField(undefined, 'fr', 'fi');
+        expect(out).toEqual({ en: '', fi: '' });
+    });
+});
+
+describe('copyOptions', () => {
+    it('migrates string options to the object shape', () => {
+        const out = copyOptions(['Yes', 'No'], 'en', 'fr');
+        expect(out).toEqual([
+            { label: { en: 'Yes', fr: 'Yes' }, value: 'Yes' },
+            { label: { en: 'No', fr: 'No' }, value: 'No' },
+        ]);
+    });
+
+    it('copies sourceLang label into activeLocale on object options', () => {
+        const out = copyOptions(
+            [{ label: { en: 'Yes', fr: 'Oui' }, value: 'y' }],
+            'fr',
+            'fi'
+        );
+        expect(out[0]?.label).toEqual({ en: 'Yes', fr: 'Oui', fi: 'Oui' });
+    });
+
+    it('preserves the value field when object option', () => {
+        const out = copyOptions(
+            [{ label: { en: 'Yes' }, value: 'y' }],
+            'en',
+            'fr'
+        );
+        expect(out[0]?.value).toBe('y');
+    });
+
+    it('uses empty string when sourceLang label is missing', () => {
+        const out = copyOptions(
+            [{ label: { en: 'Yes' }, value: 'y' }],
+            'fr',
+            'fi'
+        );
+        expect(out[0]?.label.fi).toBe('');
+    });
+
+    it('mixes string and object options correctly', () => {
+        const out = copyOptions(
+            ['One', { label: { en: 'Two' }, value: '2' }],
+            'en',
+            'fr'
+        );
+        expect(out[0]).toEqual({ label: { en: 'One', fr: 'One' }, value: 'One' });
+        expect(out[1]?.label).toEqual({ en: 'Two', fr: 'Two' });
+    });
+});

--- a/frontend/src/components/admin/designer/QuestionBuilder.helpers.ts
+++ b/frontend/src/components/admin/designer/QuestionBuilder.helpers.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure copy helpers for QuestionBuilder's "copy translations from another
+ * language" action. The question shapes (label/placeholder/options) accept
+ * BOTH legacy single-string values and the new multilang Record<string, string>
+ * shape, so each helper handles both. Tests pin the migration semantics.
+ */
+
+type MultilangField = string | Record<string, string>;
+type QuestionOption = string | { label: Record<string, string>; value: string };
+
+/**
+ * Copy a value from `sourceLang` into `activeLocale`. The output is always
+ * the multilang record shape (the migration direction is single-string →
+ * record map). When the input is already a record, we preserve all other
+ * languages and only overwrite `activeLocale`.
+ */
+export function copyMultilangField(
+    field: MultilangField | undefined,
+    sourceLang: string,
+    activeLocale: string
+): Record<string, string> {
+    if (typeof field === 'object' && field !== null) {
+        const sourceValue = field[sourceLang] ?? '';
+        return { ...field, [activeLocale]: sourceValue };
+    }
+    const legacy = field ?? '';
+    return { en: legacy, [activeLocale]: legacy };
+}
+
+/**
+ * Copy the source-language label of each option into the active-locale
+ * label. String options are migrated to the object shape (with both `en`
+ * and the active locale set to the original string).
+ */
+export function copyOptions(
+    options: QuestionOption[],
+    sourceLang: string,
+    activeLocale: string
+): { label: Record<string, string>; value: string }[] {
+    return options.map((opt) => {
+        if (typeof opt === 'string') {
+            return {
+                label: { en: opt, [activeLocale]: opt },
+                value: opt,
+            };
+        }
+        const sourceLabel = opt.label[sourceLang] ?? '';
+        return {
+            ...opt,
+            label: { ...opt.label, [activeLocale]: sourceLabel },
+        };
+    });
+}

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -49,6 +49,7 @@ import { useStudyDesigner } from '@/store/useStudyDesigner';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { MultiLangFieldIcon } from './MultiLangFieldIcon';
+import { copyMultilangField, copyOptions } from './QuestionBuilder.helpers';
 import {
     Select,
     SelectContent,
@@ -149,50 +150,21 @@ const QuestionItem = ({
     const handleCopyFrom = (sourceLang: string) => {
         if (readOnly) return;
 
-        const newQuestion = { ...question };
+        const newQuestion: QuestionConfig = {
+            ...question,
+            label: copyMultilangField(question.label, sourceLang, activeLocale),
+        };
 
-        // Copy label
-        const sourceLabel =
-            typeof question.label === 'object'
-                ? question.label[sourceLang] || ''
-                : question.label || '';
-
-        newQuestion.label =
-            typeof question.label === 'object'
-                ? { ...question.label, [activeLocale]: sourceLabel }
-                : { en: question.label || '', [activeLocale]: sourceLabel };
-
-        // Copy placeholder
-        if (question.placeholder) {
-            const sourcePlaceholder =
-                typeof question.placeholder === 'object'
-                    ? question.placeholder[sourceLang] || ''
-                    : question.placeholder || '';
-
-            newQuestion.placeholder =
-                typeof question.placeholder === 'object'
-                    ? { ...question.placeholder, [activeLocale]: sourcePlaceholder }
-                    : { en: question.placeholder || '', [activeLocale]: sourcePlaceholder };
+        if (question.placeholder !== undefined) {
+            newQuestion.placeholder = copyMultilangField(
+                question.placeholder,
+                sourceLang,
+                activeLocale
+            );
         }
 
-        // Copy options
         if (question.options) {
-            newQuestion.options = question.options.map((opt) => {
-                if (typeof opt === 'string') {
-                    return {
-                        label: { en: opt, [activeLocale]: opt },
-                        value: opt,
-                    };
-                }
-                const sourceOptLabel = opt.label[sourceLang] || '';
-                return {
-                    ...opt,
-                    label: {
-                        ...opt.label,
-                        [activeLocale]: sourceOptLabel,
-                    },
-                };
-            });
+            newQuestion.options = copyOptions(question.options, sourceLang, activeLocale);
         }
 
         onUpdate(newQuestion);


### PR DESCRIPTION
## Summary
- Designer micro-utility extractions and one P5 suppression per the W2-end backlog review checkpoint.
- Reduces frontend cognitive-complexity warnings from **39 to 35** (-4, -10%).

## Commits
- \`89ed1726\` — MultiLangFieldIcon: extract \`buildOtherTranslations\` (P3, 7 tests)
- \`d2d1d66f\` — LanguageManagerModal: extract \`applyLanguageRestore\` + \`applyLanguageInit\` (P3, 11 tests)
- \`801c71b4\` + \`f38f0489\` — QuestionBuilder: extract \`copyMultilangField\` + \`copyOptions\` from \`handleCopyFrom\` (P3, 10 tests; closes 1 of 6 sites — the other 5 are W3c P5 suppressions)
- \`5f22f7af\` — ProcessStepEditor: P5 suppress with rationale (process_steps schema typing gap blocks clean extraction)

**Sites closed:** 4 (MultiLangFieldIcon ×1, LanguageManagerModal ×1, QuestionBuilder ×1, ProcessStepEditor ×1).
**New tests:** 28 across 3 colocated \`*.helpers.test.ts\` files.

## Context
Per the W2-end backlog review (Opus extra-high effort), the original W3 plan of "refactor all 16 sites" was reduced to **6 P3 refactors + 10 P5 suppressions**. W3a delivers the easiest 4 (low risk, well-bounded helpers); W3b will tackle QSortEditor's algorithmic core (autoShapeGrid, parseBulkStatements); W3c will close the remaining 7 designer JSX shells via documented P5 suppressions.

## Test plan
- [x] \`make ci-fast\` green at every commit
- [x] \`make ci\` green pre-push
- [x] No file outside W3a scope modified
- [x] Each P3 helper has ≥5 tests covering its meaningful branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)