### PR TITLE
refactor: W4b — 12 P5 suppressions in participant runtime (cognitive complexity)

### DIFF
--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -605,6 +605,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
         distributionMode = 'forced',
         deckCards,
         qsort,
+        // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — GridSort shell. Load-bearing autofit/zoom/responsive coupling: useEffect disables autofit on mobile selection but deliberately does NOT re-enable on deselect (otherwise zoom resets on every card placement). E2E-covered. Pure-logic extractions done by W4a (resolveNextSlot for keyboard nav).
     }) => {
         const { t } = useTranslation();
         const isForcedDistribution = distributionMode === 'forced';
@@ -790,6 +791,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
                 );
             }
 
+            // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — renderDeckCards: viewport-conditional layout JSX (landscape-mobile/portrait-mobile/desktop variants × isLifted state × hovered/selected style); structural mapping
             return activeCards.map((card) => (
                 <div
                     key={card.id}

--- a/frontend/src/components/ReadingZone.tsx
+++ b/frontend/src/components/ReadingZone.tsx
@@ -55,6 +55,7 @@ const InlineIcon: React.FC<{
 interface ReadingZoneProps {
     variant: 'mobile' | 'desktop' | 'landscape' | 'overlay';
 }
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — 4-variant render switch (mobile/desktop/landscape/overlay); the variant switch IS the surface, no extractable algorithmic logic
 const ReadingZone: React.FC<ReadingZoneProps> = ({ variant }) => {
     const hoveredCard = useUIStore((state) => state.hoveredCard);
     const activeCard = useUIStore((state) => state.activeCard);

--- a/frontend/src/components/SortableCard.tsx
+++ b/frontend/src/components/SortableCard.tsx
@@ -137,6 +137,7 @@ const SortableCard: React.FC<SortableCardProps> = React.memo(
         hasComment = false,
         hasAudio = false,
         readOnly = false,
+        // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — SortableCard shell. The dynamic line-clamp useLayoutEffect uses a ResizeObserver only when `dimensions` is undefined ("only CSS-sized cards need an observer; Grid cards recompute via dimensions?.height dependency instead"). The conditional `if (dimensions) return;` before observer attach is load-bearing both for **correctness** (RO fires once synchronously on attach + setDynamicLineClamp re-renders) and for **perf** (38+ grid cards attaching their own RO would noticeably degrade scroll/drag latency). A naive `useDynamicLineClamp` hook extract would likely drop the guard.
     }) => {
         const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
             useSortable({ id, disabled: readOnly });

--- a/frontend/src/components/SortingAnimation.tsx
+++ b/frontend/src/components/SortingAnimation.tsx
@@ -38,6 +38,7 @@ interface SortingAnimationProps {
     scale?: number;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — decorative animation FSM (aria-hidden); per-phase setTimeout chain + ROUGH/FINE step machine. Refs and timers are intrinsic; aria-hidden = zero participant impact even on regression
 const SortingAnimation: React.FC<SortingAnimationProps> = ({ scale }) => {
     const [phase, setPhase] = useState<'ROUGH' | 'FINE'>('ROUGH');
     const [step, setStep] = useState(0);
@@ -53,6 +54,7 @@ const SortingAnimation: React.FC<SortingAnimationProps> = ({ scale }) => {
         return () => clearTimeout(t);
     }, []);
 
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — animation step machine (phase × step × hesitation × pause); see component-level rationale above
     useEffect(() => {
         if (!isReady) return;
         let timer: ReturnType<typeof setTimeout>;

--- a/frontend/src/components/postsort/Step1_Feedback.tsx
+++ b/frontend/src/components/postsort/Step1_Feedback.tsx
@@ -23,6 +23,7 @@ interface Step1Props {
     onNext: () => void;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — postsort feedback page shell (audio handlers + i18n prompt fallback chain + extreme-cards JSX map); pure-logic extraction selectExtremeCards already done in W4a
 export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
     const { t, i18n } = useTranslation();
     const { isDesktop } = useViewport();
@@ -82,6 +83,7 @@ export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
     const getCardText = (id: number) =>
         config?.statements.find((s) => s.id === id)?.text || t('common.unknown_card');
 
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — i18n prompt key-fallback chain over postsort_config.prompts × locale × default-text-key × hardcoded fallback. Marginal extract value.
     const getPrompt = (keys: string | string[], defaultTextKey: string, defaultValue?: string) => {
         const prompts = config?.postsort_config?.prompts;
         const currentLang = i18n.language || 'en';
@@ -299,6 +301,7 @@ export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
                     </span>
                 </div>
 
+                {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — extreme-card render with score → label/colour conditional chain (positive/neutral/negative variants × audio recording state × edit mode); the conditional JSX IS the surface */}
                 {extremeCards.map((card) => {
                     const colDef = gridColumns[card.col];
                     const scoreVal = colDef ? colDef.score : 0;

--- a/frontend/src/components/postsort/Step2_Questionnaire.tsx
+++ b/frontend/src/components/postsort/Step2_Questionnaire.tsx
@@ -30,6 +30,7 @@ interface Step2Props {
     isLoading: boolean;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — postsort form orchestrator (RHF + zod resolver + audio handlers + textAudio errors local state + final-submit multi-stage); each stage is its own concern, no further extraction without prop drilling
 export const Step2_Questionnaire: React.FC<Step2Props> = ({ onBack, onSubmit, isLoading }) => {
     const { t, i18n } = useTranslation();
     const config = useConfigStore((state) => state.config);
@@ -229,6 +230,7 @@ export const Step2_Questionnaire: React.FC<Step2Props> = ({ onBack, onSubmit, is
     // Track text_audio validation errors separately (not handled by Zod)
     const [textAudioErrors, setTextAudioErrors] = useState<Record<string, string>>({});
 
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — handleFinalSubmit multi-stage validation (upload-in-progress check, text_audio per-question validation, RHF errors, then submit). Each stage is already its own concern.
     const handleFinalSubmit = async () => {
         if (isUploadInProgress) {
             toast.info(

--- a/frontend/src/pages/ConsentPage.tsx
+++ b/frontend/src/pages/ConsentPage.tsx
@@ -65,6 +65,7 @@ const ConsentPage: React.FC = () => {
     // If no config, redirect home or show loading
     if (!config) return null;
 
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — consent recording flow; branching IS the contract: pilot-mode skip → session-token init → consent hash construction → record-consent fetch → block navigation on failure (load-bearing GDPR guarantee — see CLAUDE.md security invariants)
     const onSubmit = async (data: ConsentForm) => {
         if (data.consent) {
             const sessionToken = token || crypto.randomUUID();


### PR DESCRIPTION
## Summary
- 12 documented P5 suppressions in the participant runtime (GridSort, SortableCard, ReadingZone, SortingAnimation, Step1/2 postsort, ConsentPage).
- Reduces frontend cognitive-complexity warnings from **22 to 10** (-12, -55%).
- Each suppression cites P5 with concrete one-line rationale per spec convention.

## Double Opus review on high-risk sites

Per the W2-end backlog review, three sites carry W2-T7-style invariants and received **double Opus review at extra-high effort**:

1. **GridSort.tsx:608** (component shell) — autofit-disable-on-mobile-selection is deliberately one-way; re-enabling on deselect would reset zoom on every card placement on mobile. Both reviewers confirmed the asymmetry is intact in code and that W4a's \`resolveNextSlot\` extraction has closed the testable kernel. APPROVED.
2. **GridSort.tsx:793** (renderDeckCards) — viewport-conditional layout JSX, e2e-covered via \`GridSort.mobile-layout.test.tsx\` + \`FORM_FACTORS\` across mobile/tablet/landscape. APPROVED.
3. **SortableCard.tsx:140** (dynamic line-clamp) — \`if (dimensions) return;\` guard is load-bearing for both correctness (RO fires synchronously on attach + setDynamicLineClamp re-renders) AND perf (38+ grid cards each attaching their own RO would degrade scroll/drag latency). APPROVED with one YELLOW note (see follow-up below).

## Follow-up tracked

- **YELLOW** on SortableCard:140: the second reviewer noted that the perf/correctness invariant has no regression test — a naive \`useDynamicLineClamp\` extract by a future hire would pass CI. Add a test in \`SortableCard.test.tsx\` asserting \`ResizeObserver\` is NOT instantiated on dimensions-provided cards. Non-blocking, tracked for a future hygiene pass.

## Out of scope (deferred)

- AudioRecorder.tsx:199 (cleanup useEffect)
- AudioRecorder.tsx:476 (playRecording)

Both deferred per the W2-end checkpoint: the cleanup ordering (clearInterval before cancelAnimationFrame before AudioContext.close before stream.getTracks().stop()) and the cross-origin AudioContext branch (real Web Audio API for blob URLs vs simulated waveform for presigned URLs) are structural refactors needing their own \`useAudioRecorder\` extraction with jsdom MediaRecorder mock — out of cognitive-complexity remediation scope.

## Test plan
- [x] \`make ci-fast\` green
- [x] \`make ci\` green pre-push
- [x] No file outside W4b scope modified
- [x] Each suppression cites P5 with concrete one-line rationale
- [x] High-risk sites reviewed by two independent Opus passes
- [x] Cross-cutting verification: ConsentPage GDPR branch intact, Step2 multi-stage validation chain intact, SortingAnimation aria-hidden verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)