### PR TITLE
refactor: W3c — designer JSX shell suppressions (cognitive complexity)

### DIFF
--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -22,13 +22,13 @@ import QuestionBuilder from './QuestionBuilder';
 import { useTranslation } from 'react-i18next';
 import { MultiLangFieldIcon } from './MultiLangFieldIcon';
 
-const PostSortConfigEditor = ({
-    readOnly,
-    structureLocked,
-}: {
+interface PostSortConfigEditorProps {
     readOnly?: boolean;
     structureLocked?: boolean;
-}) => {
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — declarative tabbed form with conditional sections (consent / questions / audio / extreme-cards / contact); each mutation handler is a thin JSON-shape setter on postsort_config (load-bearing dynamic JSON column at the ORM boundary, see CLAUDE.md)
+const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEditorProps) => {
     const { t, i18n } = useTranslation();
     const { draft, activeLocale, updateDraft } = useStudyDesigner();
     const [selectedScore, setSelectedScore] = useState<number | null>(null);
@@ -514,6 +514,7 @@ const PostSortConfigEditor = ({
                                     checked={config?.audio?.enabled || false}
                                     onCheckedChange={(checked: boolean) => {
                                         if (checked === (config?.audio?.enabled || false)) return;
+                                        // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — audio-section toggle with conditional default-config seed (steps/durations/required defaults inlined for legibility); the conditional seeding IS the contract for "first-time enable"
                                         updateDraft((d) => {
                                             if (!d.postsort_config) d.postsort_config = {};
                                             // biome-ignore lint/suspicious/noExplicitAny: complex config

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -105,17 +105,19 @@ interface QuestionItemProps {
     availableLanguages: string[];
 }
 
-const QuestionItem = ({
-    id,
-    question,
-    onUpdate,
-    onDelete,
-    activeLocale,
-    readOnly,
-    structureLocked,
-    availableQuestions,
-    availableLanguages,
-}: QuestionItemProps) => {
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — declarative QuestionItem render with type-icon switch + multi-section accordion + visibility-condition editor; conditional JSX IS the surface (handleCopyFrom extracted to helpers in W3a)
+const QuestionItem = (props: QuestionItemProps) => {
+    const {
+        id,
+        question,
+        onUpdate,
+        onDelete,
+        activeLocale,
+        readOnly,
+        structureLocked,
+        availableQuestions,
+        availableLanguages,
+    } = props;
     const { t } = useTranslation();
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
         id,
@@ -734,6 +736,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                 newQuestionsMap[id] = rest;
             });
 
+            // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — handleDragEnd over presort_config legacy/new union; branches mirror the data shape (legacy: bare record vs new: { enabled, questions }), each closes over the reconstructed map and the type discriminator
             updateDraft((d) => {
                 if (type === 'pre') {
                     // Maintain enabled state if present
@@ -794,6 +797,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
         };
 
         // biome-ignore lint/suspicious/noExplicitAny: dynamic draft update
+        // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — addQuestion mutates legacy/new presort_config union; branches mirror the data shape and auto-migrate legacy → new on first add
         updateDraft((d: any) => {
             if (type === 'pre') {
                 if (!d.presort_config) d.presort_config = {};
@@ -954,6 +958,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                                             }
                                             onUpdate={(data: QuestionConfig) => {
                                                 // biome-ignore lint/suspicious/noExplicitAny: dynamic draft update
+                                                // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — inline onUpdate over legacy/new presort_config union; closes over q.id + type, not extractable cleanly without duplicating the branch surface
                                                 updateDraft((d: any) => {
                                                     if (type === 'pre') {
                                                         // Handle both legacy and new structure
@@ -975,6 +980,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                                             }}
                                             onDelete={() => {
                                                 // biome-ignore lint/suspicious/noExplicitAny: dynamic draft update
+                                                // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — inline onDelete over legacy/new presort_config union; mirrors the onUpdate branch above (same constraint: closes over q.id + type)
                                                 updateDraft((d: any) => {
                                                     if (type === 'pre') {
                                                         // Handle both legacy and new structure


### PR DESCRIPTION
## Summary
- Closes the W3 designer subsystem in full: 7 documented P5 suppressions on QuestionBuilder + PostSortConfigEditor JSX shells.
- Reduces frontend cognitive-complexity warnings from **30 to 23** (-7, -23%).

## Commits
- \`1b1b70a6\` — 5 suppressions on QuestionBuilder.tsx (QuestionItem render shell + 4 inline updateDraft callbacks over the legacy/new presort_config union) + 2 suppressions on PostSortConfigEditor.tsx (page shell + audio toggle).

Each suppression cites P5 with a concrete one-line rationale per spec convention.

## W3 closing summary

| Sub-PR | Sites | P3 | P5 |
|---|---|---|---|
| #143 W3a | 4 | 3 | 1 |
| #144 W3b | 5 | 3 | 2 |
| **W3c (this)** | 7 | 0 | 7 |
| **W3 total** | **16/16** | **6** | **10** |

The W2-end backlog review predicted exactly this distribution (6 refactors + 10 suppressions). Spec hypothesis validated: the QuestionBuilder/QSortEditor cluster is NOT one coherent refactor — it's 6 testable utilities buried inside 10 JSX shells / draft mutator handlers.

## Test plan
- [x] \`make ci-fast\` green
- [x] \`make ci\` green pre-push
- [x] No file outside W3c scope modified
- [x] Each suppression cites P5 with concrete one-line rationale
- [x] No biome-ignore without rationale (per spec convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)