### PR TITLE
test(SortableCard): regression test for ResizeObserver guard (W4b follow-up)

### DIFF
--- a/frontend/src/components/SortableCard.test.tsx
+++ b/frontend/src/components/SortableCard.test.tsx
@@ -188,4 +188,54 @@ describe('SortableCard', () => {
         const textContainer = screen.getByTestId('card-123').querySelector('.line-clamp-4');
         expect(textContainer).toBeTruthy();
     });
+
+    // --------------------------------------------------------------------
+    // ResizeObserver guard regression test (W4b retro-fix)
+    //
+    // The dynamic line-clamp useLayoutEffect attaches a ResizeObserver
+    // ONLY when `dimensions` is undefined ("only CSS-sized cards need an
+    // observer; Grid cards recompute via dimensions?.height dependency
+    // instead"). The conditional `if (dimensions) return;` is load-bearing
+    // for both correctness (RO fires synchronously on attach + re-render
+    // loop risk) and perf (38+ grid cards each attaching their own RO).
+    //
+    // Without these tests, a future `useDynamicLineClamp` hook extract
+    // could silently drop the guard and pass CI.
+    // --------------------------------------------------------------------
+    describe('ResizeObserver guard (W4b invariant)', () => {
+        let instanceCount = 0;
+
+        class CountingResizeObserver {
+            observe = vi.fn();
+            unobserve = vi.fn();
+            disconnect = vi.fn();
+            constructor() {
+                instanceCount++;
+            }
+        }
+
+        beforeEach(() => {
+            instanceCount = 0;
+            vi.stubGlobal('ResizeObserver', CountingResizeObserver);
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('does NOT instantiate ResizeObserver when dimensions are provided', () => {
+            render(<SortableCard {...defaultProps} dimensions={{ width: 100, height: 150 }} />);
+            expect(instanceCount).toBe(0);
+        });
+
+        it('DOES instantiate ResizeObserver when dimensions are NOT provided (CSS-sized card)', () => {
+            render(<SortableCard {...defaultProps} />);
+            expect(instanceCount).toBe(1);
+        });
+
+        it('does NOT instantiate ResizeObserver when allowScroll is true (early return)', () => {
+            render(<SortableCard {...defaultProps} allowScroll={true} />);
+            expect(instanceCount).toBe(0);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Adds a regression test for the W4b high-risk P5 invariant on \`SortableCard.tsx:140\`: the \`if (dimensions) return;\` guard before attaching a ResizeObserver.
- Closes the YELLOW finding from the second Opus review on PR #147.

## Context
The W4b backlog review (Opus #2) flagged that the perf/correctness invariant cited in the SortableCard:140 P5 suppression rationale has no regression test:

> "the perf/correctness invariant cited on \`SortableCard:140\` has no regression test. A naive \`useDynamicLineClamp\` extract by a future hire would pass CI."

This PR adds three tests in a \`ResizeObserver guard\` describe block:

1. **NO RO instantiation when \`dimensions\` is provided** — grid cards recompute via the \`dimensions?.height\` dep instead.
2. **DOES instantiate RO when \`dimensions\` is undefined** — positive control for CSS-sized deck/sidebar cards.
3. **NO RO instantiation when \`allowScroll=true\`** — earlier early-return short-circuit.

## Implementation
A per-test \`CountingResizeObserver\` class stubbed via \`vi.stubGlobal('ResizeObserver', ...)\` counts constructor invocations. The setup-level polyfill in \`setupTests.ts\` remains the default for tests that don't care about the guard.

## Test plan
- [x] \`npx vitest run src/components/SortableCard.test.tsx\` → 14/14 pass
- [x] \`make ci-fast\` green
- [x] No production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)