### PR TITLE
docs: fix documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Design studies, collect Q-sorts, and run factor analysis in the browser. Partici
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![CI](https://github.com/jvastenaekels/qualis/actions/workflows/ci.yml/badge.svg)](https://github.com/jvastenaekels/qualis/actions/workflows/ci.yml)
 
-<!-- TODO: Add hero screenshot of the Q-sort grid interface, e.g. docs/assets/hero-qsort.png -->
-<!-- Suggested capture: a participant's mid-sort view on a tablet, statements visible, grid partially populated, language switcher visible. -->
+<p align="center">
+  <img src="participant-landing.png" alt="Participant landing page" width="31%" />
+  <img src="presort-rating-participant.png" alt="Participant statement rating screen" width="31%" />
+  <img src="postsort-tab.png" alt="Post-sort response screen" width="31%" />
+</p>
 
 ---
 
@@ -121,7 +124,7 @@ A reusable pool of candidate statements that lives at the project level, not the
 - **Security headers** (HSTS, CSP, X-Frame-Options) and bcrypt password hashing.
 - **Two-factor authentication** — TOTP (authenticator app) or email-OTP as a fallback channel; self-serve recovery flow to disable 2FA when the authenticator is lost.
 - **Email-driven account flows** — sign-up email verification and password reset via time-limited tokens; graceful degradation when SMTP is not configured (dev-friendly).
-- **Role-based access control.** Project-level roles (Owner, Researcher, Viewer) control who can edit, export, or manage team members.
+- **Role-based access control.** Project-level roles (Owner, Member, Viewer) control who can edit, export, or manage team members.
 
 ### Collaboration
 
@@ -186,7 +189,7 @@ cd qualis
 cp .env.example .env
 # Edit .env to set:
 #   - DATABASE_URL  (your local Postgres connection string)
-#   - SECRET_KEY    (generate: python -c 'import secrets; print(secrets.token_urlsafe(48))')
+#   - SECRET_KEY    (generate: python3 -c 'import secrets; print(secrets.token_urlsafe(48))')
 #   - IP_HASH_SALT  (same generation as SECRET_KEY)
 #   - ENVIRONMENT=development  (enables tutorial / E2E test routes)
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -365,7 +365,7 @@ Permissions are scoped per-project via the `ProjectMember` relationship:
 | Role           | Ability                                                                 |
 | :------------- | :---------------------------------------------------------------------- |
 | **Owner**      | Full control over project: manage members, create/delete studies.       |
-| **Researcher** | Can create/edit studies, export results. Cannot manage project users.   |
+| **Member**     | Can create/edit studies, export results. Cannot manage project users.   |
 | **Viewer**     | Read-only access to study configuration. Cannot export data.            |
 
 ---

--- a/docs/reference/admin-dashboard.md
+++ b/docs/reference/admin-dashboard.md
@@ -17,7 +17,7 @@ The dashboard is scoped to a single study at a time. The active study is selecte
 | Recruitment | `/admin/studies/{slug}/recruitment` | Access links, conversion funnel |
 | Data | `/admin/studies/{slug}/data` | Participant table, charts, individual sessions, exports |
 | Analysis | `/admin/studies/{slug}/analysis` | Factor analysis runs, scree plot, results tabs |
-| Members | `/admin/projects/{slug}/members` | Project-level: invitations, roles, removal |
+| Members | `/app/{projectSlug}/members` | Project-level: invitations, roles, removal |
 | Profile | `/admin/profile` | Account settings, 2FA |
 
 A **Memos** drawer is available on every study and concourse page via a toolbar icon (see [Memos](#memos)).
@@ -230,14 +230,14 @@ Memos are included in the Research Package export. See [Data Export](../guides/d
 
 ## Members
 
-Project-scoped page (path: `/admin/projects/{slug}/members`). Lists project members with their role and supports invitations and removals. Source: `GET /api/admin/projects/{slug}/members`.
+Project-scoped page (path: `/app/{projectSlug}/members`). Lists project members with their role and supports invitations and removals. Source: `GET /api/admin/projects/{slug}/members`.
 
 ### Member table
 
 | Column | Notes |
 | ------ | ----- |
 | Member | Name + email; current user marked. |
-| Role | `Owner` / `Editor` / `Viewer` (see [API roles](api.md#roles)). Editable inline by Owners via a select. |
+| Role | `Owner` / `Member` / `Viewer` (see [API roles](api.md#roles)). Editable inline by Owners via a select. |
 | Actions | Remove member (Owners only; cannot self-remove). |
 
 ### Invitations

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -55,8 +55,8 @@ The middleware uses this to scope queries and to enforce project-membership perm
 
 Endpoints below indicate the minimum role required:
 
-- **Project roles** (apply across the whole project): `Viewer` < `Researcher` < `Owner`.
-- **Study roles** (apply per study, on top of project membership): `Viewer` < `Editor` < `Owner`.
+- **Project roles** (apply across the whole project): `Viewer` < `Member` < `Owner`.
+- **Study roles** (apply per study, on top of project membership): `Viewer` < `Editor` < `Owner`. A project `Member` has the effective study role `Editor`.
 - **Superuser** is a system-wide flag; it grants access to user-management endpoints and to a small set of destructive operations.
 
 "Public" means no authentication at all.
@@ -124,7 +124,7 @@ Wired only when `ENVIRONMENT in ("development", "test")`. The router is not regi
 
 | Method | Path | Min role | Rate limit | Purpose |
 | --- | --- | --- | --- | --- |
-| POST | `/api/admin/studies` | Researcher | 30/min | Create a study (DRAFT) in the active project |
+| POST | `/api/admin/studies` | Member | 30/min | Create a study (DRAFT) in the active project |
 | GET | `/api/admin/studies` | Viewer | — | List studies in active project (paginated) |
 | GET | `/api/admin/studies/{slug}` | Viewer | — | Study detail with statements + counts |
 | PATCH | `/api/admin/studies/{slug}` | Editor | 30/min | Update study config (structural changes only in DRAFT) |
@@ -188,8 +188,8 @@ Polymorphic memo subsystem attached to either a study or a concourse.
 | GET | `.../export/r-kit` | Editor | 10/min | R-Kit ZIP (CSV + auto-generated `qmethod` script) |
 | GET | `.../export/package` | Editor | 10/min | Research package ZIP (CSV + JSON + codebook + metadata) |
 | GET | `.../export/config` | Viewer | — | Study configuration only (no participant data) |
-| POST | `/api/admin/studies/validate-import` | Researcher | 30/min | Dry-run validation of an exported config |
-| POST | `/api/admin/studies/import` | Researcher | 30/min | Import a config; creates a new DRAFT study |
+| POST | `/api/admin/studies/validate-import` | Member | 30/min | Dry-run validation of an exported config |
+| POST | `/api/admin/studies/import` | Member | 30/min | Import a config; creates a new DRAFT study |
 | GET | `.../dump` | Editor | 10/min | Full study + participant placements as JSON |
 | GET | `.../storage-usage` | Viewer | — | Audio storage stats (bytes used, quota, % used) |
 | GET | `.../participants/{participant_id}/export/csv` | Editor | 10/min | Single participant as CSV |
@@ -201,8 +201,8 @@ Polymorphic memo subsystem attached to either a study or a concourse.
 | Method | Path | Min role | Rate limit | Purpose |
 | --- | --- | --- | --- | --- |
 | GET | `.../participants` | Viewer | — | List participants (paginated) |
-| GET | `.../participants/{participant_id}` | Researcher | — | Detail: Q-sort entries, postsort answers, audio metadata |
-| PATCH | `.../participants/{participant_id}/discard` | Researcher | 30/min | Flag/unflag a participant for exclusion (preserves the record) |
+| GET | `.../participants/{participant_id}` | Member | — | Detail: Q-sort entries, postsort answers, audio metadata |
+| PATCH | `.../participants/{participant_id}/discard` | Member | 30/min | Flag/unflag a participant for exclusion (preserves the record) |
 | DELETE | `.../participants` | Editor | 30/min | Delete all participants (study must be in DRAFT) |
 | DELETE | `.../participants/{participant_id}/personal-data` | Editor | 30/min | Admin-mediated GDPR Art. 17 erasure (preserves Q-sort data) |
 
@@ -212,7 +212,7 @@ Polymorphic memo subsystem attached to either a study or a concourse.
 | --- | --- | --- | --- | --- |
 | GET | `/api/admin/projects` | authenticated | — | List projects the user is a member of, with their role |
 | POST | `/api/admin/projects` | authenticated | 30/min | Create a project (creator becomes Owner) |
-| GET | `/api/admin/projects/{slug}` | member | — | Project detail |
+| GET | `/api/admin/projects/{slug}` | Viewer | — | Project detail |
 | PATCH | `/api/admin/projects/{slug}` | Owner | 30/min | Update project title or slug |
 | DELETE | `/api/admin/projects/{slug}` | Owner | 30/min | Delete a project (must contain no studies) |
 | GET | `/api/admin/projects/{slug}/members` | Viewer | — | List members and their roles |
@@ -239,22 +239,22 @@ Polymorphic memo subsystem attached to either a study or a concourse.
 
 | Method | Path | Min role | Rate limit | Purpose |
 | --- | --- | --- | --- | --- |
-| GET | `/api/admin/concourses` | member | — | List concourses in the active project |
-| POST | `/api/admin/concourses` | Researcher | 30/min | Create a concourse |
-| GET | `/api/admin/concourses/{concourse_id}` | member | — | Concourse with items and comment counts |
-| PATCH | `/api/admin/concourses/{concourse_id}` | Researcher | 30/min | Update concourse title / description |
+| GET | `/api/admin/concourses` | Viewer | — | List concourses in the active project |
+| POST | `/api/admin/concourses` | Member | 30/min | Create a concourse |
+| GET | `/api/admin/concourses/{concourse_id}` | Viewer | — | Concourse with items and comment counts |
+| PATCH | `/api/admin/concourses/{concourse_id}` | Member | 30/min | Update concourse title / description |
 | DELETE | `/api/admin/concourses/{concourse_id}` | Owner | 30/min | Delete a concourse |
-| POST | `/api/admin/concourses/{concourse_id}/items` | Researcher | 60/min | Create a single item |
-| POST | `/api/admin/concourses/{concourse_id}/items/bulk` | Researcher | 10/min | Bulk-create items |
-| POST | `/api/admin/concourses/{concourse_id}/items/import` | Researcher | 10/min | Parse + dedupe + create from a text block |
-| PATCH | `/api/admin/concourses/{concourse_id}/items/{item_id}` | Researcher | 60/min | Update item text |
-| DELETE | `/api/admin/concourses/{concourse_id}/items/{item_id}` | Researcher | 60/min | Delete an item |
-| GET | `/api/admin/concourses/{concourse_id}/items/{item_id}/versions` | member | — | Item version history |
-| GET | `/api/admin/concourses/{concourse_id}/items/{item_id}/comments` | member | — | Comments on an item |
-| POST | `/api/admin/concourses/{concourse_id}/items/{item_id}/comments` | Researcher | 30/min | Add a comment |
-| GET | `/api/admin/concourses/tags` | member | — | List tags in the active project |
-| POST | `/api/admin/concourses/tags` | Researcher | 30/min | Create a tag |
-| DELETE | `/api/admin/concourses/tags/{tag_id}` | Researcher | 30/min | Delete a tag |
+| POST | `/api/admin/concourses/{concourse_id}/items` | Member | 60/min | Create a single item |
+| POST | `/api/admin/concourses/{concourse_id}/items/bulk` | Member | 10/min | Bulk-create items |
+| POST | `/api/admin/concourses/{concourse_id}/items/import` | Member | 10/min | Parse + dedupe + create from a text block |
+| PATCH | `/api/admin/concourses/{concourse_id}/items/{item_id}` | Member | 60/min | Update item text |
+| DELETE | `/api/admin/concourses/{concourse_id}/items/{item_id}` | Member | 60/min | Delete an item |
+| GET | `/api/admin/concourses/{concourse_id}/items/{item_id}/versions` | Viewer | — | Item version history |
+| GET | `/api/admin/concourses/{concourse_id}/items/{item_id}/comments` | Viewer | — | Comments on an item |
+| POST | `/api/admin/concourses/{concourse_id}/items/{item_id}/comments` | Member | 30/min | Add a comment |
+| GET | `/api/admin/concourses/tags` | Viewer | — | List tags in the active project |
+| POST | `/api/admin/concourses/tags` | Member | 30/min | Create a tag |
+| DELETE | `/api/admin/concourses/tags/{tag_id}` | Member | 30/min | Delete a tag |
 
 ### Admin — users (`/api/admin/users`)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -158,7 +158,7 @@ All settings are read from the `Settings` Pydantic class in `backend/app/core/co
 
 | ENV_VAR | Type | Default | Description |
 | ------- | ---- | ------- | ----------- |
-| `SECRET_KEY` | string | dev-only | JWT signing key. **Required in production.** Generate with `python -c 'import secrets; print(secrets.token_urlsafe(48))'`. |
+| `SECRET_KEY` | string | dev-only | JWT signing key. **Required in production.** Generate with `python3 -c 'import secrets; print(secrets.token_urlsafe(48))'`. |
 | `ALGORITHM` | string | `HS256` | JWT signing algorithm. |
 | `ACCESS_TOKEN_EXPIRE_MINUTES` | int | `480` | Access token lifetime (minutes). |
 | `IP_HASH_SALT` | string | dev-only | Salt for SHA-256 hashing of participant IPs. **Required in production.** |

--- a/docs/tutorials/collecting-responses.md
+++ b/docs/tutorials/collecting-responses.md
@@ -131,7 +131,7 @@ Discarded participants are excluded from exports and analysis by default, but th
 
 For the full set of state transitions a study goes through (Active → Paused → Closed → Archived), see [`../reference/admin-dashboard.md#general`](../reference/admin-dashboard.md#general). For now, leave your tutorial study Active.
 
-> **Sharing access with team members.** To give a colleague access to monitor responses, invite them via the project Members page (`/admin/projects/<slug>/members`). Roles: `Viewer` (read-only), `Editor` (run analyses, manage recruitment), `Owner` (full access including member management). See [Admin Dashboard — Members](../reference/admin-dashboard.md#members).
+> **Sharing access with team members.** To give a colleague access to monitor responses, invite them via the project Members page (`/app/<projectSlug>/members`). Roles: `Viewer` (read-only), `Member` (run analyses, manage recruitment), `Owner` (full access including member management). See [Admin Dashboard — Members](../reference/admin-dashboard.md#members).
 
 ---
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -11,6 +11,7 @@ exclude = [
     "doi\\.org/10\\.5281/zenodo\\.XXXXXXX",
     "doi\\.org/10\\.4135/9781446251911",
     "zenodo\\.org/account/settings/github/",
+    "localhost:3000",
 ]
 
 # Skip localhost URLs in tutorial code blocks


### PR DESCRIPTION
## Summary
- Replace the README placeholder screenshot TODO with existing participant-flow screenshots.
- Align role terminology with the current project roles: Owner, Member, Viewer.
- Correct the Members page UI route while keeping API endpoint references distinct.

## Verification
- python3 scripts/check_installation_docs.py
- git diff --check origin/main...HEAD