### PR TITLE
refactor: W4a — participant runtime helper extractions (cognitive complexity)

### DIFF
--- a/frontend/src/components/GridSort.helpers.test.ts
+++ b/frontend/src/components/GridSort.helpers.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { resolveNextSlot } from './GridSort.helpers';
+
+const cols = [
+    { capacity: 3 }, // col 0
+    { capacity: 5 }, // col 1
+    { capacity: 5 }, // col 2
+    { capacity: 3 }, // col 3
+];
+
+describe('resolveNextSlot', () => {
+    it('returns null for unrecognised slot id', () => {
+        expect(resolveNextSlot('not-a-slot', 'ArrowUp', cols, true)).toBeNull();
+        expect(resolveNextSlot('slot_x_y', 'ArrowUp', cols, true)).toBeNull();
+    });
+
+    it('returns null for non-arrow keys', () => {
+        expect(resolveNextSlot('slot_1_1', 'Enter', cols, true)).toBeNull();
+        expect(resolveNextSlot('slot_1_1', 'Tab', cols, true)).toBeNull();
+    });
+
+    it('returns null when source col is out of range', () => {
+        expect(resolveNextSlot('slot_99_0', 'ArrowUp', cols, true)).toBeNull();
+    });
+
+    it('ArrowUp moves up one row, clamped at 0', () => {
+        expect(resolveNextSlot('slot_1_2', 'ArrowUp', cols, true)).toEqual({ col: 1, row: 1 });
+        expect(resolveNextSlot('slot_1_0', 'ArrowUp', cols, true)).toBeNull();
+    });
+
+    it('ArrowDown moves down one row in forced mode, clamped at capacity-1', () => {
+        expect(resolveNextSlot('slot_1_2', 'ArrowDown', cols, true)).toEqual({ col: 1, row: 3 });
+        // At capacity-1 already, no movement
+        expect(resolveNextSlot('slot_1_4', 'ArrowDown', cols, true)).toBeNull();
+    });
+
+    it('ArrowDown allows growth beyond capacity in free/flexible mode', () => {
+        expect(resolveNextSlot('slot_1_4', 'ArrowDown', cols, false)).toEqual({
+            col: 1,
+            row: 5,
+        });
+        expect(resolveNextSlot('slot_0_2', 'ArrowDown', cols, false)).toEqual({
+            col: 0,
+            row: 3,
+        });
+    });
+
+    it('ArrowLeft moves left one col, row clamped to new column capacity (forced)', () => {
+        // From col 1 row 4 → col 0 with capacity 3 → row clamped to 2
+        expect(resolveNextSlot('slot_1_4', 'ArrowLeft', cols, true)).toEqual({ col: 0, row: 2 });
+        // From col 1 row 0 → col 0 row 0 (no clamp needed)
+        expect(resolveNextSlot('slot_1_0', 'ArrowLeft', cols, true)).toEqual({ col: 0, row: 0 });
+    });
+
+    it('ArrowLeft from col 0 is a no-op', () => {
+        expect(resolveNextSlot('slot_0_0', 'ArrowLeft', cols, true)).toBeNull();
+    });
+
+    it('ArrowRight moves right one col, clamps row to new col capacity', () => {
+        // From col 2 row 4 → col 3 with capacity 3 → row clamped to 2
+        expect(resolveNextSlot('slot_2_4', 'ArrowRight', cols, true)).toEqual({ col: 3, row: 2 });
+    });
+
+    it('ArrowRight from last col is a no-op', () => {
+        expect(resolveNextSlot('slot_3_0', 'ArrowRight', cols, true)).toBeNull();
+    });
+
+    it('horizontal nav in free mode does not clamp row', () => {
+        // From col 1 row 10 → col 2 (capacity 5) but free mode → no clamp
+        expect(resolveNextSlot('slot_1_10', 'ArrowRight', cols, false)).toEqual({
+            col: 2,
+            row: 10,
+        });
+    });
+});

--- a/frontend/src/components/GridSort.helpers.ts
+++ b/frontend/src/components/GridSort.helpers.ts
@@ -65,9 +65,7 @@ export function resolveNextSlot(
 
     if (nextCol !== col) {
         const declaredCap = gridColumns[nextCol]?.capacity ?? 0;
-        const newColCapacity = isForcedDistribution
-            ? declaredCap
-            : Number.MAX_SAFE_INTEGER;
+        const newColCapacity = isForcedDistribution ? declaredCap : Number.MAX_SAFE_INTEGER;
         nextRow = Math.min(nextRow, newColCapacity - 1);
     }
 

--- a/frontend/src/components/GridSort.helpers.ts
+++ b/frontend/src/components/GridSort.helpers.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure helpers extracted from GridSort for testability.
+ *
+ * - `resolveNextSlot`: keyboard-navigation grid-cell resolver. Given the
+ *   current slot id (`slot_{col}_{row}`), the pressed arrow key, the grid
+ *   column shape, and whether the current sort is forced-distribution,
+ *   returns the next slot's `{col, row}` or null when navigation is a no-op
+ *   (unrecognised slot id, non-arrow key, or already at the edge).
+ *
+ * Distribution-mode behaviour:
+ * - Forced: the per-column `capacity` is a hard cap on row index.
+ * - Free / flexible: capacity is a soft visual hint; rows can grow beyond
+ *   it (we use Number.MAX_SAFE_INTEGER as the upper bound).
+ */
+
+interface GridColumnLite {
+    capacity: number;
+}
+
+const SLOT_ID_RE = /^slot_(\d+)_(\d+)$/;
+
+/**
+ * Resolve the destination slot for an arrow-key press starting from `slotId`.
+ * Returns null when the navigation is a no-op (unrecognised slot id, non-
+ * arrow key, or already at the edge of the grid).
+ */
+export function resolveNextSlot(
+    slotId: string,
+    key: string,
+    gridColumns: GridColumnLite[],
+    isForcedDistribution: boolean
+): { col: number; row: number } | null {
+    const match = slotId.match(SLOT_ID_RE);
+    if (!match || !match[1] || !match[2]) return null;
+
+    const col = parseInt(match[1], 10);
+    const row = parseInt(match[2], 10);
+    const maxCols = gridColumns.length;
+    const currentColumn = gridColumns[col];
+    if (!currentColumn) return null;
+
+    let nextCol = col;
+    let nextRow = row;
+
+    switch (key) {
+        case 'ArrowUp':
+            nextRow = Math.max(0, row - 1);
+            break;
+        case 'ArrowDown': {
+            const maxRowsInCol = isForcedDistribution
+                ? currentColumn.capacity
+                : Number.MAX_SAFE_INTEGER;
+            nextRow = Math.min(maxRowsInCol - 1, row + 1);
+            break;
+        }
+        case 'ArrowLeft':
+            nextCol = Math.max(0, col - 1);
+            break;
+        case 'ArrowRight':
+            nextCol = Math.min(maxCols - 1, col + 1);
+            break;
+        default:
+            return null;
+    }
+
+    if (nextCol !== col) {
+        const declaredCap = gridColumns[nextCol]?.capacity ?? 0;
+        const newColCapacity = isForcedDistribution
+            ? declaredCap
+            : Number.MAX_SAFE_INTEGER;
+        nextRow = Math.min(nextRow, newColCapacity - 1);
+    }
+
+    if (nextCol === col && nextRow === row) return null;
+    return { col: nextCol, row: nextRow };
+}

--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -709,12 +709,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
             (e: React.KeyboardEvent) => {
                 if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) return;
                 const target = e.target as HTMLElement;
-                const next = resolveNextSlot(
-                    target.id,
-                    e.key,
-                    gridColumns,
-                    isForcedDistribution
-                );
+                const next = resolveNextSlot(target.id, e.key, gridColumns, isForcedDistribution);
                 if (!next) return;
                 e.preventDefault();
                 document.getElementById(`slot_${next.col}_${next.row}`)?.focus();

--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -35,6 +35,7 @@ import { useViewport } from '@/contexts/ViewportContext';
 
 import { cn } from '@/lib/utils';
 import { inlineMarkdownComponents } from './markdown-config';
+import { resolveNextSlot } from './GridSort.helpers';
 
 // Sub-component: Droppable Pile
 const DroppablePile: React.FC<
@@ -706,70 +707,17 @@ const GridSort: React.FC<GridSortProps> = React.memo(
         // --- Keyboard Focus Management (Roving-like) ---
         const handleGridKeyDown = useCallback(
             (e: React.KeyboardEvent) => {
-                // Only handle navigation if no modifiers are pressed
                 if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) return;
-
                 const target = e.target as HTMLElement;
-                const slotId = target.id;
-
-                // Parse current position
-                // Format: slot_{col}_{row}
-                const match = slotId.match(/^slot_(\d+)_(\d+)$/);
-                if (!match || !match[1] || !match[2]) return;
-
-                const col = parseInt(match[1], 10);
-                const row = parseInt(match[2], 10);
-                const maxCols = gridColumns.length;
-                const currentColumn = gridColumns[col];
-                if (!currentColumn) return;
-
-                let nextCol = col;
-                let nextRow = row;
-
-                switch (e.key) {
-                    case 'ArrowUp':
-                        nextRow = Math.max(0, row - 1);
-                        break;
-                    case 'ArrowDown': {
-                        // In free/flexible mode the per-column capacity is a
-                        // soft visual hint, not a hard cap, so allow keyboard
-                        // navigation past the declared row count.
-                        const maxRowsInCol = isForcedDistribution
-                            ? currentColumn.capacity
-                            : Number.MAX_SAFE_INTEGER;
-                        nextRow = Math.min(maxRowsInCol - 1, row + 1);
-                        break;
-                    }
-                    case 'ArrowLeft':
-                        nextCol = Math.max(0, col - 1);
-                        break;
-                    case 'ArrowRight':
-                        nextCol = Math.min(maxCols - 1, col + 1);
-                        break;
-                    default:
-                        return; // Exit if not an arrow key
-                }
-
-                // If moving columns, clamp the row to the new column's capacity
-                // We try to stay at the same relative height (center) or just clamp
-                if (nextCol !== col) {
-                    const declaredCap = gridColumns[nextCol]?.capacity ?? 0;
-                    const newColCapacity = isForcedDistribution
-                        ? declaredCap
-                        : Number.MAX_SAFE_INTEGER;
-                    // Sophisticated logic: try to stay visually close?
-                    // Simple logic: clamp to bottom
-                    nextRow = Math.min(nextRow, newColCapacity - 1);
-                }
-
-                if (nextCol !== col || nextRow !== row) {
-                    e.preventDefault();
-                    const nextId = `slot_${nextCol}_${nextRow}`;
-                    const nextEl = document.getElementById(nextId);
-                    if (nextEl) {
-                        nextEl.focus();
-                    }
-                }
+                const next = resolveNextSlot(
+                    target.id,
+                    e.key,
+                    gridColumns,
+                    isForcedDistribution
+                );
+                if (!next) return;
+                e.preventDefault();
+                document.getElementById(`slot_${next.col}_${next.row}`)?.focus();
             },
             [gridColumns, isForcedDistribution]
         );

--- a/frontend/src/components/postsort/Step1_Feedback.helpers.test.ts
+++ b/frontend/src/components/postsort/Step1_Feedback.helpers.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { selectExtremeCards } from './Step1_Feedback.helpers';
+
+const grid = [
+    { score: -4 }, // col 0
+    { score: -1 }, // col 1
+    { score: 0 }, // col 2
+    { score: 1 }, // col 3
+    { score: 4 }, // col 4
+];
+
+describe('selectExtremeCards', () => {
+    it('returns [] when qsort is empty', () => {
+        expect(selectExtremeCards([], grid, [-4, 4])).toEqual([]);
+    });
+
+    it('returns [] when no card sits in an extreme column', () => {
+        const qsort = [
+            { statementId: 1, col: 1, row: 0 },
+            { statementId: 2, col: 2, row: 0 },
+        ];
+        expect(selectExtremeCards(qsort, grid, [-4, 4])).toEqual([]);
+    });
+
+    it('keeps only cards in extreme columns', () => {
+        const qsort = [
+            { statementId: 1, col: 0, row: 0 },
+            { statementId: 2, col: 2, row: 0 },
+            { statementId: 3, col: 4, row: 0 },
+        ];
+        const r = selectExtremeCards(qsort, grid, [-4, 4]);
+        expect(r).toHaveLength(2);
+        expect(r.map((c) => c.statementId)).toEqual([1, 3]);
+    });
+
+    it('sorts by ascending column score', () => {
+        const qsort = [
+            { statementId: 3, col: 4, row: 0 }, // score +4
+            { statementId: 1, col: 0, row: 0 }, // score -4
+        ];
+        const r = selectExtremeCards(qsort, grid, [-4, 4]);
+        expect(r.map((c) => c.statementId)).toEqual([1, 3]);
+    });
+
+    it('within the same score, sorts by row', () => {
+        const qsort = [
+            { statementId: 2, col: 0, row: 1 },
+            { statementId: 1, col: 0, row: 0 },
+        ];
+        const r = selectExtremeCards(qsort, grid, [-4, 4]);
+        expect(r.map((c) => c.statementId)).toEqual([1, 2]);
+    });
+
+    it('handles cards in unknown columns (out of grid range) by skipping them', () => {
+        const qsort = [
+            { statementId: 1, col: 0, row: 0 },
+            { statementId: 2, col: 99, row: 0 }, // bogus
+        ];
+        const r = selectExtremeCards(qsort, grid, [-4, 4]);
+        expect(r).toHaveLength(1);
+        expect(r[0]?.statementId).toBe(1);
+    });
+
+    it('respects custom extremeCols (e.g. [-3, 3] instead of defaults)', () => {
+        const customGrid = [
+            { score: -3 },
+            { score: 0 },
+            { score: 3 },
+        ];
+        const qsort = [
+            { statementId: 1, col: 0, row: 0 },
+            { statementId: 2, col: 1, row: 0 },
+            { statementId: 3, col: 2, row: 0 },
+        ];
+        const r = selectExtremeCards(qsort, customGrid, [-3, 3]);
+        expect(r.map((c) => c.statementId)).toEqual([1, 3]);
+    });
+});

--- a/frontend/src/components/postsort/Step1_Feedback.helpers.test.ts
+++ b/frontend/src/components/postsort/Step1_Feedback.helpers.test.ts
@@ -62,11 +62,7 @@ describe('selectExtremeCards', () => {
     });
 
     it('respects custom extremeCols (e.g. [-3, 3] instead of defaults)', () => {
-        const customGrid = [
-            { score: -3 },
-            { score: 0 },
-            { score: 3 },
-        ];
+        const customGrid = [{ score: -3 }, { score: 0 }, { score: 3 }];
         const qsort = [
             { statementId: 1, col: 0, row: 0 },
             { statementId: 2, col: 1, row: 0 },

--- a/frontend/src/components/postsort/Step1_Feedback.helpers.ts
+++ b/frontend/src/components/postsort/Step1_Feedback.helpers.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for Step1_Feedback.
+ *
+ * - `selectExtremeCards`: filter the participant's qsort to keep only cards
+ *   placed in extreme columns (defined by score), then sort by ascending
+ *   score then by row. Pure function for testability.
+ */
+
+interface QSortPlacement {
+    statementId: number;
+    col: number;
+    row: number;
+}
+
+interface GridColumnLite {
+    score: number;
+}
+
+/**
+ * Return the qsort placements that sit in `extremeCols` (a list of scores
+ * such as [-4, 4]), sorted by ascending column score then by row index.
+ */
+export function selectExtremeCards(
+    qsort: QSortPlacement[],
+    gridColumns: GridColumnLite[],
+    extremeCols: number[]
+): QSortPlacement[] {
+    return qsort
+        .filter((p) => {
+            const colDef = gridColumns[p.col];
+            return colDef !== undefined && extremeCols.includes(colDef.score);
+        })
+        .sort((a, b) => {
+            const scoreA = gridColumns[a.col]?.score ?? 0;
+            const scoreB = gridColumns[b.col]?.score ?? 0;
+            if (scoreA !== scoreB) return scoreA - scoreB;
+            return a.row - b.row;
+        });
+}

--- a/frontend/src/components/postsort/Step1_Feedback.tsx
+++ b/frontend/src/components/postsort/Step1_Feedback.tsx
@@ -17,6 +17,7 @@ import {
     deleteAudioRecordingApiAudioRecordingIdDelete,
 } from '@/api/generated';
 import { toast } from 'sonner';
+import { selectExtremeCards } from './Step1_Feedback.helpers';
 
 interface Step1Props {
     onNext: () => void;
@@ -73,20 +74,7 @@ export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
 
     // --- Data Preparation ---
     const extremeCards = useMemo(
-        () =>
-            qsort
-                .filter((p) => {
-                    const colDef = gridColumns[p.col];
-                    if (!colDef) return false;
-                    return extremeCols.includes(colDef.score);
-                })
-                .sort((a, b) => {
-                    // Sort by score (asc) then row
-                    const scoreA = gridColumns[a.col]?.score ?? 0;
-                    const scoreB = gridColumns[b.col]?.score ?? 0;
-                    if (scoreA !== scoreB) return scoreA - scoreB;
-                    return a.row - b.row;
-                }),
+        () => selectExtremeCards(qsort, gridColumns, extremeCols),
         [qsort, gridColumns, extremeCols]
     );
 


### PR DESCRIPTION
## Summary
- Two pure-helper extractions in the participant runtime: \`resolveNextSlot\` (GridSort keyboard nav) + \`selectExtremeCards\` (Step1_Feedback).
- Reduces frontend cognitive-complexity warnings from **23 to 22** (-1, -4%).

## Commits
- \`3c1522c8\` — extract \`resolveNextSlot\` (P3, 11 tests on keyboard navigation grid resolver) + extract \`selectExtremeCards\` (P3, 7 tests on extreme-card filter+sort)
- \`009f9613\` — biome auto-format on the three touched files

## Sites closed: 1 (GridSort:708)

The \`selectExtremeCards\` helper extraction did not on its own move the
Step1_Feedback line-25 component-body warning below threshold (audio
handlers + getPrompt fallback chain + JSX shell are the remaining
contributors). Per the W2-end backlog review, the 3 Step1 sites are P5
candidates that will be suppressed in W4b. The helper is still kept here
because the testability gain stands on its own.

## Test plan
- [x] \`make ci-fast\` green
- [x] \`make ci\` green pre-push
- [x] No file outside W4a scope modified
- [x] resolveNextSlot: 11 tests covering unrecognised slot ids, non-arrow keys, ArrowUp/Down/Left/Right with edge clamping, forced vs free distribution mode, horizontal nav clamping
- [x] selectExtremeCards: 7 tests covering empty qsort, no-extreme-card, score sort, row tiebreak, out-of-range column skip, custom extremeCols

🤖 Generated with [Claude Code](https://claude.com/claude-code)