### PR TITLE
refactor: W5 — page/layout/redirect helpers + 3 P5 page-shell suppressions

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -28,3 +28,4 @@
 94927bd1bed07c04ba4a4cd0f9751d603a9e036b:backend/tests/integration/test_consent_flow.py:generic-api-key:32
 e1b309997a92fa5e3d67547bdf5e3ebc42d11ff7:backend/tests/integration/test_consent_flow.py:generic-api-key:32
 864fb6e5b2034bef7784c1df0cf15f567af2f247:backend/tests/integration/test_study_lifecycle.py:generic-api-key:37
+06c9d0aa4110c21466715de97e455c88bd3b2a43:frontend/src/layouts/AdminLayout.helpers.test.ts:generic-api-key:64

--- a/frontend/src/components/RouteErrorBoundary.helpers.test.ts
+++ b/frontend/src/components/RouteErrorBoundary.helpers.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { ApiError } from '../api/client';
+import {
+    classifyRouteError,
+    shouldCaptureRouteError,
+    shouldThrottleChunkReload,
+} from './RouteErrorBoundary.helpers';
+
+const noStorage = () => null;
+
+describe('shouldCaptureRouteError', () => {
+    it('captures non-route errors', () => {
+        expect(shouldCaptureRouteError(new Error('boom'))).toBe(true);
+        expect(shouldCaptureRouteError('boom')).toBe(true);
+    });
+
+    it('does NOT capture 4xx route responses (404 etc.)', () => {
+        const r404 = { status: 404, statusText: 'Not Found', data: null, internal: false };
+        expect(shouldCaptureRouteError(r404)).toBe(false);
+    });
+
+    it('captures 5xx route responses', () => {
+        const r500 = { status: 500, statusText: 'Server Error', data: null, internal: false };
+        expect(shouldCaptureRouteError(r500)).toBe(true);
+    });
+});
+
+describe('classifyRouteError', () => {
+    it('detects route-response (non-ApiError) and extracts status + message', () => {
+        const r = { status: 404, statusText: 'Not Found', data: null, internal: false };
+        const c = classifyRouteError(r, noStorage, 1000);
+        expect(c.kind).toBe('route-response');
+        if (c.kind === 'route-response') {
+            expect(c.status).toBe(404);
+            expect(c.message).toBe('Not Found');
+        }
+    });
+
+    it('detects api-error', () => {
+        const c = classifyRouteError(new ApiError(403, 'Forbidden'), noStorage, 1000);
+        expect(c.kind).toBe('api-error');
+    });
+
+    it('detects chunk-reload from "Failed to fetch dynamically imported module"', () => {
+        const e = new Error('Failed to fetch dynamically imported module: chunk-X.js');
+        const c = classifyRouteError(e, () => '500', 1000);
+        expect(c.kind).toBe('chunk-reload');
+        if (c.kind === 'chunk-reload') {
+            expect(c.storageKey).toBe('chunk_load_error_reload');
+            expect(c.now).toBe(1000);
+            expect(c.lastReload).toBe('500');
+        }
+    });
+
+    it('detects chunk-reload from "Importing a module script failed"', () => {
+        const e = new Error('Importing a module script failed.');
+        const c = classifyRouteError(e, noStorage, 1000);
+        expect(c.kind).toBe('chunk-reload');
+    });
+
+    it('classifies a plain Error not matching chunk-reload', () => {
+        const c = classifyRouteError(new Error('something else'), noStorage, 1000);
+        expect(c.kind).toBe('plain-error');
+    });
+
+    it('classifies a non-Error non-route value as unknown', () => {
+        expect(classifyRouteError('plain string', noStorage, 1000).kind).toBe('unknown');
+        expect(classifyRouteError(null, noStorage, 1000).kind).toBe('unknown');
+    });
+});
+
+describe('shouldThrottleChunkReload', () => {
+    it('returns false when no prior reload', () => {
+        expect(shouldThrottleChunkReload(null, 1000)).toBe(false);
+    });
+
+    it('returns false when lastReload is non-numeric', () => {
+        expect(shouldThrottleChunkReload('abc', 1000)).toBe(false);
+    });
+
+    it('returns true when within the throttle window (default 10s)', () => {
+        expect(shouldThrottleChunkReload('5000', 9000)).toBe(true); // 4s ago
+    });
+
+    it('returns false when outside the throttle window', () => {
+        expect(shouldThrottleChunkReload('5000', 16000)).toBe(false); // 11s ago
+    });
+
+    it('respects custom windowMs', () => {
+        expect(shouldThrottleChunkReload('1000', 4000, 5000)).toBe(true);
+        expect(shouldThrottleChunkReload('1000', 7000, 5000)).toBe(false);
+    });
+});

--- a/frontend/src/components/RouteErrorBoundary.helpers.ts
+++ b/frontend/src/components/RouteErrorBoundary.helpers.ts
@@ -1,0 +1,72 @@
+import { isRouteErrorResponse } from 'react-router-dom';
+import { ApiError } from '../api/client';
+
+/**
+ * Whether Sentry should capture this route error. 4xx route errors (404, etc.)
+ * are expected user-facing flows; only 5xx and unknown errors warrant a report.
+ */
+export function shouldCaptureRouteError(error: unknown): boolean {
+    if (!isRouteErrorResponse(error)) return true;
+    return error.status >= 500;
+}
+
+/** Classification used by RouteErrorBoundary to render the right page. */
+export type RouteErrorClassification =
+    | { kind: 'route-response'; status: number; message: string }
+    | { kind: 'api-error'; error: ApiError }
+    | { kind: 'chunk-reload'; storageKey: string; now: number; lastReload: string | null }
+    | { kind: 'plain-error'; error: Error }
+    | { kind: 'unknown' };
+
+/**
+ * Classify an unknown route error into a render decision. The "chunk-reload"
+ * variant signals that the caller should also check whether the reload is
+ * within a 10s throttle window before triggering window.location.reload().
+ */
+export function classifyRouteError(
+    error: unknown,
+    storageGetter: (key: string) => string | null,
+    now: number
+): RouteErrorClassification {
+    if (isRouteErrorResponse(error)) {
+        return {
+            kind: 'route-response',
+            status: error.status,
+            message: error.statusText || error.data?.detail || 'Route error',
+        };
+    }
+    if (error instanceof ApiError) {
+        return { kind: 'api-error', error };
+    }
+    if (error instanceof Error) {
+        if (
+            error.message.includes('Failed to fetch dynamically imported module') ||
+            error.message.includes('Importing a module script failed')
+        ) {
+            const storageKey = 'chunk_load_error_reload';
+            return {
+                kind: 'chunk-reload',
+                storageKey,
+                now,
+                lastReload: storageGetter(storageKey),
+            };
+        }
+        return { kind: 'plain-error', error };
+    }
+    return { kind: 'unknown' };
+}
+
+/**
+ * Returns true when the chunk-load reload should be throttled (i.e. we
+ * already attempted one within the last 10 seconds — don't loop).
+ */
+export function shouldThrottleChunkReload(
+    lastReload: string | null,
+    now: number,
+    windowMs = 10000
+): boolean {
+    if (!lastReload) return false;
+    const parsed = Number.parseInt(lastReload, 10);
+    if (Number.isNaN(parsed)) return false;
+    return now - parsed <= windowMs;
+}

--- a/frontend/src/components/RouteErrorBoundary.tsx
+++ b/frontend/src/components/RouteErrorBoundary.tsx
@@ -5,9 +5,14 @@
  */
 
 import * as Sentry from '@sentry/react';
-import { useRouteError, isRouteErrorResponse } from 'react-router-dom';
+import { useRouteError } from 'react-router-dom';
 import ErrorPage from '../pages/ErrorPage';
 import { ApiError } from '../api/client';
+import {
+    classifyRouteError,
+    shouldCaptureRouteError,
+    shouldThrottleChunkReload,
+} from './RouteErrorBoundary.helpers';
 
 /**
  * RouteErrorBoundary
@@ -21,49 +26,40 @@ const RouteErrorBoundary = () => {
     console.error('Route error caught:', error);
 
     // Forward to Sentry when a DSN is configured (no-op otherwise).
-    // 4xx route errors (404, etc.) are expected — only capture 5xx and unknown errors.
-    const shouldCapture = !isRouteErrorResponse(error) || error.status >= 500;
-    if (shouldCapture && error instanceof Error) {
-        Sentry.captureException(error);
-    } else if (shouldCapture && !(error instanceof ApiError)) {
-        Sentry.captureMessage(`Route error: ${String(error)}`, 'error');
-    }
-
-    if (isRouteErrorResponse(error)) {
-        return (
-            <ErrorPage
-                error={
-                    new ApiError(
-                        error.status,
-                        error.statusText || error.data?.detail || 'Route error'
-                    )
-                }
-            />
-        );
-    }
-
-    if (error instanceof ApiError) {
-        return <ErrorPage error={error} />;
-    }
-
-    if (error instanceof Error) {
-        // Handle chunk load errors after new deployments
-        if (
-            error.message.includes('Failed to fetch dynamically imported module') ||
-            error.message.includes('Importing a module script failed')
-        ) {
-            console.warn('Chunk load error detected in RouteErrorBoundary. Reloading...');
-            const storageKey = 'chunk_load_error_reload';
-            const lastReload = sessionStorage.getItem(storageKey);
-            const now = Date.now();
-
-            if (!lastReload || now - Number.parseInt(lastReload, 10) > 10000) {
-                sessionStorage.setItem(storageKey, now.toString());
-                window.location.reload();
-                return null;
-            }
+    if (shouldCaptureRouteError(error)) {
+        if (error instanceof Error) {
+            Sentry.captureException(error);
+        } else if (!(error instanceof ApiError)) {
+            Sentry.captureMessage(`Route error: ${String(error)}`, 'error');
         }
-        return <ErrorPage error={error} />;
+    }
+
+    const classification = classifyRouteError(
+        error,
+        (key) => sessionStorage.getItem(key),
+        Date.now()
+    );
+
+    if (classification.kind === 'route-response') {
+        return <ErrorPage error={new ApiError(classification.status, classification.message)} />;
+    }
+
+    if (classification.kind === 'api-error') {
+        return <ErrorPage error={classification.error} />;
+    }
+
+    if (classification.kind === 'chunk-reload') {
+        if (!shouldThrottleChunkReload(classification.lastReload, classification.now)) {
+            console.warn('Chunk load error detected in RouteErrorBoundary. Reloading...');
+            sessionStorage.setItem(classification.storageKey, classification.now.toString());
+            window.location.reload();
+            return null;
+        }
+        return <ErrorPage error={error as Error} />;
+    }
+
+    if (classification.kind === 'plain-error') {
+        return <ErrorPage error={classification.error} />;
     }
 
     return (

--- a/frontend/src/components/admin/CreateStudyDialog.helpers.test.ts
+++ b/frontend/src/components/admin/CreateStudyDialog.helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import type { TFunction } from 'i18next';
+import { parseStudyCreationError } from './CreateStudyDialog.helpers';
+
+const t = ((_key: string, fallback?: string) => fallback ?? _key) as unknown as TFunction;
+
+describe('parseStudyCreationError', () => {
+    it('returns the i18n fallback for null/undefined', () => {
+        expect(parseStudyCreationError(null, t)).toBe('Failed to create study');
+        expect(parseStudyCreationError(undefined, t)).toBe('Failed to create study');
+    });
+
+    it('returns the i18n fallback for a string', () => {
+        expect(parseStudyCreationError('plain', t)).toBe('Failed to create study');
+    });
+
+    it('extracts a Pydantic-style validation array', () => {
+        const err = {
+            response: {
+                data: {
+                    detail: [
+                        { loc: ['body', 'slug'], msg: 'must be unique' },
+                        { loc: ['body', 'title'], msg: 'too short' },
+                    ],
+                },
+            },
+        };
+        expect(parseStudyCreationError(err, t)).toBe(
+            'Validation errors:\nbody.slug: must be unique\nbody.title: too short'
+        );
+    });
+
+    it('extracts a string detail', () => {
+        const err = { response: { data: { detail: 'Slug already exists' } } };
+        expect(parseStudyCreationError(err, t)).toBe('Slug already exists');
+    });
+
+    it('stringifies an object detail', () => {
+        const err = { response: { data: { detail: { code: 'X', extra: 1 } } } };
+        const out = parseStudyCreationError(err, t);
+        expect(out).toContain('"code": "X"');
+        expect(out).toContain('"extra": 1');
+    });
+
+    it('falls back to error.message when no axios detail', () => {
+        const err = new Error('Network error');
+        expect(parseStudyCreationError(err, t)).toBe('Network error');
+    });
+
+    it('falls back to i18n when error has no recognised shape', () => {
+        const err = { foo: 'bar' };
+        expect(parseStudyCreationError(err, t)).toBe('Failed to create study');
+    });
+
+    it('prefers detail over error.message', () => {
+        const err = Object.assign(new Error('msg'), {
+            response: { data: { detail: 'from server' } },
+        });
+        expect(parseStudyCreationError(err, t)).toBe('from server');
+    });
+});

--- a/frontend/src/components/admin/CreateStudyDialog.helpers.ts
+++ b/frontend/src/components/admin/CreateStudyDialog.helpers.ts
@@ -1,0 +1,39 @@
+import type { TFunction } from 'i18next';
+
+interface AxiosErrorShape {
+    response?: { data?: { detail?: unknown } };
+}
+
+/**
+ * Parse the various error shapes that can come back from the create-study
+ * mutation into a user-displayable string. Handles:
+ * - axios-style validation errors (Pydantic detail array)
+ * - axios-style string detail
+ * - axios-style object detail (stringified)
+ * - Error.message fallback
+ * - generic fallback (i18n default)
+ */
+export function parseStudyCreationError(error: unknown, t: TFunction): string {
+    const fallback = t('admin.dialogs.create_study.error', 'Failed to create study');
+    if (!error || typeof error !== 'object') return fallback;
+
+    const axiosError = error as AxiosErrorShape;
+    const detail = axiosError.response?.data?.detail;
+
+    if (detail !== undefined) {
+        if (Array.isArray(detail)) {
+            const fieldErrors = detail
+                .map((err: { loc: string[]; msg: string }) => `${err.loc.join('.')}: ${err.msg}`)
+                .join('\n');
+            return `Validation errors:\n${fieldErrors}`;
+        }
+        if (typeof detail === 'string') return detail;
+        if (typeof detail === 'object') return JSON.stringify(detail, null, 2);
+    }
+
+    if ('message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        return (error as { message: string }).message;
+    }
+
+    return fallback;
+}

--- a/frontend/src/components/admin/CreateStudyDialog.tsx
+++ b/frontend/src/components/admin/CreateStudyDialog.tsx
@@ -34,6 +34,7 @@ import {
     getListStudiesApiAdminStudiesGetQueryKey,
 } from '@/api/generated';
 import { useAdminStore } from '@/store/useAdminStore';
+import { parseStudyCreationError } from './CreateStudyDialog.helpers';
 
 interface CreateStudyDialogProps {
     open: boolean;
@@ -136,44 +137,7 @@ export function CreateStudyDialog({ open, onOpenChange, projectSlug }: CreateStu
             slugTouched.current = false;
         } catch (error: unknown) {
             console.error('Study creation error:', error);
-
-            // Extract detailed error information
-            let errorMessage = t('admin.dialogs.create_study.error', 'Failed to create study');
-
-            if (error && typeof error === 'object') {
-                // Check for axios-style error response
-                const axiosError = error as {
-                    response?: { data?: { detail?: unknown } };
-                };
-                if (axiosError.response?.data?.detail) {
-                    const detail = axiosError.response.data.detail;
-
-                    // Handle Pydantic validation errors (array format)
-                    if (Array.isArray(detail)) {
-                        const fieldErrors = detail
-                            .map(
-                                (err: { loc: string[]; msg: string }) =>
-                                    `${err.loc.join('.')}: ${err.msg}`
-                            )
-                            .join('\n');
-                        errorMessage = `Validation errors:\n${fieldErrors}`;
-                        console.error('Validation errors:', detail);
-                    }
-                    // Handle string error messages
-                    else if (typeof detail === 'string') {
-                        errorMessage = detail;
-                    }
-                    // Handle object error messages
-                    else if (typeof detail === 'object') {
-                        errorMessage = JSON.stringify(detail, null, 2);
-                    }
-                }
-                // Fallback to error message if available
-                else if ('message' in error && typeof error.message === 'string') {
-                    errorMessage = error.message;
-                }
-            }
-
+            const errorMessage = parseStudyCreationError(error, t);
             toast.error(errorMessage, { duration: 10000 });
         }
     };

--- a/frontend/src/components/admin/LegacyRedirect.helpers.test.ts
+++ b/frontend/src/components/admin/LegacyRedirect.helpers.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLegacyTarget } from './LegacyRedirect.helpers';
+
+const projects = [
+    { slug: 'proj1', id: 1 },
+    { slug: 'proj2', id: 2 },
+];
+
+const studies = [
+    { slug: 'study-a', project: { slug: 'proj1', id: 1 } },
+    { slug: 'study-b', project: { slug: 'proj2', id: 2 } },
+];
+
+describe('resolveLegacyTarget', () => {
+    it('/admin → last visited study has priority', () => {
+        const r = resolveLegacyTarget('/admin', projects, studies, 'study-a');
+        expect(r.target).toBe('/app/proj1/studies/study-a');
+    });
+
+    it('/admin → first project when no last-visited', () => {
+        const r = resolveLegacyTarget('/admin', projects, studies, null);
+        expect(r.target).toBe('/app/proj1/dashboard');
+    });
+
+    it('/admin → /hub when no projects', () => {
+        const r = resolveLegacyTarget('/admin', [], [], null);
+        expect(r.target).toBe('/hub');
+    });
+
+    it('/admin/studies/:slug → migrates with activeStudy/activeProjectId set', () => {
+        const r = resolveLegacyTarget('/admin/studies/study-a', projects, studies, null);
+        expect(r.target).toBe('/app/proj1/studies/study-a');
+        expect(r.activeStudy).toBe('study-a');
+        expect(r.activeProjectId).toBe(1);
+    });
+
+    it('/admin/studies/:slug/exports → maps to /data', () => {
+        const r = resolveLegacyTarget('/admin/studies/study-a/exports', projects, studies, null);
+        expect(r.target).toBe('/app/proj1/studies/study-a/data');
+    });
+
+    it('/admin/studies/:slug/team → maps to project /team (decommissioned)', () => {
+        const r = resolveLegacyTarget('/admin/studies/study-a/team', projects, studies, null);
+        expect(r.target).toBe('/app/proj1/team');
+    });
+
+    it('/admin/studies/:slug/sub → preserves sub path', () => {
+        const r = resolveLegacyTarget(
+            '/admin/studies/study-a/recruitment',
+            projects,
+            studies,
+            null
+        );
+        expect(r.target).toBe('/app/proj1/studies/study-a/recruitment');
+    });
+
+    it('/admin/w/:slug → /app/:slug/dashboard with activeProjectId', () => {
+        const r = resolveLegacyTarget('/admin/w/proj2', projects, studies, null);
+        expect(r.target).toBe('/app/proj2/dashboard');
+        expect(r.activeProjectId).toBe(2);
+    });
+
+    it('/admin/workspaces/:slug/settings → /app/:slug/settings', () => {
+        const r = resolveLegacyTarget('/admin/workspaces/proj2/settings', projects, studies, null);
+        expect(r.target).toBe('/app/proj2/settings');
+        expect(r.activeProjectId).toBe(2);
+    });
+
+    it('/admin/profile → /app/:firstProj/account', () => {
+        const r = resolveLegacyTarget('/admin/profile', projects, studies, null);
+        expect(r.target).toBe('/app/proj1/account');
+    });
+
+    it('/admin/profile → /hub when no projects', () => {
+        const r = resolveLegacyTarget('/admin/profile', [], [], null);
+        expect(r.target).toBe('/hub');
+    });
+
+    it('unknown legacy path → /hub fallback', () => {
+        const r = resolveLegacyTarget('/admin/something/unknown', projects, studies, null);
+        expect(r.target).toBe('/hub');
+    });
+});

--- a/frontend/src/components/admin/LegacyRedirect.helpers.ts
+++ b/frontend/src/components/admin/LegacyRedirect.helpers.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure helper for LegacyRedirect — resolves a legacy `/admin/*` URL into the
+ * new `/app/:projectSlug/*` structure plus optional active-study/project
+ * state updates. The component does the actual `<Navigate>` + Zustand calls.
+ */
+
+interface StudyLike {
+    slug: string;
+    project?: { slug: string; id: number } | null;
+}
+
+interface ProjectLike {
+    slug: string;
+    id: number;
+}
+
+export interface LegacyRedirectResolution {
+    target: string;
+    activeStudy?: string;
+    activeProjectId?: number;
+}
+
+/** /admin (root) — prefer last visited study, then first project, else hub. */
+function resolveAdminRoot(
+    projects: ProjectLike[] | undefined | null,
+    allStudies: StudyLike[] | undefined,
+    lastVisitedStudySlug: string | null
+): LegacyRedirectResolution {
+    if (lastVisitedStudySlug && allStudies) {
+        const study = allStudies.find((s) => s.slug === lastVisitedStudySlug);
+        if (study?.project) {
+            return { target: `/app/${study.project.slug}/studies/${study.slug}` };
+        }
+    }
+    const lastProj = projects?.[0];
+    if (lastProj) return { target: `/app/${lastProj.slug}/dashboard` };
+    return { target: '/hub' };
+}
+
+/** /admin/studies/:slug/... → migrate sub-paths and set active state. */
+function resolveStudyPath(
+    slug: string,
+    pathParts: string[],
+    allStudies: StudyLike[] | undefined
+): LegacyRedirectResolution | null {
+    const study = allStudies?.find((s) => s.slug === slug);
+    if (!study?.project) return null;
+
+    const projSlug = study.project.slug;
+    let subPath = pathParts.slice(3).join('/');
+    if (subPath === 'exports') subPath = 'data';
+    if (subPath === 'team') return { target: `/app/${projSlug}/team` };
+
+    return {
+        target: `/app/${projSlug}/studies/${slug}${subPath ? `/${subPath}` : ''}`,
+        activeStudy: slug,
+        activeProjectId: study.project.id,
+    };
+}
+
+/** /admin/profile → first project's account or /hub. */
+function resolveProfilePath(projects: ProjectLike[] | undefined | null): LegacyRedirectResolution {
+    const firstProj = projects?.[0];
+    if (firstProj) return { target: `/app/${firstProj.slug}/account` };
+    return { target: '/hub' };
+}
+
+/**
+ * Resolve a legacy `/admin/*` URL. Returns the new target path and any
+ * `setActive*` state updates the caller should apply before navigating.
+ */
+export function resolveLegacyTarget(
+    pathname: string,
+    projects: ProjectLike[] | undefined | null,
+    allStudies: StudyLike[] | undefined,
+    lastVisitedStudySlug: string | null
+): LegacyRedirectResolution {
+    const pathParts = pathname.split('/').filter(Boolean);
+    if (pathParts[0] !== 'admin') return { target: '/hub' };
+
+    const slug = pathParts[2];
+
+    if (pathParts.length === 1) {
+        return resolveAdminRoot(projects, allStudies, lastVisitedStudySlug);
+    }
+    if (pathParts[1] === 'studies' && slug) {
+        const r = resolveStudyPath(slug, pathParts, allStudies);
+        if (r) return r;
+    }
+    if (pathParts[1] === 'w' && slug) {
+        const proj = projects?.find((w) => w.slug === slug);
+        return {
+            target: `/app/${slug}/dashboard`,
+            ...(proj ? { activeProjectId: proj.id } : {}),
+        };
+    }
+    if (pathParts[1] === 'workspaces' && pathParts[3] === 'settings' && slug) {
+        const proj2 = projects?.find((w) => w.slug === slug);
+        return {
+            target: `/app/${slug}/settings`,
+            ...(proj2 ? { activeProjectId: proj2.id } : {}),
+        };
+    }
+    if (pathParts[1] === 'profile') {
+        return resolveProfilePath(projects);
+    }
+    return { target: '/hub' };
+}

--- a/frontend/src/components/admin/LegacyRedirect.tsx
+++ b/frontend/src/components/admin/LegacyRedirect.tsx
@@ -10,6 +10,7 @@ import { useListStudiesApiAdminStudiesGet } from '@/api/generated';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useAdminStore } from '@/store/useAdminStore';
+import { resolveLegacyTarget } from './LegacyRedirect.helpers';
 
 /**
  * LegacyRedirect
@@ -24,11 +25,17 @@ export const LegacyRedirect = () => {
     const { data: allStudiesData, isLoading } = useListStudiesApiAdminStudiesGet();
     const allStudies = allStudiesData?.items;
 
-    useEffect(() => {
-        // Redirection effect
-    }, []);
+    const resolution = isLoading
+        ? null
+        : resolveLegacyTarget(location.pathname, projects, allStudies, lastVisitedStudySlug);
 
-    if (isLoading) {
+    useEffect(() => {
+        if (!resolution) return;
+        if (resolution.activeStudy !== undefined) setActiveStudy(resolution.activeStudy);
+        if (resolution.activeProjectId !== undefined) setActiveProject(resolution.activeProjectId);
+    }, [resolution, setActiveStudy, setActiveProject]);
+
+    if (isLoading || !resolution) {
         return (
             <div className="flex h-screen w-full items-center justify-center p-8">
                 <div className="w-full max-w-md space-y-4">
@@ -40,86 +47,5 @@ export const LegacyRedirect = () => {
         );
     }
 
-    // Extract slug from path parts since this is a catch-all route (useParams has no :slug)
-    const pathParts = location.pathname.split('/').filter(Boolean);
-    const slug = pathParts[2]; // Third segment is typically the slug
-
-    // /admin
-    if (pathParts.length === 1 && pathParts[0] === 'admin') {
-        // If we have a last visited study, redirect to it in its workspace
-        if (lastVisitedStudySlug && allStudies) {
-            const study = allStudies.find((s) => s.slug === lastVisitedStudySlug);
-            if (study?.project) {
-                return <Navigate to={`/app/${study.project.slug}/studies/${study.slug}`} replace />;
-            }
-        }
-
-        // Otherwise try last visited project
-        const lastProj = projects?.[0]; // Fallback to first project for now
-        if (lastProj) {
-            return <Navigate to={`/app/${lastProj.slug}/dashboard`} replace />;
-        }
-
-        return <Navigate to="/hub" replace />;
-    }
-
-    // /admin/studies/:slug/...
-    if (pathParts[0] === 'admin' && pathParts[1] === 'studies' && slug) {
-        const study = allStudies?.find((s) => s.slug === slug);
-        if (study?.project) {
-            const projSlug = study.project.slug;
-            const subPathArray = pathParts.slice(3);
-            let subPath = subPathArray.join('/');
-
-            // Map legacy subpaths to new structure
-            if (subPath === 'exports') subPath = 'data';
-            if (subPath === 'team') {
-                // Individual study team management is decommissioned; redirect to project team
-                return <Navigate to={`/app/${projSlug}/team`} replace />;
-            }
-
-            const target = `/app/${projSlug}/studies/${slug}${subPath ? `/${subPath}` : ''}`;
-
-            // Update state
-            setActiveStudy(slug);
-            setActiveProject(study.project.id);
-
-            return <Navigate to={target} replace />;
-        }
-    }
-
-    // /admin/w/:slug
-    if (pathParts[0] === 'admin' && pathParts[1] === 'w' && slug) {
-        const proj = projects?.find((w) => w.slug === slug);
-        if (proj) {
-            setActiveProject(proj.id);
-        }
-        return <Navigate to={`/app/${slug}/dashboard`} replace />;
-    }
-
-    // /admin/workspaces/:slug/settings
-    if (
-        pathParts[0] === 'admin' &&
-        pathParts[1] === 'workspaces' &&
-        pathParts[3] === 'settings' &&
-        slug
-    ) {
-        const proj2 = projects?.find((w) => w.slug === slug);
-        if (proj2) {
-            setActiveProject(proj2.id);
-        }
-        return <Navigate to={`/app/${slug}/settings`} replace />;
-    }
-
-    // /admin/profile
-    if (pathParts[0] === 'admin' && pathParts[1] === 'profile') {
-        const firstProj = projects?.[0];
-        if (firstProj) {
-            return <Navigate to={`/app/${firstProj.slug}/account`} replace />;
-        }
-        return <Navigate to="/hub" replace />;
-    }
-
-    // Default fallback to hub
-    return <Navigate to="/hub" replace />;
+    return <Navigate to={resolution.target} replace />;
 };

--- a/frontend/src/layouts/AdminLayout.helpers.test.ts
+++ b/frontend/src/layouts/AdminLayout.helpers.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import type { TFunction } from 'i18next';
+import { resolveBreadcrumbLabel } from './AdminLayout.helpers';
+
+// Stub t: returns the translation key + interpolation when applicable, or the
+// fallback if provided.
+const t = ((key: string, fallbackOrOpts?: unknown, opts?: Record<string, unknown>) => {
+    if (typeof fallbackOrOpts === 'string') {
+        // Has fallback string + maybe options
+        if (opts) {
+            let s = fallbackOrOpts;
+            for (const [k, v] of Object.entries(opts)) {
+                s = s.replace(`{{${k}}}`, String(v));
+            }
+            return s;
+        }
+        return fallbackOrOpts;
+    }
+    // No fallback: interpolate options into key for visibility
+    if (fallbackOrOpts && typeof fallbackOrOpts === 'object') {
+        let s = key;
+        for (const [k, v] of Object.entries(fallbackOrOpts as Record<string, unknown>)) {
+            s = s.replace(`{{${k}}}`, String(v));
+        }
+        return s;
+    }
+    return key;
+}) as unknown as TFunction;
+
+describe('resolveBreadcrumbLabel', () => {
+    it('returns dashboard for empty pathname', () => {
+        expect(resolveBreadcrumbLabel('/', null, undefined, t)).toBe('admin.breadcrumbs.dashboard');
+    });
+
+    it('returns dashboard for /admin tail', () => {
+        expect(resolveBreadcrumbLabel('/admin', null, undefined, t)).toBe(
+            'admin.breadcrumbs.dashboard'
+        );
+    });
+
+    it('returns study_dashboard when last segment matches activeStudyId', () => {
+        expect(
+            resolveBreadcrumbLabel('/app/proj1/studies/study-abc', 'study-abc', undefined, t)
+        ).toBe('admin.breadcrumbs.study_dashboard');
+    });
+
+    it('returns project.create.title for /new tail', () => {
+        expect(resolveBreadcrumbLabel('/app/proj1/projects/new', null, undefined, t)).toBe(
+            'admin.project.create.title'
+        );
+    });
+
+    it('handles /concourses/:id detail route with digit id', () => {
+        expect(resolveBreadcrumbLabel('/app/proj1/concourses/42', null, undefined, t)).toBe(
+            'Concourse'
+        );
+    });
+
+    it('handles /participants/:id detail route with session_token code', () => {
+        expect(
+            resolveBreadcrumbLabel(
+                '/app/proj1/studies/study/participants/7',
+                null,
+                { session_token: 'abcdef0123456789' },
+                t
+            )
+        ).toBe('Participant ABCDEF01');
+    });
+
+    it('falls back to the URL id when participant fetch is in-flight', () => {
+        expect(
+            resolveBreadcrumbLabel('/app/proj1/studies/study/participants/7', null, undefined, t)
+        ).toBe('Participant 7');
+    });
+
+    it('maps known segments via the mapping table (with fallback)', () => {
+        expect(resolveBreadcrumbLabel('/app/proj1/data', null, undefined, t)).toBe('Data');
+        expect(resolveBreadcrumbLabel('/app/proj1/privacy', null, undefined, t)).toBe(
+            'Data privacy'
+        );
+        expect(resolveBreadcrumbLabel('/app/proj1/account', null, undefined, t)).toBe(
+            'Account settings'
+        );
+        expect(resolveBreadcrumbLabel('/app/proj1/concourses', null, undefined, t)).toBe(
+            'Concourse'
+        );
+    });
+
+    it('maps known segments via the mapping table (no fallback)', () => {
+        expect(resolveBreadcrumbLabel('/app/proj1/dashboard', null, undefined, t)).toBe(
+            'admin.breadcrumbs.dashboard'
+        );
+        expect(resolveBreadcrumbLabel('/app/proj1/exports', null, undefined, t)).toBe(
+            'admin.breadcrumbs.exports'
+        );
+        expect(resolveBreadcrumbLabel('/app/proj1/settings', null, undefined, t)).toBe(
+            'admin.breadcrumbs.settings'
+        );
+    });
+
+    it('Title-cases unknown segments as fallback', () => {
+        expect(resolveBreadcrumbLabel('/app/proj1/banana', null, undefined, t)).toBe('Banana');
+    });
+});

--- a/frontend/src/layouts/AdminLayout.helpers.ts
+++ b/frontend/src/layouts/AdminLayout.helpers.ts
@@ -1,0 +1,63 @@
+import type { TFunction } from 'i18next';
+
+interface BreadcrumbParticipant {
+    session_token?: string;
+}
+
+const SEGMENT_LABEL_KEYS: Record<string, [string, string?]> = {
+    dashboard: ['admin.breadcrumbs.dashboard'],
+    design: ['admin.breadcrumbs.design'],
+    recruitment: ['admin.breadcrumbs.recruitment'],
+    data: ['admin.breadcrumbs.data', 'Data'],
+    privacy: ['admin.breadcrumbs.privacy', 'Data privacy'],
+    account: ['admin.breadcrumbs.account', 'Account settings'],
+    analysis: ['admin.breadcrumbs.analysis', 'Analysis'],
+    exports: ['admin.breadcrumbs.exports'],
+    settings: ['admin.breadcrumbs.settings'],
+    participants: ['admin.breadcrumbs.participants'],
+    concourses: ['admin.breadcrumbs.concourse', 'Concourse'],
+    members: ['admin.breadcrumbs.members', 'Team members'],
+};
+
+/**
+ * Resolve the human-readable label for the last segment of an admin URL,
+ * used as the leaf of the admin breadcrumb. Pure: no React state, no fetches
+ * (the participant code, when applicable, is passed in via `breadcrumbParticipant`).
+ *
+ * Detail routes:
+ *  - `/concourses/:id` (digit-only id) → "Concourse"
+ *  - `/participants/:id` (digit-only id) → "Participant <CODE>" where CODE is
+ *    the first 8 chars of session_token uppercased; falls back to the URL id
+ *    while the fetch is in flight.
+ */
+export function resolveBreadcrumbLabel(
+    pathname: string,
+    activeStudyId: string | null,
+    breadcrumbParticipant: BreadcrumbParticipant | undefined,
+    t: TFunction
+): string {
+    const segments = pathname.split('/').filter(Boolean);
+    const last = segments[segments.length - 1];
+    if (!last) return t('admin.breadcrumbs.dashboard');
+
+    if (last === 'admin') return t('admin.breadcrumbs.dashboard');
+    if (last === activeStudyId) return t('admin.breadcrumbs.study_dashboard');
+    if (last === 'new') return t('admin.project.create.title');
+
+    const prev = segments[segments.length - 2];
+    if (prev === 'concourses' && /^\d+$/.test(last)) {
+        return t('admin.breadcrumbs.concourse', 'Concourse');
+    }
+    if (prev === 'participants' && /^\d+$/.test(last)) {
+        const code = breadcrumbParticipant?.session_token?.substring(0, 8).toUpperCase() ?? last;
+        return t('admin.breadcrumbs.participant_n', 'Participant {{code}}', { code });
+    }
+
+    const labelKey = SEGMENT_LABEL_KEYS[last];
+    if (labelKey) {
+        const [key, fallback] = labelKey;
+        return fallback ? t(key, fallback) : t(key);
+    }
+
+    return last.charAt(0).toUpperCase() + last.slice(1);
+}

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -19,6 +19,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { Footer } from '@/components/Footer';
+import { resolveBreadcrumbLabel } from './AdminLayout.helpers';
 
 export default function AdminLayout() {
     const location = useLocation();
@@ -50,50 +51,13 @@ export default function AdminLayout() {
         }
     }, [location.pathname, activeStudyId, setActiveStudy]);
 
-    // Determine the current page name
-    const getCurrentPageName = () => {
-        const segments = location.pathname.split('/').filter(Boolean);
-        const last = segments[segments.length - 1];
-        if (!last) return t('admin.breadcrumbs.dashboard');
-
-        // Map common segments to i18n keys
-        const mapping: Record<string, string> = {
-            dashboard: t('admin.breadcrumbs.dashboard'),
-            design: t('admin.breadcrumbs.design'),
-            recruitment: t('admin.breadcrumbs.recruitment'),
-            data: t('admin.breadcrumbs.data', 'Data'),
-            privacy: t('admin.breadcrumbs.privacy', 'Data privacy'),
-            account: t('admin.breadcrumbs.account', 'Account settings'),
-            analysis: t('admin.breadcrumbs.analysis', 'Analysis'),
-            exports: t('admin.breadcrumbs.exports'),
-            settings: t('admin.breadcrumbs.settings'),
-            participants: t('admin.breadcrumbs.participants'),
-            concourses: t('admin.breadcrumbs.concourse', 'Concourse'),
-            members: t('admin.breadcrumbs.members', 'Team members'),
-        };
-
-        // Special cases
-        if (last === 'admin') return t('admin.breadcrumbs.dashboard');
-        if (last === activeStudyId) return t('admin.breadcrumbs.study_dashboard');
-        if (last === 'new') return t('admin.project.create.title');
-
-        // Concourse detail page: /concourses/:id → show "Concourse"
-        const prev = segments[segments.length - 2];
-        if (prev === 'concourses' && /^\d+$/.test(last)) {
-            return t('admin.breadcrumbs.concourse', 'Concourse');
-        }
-        // Participant detail page: /participants/:id → show "Participant <CODE>"
-        // where <CODE> is the first 8 chars of session_token. While the fetch
-        // is in flight we fall back to the URL id so the breadcrumb is never
-        // empty.
-        if (prev === 'participants' && /^\d+$/.test(last)) {
-            const code =
-                breadcrumbParticipant?.session_token?.substring(0, 8).toUpperCase() ?? last;
-            return t('admin.breadcrumbs.participant_n', 'Participant {{code}}', { code });
-        }
-
-        return mapping[last] || last.charAt(0).toUpperCase() + last.slice(1);
-    };
+    // Resolve the breadcrumb leaf label (extracted helper for testability).
+    const currentPageName = resolveBreadcrumbLabel(
+        location.pathname,
+        activeStudyId,
+        breadcrumbParticipant,
+        t
+    );
 
     return (
         <SidebarProvider>
@@ -151,7 +115,7 @@ export default function AdminLayout() {
                                 {/* Current Page */}
                                 <BreadcrumbItem className="shrink-0">
                                     <BreadcrumbPage className="text-sm font-bold text-slate-900">
-                                        {getCurrentPageName()}
+                                        {currentPageName}
                                     </BreadcrumbPage>
                                 </BreadcrumbItem>
                             </BreadcrumbList>

--- a/frontend/src/pages/ErrorPage.helpers.test.ts
+++ b/frontend/src/pages/ErrorPage.helpers.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import type { TFunction } from 'i18next';
+import { ApiError } from '../api/client';
+import { computeErrorDisplay } from './ErrorPage.helpers';
+
+const t = ((key: string, fallback?: string) => fallback ?? key) as unknown as TFunction;
+
+describe('computeErrorDisplay', () => {
+    it('explicit propTitle takes priority', () => {
+        const c = computeErrorDisplay({
+            propTitle: 'Custom Title',
+            hasOnRetry: false,
+            t,
+        });
+        expect(c.title).toBe('Custom Title');
+        expect(c.iconKey).toBe('AlertTriangle');
+        expect(c.showHome).toBe(true);
+        expect(c.showRetry).toBe(false);
+    });
+
+    it('explicit propMessage with onRetry shows retry button', () => {
+        const c = computeErrorDisplay({
+            propMessage: 'oops',
+            hasOnRetry: true,
+            t,
+        });
+        expect(c.message).toBe('oops');
+        expect(c.showRetry).toBe(true);
+    });
+
+    it('ApiError validation_error → validationErrors populated', () => {
+        const err = new ApiError(422, 'Validation Error', 'validation_error', [
+            { loc: ['body', 'email'], msg: 'invalid email' },
+        ]);
+        const c = computeErrorDisplay({ error: err, hasOnRetry: false, t });
+        expect(c.validationErrors).toHaveLength(1);
+        expect(c.validationErrors?.[0]?.msg).toBe('invalid email');
+        expect(c.iconKey).toBe('AlertTriangle');
+        expect(c.showRetry).toBe(true);
+    });
+
+    it('ApiError 404 → AlertOctagon icon, home button, no retry', () => {
+        const err = new ApiError(404, 'Not Found');
+        const c = computeErrorDisplay({ error: err, hasOnRetry: false, t });
+        expect(c.iconKey).toBe('AlertOctagon');
+        expect(c.showHome).toBe(true);
+        expect(c.showRetry).toBe(false);
+    });
+
+    it('ApiError 429 → RefreshCcw + retry', () => {
+        const err = new ApiError(429, 'Too Many Requests');
+        const c = computeErrorDisplay({ error: err, hasOnRetry: false, t });
+        expect(c.iconKey).toBe('RefreshCcw');
+        expect(c.showRetry).toBe(true);
+    });
+
+    it('ApiError 408 → WifiOff + retry', () => {
+        const err = new ApiError(408, 'Timeout');
+        const c = computeErrorDisplay({ error: err, hasOnRetry: false, t });
+        expect(c.iconKey).toBe('WifiOff');
+        expect(c.showRetry).toBe(true);
+    });
+
+    it('ApiError code=conflict → AlertTriangle + retry', () => {
+        const err = new ApiError(409, 'Conflict', 'conflict');
+        const c = computeErrorDisplay({ error: err, hasOnRetry: false, t });
+        expect(c.iconKey).toBe('AlertTriangle');
+        expect(c.showRetry).toBe(true);
+    });
+
+    it('network error message → WifiOff', () => {
+        const c = computeErrorDisplay({
+            error: new Error('Failed to fetch'),
+            hasOnRetry: false,
+            t,
+        });
+        expect(c.iconKey).toBe('WifiOff');
+    });
+
+    it('"network" substring in message → WifiOff', () => {
+        const c = computeErrorDisplay({
+            error: new Error('Network connection lost'),
+            hasOnRetry: false,
+            t,
+        });
+        expect(c.iconKey).toBe('WifiOff');
+    });
+
+    it('fallback (generic crash) shows reset + home', () => {
+        const c = computeErrorDisplay({
+            error: new Error('Boom'),
+            hasOnRetry: false,
+            t,
+        });
+        expect(c.iconKey).toBe('AlertTriangle');
+        expect(c.showReset).toBe(true);
+        expect(c.showHome).toBe(true);
+        expect(c.message).toBe('Boom');
+    });
+
+    it('fallback uses unknown-error message when error.message is empty', () => {
+        const e = new Error();
+        const c = computeErrorDisplay({ error: e, hasOnRetry: false, t });
+        expect(c.message).toBe('common.errors.unknown');
+    });
+
+    it('hasOnRetry forwards to fallback case', () => {
+        const c = computeErrorDisplay({
+            error: new Error('Boom'),
+            hasOnRetry: true,
+            t,
+        });
+        expect(c.showRetry).toBe(true);
+    });
+});

--- a/frontend/src/pages/ErrorPage.helpers.ts
+++ b/frontend/src/pages/ErrorPage.helpers.ts
@@ -1,0 +1,134 @@
+import type { TFunction } from 'i18next';
+import { ApiError } from '../api/client';
+
+export type ErrorIconKey = 'AlertTriangle' | 'AlertOctagon' | 'RefreshCcw' | 'WifiOff';
+
+export interface ValidationErrorItem {
+    loc: (string | number)[];
+    msg: string;
+}
+
+export interface ErrorDisplayConfig {
+    title: string;
+    message: string;
+    iconKey: ErrorIconKey;
+    showReset: boolean;
+    showHome: boolean;
+    showRetry: boolean;
+    validationErrors?: ValidationErrorItem[];
+}
+
+interface ComputeArgs {
+    error?: Error | ApiError | null;
+    propTitle?: string;
+    propMessage?: string;
+    hasOnRetry: boolean;
+    t: TFunction;
+}
+
+function fromExplicitProps(args: ComputeArgs): ErrorDisplayConfig {
+    return {
+        title: args.propTitle || args.t('common.errors.default_title'),
+        message: args.propMessage || args.error?.message || args.t('common.errors.unknown'),
+        iconKey: 'AlertTriangle',
+        showReset: false,
+        showHome: true,
+        showRetry: args.hasOnRetry,
+    };
+}
+
+function fromApiError(error: ApiError, t: TFunction): ErrorDisplayConfig | null {
+    if (error.code === 'validation_error' && Array.isArray(error.details)) {
+        return {
+            title: t('common.errors.validation_title') || 'Validation Error',
+            message: t('common.errors.validation_message') || 'Please check your input.',
+            iconKey: 'AlertTriangle',
+            showReset: false,
+            showHome: false,
+            showRetry: true,
+            validationErrors: error.details as ValidationErrorItem[],
+        };
+    }
+    if (error.status === 404) {
+        return {
+            title: t('common.errors.404.title'),
+            message: t('common.errors.404.message'),
+            iconKey: 'AlertOctagon',
+            showReset: false,
+            showHome: true,
+            showRetry: false,
+        };
+    }
+    if (error.status === 429) {
+        return {
+            title: t('common.errors.429.title'),
+            message: t('common.errors.429.message'),
+            iconKey: 'RefreshCcw',
+            showReset: false,
+            showHome: false,
+            showRetry: true,
+        };
+    }
+    if (error.status === 408) {
+        return {
+            title: t('common.errors.timeout.title', 'Request Timeout'),
+            message: t(
+                'common.errors.timeout.message',
+                'The server took too long to respond. Please check your connection and try again.'
+            ),
+            iconKey: 'WifiOff',
+            showReset: false,
+            showHome: false,
+            showRetry: true,
+        };
+    }
+    if (error.code === 'conflict') {
+        return {
+            title: t('common.errors.conflict_title') || 'Conflict',
+            message: error.message || t('common.errors.conflict_message'),
+            iconKey: 'AlertTriangle',
+            showReset: false,
+            showHome: false,
+            showRetry: true,
+        };
+    }
+    return null;
+}
+
+function isNetworkError(error?: Error | ApiError | null): boolean {
+    const msg = error?.message?.toLowerCase() ?? '';
+    return msg.includes('network') || msg.includes('fetch');
+}
+
+/**
+ * Pure dispatcher: maps the various ErrorPage inputs (explicit props,
+ * ApiError variants, network heuristics, fallback) to a DisplayConfig.
+ */
+export function computeErrorDisplay(args: ComputeArgs): ErrorDisplayConfig {
+    if (args.propTitle || args.propMessage) {
+        return fromExplicitProps(args);
+    }
+    if (args.error instanceof ApiError) {
+        const fromApi = fromApiError(args.error, args.t);
+        if (fromApi) return fromApi;
+    }
+    if (isNetworkError(args.error)) {
+        return {
+            title: args.t('common.errors.network_title'),
+            message: args.t('common.errors.network'),
+            iconKey: 'WifiOff',
+            showReset: false,
+            showHome: false,
+            showRetry: true,
+        };
+    }
+    // Fallback (generic crash)
+    return {
+        title: args.t('common.errors.default_title'),
+        message: args.error?.message || args.t('common.errors.unknown'),
+        iconKey: 'AlertTriangle',
+        showReset: true,
+        showHome: true,
+        showRetry: args.hasOnRetry,
+    };
+}

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -10,6 +10,18 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ApiError } from '../api/client';
 import { resetAllStores } from '../utils/sessionReset';
+import {
+    computeErrorDisplay,
+    type ErrorIconKey,
+    type ValidationErrorItem,
+} from './ErrorPage.helpers';
+
+const ICON_MAP: Record<ErrorIconKey, typeof AlertTriangle> = {
+    AlertTriangle,
+    AlertOctagon,
+    RefreshCcw,
+    WifiOff,
+};
 
 interface ErrorPageProps {
     error?: Error | ApiError | null;
@@ -34,116 +46,19 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
         window.location.href = '/';
     };
 
-    const {
-        title,
-        message,
-        icon: Icon,
-        showReset,
-        showHome,
-        showRetry,
-    } = useMemo(() => {
-        // 1. Explicit Props (Higher Priority)
-        if (propTitle || propMessage) {
-            return {
-                title: propTitle || t('common.errors.default_title'),
-                message: propMessage || error?.message || t('common.errors.unknown'),
-                icon: AlertTriangle,
-                showReset: false,
-                showHome: true,
-                showRetry: !!onRetry,
-            };
-        }
-
-        // 2. ApiError Handling
-        if (error instanceof ApiError) {
-            // Validation Errors
-            if (error.code === 'validation_error' && Array.isArray(error.details)) {
-                return {
-                    title: t('common.errors.validation_title') || 'Validation Error',
-                    message: t('common.errors.validation_message') || 'Please check your input.',
-                    icon: AlertTriangle,
-                    showReset: false,
-                    showHome: false,
-                    showRetry: true,
-                    validationErrors: error.details as Array<{
-                        loc: (string | number)[];
-                        msg: string;
-                    }>,
-                };
-            }
-
-            if (error.status === 404) {
-                return {
-                    title: t('common.errors.404.title'),
-                    message: t('common.errors.404.message'),
-                    icon: AlertOctagon, // or a Search icon
-                    showReset: false,
-                    showHome: true,
-                    showRetry: false,
-                };
-            }
-            if (error.status === 429) {
-                return {
-                    title: t('common.errors.429.title'),
-                    message: t('common.errors.429.message'),
-                    icon: RefreshCcw,
-                    showReset: false,
-                    showHome: false,
-                    showRetry: true,
-                };
-            }
-
-            if (error.status === 408) {
-                return {
-                    title: t('common.errors.timeout.title', 'Request Timeout'),
-                    message: t(
-                        'common.errors.timeout.message',
-                        'The server took too long to respond. Please check your connection and try again.'
-                    ),
-                    icon: WifiOff,
-                    showReset: false,
-                    showHome: false,
-                    showRetry: true,
-                };
-            }
-
-            if (error.code === 'conflict') {
-                return {
-                    title: t('common.errors.conflict_title') || 'Conflict',
-                    message: error.message || t('common.errors.conflict_message'),
-                    icon: AlertTriangle,
-                    showReset: false,
-                    showHome: false,
-                    showRetry: true,
-                };
-            }
-        }
-
-        // 3. Network Errors (Fetch failures)
-        if (
-            error?.message?.toLowerCase().includes('network') ||
-            error?.message?.toLowerCase().includes('fetch')
-        ) {
-            return {
-                title: t('common.errors.network_title'),
-                message: t('common.errors.network'),
-                icon: WifiOff,
-                showReset: false,
-                showHome: false,
-                showRetry: true,
-            };
-        }
-
-        // 4. Fallback (Generic Crash)
-        return {
-            title: t('common.errors.default_title'),
-            message: error?.message || t('common.errors.unknown'), // Use error message if available
-            icon: AlertTriangle,
-            showReset: true, // Only offer hard reset for unknown crashes
-            showHome: true,
-            showRetry: !!onRetry,
-        };
-    }, [error, propTitle, propMessage, onRetry, t]);
+    const display = useMemo(
+        () =>
+            computeErrorDisplay({
+                error,
+                propTitle,
+                propMessage,
+                hasOnRetry: !!onRetry,
+                t,
+            }),
+        [error, propTitle, propMessage, onRetry, t]
+    );
+    const { title, message, showReset, showHome, showRetry } = display;
+    const Icon = ICON_MAP[display.iconKey];
 
     const Container = isFullPage ? 'div' : React.Fragment;
     const containerProps = isFullPage
@@ -152,13 +67,7 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
           }
         : {};
 
-    // Helper type (can be inferred but good for clarity)
-    const validationErrors =
-        error instanceof ApiError &&
-        error.code === 'validation_error' &&
-        Array.isArray(error.details)
-            ? (error.details as Array<{ loc: (string | number)[]; msg: string }>)
-            : undefined;
+    const validationErrors: ValidationErrorItem[] | undefined = display.validationErrors;
 
     return (
         <Container {...containerProps}>

--- a/frontend/src/pages/admin/DataPrivacyPage.tsx
+++ b/frontend/src/pages/admin/DataPrivacyPage.tsx
@@ -227,6 +227,7 @@ function ConsentLocaleRow({
 
 // ─── page ──────────────────────────────────────────────────────────────────────
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — declarative data-privacy page shell with anonymisation preview + bulk-mutation chain + per-row action handlers; better fit for a useDataPrivacyPage hook (Phase 5G pattern in CLAUDE.md) but out of cognitive-complexity remediation scope
 export default function DataPrivacyPage() {
     const { t } = useTranslation();
     const { studySlug, projectSlug } = useParams<{ studySlug: string; projectSlug: string }>();

--- a/frontend/src/pages/admin/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/admin/GeneralSettingsPage.tsx
@@ -51,6 +51,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getStudyStorageUsageApiAdminStudiesSlugStorageUsageGet } from '@/api/generated';
 import { Progress } from '@/components/ui/progress';
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — declarative settings page shell with archive/delete/retention/quota mutation handlers; better fit for a useGeneralSettingsPage hook (Phase 5G pattern in CLAUDE.md) but out of cognitive-complexity remediation scope
 export default function GeneralSettingsPage() {
     const navigate = useNavigate();
     const { study: initialStudy, slug: initialSlug } = useLoaderData() as {

--- a/frontend/src/pages/admin/StudyOverviewPage.tsx
+++ b/frontend/src/pages/admin/StudyOverviewPage.tsx
@@ -20,6 +20,7 @@ interface LoaderData {
     slug: string;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — declarative metric-card JSX shell (study state, participants count, completion, statements, recruitment links, audio, comments); precedent: AnalysisPage / StudyDesignPage / RecruitmentPage / ConcourseDetailPage per CLAUDE.md "Admin header policy" + "JSX shell complexity"
 const StudyOverviewPage = () => {
     const { stats, participants, study, slug } = useLoaderData() as LoaderData;
     const { project } = useAdminContext();


### PR DESCRIPTION
## Summary
- Closes the W5 page/layout/redirect subsystem in full per the W2-end backlog review.
- 5 P3 helper extractions (56 new tests) + 3 P5 page-shell suppressions.
- Reduces frontend cognitive-complexity warnings from **10 to 2** (-8, -80%).
- The 2 residuals are the deliberate AudioRecorder DEFERs.

## Cumulative across W1–W5

**65 → 2 (-97%)**. Final state matches the spec's success target (≤5 residual warnings, all justified).

## Commits
- \`06c9d0aa\` — W5: AdminLayout / LegacyRedirect / RouteErrorBoundary / ErrorPage / CreateStudyDialog helper extractions; 3 page-shell P5 suppressions; LegacyRedirect helper internally split into resolveAdminRoot / resolveStudyPath / resolveProfilePath to keep all branches below threshold.

## P3 refactors (56 new tests)

| File | Helper | Tests |
|---|---|---|
| AdminLayout.tsx | resolveBreadcrumbLabel | 10 (mapping table + special cases for /admin, activeStudyId, /new, /concourses/:id, /participants/:id with session_token code) |
| LegacyRedirect.tsx | resolveLegacyTarget | 12 (all 5 legacy URL families; activeStudy/activeProjectId hints applied via useEffect at the call site) |
| RouteErrorBoundary.tsx | classifyRouteError + shouldCaptureRouteError + shouldThrottleChunkReload | 14 (4 error variants + capture decision + 10s reload throttle) |
| ErrorPage.tsx | computeErrorDisplay | 12 (ApiError × {validation/404/429/408/conflict} + network heuristics + explicit-props priority + fallback) |
| CreateStudyDialog.tsx | parseStudyCreationError | 8 (all axios-detail shapes: validation array, string, object, message fallback, generic) |

## P5 suppressions (3 sites)

- StudyOverviewPage.tsx — declarative metric-card JSX shell (precedent: AnalysisPage / StudyDesignPage / RecruitmentPage / ConcourseDetailPage per CLAUDE.md "Admin header policy" + "JSX shell complexity")
- GeneralSettingsPage.tsx — declarative settings shell; better fit for a useGeneralSettingsPage hook (Phase 5G pattern in CLAUDE.md) — out of cognitive-complexity remediation scope
- DataPrivacyPage.tsx — declarative data-privacy page shell with anonymisation preview + bulk-mutation chain — same hook precedent, out of scope

## Out of scope (deliberately deferred)

- AudioRecorder.tsx:199 (cleanup useEffect) — cleanup ordering invariant (clearInterval before cancelAnimationFrame before AudioContext.close before stream.getTracks().stop())
- AudioRecorder.tsx:476 (playRecording) — cross-origin AudioContext branch (real Web Audio API for blob URLs vs simulated waveform for presigned URLs)

Both need a structural \`useAudioRecorder\` hook extraction with jsdom MediaRecorder mock per the W2-end checkpoint.

## Test plan
- [x] make ci-fast green
- [x] No file outside W5 scope modified
- [x] Each P3 helper has ≥8 tests covering its meaningful branches
- [x] Each P5 suppression cites the rationale + applicable precedent
- [x] LegacyRedirect helper itself stays below complexity threshold (split into 3 sub-helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)