### PR TITLE
feat(questions): add rating-N scale question type for pre/post-sort

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1803,13 +1803,18 @@
                 "add_field": "Add a new field",
                 "basic_fields": "Basic fields",
                 "choice_fields": "Choice fields",
+                "scale_fields": "Scale fields",
                 "labels": {
                     "question": "Question label",
                     "required": "Required field",
                     "options": "Options",
                     "multiple": "(Multiple selection allowed)",
                     "single": "(Single selection)",
-                    "placeholder": "Enter your question here..."
+                    "placeholder": "Enter your question here...",
+                    "scale": "Rating scale",
+                    "scale_points": "Number of points",
+                    "scale_left": "Left endpoint label",
+                    "scale_right": "Right endpoint label"
                 },
                 "types": {
                     "text": "Text",
@@ -1820,7 +1825,8 @@
                     "dropdown": "Dropdown",
                     "radio": "Radio",
                     "checkboxes": "Checkboxes",
-                    "text_audio": "Text + Audio"
+                    "text_audio": "Text + Audio",
+                    "rating": "Rating scale"
                 },
                 "empty": {
                     "title": "No questions yet",
@@ -1830,7 +1836,9 @@
                     "new_question": "New question",
                     "option": "Option",
                     "enter_answer": "Enter your answer...",
-                    "untitled": "Untitled question"
+                    "untitled": "Untitled question",
+                    "scale_left": "Strongly disagree",
+                    "scale_right": "Strongly agree"
                 },
                 "actions": {
                     "add_option": "Add option",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -1717,13 +1717,18 @@
                 "add_field": "Lisää uusi kenttä",
                 "basic_fields": "Peruskentät",
                 "choice_fields": "Valintakentät",
+                "scale_fields": "Asteikkokentät",
                 "labels": {
                     "question": "Kysymyksen otsikko",
                     "required": "Pakollinen kenttä",
                     "options": "Vaihtoehdot",
                     "multiple": "(useita valintoja sallittu)",
                     "single": "(yksi valinta)",
-                    "placeholder": "Kirjoita kysymyksesi tähän..."
+                    "placeholder": "Kirjoita kysymyksesi tähän...",
+                    "scale": "Arviointiasteikko",
+                    "scale_points": "Pisteiden määrä",
+                    "scale_left": "Vasemman pään merkintä",
+                    "scale_right": "Oikean pään merkintä"
                 },
                 "types": {
                     "text": "Teksti",
@@ -1734,7 +1739,8 @@
                     "dropdown": "Pudotusvalikko",
                     "radio": "Radio-painike",
                     "checkboxes": "Valintaruudut",
-                    "text_audio": "Teksti + Ääni"
+                    "text_audio": "Teksti + Ääni",
+                    "rating": "Asteikko"
                 },
                 "empty": {
                     "title": "Ei vielä kysymyksiä",
@@ -1744,7 +1750,9 @@
                     "new_question": "Uusi kysymys",
                     "option": "Vaihtoehto",
                     "enter_answer": "Kirjoita vastauksesi...",
-                    "untitled": "Nimetön kysymys"
+                    "untitled": "Nimetön kysymys",
+                    "scale_left": "Täysin eri mieltä",
+                    "scale_right": "Täysin samaa mieltä"
                 },
                 "actions": {
                     "add_option": "Lisää vaihtoehto",

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -1755,13 +1755,18 @@
                 "add_field": "Ajouter un champ",
                 "basic_fields": "Champs basiques",
                 "choice_fields": "Champs à choix",
+                "scale_fields": "Champs d'échelle",
                 "labels": {
                     "question": "Libellé de la question",
                     "required": "Champ obligatoire",
                     "options": "Options",
                     "multiple": "(choix multiples autorisés)",
                     "single": "(choix unique)",
-                    "placeholder": "Entrez votre question ici..."
+                    "placeholder": "Entrez votre question ici...",
+                    "scale": "Échelle d'évaluation",
+                    "scale_points": "Nombre de points",
+                    "scale_left": "Libellé extrémité gauche",
+                    "scale_right": "Libellé extrémité droite"
                 },
                 "types": {
                     "text": "Texte",
@@ -1772,7 +1777,8 @@
                     "dropdown": "Menu déroulant",
                     "radio": "Radio",
                     "checkboxes": "Cases à cocher",
-                    "text_audio": "Texte + Audio"
+                    "text_audio": "Texte + Audio",
+                    "rating": "Échelle"
                 },
                 "empty": {
                     "title": "Aucune question pour le moment",
@@ -1782,7 +1788,9 @@
                     "new_question": "Nouvelle question",
                     "option": "Option",
                     "enter_answer": "Entrez votre réponse...",
-                    "untitled": "Question sans titre"
+                    "untitled": "Question sans titre",
+                    "scale_left": "Pas du tout d'accord",
+                    "scale_right": "Tout à fait d'accord"
                 },
                 "actions": {
                     "add_option": "Ajouter une option",

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -36,6 +36,7 @@ import {
     Circle,
     Languages,
     Mic,
+    BarChart3,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
@@ -73,19 +74,28 @@ type QuestionType =
     | 'email'
     | 'textarea'
     | 'radio'
-    | 'text_audio';
+    | 'text_audio'
+    | 'rating';
+
+type MultilangString = string | Record<string, string>;
 
 interface QuestionConfig {
     type: QuestionType;
-    label: string | Record<string, string>;
+    label: MultilangString;
     required: boolean;
     options?: (string | { label: Record<string, string>; value: string })[];
-    placeholder?: string | Record<string, string>;
+    placeholder?: MultilangString;
     min?: number;
     max?: number;
     minLength?: number;
     maxLength?: number;
     rows?: number; // For textarea
+    scale_points?: number; // For rating
+    scale_labels?: {
+        left?: MultilangString;
+        right?: MultilangString;
+        middle?: MultilangString;
+    };
     visibility_condition?: {
         depends_on: string;
         operator: 'equals' | 'not_equals' | 'contains' | 'greater_than' | 'less_than';
@@ -231,6 +241,9 @@ const QuestionItem = (props: QuestionItemProps) => {
                                             )}
                                             {question.type === 'text_audio' && (
                                                 <Mic className="h-4 w-4" />
+                                            )}
+                                            {question.type === 'rating' && (
+                                                <BarChart3 className="h-4 w-4" />
                                             )}
                                         </div>
                                         <span className="text-sm font-bold text-slate-900 truncate tracking-tight">
@@ -522,6 +535,188 @@ const QuestionItem = (props: QuestionItemProps) => {
                                     </div>
                                 )}
 
+                                {question.type === 'rating' && (
+                                    <div className="space-y-4 pt-4 border-t border-slate-100">
+                                        <Label className="text-2xs font-black text-slate-500">
+                                            {t('admin.design.questions.labels.scale')}
+                                        </Label>
+                                        <div className="grid gap-4">
+                                            <div className="space-y-2">
+                                                <Label className="text-2xs font-bold text-slate-500">
+                                                    {t(
+                                                        'admin.design.questions.labels.scale_points'
+                                                    )}
+                                                </Label>
+                                                <Select
+                                                    value={String(question.scale_points ?? 5)}
+                                                    onValueChange={(val: string) =>
+                                                        onUpdate({
+                                                            ...question,
+                                                            scale_points: Number(val),
+                                                        })
+                                                    }
+                                                    disabled={readOnly}
+                                                >
+                                                    <SelectTrigger className="bg-white rounded-lg h-9 text-xs">
+                                                        <SelectValue />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {[2, 3, 4, 5, 7, 10].map((n) => (
+                                                            <SelectItem key={n} value={String(n)}>
+                                                                {n}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                            <div className="grid grid-cols-2 gap-4">
+                                                <div className="space-y-2">
+                                                    <div className="flex items-center gap-2">
+                                                        <Label className="text-2xs font-bold text-slate-500">
+                                                            {t(
+                                                                'admin.design.questions.labels.scale_left'
+                                                            )}
+                                                        </Label>
+                                                        <MultiLangFieldIcon
+                                                            activeLocale={activeLocale}
+                                                            translations={
+                                                                typeof question.scale_labels
+                                                                    ?.left === 'object'
+                                                                    ? question.scale_labels.left
+                                                                    : {
+                                                                          en:
+                                                                              (question.scale_labels
+                                                                                  ?.left as
+                                                                                  | string
+                                                                                  | undefined) ||
+                                                                              '',
+                                                                      }
+                                                            }
+                                                        />
+                                                    </div>
+                                                    <Input
+                                                        readOnly={readOnly}
+                                                        value={
+                                                            (typeof question.scale_labels?.left ===
+                                                            'string'
+                                                                ? question.scale_labels.left
+                                                                : question.scale_labels?.left?.[
+                                                                      activeLocale
+                                                                  ]) || ''
+                                                        }
+                                                        placeholder={t(
+                                                            'admin.design.questions.defaults.scale_left'
+                                                        )}
+                                                        onChange={(
+                                                            e: React.ChangeEvent<HTMLInputElement>
+                                                        ) => {
+                                                            if (readOnly) return;
+                                                            const prev =
+                                                                question.scale_labels?.left;
+                                                            const next =
+                                                                typeof prev === 'object' &&
+                                                                prev !== null
+                                                                    ? {
+                                                                          ...prev,
+                                                                          [activeLocale]:
+                                                                              e.target.value,
+                                                                      }
+                                                                    : {
+                                                                          en:
+                                                                              (prev as
+                                                                                  | string
+                                                                                  | undefined) ||
+                                                                              '',
+                                                                          [activeLocale]:
+                                                                              e.target.value,
+                                                                      };
+                                                            onUpdate({
+                                                                ...question,
+                                                                scale_labels: {
+                                                                    ...question.scale_labels,
+                                                                    left: next,
+                                                                },
+                                                            });
+                                                        }}
+                                                        className="h-9 text-xs bg-white rounded-lg"
+                                                    />
+                                                </div>
+                                                <div className="space-y-2">
+                                                    <div className="flex items-center gap-2">
+                                                        <Label className="text-2xs font-bold text-slate-500">
+                                                            {t(
+                                                                'admin.design.questions.labels.scale_right'
+                                                            )}
+                                                        </Label>
+                                                        <MultiLangFieldIcon
+                                                            activeLocale={activeLocale}
+                                                            translations={
+                                                                typeof question.scale_labels
+                                                                    ?.right === 'object'
+                                                                    ? question.scale_labels.right
+                                                                    : {
+                                                                          en:
+                                                                              (question.scale_labels
+                                                                                  ?.right as
+                                                                                  | string
+                                                                                  | undefined) ||
+                                                                              '',
+                                                                      }
+                                                            }
+                                                        />
+                                                    </div>
+                                                    <Input
+                                                        readOnly={readOnly}
+                                                        value={
+                                                            (typeof question.scale_labels?.right ===
+                                                            'string'
+                                                                ? question.scale_labels.right
+                                                                : question.scale_labels?.right?.[
+                                                                      activeLocale
+                                                                  ]) || ''
+                                                        }
+                                                        placeholder={t(
+                                                            'admin.design.questions.defaults.scale_right'
+                                                        )}
+                                                        onChange={(
+                                                            e: React.ChangeEvent<HTMLInputElement>
+                                                        ) => {
+                                                            if (readOnly) return;
+                                                            const prev =
+                                                                question.scale_labels?.right;
+                                                            const next =
+                                                                typeof prev === 'object' &&
+                                                                prev !== null
+                                                                    ? {
+                                                                          ...prev,
+                                                                          [activeLocale]:
+                                                                              e.target.value,
+                                                                      }
+                                                                    : {
+                                                                          en:
+                                                                              (prev as
+                                                                                  | string
+                                                                                  | undefined) ||
+                                                                              '',
+                                                                          [activeLocale]:
+                                                                              e.target.value,
+                                                                      };
+                                                            onUpdate({
+                                                                ...question,
+                                                                scale_labels: {
+                                                                    ...question.scale_labels,
+                                                                    right: next,
+                                                                },
+                                                            });
+                                                        }}
+                                                        className="h-9 text-xs bg-white rounded-lg"
+                                                    />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                )}
+
                                 {(question.type === 'select' ||
                                     question.type === 'radio' ||
                                     question.type === 'checkbox') && (
@@ -794,6 +989,22 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                     : undefined,
             placeholder: undefined,
             rows: qType === 'textarea' ? 4 : undefined,
+            scale_points: qType === 'rating' ? 5 : undefined,
+            scale_labels:
+                qType === 'rating'
+                    ? {
+                          left: {
+                              [activeLocale]: t('admin.design.questions.defaults.scale_left', {
+                                  lng: activeLocale,
+                              }),
+                          },
+                          right: {
+                              [activeLocale]: t('admin.design.questions.defaults.scale_right', {
+                                  lng: activeLocale,
+                              }),
+                          },
+                      }
+                    : undefined,
         };
 
         // biome-ignore lint/suspicious/noExplicitAny: dynamic draft update
@@ -916,6 +1127,26 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                                             {t(`admin.design.questions.types.${field.label}`)}
                                         </Button>
                                     ))}
+                                </div>
+                            </div>
+                        )}
+
+                        {!readOnly && !structureLocked && (
+                            <div className="space-y-4">
+                                <div className="text-2xs font-black text-slate-400">
+                                    {t('admin.design.questions.scale_fields')}
+                                </div>
+                                <div className="flex flex-wrap gap-3">
+                                    <Button
+                                        data-testid="add-question-rating"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => addQuestion('rating')}
+                                        className="bg-white rounded-xl border-slate-200 hover:border-indigo-500 hover:text-indigo-600 hover:bg-indigo-50/30 transition-all font-bold h-10 px-4 shadow-sm active:scale-95"
+                                    >
+                                        <BarChart3 className="h-4 w-4 mr-2 text-slate-400 group-hover:text-indigo-500" />
+                                        {t('admin.design.questions.types.rating')}
+                                    </Button>
                                 </div>
                             </div>
                         )}

--- a/frontend/src/components/survey/SurveyField.tsx
+++ b/frontend/src/components/survey/SurveyField.tsx
@@ -11,6 +11,59 @@ interface SurveyFieldProps {
     error?: string;
 }
 
+interface RatingFieldProps {
+    id: string;
+    fieldConfig: PreSortField;
+    // biome-ignore lint/suspicious/noExplicitAny: generic form
+    register: UseFormRegister<any>;
+    localize: (obj: string | Record<string, string>) => string;
+}
+
+const RatingField: React.FC<RatingFieldProps> = ({ id, fieldConfig, register, localize }) => {
+    const points = Math.max(2, Math.min(10, fieldConfig.scale_points ?? 5));
+    const leftLabel = fieldConfig.scale_labels?.left ? localize(fieldConfig.scale_labels.left) : '';
+    const rightLabel = fieldConfig.scale_labels?.right
+        ? localize(fieldConfig.scale_labels.right)
+        : '';
+    const middleLabel = fieldConfig.scale_labels?.middle
+        ? localize(fieldConfig.scale_labels.middle)
+        : '';
+    const hasLabels = !!(leftLabel || rightLabel || middleLabel);
+    return (
+        <div className="mt-2">
+            <div
+                role="radiogroup"
+                aria-labelledby={`${id}-label`}
+                className="flex flex-wrap items-center gap-2 sm:gap-3"
+            >
+                {Array.from({ length: points }, (_, i) => i + 1).map((n) => (
+                    <label
+                        key={n}
+                        className="flex flex-col items-center gap-1 cursor-pointer p-2 rounded-md hover:bg-gray-50 active:bg-gray-100 min-w-[44px]"
+                    >
+                        <input
+                            type="radio"
+                            {...register(id)}
+                            value={String(n)}
+                            // biome-ignore lint/suspicious/noExplicitAny: style override
+                            style={{ accentColor: 'var(--brand-accent)' } as any}
+                            className="h-5 w-5"
+                        />
+                        <span className="text-sm font-semibold text-gray-700">{n}</span>
+                    </label>
+                ))}
+            </div>
+            {hasLabels && (
+                <div className="flex justify-between items-start mt-1 text-xs text-gray-500 gap-2">
+                    <span className="text-left">{leftLabel}</span>
+                    {middleLabel && <span className="text-center flex-1">{middleLabel}</span>}
+                    <span className="text-right">{rightLabel}</span>
+                </div>
+            )}
+        </div>
+    );
+};
+
 export const SurveyField: React.FC<SurveyFieldProps> = ({ id, fieldConfig, register }) => {
     const { t, i18n } = useTranslation();
 
@@ -140,6 +193,15 @@ export const SurveyField: React.FC<SurveyFieldProps> = ({ id, fieldConfig, regis
                         );
                     })}
                 </div>
+            );
+        case 'rating':
+            return (
+                <RatingField
+                    id={id}
+                    fieldConfig={fieldConfig}
+                    register={register}
+                    localize={getLocalizedText}
+                />
             );
         default: // text
             return (

--- a/frontend/src/schemas/study.ts
+++ b/frontend/src/schemas/study.ts
@@ -62,6 +62,7 @@ export const PreSortFieldSchema = z.object({
         'email',
         'textarea',
         'text_audio',
+        'rating',
     ]),
     label: z.union([z.string(), z.record(z.string())]),
     required: z.boolean().optional(),
@@ -82,6 +83,14 @@ export const PreSortFieldSchema = z.object({
     minLength: z.number().optional(),
     maxLength: z.number().optional(),
     rows: z.number().optional(),
+    scale_points: z.number().int().min(2).max(10).optional(),
+    scale_labels: z
+        .object({
+            left: z.union([z.string(), z.record(z.string())]).optional(),
+            right: z.union([z.string(), z.record(z.string())]).optional(),
+            middle: z.union([z.string(), z.record(z.string())]).optional(),
+        })
+        .optional(),
     visibility_condition: VisibilityConditionSchema.optional(),
 });
 

--- a/frontend/src/utils/buildQuestionnaireSchema.test.ts
+++ b/frontend/src/utils/buildQuestionnaireSchema.test.ts
@@ -175,6 +175,32 @@ describe('buildQuestionnaireSchema', () => {
         });
     });
 
+    describe('rating', () => {
+        it('required rating rejects empty and accepts a numeric string', () => {
+            const schema = buildQuestionnaireSchema(
+                { satisfaction: Q({ type: 'rating', required: true }) },
+                {},
+                t
+            );
+            expect(schema.safeParse({ satisfaction: '' }).success).toBe(false);
+            expect(schema.safeParse({}).success).toBe(false);
+            expect(schema.safeParse({ satisfaction: '3' }).success).toBe(true);
+            expect(schema.safeParse({ satisfaction: '5' }).success).toBe(true);
+        });
+
+        it('optional rating accepts empty / null / missing', () => {
+            const schema = buildQuestionnaireSchema(
+                { satisfaction: Q({ type: 'rating', required: false }) },
+                {},
+                t
+            );
+            expect(schema.safeParse({}).success).toBe(true);
+            expect(schema.safeParse({ satisfaction: '' }).success).toBe(true);
+            expect(schema.safeParse({ satisfaction: null }).success).toBe(true);
+            expect(schema.safeParse({ satisfaction: '4' }).success).toBe(true);
+        });
+    });
+
     describe('shape integrity', () => {
         it('returns a ZodObject containing every key from the input map', () => {
             const questions = {

--- a/frontend/src/utils/buildQuestionnaireSchema.ts
+++ b/frontend/src/utils/buildQuestionnaireSchema.ts
@@ -24,7 +24,8 @@ export interface QuestionnaireField {
         | 'radio'
         | 'date'
         | 'select'
-        | 'text_audio';
+        | 'text_audio'
+        | 'rating';
     required?: boolean;
     min?: number;
     max?: number;


### PR DESCRIPTION
## Summary

- New `rating` question type renders an N-point horizontal radio (2/3/4/5/7/10) with multilang endpoint labels. Available **in both presort and postsort** questionnaires (one schema, one renderer, used by both `PreSortPage` and `Step2_Questionnaire`).
- Likert-5 is just `rating` with `scale_points=5` and the default "Strongly disagree" / "Strongly agree" labels — no extra type to maintain.
- Closes the most actionable Quince → Qualis feature gap on the questionnaire side.

## Files

- `frontend/src/schemas/study.ts` — `PreSortFieldSchema` gains `'rating'` + `scale_points` + `scale_labels` (left / right / middle, multilang)
- `frontend/src/utils/buildQuestionnaireSchema.ts` — `'rating'` added to `QuestionnaireField` type union; treated as string-shaped (like `radio`), so empty fails on required, "3" passes
- `frontend/src/utils/buildQuestionnaireSchema.test.ts` — 2 new tests (required rejects empty, optional accepts empty/null)
- `frontend/src/components/admin/designer/QuestionBuilder.tsx` — new "Scale fields" picker section with single "Échelle" button (BarChart3 icon); editor shows `scale_points` Select + multilang endpoint inputs when `type === 'rating'`; `addQuestion` defaults to 5 points + locale-defaulted labels
- `frontend/src/components/survey/SurveyField.tsx` — `RatingField` extracted as subcomponent (keeps `SurveyField` cognitive complexity under the Biome threshold); horizontal radio group, `role="radiogroup"`, 44px tap target, optional middle label
- `frontend/public/locales/{en,fr,fi}/translation.json` — `types.rating`, `scale_fields`, `labels.scale*`, `defaults.scale_left`/`scale_right`

## Test plan

- [x] `make ci-fast` — mypy / tsc / pytest 264 / vitest 1343 all green
- [x] `npm run i18n-check` — perfect parity en/fr/fi
- [x] Visual smoke (Playwright): admin builder shows new "Scale fields" picker; `rating` editor exposes `scale_points` + endpoint labels; participant presort renders 5-point and 7-point scales correctly on desktop; mobile (390px) wraps cleanly with labels still aligned at the extremities; required validation gate works; persisted JSON matches expected shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)