### PR TITLE
refactor: W3b — QSortEditor algorithmic core (cognitive complexity)

### DIFF
--- a/frontend/src/components/admin/designer/QSortEditor.helpers.test.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { computeAutoShapedCapacities, mergeParsedItemIntoStatements } from './QSortEditor.helpers';
+import {
+    applyCapacityDelta,
+    computeAutoShapedCapacities,
+    mergeParsedItemIntoStatements,
+} from './QSortEditor.helpers';
 
 describe('computeAutoShapedCapacities', () => {
     it('returns [] when numColumns is 0', () => {
@@ -244,5 +248,63 @@ describe('mergeParsedItemIntoStatements', () => {
         );
         expect(statements[0]?.translations).toHaveLength(2);
         expect(statements[0]?.translations[1]).toEqual({ language_code: 'fr', text: 'nouveau' });
+    });
+});
+
+describe('applyCapacityDelta', () => {
+    const makeGrid = () => [
+        { score: -2, capacity: 1 },
+        { score: -1, capacity: 2 },
+        { score: 0, capacity: 3 },
+        { score: 1, capacity: 2 },
+        { score: 2, capacity: 1 },
+    ];
+
+    it('increments the picked column by +delta with symmetryLock=true', () => {
+        const grid = makeGrid();
+        applyCapacityDelta(grid, 0, 1, true);
+        expect(grid[0]?.capacity).toBe(2);
+        expect(grid[4]?.capacity).toBe(2); // mirrored
+    });
+
+    it('increments only the picked column with symmetryLock=false', () => {
+        const grid = makeGrid();
+        applyCapacityDelta(grid, 0, 1, false);
+        expect(grid[0]?.capacity).toBe(2);
+        expect(grid[4]?.capacity).toBe(1); // unchanged
+    });
+
+    it('clamps to 0 (no negative capacities)', () => {
+        const grid = makeGrid();
+        applyCapacityDelta(grid, 0, -10, true);
+        expect(grid[0]?.capacity).toBe(0);
+        expect(grid[4]?.capacity).toBe(0);
+    });
+
+    it('no-op on out-of-range idx', () => {
+        const grid = makeGrid();
+        const before = JSON.stringify(grid);
+        applyCapacityDelta(grid, 99, 1, true);
+        expect(JSON.stringify(grid)).toBe(before);
+    });
+
+    it('center column with odd-length grid: symmetric write is a no-op (oppositeIdx === idx)', () => {
+        const grid = makeGrid();
+        applyCapacityDelta(grid, 2, 1, true);
+        expect(grid[2]?.capacity).toBe(4);
+        // Centre is its own opposite — still increments only once total.
+        expect(grid[0]?.capacity).toBe(1);
+        expect(grid[4]?.capacity).toBe(1);
+    });
+
+    it('handles missing capacity (treats as 0)', () => {
+        const grid: { score: number; capacity: number }[] = [
+            { score: -1, capacity: 0 },
+            { score: 0, capacity: 0 },
+            { score: 1, capacity: 0 },
+        ];
+        applyCapacityDelta(grid, 0, 2, true);
+        expect(grid[0]?.capacity).toBe(2);
+        expect(grid[2]?.capacity).toBe(2);
     });
 });

--- a/frontend/src/components/admin/designer/QSortEditor.helpers.test.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-    computeAutoShapedCapacities,
-    mergeParsedItemIntoStatements,
-} from './QSortEditor.helpers';
+import { computeAutoShapedCapacities, mergeParsedItemIntoStatements } from './QSortEditor.helpers';
 
 describe('computeAutoShapedCapacities', () => {
     it('returns [] when numColumns is 0', () => {
@@ -104,7 +101,10 @@ describe('mergeParsedItemIntoStatements', () => {
     const draftLangs = [{ language_code: 'en' }, { language_code: 'fr' }];
 
     it('append mode: adds new statement with seeded translations (active locale gets item.text)', () => {
-        const statements: { code: string; translations: { language_code: string; text: string }[] }[] = [];
+        const statements: {
+            code: string;
+            translations: { language_code: string; text: string }[];
+        }[] = [];
         mergeParsedItemIntoStatements(
             { code: 'S1', text: 'Hello' },
             statements,
@@ -122,19 +122,16 @@ describe('mergeParsedItemIntoStatements', () => {
 
     it('append mode: assigns auto-generated code when item.code is missing', () => {
         const statements = [{ code: 'A', translations: [] }];
-        mergeParsedItemIntoStatements(
-            { text: 'New' },
-            statements,
-            draftLangs,
-            'append',
-            'en'
-        );
+        mergeParsedItemIntoStatements({ text: 'New' }, statements, draftLangs, 'append', 'en');
         expect(statements).toHaveLength(2);
         expect(statements[1]?.code).toBe('s2');
     });
 
     it('append mode: per-language translations override the item.text fallback', () => {
-        const statements: { code: string; translations: { language_code: string; text: string }[] }[] = [];
+        const statements: {
+            code: string;
+            translations: { language_code: string; text: string }[];
+        }[] = [];
         mergeParsedItemIntoStatements(
             {
                 code: 'S1',
@@ -227,13 +224,14 @@ describe('mergeParsedItemIntoStatements', () => {
             'en'
         );
         expect(statements[0]?.translations).toHaveLength(1);
-        expect(statements[0]?.translations[0]).toEqual({ language_code: 'en', text: 'late binding' });
+        expect(statements[0]?.translations[0]).toEqual({
+            language_code: 'en',
+            text: 'late binding',
+        });
     });
 
     it('sync mode: per-language item.translations adds missing language entry to existing', () => {
-        const statements = [
-            { code: 'S1', translations: [{ language_code: 'en', text: 'old' }] },
-        ];
+        const statements = [{ code: 'S1', translations: [{ language_code: 'en', text: 'old' }] }];
         mergeParsedItemIntoStatements(
             {
                 code: 'S1',

--- a/frontend/src/components/admin/designer/QSortEditor.helpers.test.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { computeAutoShapedCapacities } from './QSortEditor.helpers';
+import {
+    computeAutoShapedCapacities,
+    mergeParsedItemIntoStatements,
+} from './QSortEditor.helpers';
 
 describe('computeAutoShapedCapacities', () => {
     it('returns [] when numColumns is 0', () => {
@@ -94,5 +97,154 @@ describe('computeAutoShapedCapacities', () => {
         expect(r.reduce((a, b) => a + b, 0)).toBe(1);
         // The lone statement should land on the centre (index 2) for odd cols.
         expect(r[2]).toBe(1);
+    });
+});
+
+describe('mergeParsedItemIntoStatements', () => {
+    const draftLangs = [{ language_code: 'en' }, { language_code: 'fr' }];
+
+    it('append mode: adds new statement with seeded translations (active locale gets item.text)', () => {
+        const statements: { code: string; translations: { language_code: string; text: string }[] }[] = [];
+        mergeParsedItemIntoStatements(
+            { code: 'S1', text: 'Hello' },
+            statements,
+            draftLangs,
+            'append',
+            'en'
+        );
+        expect(statements).toHaveLength(1);
+        expect(statements[0]?.code).toBe('S1');
+        expect(statements[0]?.translations).toEqual([
+            { language_code: 'en', text: 'Hello' },
+            { language_code: 'fr', text: '' },
+        ]);
+    });
+
+    it('append mode: assigns auto-generated code when item.code is missing', () => {
+        const statements = [{ code: 'A', translations: [] }];
+        mergeParsedItemIntoStatements(
+            { text: 'New' },
+            statements,
+            draftLangs,
+            'append',
+            'en'
+        );
+        expect(statements).toHaveLength(2);
+        expect(statements[1]?.code).toBe('s2');
+    });
+
+    it('append mode: per-language translations override the item.text fallback', () => {
+        const statements: { code: string; translations: { language_code: string; text: string }[] }[] = [];
+        mergeParsedItemIntoStatements(
+            {
+                code: 'S1',
+                text: 'fallback',
+                translations: [
+                    { language_code: 'en', text: 'English' },
+                    { language_code: 'fr', text: 'Français' },
+                ],
+            },
+            statements,
+            draftLangs,
+            'append',
+            'en'
+        );
+        expect(statements[0]?.translations).toEqual([
+            { language_code: 'en', text: 'English' },
+            { language_code: 'fr', text: 'Français' },
+        ]);
+    });
+
+    it('sync mode: matching code updates existing translation in active locale', () => {
+        const statements = [
+            {
+                code: 'S1',
+                translations: [
+                    { language_code: 'en', text: 'old' },
+                    { language_code: 'fr', text: 'ancien' },
+                ],
+            },
+        ];
+        mergeParsedItemIntoStatements(
+            { code: 'S1', text: 'new' },
+            statements,
+            draftLangs,
+            'sync',
+            'en'
+        );
+        expect(statements).toHaveLength(1);
+        expect(statements[0]?.translations[0]?.text).toBe('new');
+        expect(statements[0]?.translations[1]?.text).toBe('ancien');
+    });
+
+    it('sync mode: matching code with item.translations updates per-language', () => {
+        const statements = [
+            {
+                code: 'S1',
+                translations: [
+                    { language_code: 'en', text: 'old en' },
+                    { language_code: 'fr', text: 'old fr' },
+                ],
+            },
+        ];
+        mergeParsedItemIntoStatements(
+            {
+                code: 'S1',
+                translations: [
+                    { language_code: 'en', text: 'new en' },
+                    { language_code: 'fr', text: 'new fr' },
+                ],
+            },
+            statements,
+            draftLangs,
+            'sync',
+            'en'
+        );
+        expect(statements[0]?.translations[0]?.text).toBe('new en');
+        expect(statements[0]?.translations[1]?.text).toBe('new fr');
+    });
+
+    it('sync mode: non-matching code creates a new statement', () => {
+        const statements = [{ code: 'S1', translations: [] }];
+        mergeParsedItemIntoStatements(
+            { code: 'S2', text: 'hello' },
+            statements,
+            draftLangs,
+            'sync',
+            'en'
+        );
+        expect(statements).toHaveLength(2);
+        expect(statements[1]?.code).toBe('S2');
+    });
+
+    it('sync mode: existing match without translations on it gets the active-locale entry pushed', () => {
+        const statements = [{ code: 'S1', translations: [] }];
+        mergeParsedItemIntoStatements(
+            { code: 'S1', text: 'late binding' },
+            statements,
+            draftLangs,
+            'sync',
+            'en'
+        );
+        expect(statements[0]?.translations).toHaveLength(1);
+        expect(statements[0]?.translations[0]).toEqual({ language_code: 'en', text: 'late binding' });
+    });
+
+    it('sync mode: per-language item.translations adds missing language entry to existing', () => {
+        const statements = [
+            { code: 'S1', translations: [{ language_code: 'en', text: 'old' }] },
+        ];
+        mergeParsedItemIntoStatements(
+            {
+                code: 'S1',
+                translations: [{ language_code: 'fr', text: 'nouveau' }],
+            },
+            statements,
+            draftLangs,
+            'sync',
+            'en'
+        );
+        expect(statements[0]?.translations).toHaveLength(2);
+        expect(statements[0]?.translations[1]).toEqual({ language_code: 'fr', text: 'nouveau' });
     });
 });

--- a/frontend/src/components/admin/designer/QSortEditor.helpers.test.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { computeAutoShapedCapacities } from './QSortEditor.helpers';
+
+describe('computeAutoShapedCapacities', () => {
+    it('returns [] when numColumns is 0', () => {
+        expect(computeAutoShapedCapacities(40, 0)).toEqual([]);
+    });
+
+    it('returns all-zeros when N is 0', () => {
+        expect(computeAutoShapedCapacities(0, 5)).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    it('total of capacities equals N (odd cols, N=40)', () => {
+        const r = computeAutoShapedCapacities(40, 7);
+        expect(r.reduce((a, b) => a + b, 0)).toBe(40);
+    });
+
+    it('total of capacities equals N (even cols, N=40)', () => {
+        const r = computeAutoShapedCapacities(40, 6);
+        expect(r.reduce((a, b) => a + b, 0)).toBe(40);
+    });
+
+    it('total of capacities equals N (odd cols, N=20 — small but ≥numCols)', () => {
+        const r = computeAutoShapedCapacities(20, 5);
+        expect(r.reduce((a, b) => a + b, 0)).toBe(20);
+    });
+
+    it('total of capacities equals N (N<numCols — minPerCol=0)', () => {
+        const r = computeAutoShapedCapacities(3, 5);
+        expect(r.reduce((a, b) => a + b, 0)).toBe(3);
+    });
+
+    it('total of capacities equals N for various N×cols', () => {
+        for (const N of [9, 11, 16, 24, 30, 41, 60, 100]) {
+            for (const cols of [3, 5, 7, 9, 11]) {
+                const r = computeAutoShapedCapacities(N, cols);
+                expect(r.reduce((a, b) => a + b, 0)).toBe(N);
+                expect(r).toHaveLength(cols);
+            }
+        }
+    });
+
+    it('produces a symmetric (mirrored) distribution for odd columns when N is even', () => {
+        const r = computeAutoShapedCapacities(40, 7);
+        // Mirror around center: r[0]==r[6], r[1]==r[5], r[2]==r[4]
+        expect(r[0]).toBe(r[6]);
+        expect(r[1]).toBe(r[5]);
+        expect(r[2]).toBe(r[4]);
+    });
+
+    it('produces a symmetric distribution for even columns when N is even', () => {
+        const r = computeAutoShapedCapacities(40, 6);
+        expect(r[0]).toBe(r[5]);
+        expect(r[1]).toBe(r[4]);
+        expect(r[2]).toBe(r[3]);
+    });
+
+    it('center column has the largest capacity for odd cols', () => {
+        const r = computeAutoShapedCapacities(40, 7);
+        const centerIdx = 3;
+        const center = r[centerIdx] ?? 0;
+        for (let i = 0; i < r.length; i++) {
+            if (i === centerIdx) continue;
+            expect(center).toBeGreaterThanOrEqual(r[i] ?? 0);
+        }
+    });
+
+    it('extreme columns have the smallest capacity (monotone non-increasing toward edges)', () => {
+        const r = computeAutoShapedCapacities(40, 7);
+        // Going from center to edge, capacity should not increase.
+        expect(r[3] ?? 0).toBeGreaterThanOrEqual(r[2] ?? 0);
+        expect(r[2] ?? 0).toBeGreaterThanOrEqual(r[1] ?? 0);
+        expect(r[1] ?? 0).toBeGreaterThanOrEqual(r[0] ?? 0);
+    });
+
+    it('respects minPerCol=2 baseline when N>=40', () => {
+        const r = computeAutoShapedCapacities(40, 7);
+        for (const c of r) expect(c).toBeGreaterThanOrEqual(2);
+    });
+
+    it('respects minPerCol=1 baseline when 1<=numCols<=N<40', () => {
+        const r = computeAutoShapedCapacities(20, 7);
+        for (const c of r) expect(c).toBeGreaterThanOrEqual(1);
+    });
+
+    it('handles N<numCols with sparse non-zero columns (sum still N)', () => {
+        const r = computeAutoShapedCapacities(2, 7);
+        expect(r.reduce((a, b) => a + b, 0)).toBe(2);
+        expect(r).toHaveLength(7);
+    });
+
+    it('handles N=1 (single statement → centre column)', () => {
+        const r = computeAutoShapedCapacities(1, 5);
+        expect(r.reduce((a, b) => a + b, 0)).toBe(1);
+        // The lone statement should land on the centre (index 2) for odd cols.
+        expect(r[2]).toBe(1);
+    });
+});

--- a/frontend/src/components/admin/designer/QSortEditor.helpers.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.ts
@@ -191,3 +191,36 @@ function applyTranslationsToExisting(
         else existing.translations.push({ language_code: activeLocale, text: item.text });
     }
 }
+
+// ---------------------------------------------------------------------------
+// Grid capacity mutation
+// ---------------------------------------------------------------------------
+
+interface GridColumnLite {
+    score: number;
+    capacity: number;
+}
+
+/**
+ * Apply a +/- capacity delta to a column. With `symmetryLock` true (the
+ * default in the designer), the mirrored column receives the same delta.
+ * Capacities are clamped to >= 0. Mutates `grid` in place. No-ops when
+ * the index is out of range or grid is empty.
+ */
+export function applyCapacityDelta(
+    grid: GridColumnLite[],
+    idx: number,
+    delta: number,
+    symmetryLock: boolean
+): void {
+    const col = grid[idx];
+    if (!col) return;
+    col.capacity = Math.max(0, (col.capacity || 0) + delta);
+
+    if (!symmetryLock) return;
+    const oppositeIdx = grid.length - 1 - idx;
+    if (oppositeIdx === idx) return;
+    const opposite = grid[oppositeIdx];
+    if (!opposite) return;
+    opposite.capacity = Math.max(0, (opposite.capacity || 0) + delta);
+}

--- a/frontend/src/components/admin/designer/QSortEditor.helpers.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.ts
@@ -144,9 +144,7 @@ export function mergeParsedItemIntoStatements(
     activeLocale: string
 ): void {
     const existing =
-        importMode === 'sync' && item.code
-            ? statements.find((s) => s.code === item.code)
-            : null;
+        importMode === 'sync' && item.code ? statements.find((s) => s.code === item.code) : null;
 
     if (existing) {
         applyTranslationsToExisting(existing, item, activeLocale);
@@ -159,7 +157,7 @@ export function mergeParsedItemIntoStatements(
         if (headerT) return { language_code, text: headerT.text };
         return {
             language_code,
-            text: language_code === activeLocale ? item.text ?? '' : '',
+            text: language_code === activeLocale ? (item.text ?? '') : '',
         };
     });
     statements.push({ code, translations });

--- a/frontend/src/components/admin/designer/QSortEditor.helpers.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.ts
@@ -6,6 +6,9 @@
  *   per-column capacity array using a Power-curve weighting (exponent 1.4 —
  *   sweet spot for reproducing common research tables) and greedy symmetric
  *   assignment with parity-break on even-column counts.
+ * - `mergeParsedItemIntoStatements`: pure mutator that applies a single
+ *   bulk-imported statement to the draft's `statements` array, handling
+ *   sync-mode merges (existing match by code) vs append/replace creation.
  */
 
 const POWER_EXPONENT = 1.4;
@@ -104,4 +107,89 @@ export function computeAutoShapedCapacities(N: number, numColumns: number): numb
     }
 
     return capacities;
+}
+
+// ---------------------------------------------------------------------------
+// Bulk-import merge
+// ---------------------------------------------------------------------------
+
+export interface ParsedStatement {
+    code?: string | null;
+    text?: string;
+    translations?: { language_code: string; text: string }[];
+}
+
+export type ImportMode = 'append' | 'replace' | 'sync';
+
+// biome-ignore lint/suspicious/noExplicitAny: load-bearing dynamic statement shape
+type Statement = any;
+
+interface DraftTranslationLite {
+    language_code: string;
+}
+
+/**
+ * Apply one parsed bulk-import item to the statements array. Mutates
+ * `statements` in place. In `'sync'` mode, items whose `code` matches an
+ * existing statement update that statement's translations rather than
+ * creating a new one. New statements are seeded with one translation per
+ * draft language; the active locale gets `item.text` when no per-language
+ * `item.translations` are provided.
+ */
+export function mergeParsedItemIntoStatements(
+    item: ParsedStatement,
+    statements: Statement[],
+    draftTranslations: DraftTranslationLite[],
+    importMode: ImportMode,
+    activeLocale: string
+): void {
+    const existing =
+        importMode === 'sync' && item.code
+            ? statements.find((s) => s.code === item.code)
+            : null;
+
+    if (existing) {
+        applyTranslationsToExisting(existing, item, activeLocale);
+        return;
+    }
+
+    const code = item.code || `s${statements.length + 1}`;
+    const translations = draftTranslations.map(({ language_code }) => {
+        const headerT = item.translations?.find((ht) => ht.language_code === language_code);
+        if (headerT) return { language_code, text: headerT.text };
+        return {
+            language_code,
+            text: language_code === activeLocale ? item.text ?? '' : '',
+        };
+    });
+    statements.push({ code, translations });
+}
+
+function applyTranslationsToExisting(
+    existing: Statement,
+    item: ParsedStatement,
+    activeLocale: string
+): void {
+    if (!Array.isArray(existing.translations)) existing.translations = [];
+
+    if (item.translations && item.translations.length > 0) {
+        for (const newT of item.translations) {
+            const tEntry = existing.translations.find(
+                // biome-ignore lint/suspicious/noExplicitAny: dynamic translation entry
+                (t: any) => t.language_code === newT.language_code
+            );
+            if (tEntry) tEntry.text = newT.text;
+            else existing.translations.push(newT);
+        }
+        return;
+    }
+
+    if (item.text !== undefined) {
+        const tEntry = existing.translations.find(
+            // biome-ignore lint/suspicious/noExplicitAny: dynamic translation entry
+            (t: any) => t.language_code === activeLocale
+        );
+        if (tEntry) tEntry.text = item.text;
+        else existing.translations.push({ language_code: activeLocale, text: item.text });
+    }
 }

--- a/frontend/src/components/admin/designer/QSortEditor.helpers.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure helpers extracted from QSortEditor for testability.
+ *
+ * - `computeAutoShapedCapacities`: Q-methodology quasi-normal forced-choice
+ *   distribution. Given N statements and numColumns columns, returns the
+ *   per-column capacity array using a Power-curve weighting (exponent 1.4 —
+ *   sweet spot for reproducing common research tables) and greedy symmetric
+ *   assignment with parity-break on even-column counts.
+ */
+
+const POWER_EXPONENT = 1.4;
+
+/** Generate per-column ideal weights using a Power curve from the centre. */
+function computeIdealCapacities(N: number, numColumns: number): number[] {
+    const centerIdx = Math.floor(numColumns / 2);
+    const maxDist = Math.max(centerIdx, numColumns - 1 - centerIdx);
+    const weights: number[] = [];
+    for (let i = 0; i < numColumns; i++) {
+        const dist = Math.abs(i - centerIdx);
+        weights.push((maxDist - dist + 1) ** POWER_EXPONENT);
+    }
+    const totalWeight = weights.reduce((a, b) => a + b, 0);
+    return weights.map((w) => (w / totalWeight) * N);
+}
+
+/** Choose the minimum baseline per column based on N vs numColumns. */
+function computeMinPerColumn(N: number, numColumns: number): number {
+    if (N >= 40) return 2;
+    if (N >= numColumns) return 1;
+    return 0;
+}
+
+/** Pick the unsaturated left-half column with the largest deficit vs ideal. */
+function pickBestLeftColumn(
+    ideal: number[],
+    capacities: number[],
+    centerIdx: number,
+    isOddCols: boolean
+): number {
+    const limit = isOddCols ? centerIdx : centerIdx - 1;
+    let bestIdx = -1;
+    let maxDiff = -Infinity;
+    for (let i = 0; i <= limit; i++) {
+        const diff = (ideal[i] ?? 0) - (capacities[i] ?? 0);
+        if (diff > maxDiff) {
+            maxDiff = diff;
+            bestIdx = i;
+        }
+    }
+    return bestIdx;
+}
+
+/**
+ * Compute the per-column capacity array for an "auto-shape" of the Q-sort
+ * grid given N total statements and numColumns columns. Returns a flat
+ * `number[]` of length numColumns.
+ *
+ * Returns an empty array when numColumns is 0. Returns all-zeros when N is 0.
+ *
+ * Algorithm:
+ * 1. Power-curve ideal: weight ∝ (maxDist − dist + 1)^1.4 normalised to sum N.
+ * 2. Baseline: minPerCol = 2 if N≥40, 1 if N≥numCols, else 0.
+ * 3. Greedy: until total === N, pick the left-half column with the largest
+ *    deficit vs ideal. Mirror the increment to its symmetric counterpart
+ *    (or to the centre column when odd-cols and the pick is the centre).
+ *    When only 1 slot remains and N is even-cols, parity-break by adding
+ *    just one to the picked column.
+ */
+export function computeAutoShapedCapacities(N: number, numColumns: number): number[] {
+    if (numColumns === 0) return [];
+    if (N === 0) return new Array(numColumns).fill(0);
+
+    const centerIdx = Math.floor(numColumns / 2);
+    const isOddCols = numColumns % 2 !== 0;
+    const ideal = computeIdealCapacities(N, numColumns);
+    const minPerCol = computeMinPerColumn(N, numColumns);
+    const capacities: number[] = new Array(numColumns).fill(minPerCol);
+    let total = capacities.reduce((a, b) => a + b, 0);
+
+    while (total < N) {
+        const bestIdx = pickBestLeftColumn(ideal, capacities, centerIdx, isOddCols);
+        if (bestIdx === -1) break;
+
+        if (isOddCols && bestIdx === centerIdx) {
+            capacities[centerIdx] = (capacities[centerIdx] ?? 0) + 1;
+            total += 1;
+            continue;
+        }
+
+        const remaining = N - total;
+        if (remaining >= 2) {
+            capacities[bestIdx] = (capacities[bestIdx] ?? 0) + 1;
+            const mirrorIdx = numColumns - 1 - bestIdx;
+            capacities[mirrorIdx] = (capacities[mirrorIdx] ?? 0) + 1;
+            total += 2;
+        } else if (isOddCols) {
+            capacities[centerIdx] = (capacities[centerIdx] ?? 0) + 1;
+            total += 1;
+        } else {
+            // Even columns parity break: add the last unit to the picked column only.
+            capacities[bestIdx] = (capacities[bestIdx] ?? 0) + 1;
+            total += 1;
+        }
+    }
+
+    return capacities;
+}

--- a/frontend/src/components/admin/designer/QSortEditor.helpers.ts
+++ b/frontend/src/components/admin/designer/QSortEditor.helpers.ts
@@ -69,41 +69,60 @@ function pickBestLeftColumn(
  *    When only 1 slot remains and N is even-cols, parity-break by adding
  *    just one to the picked column.
  */
+interface DistributionContext {
+    centerIdx: number;
+    numColumns: number;
+    isOddCols: boolean;
+}
+
+/**
+ * Apply one increment step to the capacities array. Returns the delta added
+ * to the running total (1 for centre/parity-break/last-slot odd, 2 for the
+ * normal mirrored increment).
+ */
+function applyOneIncrementStep(
+    capacities: number[],
+    pickedIdx: number,
+    remaining: number,
+    ctx: DistributionContext
+): number {
+    if (ctx.isOddCols && pickedIdx === ctx.centerIdx) {
+        capacities[ctx.centerIdx] = (capacities[ctx.centerIdx] ?? 0) + 1;
+        return 1;
+    }
+    if (remaining >= 2) {
+        capacities[pickedIdx] = (capacities[pickedIdx] ?? 0) + 1;
+        const mirrorIdx = ctx.numColumns - 1 - pickedIdx;
+        capacities[mirrorIdx] = (capacities[mirrorIdx] ?? 0) + 1;
+        return 2;
+    }
+    if (ctx.isOddCols) {
+        capacities[ctx.centerIdx] = (capacities[ctx.centerIdx] ?? 0) + 1;
+        return 1;
+    }
+    // Even columns parity break: add the last unit to the picked column only.
+    capacities[pickedIdx] = (capacities[pickedIdx] ?? 0) + 1;
+    return 1;
+}
+
 export function computeAutoShapedCapacities(N: number, numColumns: number): number[] {
     if (numColumns === 0) return [];
     if (N === 0) return new Array(numColumns).fill(0);
 
-    const centerIdx = Math.floor(numColumns / 2);
-    const isOddCols = numColumns % 2 !== 0;
+    const ctx: DistributionContext = {
+        centerIdx: Math.floor(numColumns / 2),
+        numColumns,
+        isOddCols: numColumns % 2 !== 0,
+    };
     const ideal = computeIdealCapacities(N, numColumns);
     const minPerCol = computeMinPerColumn(N, numColumns);
     const capacities: number[] = new Array(numColumns).fill(minPerCol);
     let total = capacities.reduce((a, b) => a + b, 0);
 
     while (total < N) {
-        const bestIdx = pickBestLeftColumn(ideal, capacities, centerIdx, isOddCols);
+        const bestIdx = pickBestLeftColumn(ideal, capacities, ctx.centerIdx, ctx.isOddCols);
         if (bestIdx === -1) break;
-
-        if (isOddCols && bestIdx === centerIdx) {
-            capacities[centerIdx] = (capacities[centerIdx] ?? 0) + 1;
-            total += 1;
-            continue;
-        }
-
-        const remaining = N - total;
-        if (remaining >= 2) {
-            capacities[bestIdx] = (capacities[bestIdx] ?? 0) + 1;
-            const mirrorIdx = numColumns - 1 - bestIdx;
-            capacities[mirrorIdx] = (capacities[mirrorIdx] ?? 0) + 1;
-            total += 2;
-        } else if (isOddCols) {
-            capacities[centerIdx] = (capacities[centerIdx] ?? 0) + 1;
-            total += 1;
-        } else {
-            // Even columns parity break: add the last unit to the picked column only.
-            capacities[bestIdx] = (capacities[bestIdx] ?? 0) + 1;
-            total += 1;
-        }
+        total += applyOneIncrementStep(capacities, bestIdx, N - total, ctx);
     }
 
     return capacities;

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -32,10 +32,7 @@ import { Switch } from '@/components/ui/switch';
 import { useTranslation } from 'react-i18next';
 import { MultiLangFieldIcon } from './MultiLangFieldIcon';
 import { ImportFromConcourseDialog } from './ImportFromConcourseDialog';
-import {
-    computeAutoShapedCapacities,
-    mergeParsedItemIntoStatements,
-} from './QSortEditor.helpers';
+import { computeAutoShapedCapacities, mergeParsedItemIntoStatements } from './QSortEditor.helpers';
 import {
     getGetStudyApiAdminStudiesSlugGetQueryKey,
     useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet,

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -32,7 +32,11 @@ import { Switch } from '@/components/ui/switch';
 import { useTranslation } from 'react-i18next';
 import { MultiLangFieldIcon } from './MultiLangFieldIcon';
 import { ImportFromConcourseDialog } from './ImportFromConcourseDialog';
-import { computeAutoShapedCapacities, mergeParsedItemIntoStatements } from './QSortEditor.helpers';
+import {
+    applyCapacityDelta,
+    computeAutoShapedCapacities,
+    mergeParsedItemIntoStatements,
+} from './QSortEditor.helpers';
 import {
     getGetStudyApiAdminStudiesSlugGetQueryKey,
     useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet,
@@ -587,20 +591,7 @@ const QSortEditor = ({
     const updateGridCapacity = (idx: number, delta: number) => {
         updateDraft((d) => {
             if (!d.grid_config) return;
-            const col = d.grid_config[idx];
-            if (!col) return;
-            col.capacity = Math.max(0, (col.capacity || 0) + delta);
-
-            // Symmetry Lock Logic
-            if (d.symmetry_lock ?? true) {
-                const oppositeIdx = d.grid_config.length - 1 - idx;
-                if (oppositeIdx !== idx && d.grid_config[oppositeIdx]) {
-                    d.grid_config[oppositeIdx].capacity = Math.max(
-                        0,
-                        (d.grid_config[oppositeIdx].capacity || 0) + delta
-                    );
-                }
-            }
+            applyCapacityDelta(d.grid_config, idx, delta, d.symmetry_lock ?? true);
         });
     };
 

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -32,7 +32,10 @@ import { Switch } from '@/components/ui/switch';
 import { useTranslation } from 'react-i18next';
 import { MultiLangFieldIcon } from './MultiLangFieldIcon';
 import { ImportFromConcourseDialog } from './ImportFromConcourseDialog';
-import { computeAutoShapedCapacities } from './QSortEditor.helpers';
+import {
+    computeAutoShapedCapacities,
+    mergeParsedItemIntoStatements,
+} from './QSortEditor.helpers';
 import {
     getGetStudyApiAdminStudiesSlugGetQueryKey,
     useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet,
@@ -533,61 +536,17 @@ const QSortEditor = ({
             if (importMode === 'replace') {
                 d.statements = [];
             }
-
             const currentStatements = d.statements || [];
-
-            parsedItems.forEach((item) => {
-                let existing = null;
-                if (importMode === 'sync' && item.code) {
-                    // biome-ignore lint/suspicious/noExplicitAny: statement search
-                    existing = currentStatements.find((s: any) => s.code === item.code);
-                }
-
-                if (existing) {
-                    // Sync Traductions
-                    if (item.translations && item.translations.length > 0) {
-                        item.translations.forEach(
-                            (newT: { language_code: string; text: string }) => {
-                                const tEntry = existing.translations.find(
-                                    (t: Translation) => t.language_code === newT.language_code
-                                );
-                                if (tEntry) tEntry.text = newT.text;
-                                else existing.translations.push(newT);
-                            }
-                        );
-                    } else if (item.text) {
-                        const tEntry = existing.translations.find(
-                            (t: Translation) => t.language_code === activeLocale
-                        );
-                        if (tEntry) tEntry.text = item.text;
-                        else
-                            existing.translations.push({
-                                language_code: activeLocale,
-                                text: item.text,
-                            });
-                    }
-                } else {
-                    // Add New
-                    const code = item.code || `s${currentStatements.length + 1}`;
-                    const translations = (d.translations || []).map(
-                        (t: { language_code: string }) => {
-                            const headerT = item.translations?.find(
-                                (ht: { language_code: string; text: string }) =>
-                                    ht.language_code === t.language_code
-                            );
-                            return {
-                                language_code: t.language_code,
-                                text: headerT
-                                    ? headerT.text
-                                    : t.language_code === activeLocale
-                                      ? item.text || ''
-                                      : '',
-                            };
-                        }
-                    );
-                    currentStatements.push({ code, translations });
-                }
-            });
+            const draftLangs = (d.translations || []) as { language_code: string }[];
+            for (const item of parsedItems) {
+                mergeParsedItemIntoStatements(
+                    item,
+                    currentStatements,
+                    draftLangs,
+                    importMode,
+                    activeLocale
+                );
+            }
             d.statements = currentStatements;
         });
 

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -32,6 +32,7 @@ import { Switch } from '@/components/ui/switch';
 import { useTranslation } from 'react-i18next';
 import { MultiLangFieldIcon } from './MultiLangFieldIcon';
 import { ImportFromConcourseDialog } from './ImportFromConcourseDialog';
+import { computeAutoShapedCapacities } from './QSortEditor.helpers';
 import {
     getGetStudyApiAdminStudiesSlugGetQueryKey,
     useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet,
@@ -703,72 +704,13 @@ const QSortEditor = ({
         updateDraft((d) => {
             if (!d.grid_config || d.grid_config.length === 0) return;
 
-            const numColumns = d.grid_config.length;
-            const N = totalStatements;
-            const centerIdx = Math.floor(numColumns / 2);
-            const isOddCols = numColumns % 2 !== 0;
+            const newCapacities = computeAutoShapedCapacities(
+                totalStatements,
+                d.grid_config.length
+            );
 
-            // 1. Generate Target Weights
-            // Standard Q-sorts are "quasi-normal" but flatter than pure binomial.
-            // We use a Power curve which produces a more professional forced-choice distribution.
-            const weights = [];
-            const maxDist = Math.max(centerIdx, numColumns - 1 - centerIdx);
-
-            for (let i = 0; i < numColumns; i++) {
-                const dist = Math.abs(i - centerIdx);
-                // 1.4 is a sweet spot for reproducing common research tables
-                weights.push((maxDist - dist + 1) ** 1.4);
-            }
-
-            const totalWeight = weights.reduce((a, b) => a + b, 0);
-            const idealCapacities = weights.map((w) => (w / totalWeight) * N);
-
-            // 2. Initial Distribution
-            // Start with minimum: 2 per col if N is large, 1 if medium, 0 if small
-            const minPerCol = N >= 40 ? 2 : N >= numColumns ? 1 : 0;
-            const newCapacities: number[] = new Array(numColumns).fill(minPerCol);
-            let currentTotal = newCapacities.reduce((a, b) => a + b, 0);
-
-            // 3. Greedy distribution with symmetry
-            while (currentTotal < N) {
-                let bestIdx = -1;
-                let maxDiff = -Infinity;
-
-                const limit = isOddCols ? centerIdx : centerIdx - 1;
-
-                for (let i = 0; i <= limit; i++) {
-                    const diff = (idealCapacities[i] ?? 0) - (newCapacities[i] ?? 0);
-                    if (diff > maxDiff) {
-                        maxDiff = diff;
-                        bestIdx = i;
-                    }
-                }
-
-                if (bestIdx === -1) break;
-
-                if (isOddCols && bestIdx === centerIdx) {
-                    newCapacities[centerIdx] = (newCapacities[centerIdx] ?? 0) + 1;
-                    currentTotal++;
-                } else {
-                    if (N - currentTotal >= 2) {
-                        newCapacities[bestIdx] = (newCapacities[bestIdx] ?? 0) + 1;
-                        const mirrorIdx = numColumns - 1 - bestIdx;
-                        newCapacities[mirrorIdx] = (newCapacities[mirrorIdx] ?? 0) + 1;
-                        currentTotal += 2;
-                    } else if (isOddCols) {
-                        newCapacities[centerIdx] = (newCapacities[centerIdx] ?? 0) + 1;
-                        currentTotal++;
-                    } else {
-                        // Even columns parity break
-                        newCapacities[bestIdx] = (newCapacities[bestIdx] ?? 0) + 1;
-                        currentTotal++;
-                    }
-                }
-            }
-
-            // Apply to draft
-            for (let i = 0; i < numColumns; i++) {
-                const col = d.grid_config?.[i];
+            for (let i = 0; i < newCapacities.length; i++) {
+                const col = d.grid_config[i];
                 const cap = newCapacities[i];
                 if (col && cap !== undefined) {
                     col.capacity = cap;

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -92,6 +92,7 @@ interface SortableStatementItemProps {
     isSyncing?: boolean;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — large declarative dnd-kit sortable item with conditional rendering for the edit/sync/stale states (no extractable algorithmic logic; the conditional JSX IS the surface)
 function SortableStatementItem({
     item,
     idx,
@@ -300,13 +301,13 @@ function SortableStatementItem({
 
 // CSV/TSV parsing moved to @/utils/parseCsvTsv (shared with ConcourseDetailPage).
 
-const QSortEditor = ({
-    readOnly,
-    structureLocked,
-}: {
+interface QSortEditorProps {
     readOnly?: boolean;
     structureLocked?: boolean;
-}) => {
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — page-level orchestrator (6 useEffects, multiple inline handlers, tabbed JSX shell). Pure-logic extractions done by W3b T1-T3 (autoShape / mergeParsedItem / applyCapacityDelta); what remains is glue.
+const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
     const { t } = useTranslation();
     const { draft, original, activeLocale, updateDraft, activeSubStep, setActiveSubStep } =
         useStudyDesigner();


### PR DESCRIPTION
## Summary
- QSortEditor algorithmic-core extractions and two P5 suppressions per the W2-end backlog review checkpoint.
- Reduces frontend cognitive-complexity warnings from **35 to 30** (-5, -14%).
- This is the highest-ROI testability PR of the entire backlog: \`computeAutoShapedCapacities\` is the Q-methodology quasi-normal forced-choice distribution algorithm, now pinned by 15 tests including a 40-cell N×cols sweep.

## Commits
- \`81a71185\` — extract \`computeAutoShapedCapacities\` (P3, 15 tests on the bell-curve algo)
- \`a8d12ef5\` + \`d29e3baf\` — extract \`mergeParsedItemIntoStatements\` (P3, 8 tests on bulk import)
- \`7a08ea6a\` — extract \`applyCapacityDelta\` (P3, 6 tests on grid mutation)
- \`68a27c36\` — P5 suppressions on \`SortableStatementItem\` + \`QSortEditor\` body shells; split greedy loop into \`applyOneIncrementStep\` for the helper itself

**Sites closed:** 5 (autoShapeGrid + handleBulkSave + updateGridCapacity + 2 P5 shells).
**New tests:** 29 across one colocated \`*.helpers.test.ts\` file.

## Algorithmic changes worth flagging

- The Q-methodology distribution (\`computeAutoShapedCapacities\`): Power-curve weighting (exponent 1.4), greedy symmetric assignment, parity-break on even cols. Sweep tested across 8 N values × 5 col counts (40 combinations) for sum-equals-N, mirror symmetry, centre-largest, edge-smallest invariants.
- Bulk import merge (\`mergeParsedItemIntoStatements\`): sync vs append semantics; per-language translations override item.text fallback; auto-generated \`s${len+1}\` codes when missing.
- Capacity delta (\`applyCapacityDelta\`): symmetry-lock mirror, clamp-to-zero, centre-column self-mirror short-circuit.

## Context
Per the W2-end backlog review, W3 split into W3a (delivered) + W3b (this PR) + W3c (pending: 7 P5 suppressions on QuestionBuilder + PostSortConfigEditor JSX shells).

## Test plan
- [x] \`make ci-fast\` green at every commit
- [x] \`make ci\` green pre-push
- [x] No file outside W3b scope modified
- [x] Each P3 helper has ≥6 tests covering its meaningful branches
- [x] Suppressions cite P5 with concrete one-line rationale per the spec convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)