### PR TITLE
docs: sync i18n references with current locale architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ backend/        # FastAPI app
   tests/        # Unit + integration tests (pytest)
 frontend/       # React SPA
   src/           # Components, pages, hooks, store, api
-  public/locales/  # i18n translation files (en, fr, fi)
+  public/locales/  # i18n translation files (one dir per locale; see `SUPPORTED_LANGUAGES`)
 ```
 
 ## Key Commands (from project root)
@@ -112,8 +112,10 @@ Inside a strict module: every function declares its return type, no implicit `An
 
 ### Internationalization
 - All user-facing strings must use `useTranslation()` / `t()` with a key and English fallback: `t('key', 'Fallback')`
-- Three locales: `en`, `fr`, `fi` — keep all translation files in sync
-- Run `npm run i18n-check` to verify key parity
+- Supported locales: see `SUPPORTED_LANGUAGES` in `frontend/src/constants/languages.ts` (canonical source). Each entry has a `hasAdmin` flag — when false, admin chrome falls back to English via i18next's `fallbackLng`.
+- Locale files: `frontend/public/locales/<lang>/{participant,admin}.json`. **Participant strict** parity (mandatory), **admin best-effort** (warning-only). Policy enforced by `frontend/scripts/check_i18n.py`.
+- Adding a new locale: write `frontend/scripts/i18n/glossaries/<code>.yaml` first, then follow `frontend/scripts/i18n/translation-runbook.md`. Cross-consistency tests catch missing `SUPPORTED_I18N_LANGUAGES` entries and `setupTests.ts` mock drift automatically.
+- Run `npm run i18n-check` to verify key parity. `npm run check-interpolations` verifies per-key `{{var}}` parity.
 
 ### Testing
 - Backend: pytest with async fixtures. Mocks must include all methods used by the code under test.

--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -60,7 +60,7 @@ A handful of domain rules must hold in every change that touches the participant
 ## 7. Conventional checklist before opening a PR
 
 - `make ci` passes.
-- New user-facing strings use `t('key', 'Fallback')` and exist in `en`, `fr`, `fi`. `npm run i18n-check` passes.
+- New user-facing strings use `t('key', 'Fallback')` and exist in every locale's `participant.json` or `admin.json` (depending on which namespace the key lives in). `npm run i18n-check` passes.
 - Backend route or schema changes are followed by `make generate-api`; the regenerated client is committed.
 - New database columns ship with a reviewed Alembic migration (`make migration-new`).
 - New tests cover the behaviour. Non-trivial code without a test is a blocker.

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -194,7 +194,7 @@ For the migration chain and conventions, see the "Database Migrations" section i
 | `src/components/admin/analysis/` | Analysis result visualizations |
 | `src/store/` | Zustand state management stores |
 | `src/api/` | Generated API client (Orval) |
-| `public/locales/` | i18n translation files (en, fr, fi) |
+| `public/locales/` | i18n translation files (one dir per locale; see `SUPPORTED_LANGUAGES` constant) |
 
 ## Common troubleshooting
 

--- a/docs/contributing/frontend-guidelines.md
+++ b/docs/contributing/frontend-guidelines.md
@@ -30,9 +30,10 @@ const { t } = useTranslation();
 return <button>{t('study.activate', 'Activate Study')}</button>;
 ```
 
-- Three locales: `en`, `fr`, `fi`. Keep them in sync.
-- `npm run i18n-check` verifies key parity. CI runs it; do not let it drift.
-- Translation files live under `frontend/public/locales/<lang>/`, split into `participant.json` (participant flow + public chrome) and `admin.json` (admin + auth). Add the new key in `en/<namespace>.json` first, then mirror it to `fr`, `fi`, and `de`.
+- Supported locales: see `SUPPORTED_LANGUAGES` in `frontend/src/constants/languages.ts`. Each entry carries a `hasAdmin` flag controlling whether the locale appears in the admin sidebar selector.
+- Translation files live under `frontend/public/locales/<lang>/`, split into `participant.json` (participant flow + public chrome — **strict parity**, mandatory) and `admin.json` (admin + auth — **best-effort**, may be partial or absent; missing keys fall back to English via i18next's `fallbackLng`).
+- Adding a key: add it to `en/<namespace>.json` first, then mirror it to every other locale's same namespace. `npm run i18n-check` and `npm run check-interpolations` verify key and placeholder parity; CI runs both.
+- Adding a new locale: write `frontend/scripts/i18n/glossaries/<code>.yaml` first, then follow `frontend/scripts/i18n/translation-runbook.md`. Update `SUPPORTED_LANGUAGES`, `SUPPORTED_I18N_LANGUAGES` (in `frontend/src/i18n.ts`), and the mocked allowlist in `frontend/src/setupTests.ts` in lock-step — the cross-consistency invariant test in `languages.test.ts` will catch drift.
 
 ## 3. Generated API client
 


### PR DESCRIPTION
## Summary
Updates contributor-facing docs that still described i18n as a 3-locale system. After PRs #157-#163 (namespace split + 4 new locales + de rework + Dutch), several doc spots had gone stale:

- \`CLAUDE.md\`: \`# i18n translation files (en, fr, fi)\` and \`Three locales: en, fr, fi\`
- \`docs/contributing/frontend-guidelines.md\`: \`Three locales: en, fr, fi\` + outdated mirror list
- \`docs/contributing/coding-standards.md\`: PR checklist mentioned only en/fr/fi
- \`docs/contributing/development.md\`: directory map entry

## Fixes
- Eliminated hardcoded locale lists where \`SUPPORTED_LANGUAGES\` constant is canonical.
- Documented the namespace split (participant strict / admin best-effort) where it affects contributor workflow.
- Documented the cross-consistency invariant test as the guardrail for setupTests.ts mock drift.
- Referenced the new tooling (glossaries/, translation-runbook.md, check_interpolations.py).

## Test plan
- [x] \`make ci-fast\` passes (no code changes; just docs)
- [ ] Reviewer reads the four updated doc sections and confirms they match current reality

🤖 Generated with [Claude Code](https://claude.com/claude-code)