### PR TITLE
feat(i18n): differentiated parity policy (admin best-effort)

### DIFF
--- a/frontend/scripts/check_i18n.py
+++ b/frontend/scripts/check_i18n.py
@@ -1,8 +1,11 @@
 """Verify that each non-en locale has the same key set as en, per namespace.
 
-After the namespace split (PR i18n-namespace-split #1), each locale ships
-two files: participant.json and admin.json. Both must match the en key set
-exactly. Policy differentiation (admin best-effort) lands in PR #2.
+Each locale ships two files: participant.json and admin.json. Per-namespace
+parity policy:
+  - participant: strict — mismatches fail CI (exit 1).
+  - admin:       best-effort — mismatches warn, CI still passes (exit 0).
+                 A missing admin.json file is acceptable; i18next falls back
+                 to en/admin.json at runtime via fallbackLng.
 """
 import json
 import os
@@ -13,6 +16,15 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "i18n"))
 from i18n_utils import get_keys
 from namespace_partition import NAMESPACES
 
+# Per-namespace parity policy.
+#   strict=True   : mismatched keys → CI error (exit 1).
+#   strict=False  : mismatched keys → warning, CI passes.
+#   required=True : target file must exist for every declared language.
+NAMESPACE_POLICY: dict[str, dict[str, bool]] = {
+    "participant": {"required": True, "strict": True},
+    "admin":       {"required": False, "strict": False},
+}
+
 
 def load(path):
     with open(path, "r", encoding="utf-8") as f:
@@ -20,6 +32,7 @@ def load(path):
 
 
 def check_namespace(locales_dir, namespace, languages):
+    policy = NAMESPACE_POLICY[namespace]
     master_file = os.path.join(locales_dir, "en", f"{namespace}.json")
     if not os.path.exists(master_file):
         print(f"❌ Missing master file: {master_file}")
@@ -31,8 +44,11 @@ def check_namespace(locales_dir, namespace, languages):
     for lang in languages:
         target_file = os.path.join(locales_dir, lang, f"{namespace}.json")
         if not os.path.exists(target_file):
-            print(f"❌ {lang}/{namespace}.json missing")
-            ok = False
+            if policy["required"]:
+                print(f"❌ {lang}/{namespace}.json missing (required)")
+                ok = False
+            else:
+                print(f"⚠️  {lang}/{namespace}.json missing (best-effort, EN fallback)")
             continue
 
         target_keys = get_keys(load(target_file))
@@ -42,16 +58,19 @@ def check_namespace(locales_dir, namespace, languages):
         if not missing and not extra:
             print(f"  ✓ {lang}/{namespace}.json in sync")
         else:
-            ok = False
+            severity = "❌" if policy["strict"] else "⚠️ "
             if missing:
-                print(f"  ❌ {lang}/{namespace}.json missing keys: {sorted(missing)}")
+                print(f"  {severity} {lang}/{namespace}.json missing keys: {sorted(missing)}")
             if extra:
-                print(f"  ⚠️  {lang}/{namespace}.json extra keys: {sorted(extra)}")
+                print(f"  {severity} {lang}/{namespace}.json extra keys: {sorted(extra)}")
+            if policy["strict"]:
+                ok = False
     return ok
 
 
-def check_i18n():
-    locales_dir = os.path.join(os.path.dirname(__file__), "../public/locales")
+def check_i18n(locales_dir: str | None = None) -> int:
+    if locales_dir is None:
+        locales_dir = os.path.join(os.path.dirname(__file__), "../public/locales")
     languages = sorted(
         d
         for d in os.listdir(locales_dir)
@@ -66,9 +85,11 @@ def check_i18n():
 
     if not overall:
         print("\nFAIL: at least one locale is out of sync.")
-        sys.exit(1)
+        return 1
     print("\nAll localization files are in sync with en!")
+    return 0
 
 
 if __name__ == "__main__":
-    check_i18n()
+    arg_dir = sys.argv[1] if len(sys.argv) > 1 else None
+    sys.exit(check_i18n(arg_dir))

--- a/frontend/scripts/i18n/check_interpolations.py
+++ b/frontend/scripts/i18n/check_interpolations.py
@@ -59,6 +59,13 @@ def check_locale(en_data: dict, target_data: dict) -> list[dict]:
     return errors
 
 
+# Per-namespace parity policy. Mirrors check_i18n.py.
+NAMESPACE_POLICY: dict[str, dict[str, bool]] = {
+    "participant": {"required": True, "strict": True},
+    "admin":       {"required": False, "strict": False},
+}
+
+
 def main() -> int:
     from namespace_partition import NAMESPACES
 
@@ -75,6 +82,7 @@ def main() -> int:
 
     overall_ok = True
     for namespace in NAMESPACES:
+        policy = NAMESPACE_POLICY[namespace]
         en_path = locales_dir / "en" / f"{namespace}.json"
         if not en_path.exists():
             print(f"❌ Missing master file: {en_path}")
@@ -87,15 +95,20 @@ def main() -> int:
         for code in targets:
             target_path = locales_dir / code / f"{namespace}.json"
             if not target_path.exists():
-                print(f"❌ {code}/{namespace}.json not found")
-                overall_ok = False
+                if policy["required"]:
+                    print(f"❌ {code}/{namespace}.json not found (required)")
+                    overall_ok = False
+                else:
+                    print(f"⚠️  {code}/{namespace}.json not found (best-effort, EN fallback)")
                 continue
             with open(target_path, encoding="utf-8") as f:
                 target_data = json.load(f)
             errors = check_locale(en_data, target_data)
             if errors:
-                overall_ok = False
-                print(f"❌ {code}/{namespace}.json: {len(errors)} interpolation mismatch(es)")
+                severity = "❌" if policy["strict"] else "⚠️ "
+                if policy["strict"]:
+                    overall_ok = False
+                print(f"{severity} {code}/{namespace}.json: {len(errors)} interpolation mismatch(es)")
                 for e in errors:
                     print(f"   {e['key']}: expected {e['expected']}, got {e['found']}")
             else:

--- a/frontend/scripts/i18n/test_check_i18n_policy.py
+++ b/frontend/scripts/i18n/test_check_i18n_policy.py
@@ -1,0 +1,84 @@
+"""End-to-end policy tests: participant strict, admin best-effort.
+
+Copies the real locales tree to tmpdir, mutates it to simulate failure
+modes, and runs check_i18n() programmatically (no subprocess).
+"""
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "frontend" / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "frontend" / "scripts" / "i18n"))
+
+import check_i18n  # noqa: E402
+
+SRC_LOCALES = REPO_ROOT / "frontend" / "public" / "locales"
+
+
+@pytest.fixture
+def locales_copy(tmp_path):
+    dst = tmp_path / "locales"
+    shutil.copytree(SRC_LOCALES, dst)
+    return dst
+
+
+def remove_key_from(json_path: Path, dotted_key: str) -> None:
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    parts = dotted_key.split(".")
+    node = data
+    for p in parts[:-1]:
+        node = node[p]
+    del node[parts[-1]]
+    json_path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=4) + "\n", encoding="utf-8"
+    )
+
+
+def test_baseline_passes(locales_copy):
+    """Untouched locale tree should pass."""
+    rc = check_i18n.check_i18n(str(locales_copy))
+    assert rc == 0
+
+
+def test_missing_admin_key_warns_but_passes(locales_copy, capsys):
+    """Removing an admin key in fr produces a warning, exit 0."""
+    remove_key_from(locales_copy / "fr" / "admin.json", "admin.hub.title")
+    rc = check_i18n.check_i18n(str(locales_copy))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "⚠️" in captured.out
+    assert "admin.hub.title" in captured.out
+
+
+def test_missing_participant_key_fails(locales_copy, capsys):
+    """Removing a participant key in fr fails (exit 1)."""
+    remove_key_from(locales_copy / "fr" / "participant.json", "common.next")
+    rc = check_i18n.check_i18n(str(locales_copy))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "❌" in captured.out
+    assert "common.next" in captured.out
+
+
+def test_missing_admin_file_warns_but_passes(locales_copy, capsys):
+    """Deleting fr/admin.json entirely warns but passes."""
+    (locales_copy / "fr" / "admin.json").unlink()
+    rc = check_i18n.check_i18n(str(locales_copy))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "⚠️" in captured.out
+    assert "missing (best-effort" in captured.out
+
+
+def test_missing_participant_file_fails(locales_copy, capsys):
+    """Deleting fr/participant.json fails."""
+    (locales_copy / "fr" / "participant.json").unlink()
+    rc = check_i18n.check_i18n(str(locales_copy))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "❌" in captured.out
+    assert "missing (required)" in captured.out

--- a/frontend/src/components/admin/AppSidebar.tsx
+++ b/frontend/src/components/admin/AppSidebar.tsx
@@ -46,14 +46,13 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { usePermission } from '@/hooks/usePermission';
 import { useSidebar } from '@/components/ui/sidebar';
-import { SUPPORTED_LANGUAGES } from '@/constants/languages';
+import { getAdminLanguages } from '@/constants/languages';
 
 function NavLanguage() {
     const { i18n, t } = useTranslation();
     const currentLang = i18n.language;
-    const currentCodeUpper = SUPPORTED_LANGUAGES.find(
-        (l) => l.code === currentLang
-    )?.code.toUpperCase();
+    const adminLanguages = getAdminLanguages();
+    const currentCodeUpper = adminLanguages.find((l) => l.code === currentLang)?.code.toUpperCase();
 
     return (
         <SidebarMenu>
@@ -71,7 +70,7 @@ function NavLanguage() {
                             {t('layout.change_lang_title')}
                         </DropdownMenuLabel>
                         <DropdownMenuSeparator />
-                        {SUPPORTED_LANGUAGES.map((lang) => (
+                        {adminLanguages.map((lang) => (
                             <DropdownMenuItem
                                 key={lang.code}
                                 onSelect={() => i18n.changeLanguage(lang.code)}

--- a/frontend/src/constants/languages.test.ts
+++ b/frontend/src/constants/languages.test.ts
@@ -1,7 +1,14 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import { SUPPORTED_I18N_LANGUAGES } from '../i18n';
-import { SUPPORTED_LANGUAGES } from './languages';
+import { SUPPORTED_LANGUAGES, getAdminLanguages } from './languages';
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const localesDir = path.resolve(thisDir, '../../public/locales');
 
 describe('SUPPORTED_LANGUAGES', () => {
     it('includes German as an available study language', () => {
@@ -9,10 +16,49 @@ describe('SUPPORTED_LANGUAGES', () => {
             code: 'de',
             label: 'Deutsch',
             flag: '🇩🇪',
+            hasAdmin: true,
         });
     });
 
     it('allows German in the i18next locale allowlist', () => {
         expect(SUPPORTED_I18N_LANGUAGES).toContain('de');
+    });
+
+    it('participant.json exists on disk for every declared language', () => {
+        const missing = SUPPORTED_LANGUAGES.filter(
+            ({ code }) => !fs.existsSync(path.join(localesDir, code, 'participant.json'))
+        ).map(({ code }) => code);
+        expect(missing).toEqual([]);
+    });
+
+    it('hasAdmin flag matches admin.json presence on disk', () => {
+        const mismatches: string[] = [];
+        for (const lang of SUPPORTED_LANGUAGES) {
+            const adminExists = fs.existsSync(path.join(localesDir, lang.code, 'admin.json'));
+            if (lang.hasAdmin !== adminExists) {
+                mismatches.push(
+                    `${lang.code}: hasAdmin=${lang.hasAdmin} but admin.json ${
+                        adminExists ? 'exists' : 'is missing'
+                    }`
+                );
+            }
+        }
+        expect(mismatches).toEqual([]);
+    });
+});
+
+describe('getAdminLanguages', () => {
+    it('returns only languages with hasAdmin=true', () => {
+        const result = getAdminLanguages();
+        expect(result.length).toBeGreaterThan(0);
+        for (const lang of result) {
+            expect(lang.hasAdmin).toBe(true);
+        }
+    });
+
+    it('preserves the order of SUPPORTED_LANGUAGES', () => {
+        const adminCodes = getAdminLanguages().map((l) => l.code);
+        const expectedOrder = SUPPORTED_LANGUAGES.filter((l) => l.hasAdmin).map((l) => l.code);
+        expect(adminCodes).toEqual(expectedOrder);
     });
 });

--- a/frontend/src/constants/languages.test.ts
+++ b/frontend/src/constants/languages.test.ts
@@ -24,6 +24,18 @@ describe('SUPPORTED_LANGUAGES', () => {
         expect(SUPPORTED_I18N_LANGUAGES).toContain('de');
     });
 
+    it('SUPPORTED_LANGUAGES and SUPPORTED_I18N_LANGUAGES are in sync', () => {
+        // Both lists declare the same set of supported language codes.
+        // A divergence would silently break a selector: a code in
+        // SUPPORTED_LANGUAGES but missing from SUPPORTED_I18N_LANGUAGES gets
+        // offered in the UI but rejected by i18next's `supportedLngs` and
+        // falls back to English; the reverse means `?lang=xx` works but no
+        // selector ever offers the language.
+        const fromMeta = new Set(SUPPORTED_LANGUAGES.map((l) => l.code));
+        const fromAllowlist = new Set(SUPPORTED_I18N_LANGUAGES);
+        expect(fromMeta).toEqual(fromAllowlist);
+    });
+
     it('participant.json exists on disk for every declared language', () => {
         const missing = SUPPORTED_LANGUAGES.filter(
             ({ code }) => !fs.existsSync(path.join(localesDir, code, 'participant.json'))

--- a/frontend/src/constants/languages.ts
+++ b/frontend/src/constants/languages.ts
@@ -2,11 +2,27 @@ export interface Language {
     code: string;
     label: string;
     flag: string;
+    /**
+     * True when the locale ships an `admin.json` translation file. When false,
+     * the language is only offered in participant-facing selectors (study
+     * design, concourse, intro) and is hidden from the admin sidebar selector
+     * so researchers don't pick a locale that renders mostly via the English
+     * fallback chain.
+     */
+    hasAdmin: boolean;
 }
 
 export const SUPPORTED_LANGUAGES: Language[] = [
-    { code: 'en', label: 'English', flag: '🇬🇧' },
-    { code: 'fr', label: 'Français', flag: '🇫🇷' },
-    { code: 'fi', label: 'Suomi', flag: '🇫🇮' },
-    { code: 'de', label: 'Deutsch', flag: '🇩🇪' },
+    { code: 'en', label: 'English', flag: '🇬🇧', hasAdmin: true },
+    { code: 'fr', label: 'Français', flag: '🇫🇷', hasAdmin: true },
+    { code: 'fi', label: 'Suomi', flag: '🇫🇮', hasAdmin: true },
+    { code: 'de', label: 'Deutsch', flag: '🇩🇪', hasAdmin: true },
 ];
+
+/**
+ * Returns the subset of supported languages that ship a full admin translation.
+ * Use for the admin chrome language switcher; participant-domain selectors
+ * (study creation, concourse, intro editor) should consume `SUPPORTED_LANGUAGES`
+ * directly since `participant.json` is mandatory for every declared language.
+ */
+export const getAdminLanguages = (): Language[] => SUPPORTED_LANGUAGES.filter((l) => l.hasAdmin);

--- a/frontend/src/constants/locales.test.ts
+++ b/frontend/src/constants/locales.test.ts
@@ -10,13 +10,21 @@ const thisDir = path.dirname(fileURLToPath(import.meta.url));
 const localesDir = path.resolve(thisDir, '../../public/locales');
 
 describe('locale resources', () => {
-    it('has participant and admin namespace files for each supported language', () => {
-        const missingLanguages = SUPPORTED_LANGUAGES.filter(
-            ({ code }) =>
-                !fs.existsSync(path.join(localesDir, code, 'participant.json')) ||
-                !fs.existsSync(path.join(localesDir, code, 'admin.json'))
+    it('has a participant.json for each supported language (mandatory)', () => {
+        const missing = SUPPORTED_LANGUAGES.filter(
+            ({ code }) => !fs.existsSync(path.join(localesDir, code, 'participant.json'))
         ).map(({ code }) => code);
 
-        expect(missingLanguages).toEqual([]);
+        expect(missing).toEqual([]);
+    });
+
+    it('admin.json is optional but, if present, must be valid JSON', () => {
+        for (const { code } of SUPPORTED_LANGUAGES) {
+            const adminPath = path.join(localesDir, code, 'admin.json');
+            if (!fs.existsSync(adminPath)) {
+                continue; // best-effort: locale may legitimately skip admin
+            }
+            expect(() => JSON.parse(fs.readFileSync(adminPath, 'utf-8'))).not.toThrow();
+        }
     });
 });

--- a/frontend/src/hooks/admin/useConcourseDetailPage.ts
+++ b/frontend/src/hooks/admin/useConcourseDetailPage.ts
@@ -422,11 +422,12 @@ export function useConcourseDetailPage(): ConcourseDetailPageApi {
         return counts;
     }, [languages, concourse?.items]);
 
-    // Concourse statement languages are restricted to the same set as the
-    // study UI (en/fr/fi). A statement language outside the UI set would not
-    // be selectable when creating a study, so allowing wider codes here is a
-    // dead-end. Existing items in other codes remain visible (`languages` is
-    // derived from data) — the picker simply does not offer to add more.
+    // Concourse statement languages are restricted to the same set as
+    // SUPPORTED_LANGUAGES (the participant-domain locales). A statement
+    // language outside that set would not be selectable when creating a
+    // study, so allowing wider codes here is a dead-end. Existing items in
+    // other codes remain visible (`languages` is derived from data) — the
+    // picker simply does not offer to add more.
     const commonLanguages = useMemo(
         () =>
             SUPPORTED_LANGUAGES.filter((l) => !languages.includes(l.code))


### PR DESCRIPTION
## Summary
- Adds a per-namespace parity policy table to `check_i18n.py` and `check_interpolations.py`:
  - `participant.json` — **strict**: mismatches fail CI.
  - `admin.json` — **best-effort**: mismatches warn, CI passes.
- A locale may now legitimately ship with `participant.json` only — `admin.json` is allowed to be missing or partial, with runtime fallback to `en/admin.json` via i18next's existing `fallbackLng`.
- Refactors `check_i18n()` to accept an optional locales path argument (enables end-to-end tests to drive it against fixture trees).
- Updates `locales.test.ts` to mirror the policy: `participant.json` mandatory per declared language, `admin.json` optional but must parse if present.
- Adds 5 end-to-end regression tests proving each branch of the policy fires correctly.

## Why
Unblocks shipping participant-only locales for the 5-European-languages plan: a new locale costs ~24 KB of translation (participant), with admin translation as an optional follow-up. Without this change, every new locale had to ship a fully-translated admin namespace before merging.

## References
- Spec: `docs/superpowers/specs/2026-05-14-i18n-namespace-split-design.md` (Section: Differentiated parity policy)
- Plan: `docs/superpowers/plans/2026-05-14-i18n-namespace-split.md` (Phase 2 — Tasks 6, 7, 8)
- Builds on: #158 (file split shipped the architecture this PR now leverages)

## Test plan
- [x] `make ci-fast` passes locally (backend 266 / frontend 1377)
- [x] 30/30 i18n tests pass (split 9 + interpolations 16 + policy 5)
- [x] Smoke: removing a key from \`fr/admin.json\` warns; removing one from \`fr/participant.json\` fails
- [ ] Reviewer confirms warning vs error output is readable in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)