### PR TITLE
feat(i18n): add Polish locale (participant + admin)

### DIFF
--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1,2188 +1,2188 @@
 {
-    "auth": {
-        "login": {
-            "email_label": "Email address",
-            "password_label": "Password",
-            "submit": "Continue",
-            "cta": "Sign in",
-            "forgot_password": "Forgot?",
-            "loading": "Authenticating...",
-            "card_title": "Sign in",
-            "welcome_back": "Welcome back!",
-            "error_401": "Invalid email or password",
-            "error_generic": "Something went wrong. Please try again.",
-            "reason_session_expired": "Your session has expired. Please sign in again.",
-            "reason_auth_required": "Please sign in to continue.",
-            "forgot_password_link": "Forgot password?",
-            "reset_success_banner": "Password updated. You can now sign in with your new password.",
-            "two_factor_title": "Two-factor authentication",
-            "two_factor_app_prompt": "Enter the 6-digit code from your authenticator app.",
-            "two_factor_email_prompt": "We sent a 6-digit code to your email. Enter it below.",
-            "two_factor_submit": "Verify",
-            "two_factor_resend": "Resend code",
-            "two_factor_resend_cooldown": "Resend available in {{seconds}}s",
-            "two_factor_invalid": "Invalid code. Try again.",
-            "lost_2fa_link": "Lost access to your 2FA?"
-        },
-        "twofa": {
-            "recovery": {
-                "title": "Lost access to your two-factor authentication?",
-                "body": "Enter your account email. If two-factor is enabled on this account, we'll send you a link to disable it.",
-                "submit": "Send disable link",
-                "success": "If the email exists and has 2FA, a disable link is on its way."
-            },
-            "disable": {
-                "title": "Disable two-factor authentication",
-                "warning": "Clicking the button below will permanently remove the second factor from this account. You'll be able to sign in with just your password until you re-enable 2FA.",
-                "warning_attacker": "If you did NOT request this, close this page and change your password immediately.",
-                "confirm_button": "Yes, disable two-factor authentication",
-                "loading": "Disabling…",
-                "success": "Two-factor authentication is now disabled. You may sign in.",
-                "error_consumed": "This link has already been used.",
-                "error_expired": "This link has expired or is invalid.",
-                "missing_token": "No token in the URL."
-            }
-        },
-        "password_reset": {
-            "request_title": "Reset your password",
-            "request_body": "Enter your email and we'll send a reset link.",
-            "request_submit": "Send reset link",
-            "request_success": "If the email exists, a reset link is on its way.",
-            "confirm_title": "Choose a new password",
-            "confirm_submit": "Reset password",
-            "success_redirect": "Password updated. You can now sign in with your new password.",
-            "link_expired": "This link has expired or has already been used.",
-            "too_short": "Password must be at least 8 characters.",
-            "mismatch": "Passwords do not match.",
-            "missing_token": "No reset token in the URL.",
-            "new_password_placeholder": "New password",
-            "confirm_placeholder": "Confirm password"
-        },
-        "email": {
-            "verification_sent": {
-                "title": "Verify your email",
-                "body": "We sent a verification link to {{email}}. Click the link to activate your account.",
-                "resend": "Resend the email",
-                "cooldown": "Resend available in {{seconds}}s",
-                "error": "Could not resend. Try again later."
-            },
-            "verify": {
-                "verifying": "Verifying your email…",
-                "success": "Email verified. You can now sign in.",
-                "expired": "This link has expired or is invalid.",
-                "resend_link": "Request a new verification email"
-            }
-        },
-        "register": {
-            "title": "Create account",
-            "subtitle": "Join the research project",
-            "secure_invitation": "Secure invitation",
-            "invitation_to": "Invitation to:",
-            "study_label": "Study",
-            "role_label": "Role",
-            "email_label": "Email address",
-            "password_label": "Choose password",
-            "confirm_password_label": "Confirm password",
-            "placeholder_password": "••••••••",
-            "submit": "Complete registration",
-            "loading": "Creating account...",
-            "success_title": "Welcome aboard!",
-            "success_desc": "Your account has been created and linked to the study.",
-            "success_cta": "Go to dashboard",
-            "success_hint": "You can now log in to the administrative dashboard to begin collaborating.",
-            "invalid_title": "Invalid invitation",
-            "invalid_desc": "This invitation link is invalid or has expired.",
-            "missing_token_title": "Missing token",
-            "missing_token_desc": "This page requires a valid invitation token. Please check the link you received.",
-            "verifying": "Verifying your invitation...",
-            "privacy_hint": "By registering, you agree to follow the research ethics guidelines configured for this study.",
-            "errors": {
-                "password_mismatch": "Passwords do not match",
-                "generic_fail": "Registration failed"
-            }
-        }
+  "auth": {
+    "login": {
+      "email_label": "Adres e-mail",
+      "password_label": "Hasło",
+      "submit": "Kontynuuj",
+      "cta": "Zaloguj się",
+      "forgot_password": "Nie pamiętasz?",
+      "loading": "Uwierzytelnianie...",
+      "card_title": "Zaloguj się",
+      "welcome_back": "Witamy z powrotem!",
+      "error_401": "Nieprawidłowy adres e-mail lub hasło",
+      "error_generic": "Coś poszło nie tak. Proszę spróbować ponownie.",
+      "reason_session_expired": "Sesja wygasła. Proszę zalogować się ponownie.",
+      "reason_auth_required": "Proszę zalogować się, aby kontynuować.",
+      "forgot_password_link": "Nie pamiętasz hasła?",
+      "reset_success_banner": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
+      "two_factor_title": "Weryfikacja dwuetapowa",
+      "two_factor_app_prompt": "Proszę wpisać 6-cyfrowy kod z aplikacji uwierzytelniającej.",
+      "two_factor_email_prompt": "Wysłaliśmy 6-cyfrowy kod na podany adres e-mail. Proszę wpisać go poniżej.",
+      "two_factor_submit": "Zweryfikuj",
+      "two_factor_resend": "Wyślij kod ponownie",
+      "two_factor_resend_cooldown": "Ponowne wysłanie dostępne za {{seconds}} s",
+      "two_factor_invalid": "Nieprawidłowy kod. Proszę spróbować ponownie.",
+      "lost_2fa_link": "Brak dostępu do weryfikacji dwuetapowej?"
     },
-    "admin": {
-        "hub": {
-            "title": "Researcher Hub",
-            "welcome": "Welcome back,",
-            "new_project": "New project",
-            "your_projects": "Your projects",
-            "studies_count": "studies",
-            "recent_studies": "Recent studies",
-            "n_studies_one": "{{count}} study",
-            "n_studies_other": "{{count}} studies",
-            "n_active_one": "{{count}} active",
-            "n_active_other": "{{count}} active",
-            "collecting": "Collecting data",
-            "no_studies": "No studies yet",
-            "no_projects": "No projects yet. Create your first project to get started.",
-            "no_projects_title": "Start your first research project",
-            "no_projects_body": "Create a project before adding concourses, Q-sets, or studies."
-        },
-        "memo": {
-            "title_concourse": "Selection notes",
-            "title_study": "Methodology memo",
-            "summary_empty_concourse": "How and why you built this concourse",
-            "summary_empty_study": "Optional · for replication & pre-registration",
-            "summary_filled_one": "{{n}} entry · click to view",
-            "summary_filled_other": "{{n}} entries · click to view",
-            "summary_unread": "{{n}} unread",
-            "add_entry": "Add entry",
-            "insert_template": "Insert from template",
-            "entry_title_placeholder": "Section title…",
-            "entry_body_placeholder": "Document your rationale…",
-            "comments_count_one": "{{n}} comment",
-            "comments_count_other": "{{n}} comments",
-            "show_resolved": "Show resolved ({{n}})",
-            "hide_resolved": "Hide resolved",
-            "comment_placeholder": "Write a comment. Use @ to mention.",
-            "post_comment": "Post",
-            "edit": "Edit",
-            "delete": "Delete",
-            "deleted_body": "[deleted comment]",
-            "resolve": "Resolve",
-            "unresolve": "Unresolve",
-            "resolved_label": "[resolved]",
-            "save": "Save",
-            "cancel": "Cancel",
-            "saved": "Saved",
-            "save_error": "Could not save memo. Try again.",
-            "load_error": "Could not load memo. Refresh the page to retry.",
-            "mentions_for_you": "Mentions for you",
-            "mention_user_not_found": "Unknown user",
-            "delete_entry_confirm": "Delete this entry and all its comments?",
-            "include_discussion_in_export": "Include memo discussion threads",
-            "templates": {
-                "concourse": {
-                    "sources_canvassed": {
-                        "title": "Sources canvassed"
-                    },
-                    "voices_retained": {
-                        "title": "Voices retained"
-                    },
-                    "voices_excluded": {
-                        "title": "Voices excluded"
-                    },
-                    "sampling_rationale": {
-                        "title": "Sampling rationale"
-                    },
-                    "version_notes": {
-                        "title": "Version notes"
-                    }
-                },
-                "study": {
-                    "distribution_rationale": {
-                        "title": "Distribution rationale"
-                    },
-                    "conditions_of_instruction": {
-                        "title": "Conditions of instruction"
-                    },
-                    "qset_size": {
-                        "title": "Q-set size"
-                    },
-                    "pre_post_design": {
-                        "title": "Pre/post-sort design choices"
-                    },
-                    "limitations": {
-                        "title": "Limitations"
-                    }
-                }
-            }
-        },
-        "study_design": {
-            "distribution_mode": {
-                "title": "Distribution mode",
-                "helper": "Choose how strictly the Q-sort grid is enforced. Forced: each column must be filled to its declared capacity (the most common choice). Free: any number of cards per column, total = Q-set size. Flexible: total enforced, columns are soft hints.",
-                "forced": {
-                    "label": "Forced",
-                    "tooltip": "Each column must hold exactly its declared capacity."
-                },
-                "free": {
-                    "label": "Free",
-                    "tooltip": "Total cards = Q-set size; per-column count is unconstrained."
-                },
-                "flexible": {
-                    "label": "Flexible",
-                    "tooltip": "Total cards = Q-set size; per-column capacities are soft hints (warnings only)."
-                }
-            },
-            "rough_sort": {
-                "toggle_label": "Enable preliminary sort (3-pile triage)",
-                "lock_banner": "Toggle locked. {{count}} participant(s) have started the survey; archive or delete those sessions before changing this setting.",
-                "deck_mode_note": "Disabled. Participants see the full Q-set as a horizontally-scrollable deck."
-            }
+    "twofa": {
+      "recovery": {
+        "title": "Brak dostępu do weryfikacji dwuetapowej?",
+        "body": "Proszę podać adres e-mail konta. Jeśli weryfikacja dwuetapowa jest włączona, wyślemy link do jej wyłączenia.",
+        "submit": "Wyślij link wyłączający",
+        "success": "Jeśli adres e-mail istnieje i ma włączoną weryfikację dwuetapową, link jest już w drodze."
+      },
+      "disable": {
+        "title": "Wyłącz weryfikację dwuetapową",
+        "warning": "Kliknięcie przycisku poniżej trwale usunie drugi składnik uwierzytelnienia z tego konta. Logowanie będzie możliwe samym hasłem do momentu ponownego włączenia weryfikacji dwuetapowej.",
+        "warning_attacker": "Jeśli to nie Pan/Pani zażądał/a tej operacji, proszę zamknąć tę stronę i natychmiast zmienić hasło.",
+        "confirm_button": "Tak, wyłącz weryfikację dwuetapową",
+        "loading": "Wyłączanie…",
+        "success": "Weryfikacja dwuetapowa została wyłączona. Można się zalogować.",
+        "error_consumed": "Ten link został już wykorzystany.",
+        "error_expired": "Ten link wygasł lub jest nieprawidłowy.",
+        "missing_token": "Brak tokenu w adresie URL."
+      }
+    },
+    "password_reset": {
+      "request_title": "Zresetuj hasło",
+      "request_body": "Proszę podać adres e-mail, a wyślemy link do zresetowania hasła.",
+      "request_submit": "Wyślij link resetujący",
+      "request_success": "Jeśli adres e-mail istnieje, link resetujący jest już w drodze.",
+      "confirm_title": "Wybierz nowe hasło",
+      "confirm_submit": "Zresetuj hasło",
+      "success_redirect": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
+      "link_expired": "Ten link wygasł lub został już wykorzystany.",
+      "too_short": "Hasło musi mieć co najmniej 8 znaków.",
+      "mismatch": "Hasła nie są zgodne.",
+      "missing_token": "Brak tokenu resetowania w adresie URL.",
+      "new_password_placeholder": "Nowe hasło",
+      "confirm_placeholder": "Potwierdź hasło"
+    },
+    "email": {
+      "verification_sent": {
+        "title": "Zweryfikuj adres e-mail",
+        "body": "Wysłaliśmy link weryfikacyjny na adres {{email}}. Proszę kliknąć link, aby aktywować konto.",
+        "resend": "Wyślij e-mail ponownie",
+        "cooldown": "Ponowne wysłanie dostępne za {{seconds}} s",
+        "error": "Nie udało się wysłać ponownie. Proszę spróbować później."
+      },
+      "verify": {
+        "verifying": "Weryfikowanie adresu e-mail…",
+        "success": "Adres e-mail zweryfikowany. Można się teraz zalogować.",
+        "expired": "Ten link wygasł lub jest nieprawidłowy.",
+        "resend_link": "Poproś o nowy e-mail weryfikacyjny"
+      }
+    },
+    "register": {
+      "title": "Utwórz konto",
+      "subtitle": "Dołącz do projektu badawczego",
+      "secure_invitation": "Bezpieczne zaproszenie",
+      "invitation_to": "Zaproszenie do:",
+      "study_label": "Badanie",
+      "role_label": "Rola",
+      "email_label": "Adres e-mail",
+      "password_label": "Wybierz hasło",
+      "confirm_password_label": "Potwierdź hasło",
+      "placeholder_password": "••••••••",
+      "submit": "Zakończ rejestrację",
+      "loading": "Tworzenie konta...",
+      "success_title": "Witamy na pokładzie!",
+      "success_desc": "Konto zostało utworzone i powiązane z badaniem.",
+      "success_cta": "Przejdź do panelu",
+      "success_hint": "Można teraz zalogować się do panelu administracyjnego i rozpocząć współpracę.",
+      "invalid_title": "Nieprawidłowe zaproszenie",
+      "invalid_desc": "Ten link zaproszenia jest nieprawidłowy lub wygasł.",
+      "missing_token_title": "Brak tokenu",
+      "missing_token_desc": "Ta strona wymaga prawidłowego tokenu zaproszenia. Proszę sprawdzić otrzymany link.",
+      "verifying": "Weryfikowanie zaproszenia...",
+      "privacy_hint": "Rejestrując się, wyrażasz zgodę na przestrzeganie wytycznych etyki badawczej skonfigurowanych dla tego badania.",
+      "errors": {
+        "password_mismatch": "Hasła nie są zgodne",
+        "generic_fail": "Rejestracja nie powiodła się"
+      }
+    }
+  },
+  "admin": {
+    "hub": {
+      "title": "Panel badacza",
+      "welcome": "Witamy z powrotem,",
+      "new_project": "Nowy projekt",
+      "your_projects": "Twoje projekty",
+      "studies_count": "badań",
+      "recent_studies": "Ostatnie badania",
+      "n_studies_one": "{{count}} badanie",
+      "n_studies_other": "{{count}} badań",
+      "n_active_one": "{{count}} aktywne",
+      "n_active_other": "{{count}} aktywnych",
+      "collecting": "Zbieranie danych",
+      "no_studies": "Brak badań",
+      "no_projects": "Brak projektów. Utwórz pierwszy projekt, aby rozpocząć.",
+      "no_projects_title": "Rozpocznij pierwszy projekt badawczy",
+      "no_projects_body": "Utwórz projekt przed dodaniem konkursów, zbiorów Q lub badań."
+    },
+    "memo": {
+      "title_concourse": "Notatki selekcji",
+      "title_study": "Notatka metodologiczna",
+      "summary_empty_concourse": "Jak i dlaczego zbudowano ten konkurs",
+      "summary_empty_study": "Opcjonalnie · do replikacji i prerejstracji",
+      "summary_filled_one": "{{n}} wpis · kliknij, aby wyświetlić",
+      "summary_filled_other": "{{n}} wpisów · kliknij, aby wyświetlić",
+      "summary_unread": "{{n}} nieprzeczytanych",
+      "add_entry": "Dodaj wpis",
+      "insert_template": "Wstaw z szablonu",
+      "entry_title_placeholder": "Tytuł sekcji…",
+      "entry_body_placeholder": "Udokumentuj swoje uzasadnienie…",
+      "comments_count_one": "{{n}} komentarz",
+      "comments_count_other": "{{n}} komentarzy",
+      "show_resolved": "Pokaż rozwiązane ({{n}})",
+      "hide_resolved": "Ukryj rozwiązane",
+      "comment_placeholder": "Napisz komentarz. Użyj @, aby wspomnieć.",
+      "post_comment": "Wyślij",
+      "edit": "Edytuj",
+      "delete": "Usuń",
+      "deleted_body": "[usunięty komentarz]",
+      "resolve": "Oznacz jako rozwiązane",
+      "unresolve": "Cofnij rozwiązanie",
+      "resolved_label": "[rozwiązane]",
+      "save": "Zapisz",
+      "cancel": "Anuluj",
+      "saved": "Zapisano",
+      "save_error": "Nie udało się zapisać notatki. Proszę spróbować ponownie.",
+      "load_error": "Nie udało się wczytać notatki. Odśwież stronę, aby spróbować ponownie.",
+      "mentions_for_you": "Wzmianki dla mnie",
+      "mention_user_not_found": "Nieznany użytkownik",
+      "delete_entry_confirm": "Usunąć ten wpis i wszystkie jego komentarze?",
+      "include_discussion_in_export": "Dołącz wątki dyskusji z notatki",
+      "templates": {
+        "concourse": {
+          "sources_canvassed": {
+            "title": "Przejrzane źródła"
+          },
+          "voices_retained": {
+            "title": "Zachowane głosy"
+          },
+          "voices_excluded": {
+            "title": "Wykluczone głosy"
+          },
+          "sampling_rationale": {
+            "title": "Uzasadnienie doboru próby"
+          },
+          "version_notes": {
+            "title": "Uwagi do wersji"
+          }
         },
         "study": {
-            "activate_error": "Could not activate study. Verify the design is valid and try again.",
-            "save": {
-                "success": "Changes saved successfully",
-                "save_success": "Saved successfully",
-                "synced_warnings": "Synced with server. Kept your changes in: {{fields}}",
-                "synced_concurrent": "Synced with concurrent changes from another user",
-                "conflict": "Conflict detected. Some changes could not be merged.",
-                "error": "Failed to save changes"
-            },
-            "postsort": {
-                "missing": {
-                    "title": "Missing statements",
-                    "desc": "Are there any ideas or perspectives that you felt were missing from the set of statements?"
-                }
-            },
-            "state": {
-                "manage": "Manage study flow"
-            }
+          "distribution_rationale": {
+            "title": "Uzasadnienie rozkładu"
+          },
+          "conditions_of_instruction": {
+            "title": "Warunki instrukcji"
+          },
+          "qset_size": {
+            "title": "Rozmiar zbioru Q"
+          },
+          "pre_post_design": {
+            "title": "Decyzje projektowe wstępnego/końcowego sortowania"
+          },
+          "limitations": {
+            "title": "Ograniczenia"
+          }
+        }
+      }
+    },
+    "study_design": {
+      "distribution_mode": {
+        "title": "Tryb rozkładu",
+        "helper": "Wybierz, jak ściśle wymuszany jest rozkład siatki Q. Wymuszony: każda kolumna musi być wypełniona do zadeklarowanej pojemności (najczęstszy wybór). Swobodny: dowolna liczba kart na kolumnę, łącznie = rozmiar zbioru Q. Elastyczny: łączna liczba wymuszona, kolumny to miękkie wskazówki.",
+        "forced": {
+          "label": "Wymuszony",
+          "tooltip": "Każda kolumna musi zawierać dokładnie zadeklarowaną liczbę kart."
         },
-        "components": {
-            "markdown": {
-                "label": "Markdown",
-                "tooltip": "Supports Markdown for rich formatting",
-                "bold": "Bold",
-                "italic": "Italic",
-                "list": "List",
-                "link": "Link",
-                "edit": "Edit",
-                "preview": "Preview",
-                "empty": "Nothing to preview"
-            },
-            "click_to_edit": "Click to edit"
+        "free": {
+          "label": "Swobodny",
+          "tooltip": "Łączna liczba kart = rozmiar zbioru Q; liczba kart na kolumnę nie jest ograniczona."
         },
-        "layout": {
-            "title": "Admin",
-            "back_home": "Back to home",
-            "beta": "Research beta",
-            "logout": "Log out",
-            "account": "Account settings",
-            "admin_user": "Admin user"
-        },
-        "account": {
-            "title": "Account settings",
-            "description": "Manage your personal information and account security.",
-            "personal": {
-                "title": "Personal information",
-                "email": "Email address",
-                "email_locked": "Email changes via the API are coming soon to this page; backend support is live.",
-                "name": "Full name",
-                "save": "Save",
-                "saving": "Saving...",
-                "success": "Profile updated successfully",
-                "error": "Failed to update profile",
-                "cannot_remove_self": "You cannot remove yourself",
-                "name_required": "Full name is required"
-            },
-            "security": {
-                "title": "Security",
-                "description": "Manage two-factor authentication and your password.",
-                "tfa_subtitle": "Two-factor authentication",
-                "password_subtitle": "Password",
-                "enabled": "Enabled",
-                "setup_cta": "Setup 2FA now",
-                "configure_title": "Configure authenticator app",
-                "scan_desc": "Scan this QR code with your authenticator app (google authenticator, authy, etc.)",
-                "enter_code": "Enter 6-digit code",
-                "enable_btn": "Enable 2FA",
-                "disable_btn": "Disable 2FA",
-                "confirm_disable": "Confirm disable",
-                "confirm_password_label": "Confirm with your password",
-                "verifying": "Verifying...",
-                "cancel": "Cancel",
-                "enabled_success": "Two-factor authentication enabled",
-                "disabled_success": "Two-factor authentication disabled",
-                "secret_copied": "Secret copied",
-                "invalid_token": "Invalid verification code",
-                "disable_error": "Failed to disable 2FA",
-                "channel_select_label": "How should we deliver your 2FA codes?",
-                "channel_app": "Authenticator app (recommended)",
-                "channel_email": "Email",
-                "channel_email_desc": "We'll email you a 6-digit code each time you log in. Useful if you can't install an authenticator app.",
-                "enable_email_btn": "Enable email-based 2FA",
-                "enable_email_pending": "Enabling…"
-            },
-            "password": {
-                "title": "Password management",
-                "current": "Current password",
-                "new": "New password",
-                "change_btn": "Change password",
-                "updating": "Updating...",
-                "success": "Password changed successfully",
-                "error": "Failed to change password. Check current password.",
-                "validation": {
-                    "required": "Required",
-                    "min_length": "Min 8 characters"
-                }
-            }
-        },
-        "sidebar": {
-            "home": "Dashboard",
-            "add_study": "Add study",
-            "create_project": "CREATE NEW PROJECT",
-            "dashboard": "Dashboard",
-            "overview": "Overview",
-            "design": "Design",
-            "recruit": "Access",
-            "data": "Data",
-            "analysis": "Analysis",
-            "privacy": "Data privacy",
-            "team": "Team",
-            "settings": "Study settings",
-            "project_settings": "Project settings",
-            "study_tools": "Study tools",
-            "project": "Project",
-            "documentation": "Documentation",
-            "support": "Support",
-            "study_management": "Study management",
-            "search": "Search...",
-            "studies": "Studies",
-            "select_study": "Select study",
-            "select_study_msg": "Please select or create a study to begin.",
-            "view_all_studies": "All studies",
-            "study": "Study",
-            "select_project": "Select project",
-            "concourses": "Concourses",
-            "concourse": "Concourse",
-            "members": "Team members"
-        },
-        "concourse": {
-            "title": "Concourse",
-            "description": "Manage candidate statements for your Q-methodology study",
-            "default_title": "Concourse",
-            "default_title_for_project": "{{project}} concourse",
-            "create": "New Concourse",
-            "create_success": "Concourse created",
-            "create_error": "Failed to create concourse",
-            "create_dialog_title": "Create Concourse",
-            "create_dialog_desc": "A concourse is a collection of candidate statements from which you will select your Q-set.",
-            "field_title": "Title",
-            "field_title_placeholder": "e.g. Climate Change Attitudes",
-            "field_description": "Description",
-            "field_description_placeholder": "Brief description of this concourse...",
-            "field_code": "Code",
-            "field_text": "Statement text",
-            "field_text_placeholder": "Enter the statement text...",
-            "field_source": "Source",
-            "items_label": "items",
-            "updated": "Updated",
-            "empty_title": "No concourses yet",
-            "empty_desc": "Create a concourse to start collecting and organizing candidate statements for your Q-methodology research.",
-            "add_item": "Add Item",
-            "bulk_import": "Bulk Import",
-            "import_desc": "Paste statements separated by newlines. Each line becomes one item.",
-            "import_prefix": "Code prefix",
-            "import_statements": "Statements",
-            "import_placeholder": "One statement per line...",
-            "items_to_import": "statements to import",
-            "import_button": "Import",
-            "import_success": "{{count}} items imported",
-            "import_error": "Import failed",
-            "item_created": "Item added",
-            "item_create_error": "Failed to add item",
-            "item_updated": "Item updated",
-            "item_update_error": "Failed to update item",
-            "item_deleted": "Item deleted",
-            "item_delete_error": "Failed to delete item",
-            "status_error": "Failed to change status",
-            "search_placeholder": "Search items...",
-            "source_placeholder": "e.g. Interview #3, Literature review",
-            "no_items": "No items yet. Add your first statement.",
-            "no_matches": "No items match your filters.",
-            "danger_zone": "Danger Zone",
-            "delete": "Delete Concourse",
-            "delete_confirm": "Are you sure you want to delete this concourse and all its items?",
-            "deleted": "Concourse deleted",
-            "delete_error": "Failed to delete concourse",
-            "delete_item_title": "Delete Item",
-            "delete_item_confirm": "Delete this item? Cannot be undone.",
-            "status": {
-                "proposed": "Proposed",
-                "accepted": "Accepted",
-                "rejected": "Rejected"
-            },
-            "change_note_placeholder": "Change note (optional)",
-            "history": "History",
-            "comments": "Comments",
-            "no_history": "No edit history yet.",
-            "no_comments": "No comments yet.",
-            "add_comment": "Write a comment...",
-            "send_comment": "Send",
-            "comment_added": "Comment added",
-            "comment_error": "Could not add comment. Try again.",
-            "version_label": "v{{n}}",
-            "item_detail_desc": "History and comments for this item",
-            "manage_tags": "Tags",
-            "tag_name_placeholder": "Tag name",
-            "tag_color": "Tag color",
-            "tag_created": "Tag created",
-            "tag_create_error": "Failed to create tag",
-            "tag_deleted": "Tag deleted",
-            "tag_delete_error": "Failed to delete tag",
-            "no_tags": "No tags yet. Create your first tag above.",
-            "field_tags": "Tags",
-            "export_csv": "Export CSV",
-            "select_language": "Language",
-            "add_language": "Add language",
-            "add_language_desc": "Enter a language code (e.g. en, fr, fi).",
-            "add_language_desc_v2": "Select a language for statement translations.",
-            "add_language_tooltip": "Add a translation language",
-            "field_language": "Language",
-            "import_language": "Language",
-            "select_all": "Select all",
-            "bulk_selected": "{{count}} selected",
-            "bulk_set_status": "Set status:",
-            "bulk_clear": "Clear",
-            "bulk_status_success": "{{count}} items updated",
-            "bulk_status_error": "Failed to update some items",
-            "qset_title": "Curation",
-            "qset_pending": "{{count}} items still to review",
-            "qset_complete": "All items reviewed",
-            "show_pending": "To review",
-            "bulk_confirm_title": "Confirm status change",
-            "bulk_confirm_desc": "Set {{count}} items to \"{{status}}\"?",
-            "no_translation": "No text",
-            "language_tooltip": "Language of statement texts",
-            "loading": "Setting up concourse...",
-            "diff_code": "code",
-            "diff_status": "status",
-            "diff_text": "text",
-            "diff_tags": "tags",
-            "diff_changed": "Changed:",
-            "methodological_context": {
-                "title": "Methodological context",
-                "subtitle": "Optional documentation fields. Fill in what's relevant to your design; leave others blank."
-            },
-            "import_from_csv": "Import CSV/TSV…",
-            "import_csv_hint": "CSV/TSV needs columns: code, language, text.",
-            "import_csv_no_match": "No rows match the selected language ({{lang}}).",
-            "import_csv_skipped": "Skipped {{count}} row(s) in other languages: {{langs}}.",
-            "import_csv_more_errors": "{{count}} more issues"
-        },
-        "concourse_import": {
-            "title": "Import from Concourse",
-            "desc": "Select items from a concourse to import as study statements. Items are copied; changes to the concourse will not affect the study.",
-            "button_label": "Import from Concourse",
-            "select_concourse": "Concourse",
-            "select_placeholder": "Choose a concourse...",
-            "code_prefix": "Code prefix",
-            "code_prefix_placeholder": "e.g. S",
-            "only_accepted": "Only accepted",
-            "replace_existing": "Replace existing statements",
-            "replace_warning": "All existing statements will be permanently deleted and replaced by the selected items.",
-            "selected": "{{count}} selected",
-            "select_all": "Select all",
-            "import_button": "Import {{count}} statements",
-            "success": "{{count}} statements imported",
-            "error": "Could not import items from the concourse. Try again.",
-            "no_accepted": "No accepted items in this concourse. Uncheck \"Only accepted\" to see all.",
-            "no_items": "This concourse has no items.",
-            "no_concourses": "No concourses in this project. Create one first."
-        },
-        "concourse_sync": {
-            "update_available": "Update",
-            "source_deleted": "Source deleted",
-            "source_deleted_tip": "The source concourse item has been deleted.",
-            "new_version": "New version in concourse:",
-            "synced": "Statement updated from concourse",
-            "error": "Could not sync from the concourse. Try again.",
-            "stale_banner": "{{count}} statement(s) have updates available from the concourse."
-        },
-        "analysis": {
-            "title": "Analysis",
-            "description": "Factor analysis of Q-sort data: extract viewpoints from participant responses",
-            "configuration": "Configuration",
-            "configuration_description": "Select extraction method, number of factors, and rotation",
-            "extraction_method": "Extraction",
-            "centroid": "Centroid",
-            "n_factors": "Factors",
-            "rotation_method": "Rotation",
-            "none": "None",
-            "run": "Run Analysis",
-            "run_will_replace": "Running again will replace the current results view. Use the history panel to compare runs.",
-            "running": "Analyzing...",
-            "reanalyzing": "Re-analyzing...",
-            "success": "Analysis complete. {{n}} factors extracted.",
-            "error": "Analysis failed: {{message}}",
-            "scree_hint": "Each bar shows how much variance a factor explains (its eigenvalue). The dashed line marks eigenvalue = 1 (Kaiser criterion). Click a bar to select the number of factors to extract.",
-            "kaiser_suggestion": "{{n}} factor(s) have eigenvalues above 1 (Kaiser criterion)",
-            "factor": "Factor",
-            "factor_n": "Factor {{n}}",
-            "eigenvalue": "Eigenvalue",
-            "too_few_participants": "Need at least 2 completed participants to run analysis.",
-            "eigenvalue_error": "Failed to load analysis data. Please try again.",
-            "scree_plot_label": "Scree plot showing eigenvalues for {{n}} factors",
-            "loading_eigenvalues": "Loading eigenvalues...",
-            "empty_state": "Set parameters and run the analysis.",
-            "empty": {
-                "contract_title": "Not enough Q-sort data yet",
-                "contract_body": "Q-methodology factor analysis requires at least 2 participants who have completed the sort. Configuration choices (extraction, factors, rotation, flagging) carry meaning once data exists. Share the study link from the overview to start collecting responses.",
-                "contract_cta": "Open study overview"
-            },
-            "advanced": {
-                "title": "Advanced settings",
-                "summary": "Rotation: {{rotation}} · Flagging: {{flagging}} · Bootstrap: {{bootstrap}}",
-                "bootstrap_off": "off",
-                "bootstrap_on": "{{n}} iterations"
-            },
-            "tab_loadings": "Loadings",
-            "tab_factor_arrays": "Factor Arrays",
-            "tab_statements": "Statements",
-            "tab_summary": "Summary",
-            "participant": "Participant",
-            "flagged": "Flagged",
-            "significance_threshold": "Significance threshold (p<0.05): ±{{threshold}}",
-            "sorts": "sorts",
-            "distinguishing_legend": "Distinguishing statement",
-            "code": "Code",
-            "statement": "Statement",
-            "type": "Type",
-            "distinguishing": "Distinguishing",
-            "consensus": "Consensus",
-            "variance_explained": "Variance Explained (%)",
-            "cumulative_variance": "Cumulative Variance (%)",
-            "n_flagged": "N Flagged Sorts",
-            "composite_reliability": "Composite Reliability",
-            "se_factor_scores": "SE of Factor Scores",
-            "factor_correlations": "Factor Correlations",
-            "high_correlation": "High correlation",
-            "total_variance": "Total Variance Explained",
-            "method_used": "Method",
-            "statements_label": "statements",
-            "pca": "PCA",
-            "varimax": "Varimax",
-            "metric": "Metric",
-            "caption_loadings": "Factor loadings per participant",
-            "caption_statements": "Statement z-scores and factor arrays per factor",
-            "caption_characteristics": "Factor characteristics and reliability statistics",
-            "caption_correlations": "Factor-to-factor correlation matrix",
-            "retry": "Retry",
-            "flagging_method": "Flagging",
-            "auto": "Auto",
-            "manual": "Manual",
-            "manual_flag_hint": "Click a loading cell to flag/unflag a participant for that factor. Re-run analysis to update results.",
-            "no_flagged_participants": "No participants flagged for any factor. Try adjusting the number of factors or flagging method.",
-            "no_statement_scores": "No statement scores available. Ensure participants are flagged for at least one factor.",
-            "no_characteristics": "No factor characteristics available.",
-            "export": "Export",
-            "export_loadings": "Factor loadings (CSV)",
-            "export_scores": "Statement scores (CSV)",
-            "export_xlsx": "Complete analysis (XLSX)",
-            "export_error": "Failed to generate XLSX export.",
-            "select_factors": "Select number of factors",
-            "loadings_help": "Factor loadings show how strongly each participant's sort correlates with each factor. Highlighted cells exceed the significance threshold shown above.",
-            "factor_array_help": "Composite Q-sort showing the idealized sort pattern for this factor. Statements are placed in the distribution based on their weighted z-scores.",
-            "factor_array_label": "Factor {{n}} composite sort",
-            "factor_arrays": {
-                "toggle_narratives": "Show factor narratives",
-                "toggle_narratives_aria": "Toggle per-factor interpretive narratives"
-            },
-            "statements_help": "Z-scores show each factor's standardized position on each statement. D = distinguishing (significantly different between factors), C = consensus (no significant differences).",
-            "z_scores_description": "Z-scores and factor array positions per statement",
-            "factor_statistics": "Factor Statistics",
-            "characteristics_help": "Eigenvalues reflect the amount of variance explained. Composite reliability reflects internal consistency among flagged sorts. SE of factor scores reflects the precision of the composite estimate.",
-            "help_extraction": "PCA maximises explained variance. Centroid is less mathematically constrained.",
-            "help_n_factors": "Each factor represents a distinct viewpoint.",
-            "help_rotation": "Varimax separates factors for simpler structure.",
-            "help_flagging": "Auto: flag participants loading on exactly one factor. Manual: override per participant.",
-            "guide_loadings_title": "Reading Factor Loadings",
-            "guide_loadings_1": "Each loading is a correlation (-1 to +1) between a participant and a factor (shared viewpoint).",
-            "guide_loadings_2": "Highlighted values exceed the significance threshold shown above the table.",
-            "guide_arrays_title": "Interpreting Factor Arrays",
-            "guide_arrays_1": "Each factor array is the composite Q-sort representing one shared viewpoint.",
-            "guide_arrays_2": "Read left-to-right as most disagreed to most agreed. Extreme positions carry the strongest signal for interpretation.",
-            "guide_statements_title": "Understanding Statement Scores",
-            "guide_statements_1": "Z-scores show how strongly each factor agrees or disagrees with each statement (0 = neutral).",
-            "guide_statements_2": "D = distinguishing (placed significantly differently across factors). Stars indicate significance level.",
-            "guide_summary_title": "Evaluating Your Solution",
-            "guide_summary_1": "Eigenvalues measure how much variance a factor explains. The Kaiser criterion (eigenvalue > 1) is one common heuristic for deciding how many factors to retain.",
-            "guide_summary_2": "Composite reliability reflects how consistently the flagged sorts define each factor. Higher values mean the factor estimate is based on more agreement among its defining sorts.",
-            "benchmark_above": "Above threshold",
-            "benchmark_below": "Below threshold",
-            "history": {
-                "title": "Analysis history",
-                "loading": "Loading history…",
-                "fetch_error": "Could not load analysis history.",
-                "empty": "No previous analyses for this study yet. Run one to start the audit trail.",
-                "empty_explainer": "Each run is logged here so you can document and revisit every decision.",
-                "load_error": "Could not load this analysis run. Refresh the page to retry.",
-                "load_run_aria": "Load analysis run from {{date}}",
-                "loading_run": "Loading…",
-                "current_tag": "current",
-                "n_factors_label": "{{n}}F",
-                "edit_notes": "Edit notes",
-                "edit_notes_aria": "Edit notes for this run",
-                "notes_placeholder": "Add a note about this run…",
-                "notes_aria": "Edit notes for this run",
-                "save_notes_aria": "Save notes",
-                "cancel_edit_aria": "Cancel editing",
-                "notes_saved": "Notes saved.",
-                "notes_error": "Could not save notes. Check your connection and try again.",
-                "delete_run": "Delete run",
-                "delete_run_aria": "Delete this analysis run",
-                "delete_dialog_title": "Delete analysis run?",
-                "delete_dialog_description": "Deleting an analysis run removes evidence of an analytical choice from the audit trail. Are you sure?",
-                "cancel": "Cancel",
-                "delete_confirm": "Delete",
-                "deleted": "Analysis run deleted.",
-                "delete_error": "Failed to delete the run.",
-                "viewing_banner": "Viewing run from {{date}}: {{extraction}} · {{n}}F · {{rotation}}",
-                "back_to_current": "Back to current"
-            },
-            "factor_voices": {
-                "title": "Voices on Factor {{n}}",
-                "no_audio": "No post-sort audio recordings from participants flagged on this factor.",
-                "no_material": "No post-sort audio recordings or written comments from participants flagged on this factor.",
-                "loading": "Loading recordings…",
-                "error": "Could not load audio recordings. Please try again.",
-                "context": "Ground factor interpretation in participants' own words: their audio rationales and their written card comments.",
-                "context_aria": "About this panel",
-                "audio_label": "Recording: {{key}} by {{participant}}",
-                "url_unavailable": "Audio URL not available.",
-                "comments_label": "Card comments"
-            },
-            "factor_note": {
-                "label": "Factor narrative",
-                "placeholder": "Write the interpretive narrative for this factor: the discourse, voices, and tensions it foregrounds.",
-                "empty_hint": "Add an interpretive narrative for this factor",
-                "char_count": "{{n}}/{{max}}",
-                "edit_aria": "Edit factor {{n}} narrative",
-                "save_aria": "Save factor narrative",
-                "cancel_aria": "Cancel editing",
-                "aria": "Edit factor {{n}} narrative",
-                "saved": "Factor narrative saved.",
-                "error": "Failed to save the factor narrative."
-            },
-            "rotation": {
-                "judgmental": {
-                    "label": "Judgmental (manual)",
-                    "short": "Judgmental",
-                    "tooltip": "Manually rotate factor pairs by chosen angles to align factors with substantively-meaningful positions."
-                }
-            },
-            "manual_rotations": {
-                "title": "Manual rotations",
-                "helper": "Specify rotations as 'rotate factor F by Δ° around factor G'. Rotations are applied in order.",
-                "add": "Add rotation",
-                "remove_aria": "Remove rotation",
-                "empty": "Add at least one rotation to run the analysis.",
-                "factor_a_label": "Rotate factor",
-                "angle_label": "by",
-                "factor_b_label": "around factor"
-            },
-            "bootstrap": {
-                "toggle_label": "Run bootstrap stability",
-                "iterations_label": "Iterations (B)",
-                "helper": "Optional. Resamples Q-sorts B times to estimate confidence intervals on factor scores.",
-                "running": "Running bootstrap…",
-                "se_column": "Mean SE (z)",
-                "tooltip": "Non-parametric bootstrap of Q-sorts (resampled with replacement); analysis is repeated B times to estimate 95% CIs on z-scores."
-            },
-            "explore": {
-                "diagnostics_title": "Diagnostics",
-                "kaiser": "Kaiser",
-                "parallel": "Parallel analysis",
-                "map": "Velicer's MAP",
-                "advisory": "Advisory only. Q-method retention also depends on interpretability and stability (Watts & Stenner 2012).",
-                "preview_range_title": "Preview range",
-                "preview_range_disabled": "Preview range supports PCA + varimax only. Centroid extraction and judgmental rotation are path-dependent; commit a real run to inspect.",
-                "select_k": "{{k}} factors",
-                "empty_factor": "Empty factor (over-factorisation)",
-                "cumvar": "cumvar %",
-                "pct_flagged": "% flagged",
-                "n_distinguishing": "# distinguishing",
-                "n_cross_loaders": "# cross-loaders",
-                "min_def_sorts": "min defining sorts",
-                "advanced_title": "Advanced configuration",
-                "commit_cta": "Commit and interpret"
-            },
-            "interpret": {
-                "def_sorts": "Defining sorts: {{n}}",
-                "statements_title": "Statements",
-                "narrative_title": "F{{n}} narrative",
-                "insert_comment_quote": "Insert comment as quote",
-                "focus_mode": "Per-factor focus",
-                "overview_mode": "Overview",
-                "mode_toggle": "View mode"
-            },
-            "compare": {
-                "pin_cta": "Pin compare",
-                "no_other_runs": "No other runs available",
-                "run_label": "Run #{{id}} ({{n}} factors)",
-                "pinned": "Comparing with run #{{id}}",
-                "phi": "φ = {{phi}}",
-                "ambiguous": "ambiguous match (interpret deltas with care)",
-                "unpin": "Unpin",
-                "delta_z_aria": "Δz {{delta}} vs compare run",
-                "delta_loading_aria": "Δloading {{delta}} vs compare run"
-            },
-            "quote_insert_format": "> {{text}}\n> {{p}}, on statement {{code}}: \"{{stmt}}\""
-        },
-        "project": {
-            "remove_member": "Remove member",
-            "table_caption": "Project members",
-            "switcher": {
-                "settings": "Project settings",
-                "settings_desc": "Members & profiles",
-                "new_project": "New project",
-                "new_project_desc": "Create a new project"
-            },
-            "roles": {
-                "owner": "Owner",
-                "admin": "Administrator",
-                "viewer": "Viewer",
-                "member": "Member"
-            },
-            "study_states": {
-                "active": "Active",
-                "draft": "Draft",
-                "paused": "Paused",
-                "closed": "Closed"
-            },
-            "create": {
-                "title": "Create project",
-                "card_title": "Project details",
-                "name_label": "Project name",
-                "name_placeholder": "Climate attitudes Q study",
-                "url_label": "Project URL",
-                "url_placeholder": "climate-attitudes-q-study",
-                "url_description": "This becomes the project path under /app/.",
-                "cancel": "Cancel",
-                "create_button": "Create project",
-                "creating": "Creating...",
-                "success": "Project created successfully",
-                "error": "Failed to create project"
-            }
-        },
-        "recruitment": {
-            "title": "Access",
-            "description": "Configure the study URL, manage participant access, and track recruitment efficiency.",
-            "study_url": {
-                "title": "Study URL",
-                "description": "The public address where participants access your study.",
-                "full_url_label": "Full URL",
-                "slug_label": "URL slug",
-                "slug_description": "The unique identifier used in the study URL. Lowercase letters, numbers, and hyphens only.",
-                "slug_locked": "The URL slug can only be changed while the study is in draft mode."
-            },
-            "state_draft": "Draft mode. Links will work once you activate the study.",
-            "state_closed": "This study is closed. Existing links remain visible but new participants cannot start.",
-            "state_archived": "This study is archived. All recruitment data is read-only.",
-            "empty_title": "No recruitment links yet",
-            "empty_description": "Create your first link to start inviting participants.",
-            "empty_cta": "Create access link",
-            "stats_summary": {
-                "links": "links",
-                "started": "started",
-                "submitted": "submitted"
-            },
-            "access_rules": {
-                "title": "Access rules",
-                "description": "Control when and how participants can access the study.",
-                "password_toggle": "Require a password",
-                "password_toggle_desc": "Participants must enter a password before starting the study.",
-                "password_label": "Access password",
-                "password_placeholder": "Enter access password",
-                "password_locked": "Password protection can only be changed while the study is in draft mode.",
-                "password_set": "A password is currently set. Enter a new value to change it, or toggle off to remove.",
-                "collection_window": "Collection window",
-                "window_toggle": "Limit collection window",
-                "window_toggle_help": "Restrict participant access to a specific time range.",
-                "start_date_label": "Opens at",
-                "end_date_label": "Closes at",
-                "date_hint": "Leave empty for no time restriction.",
-                "clear_date": "Clear date",
-                "save_button": "Save access rules",
-                "save_success": "Access rules updated",
-                "save_error": "Failed to update access rules",
-                "non_draft_notice": "Outside draft, only the collection window can be edited. Switch the study back to draft to change other access rules.",
-                "archived_notice": "This study is archived. Access rules are read-only."
-            },
-            "new_link": "New access link",
-            "create_title": "Create access links",
-            "link_type": "Access strategy",
-            "select_type": "Choose a recruitment type...",
-            "campaign_name": "Channel / campaign name",
-            "name_placeholder": "E.g. LinkedIn, email batch a, student list...",
-            "link_count": "Batch size",
-            "capacity_label": "Max submissions",
-            "generate_links": "Provision links",
-            "no_links": "No recruitment links generated yet.",
-            "unnamed": "Unnamed channel",
-            "revoked": "Access revoked",
-            "qr_title": "Share via QR",
-            "copy_link": "Copy URL",
-            "table_title": "Recruitment links",
-            "share_title": "Share study",
-            "share_desc": "Distribute your study URL to invite participants.",
-            "public_url_label": "Public participation URL",
-            "hide_qr": "Hide QR",
-            "show_qr": "Show QR code",
-            "delete_link": "Delete link",
-            "qr_alt": "QR code for {{url}}",
-            "table_caption": "Recruitment links",
-            "progress_label": "{{count}} of {{max}} responses",
-            "usage": {
-                "started": "started",
-                "submitted": "submitted",
-                "completed": "Completed",
-                "in_progress": "In progress",
-                "unused": "Unused"
-            },
-            "live_study": "Live study",
-            "download_qr": "Download image",
-            "qr_print_hint": "Scan or print this code for physical recruitment materials (flyers, posters).",
-            "analytics_title": "Campaign analytics",
-            "analytics_desc": "Direct links and QR scans are automatically tracked in the health dashboard above.",
-            "copy_success": "Study link copied to clipboard",
-            "types": {
-                "public": "Open access (public)",
-                "individual": "Single-Use passcode",
-                "limited": "Capped participation"
-            },
-            "guidance": {
-                "public": "Best for high-volume recruitment. A single URL for all participants.",
-                "individual": "Maximum security. Generates unique links that expire after one successful completion.",
-                "limited": "Controlled access. One link that stops working after a fixed number of submissions."
-            },
-            "stats": {
-                "total_links": "Total channels",
-                "active_channels": "Active recruitment lots",
-                "started": "Total sessions",
-                "engagements": "Participants who started",
-                "submitted": "Valid data",
-                "completions": "Finished submissions",
-                "conversion": "Capture rate",
-                "efficiency": "Final data yield"
-            },
-            "table": {
-                "name": "Campaign / lot",
-                "type": "Entry type",
-                "token": "Security token",
-                "usage": "Capacity",
-                "status": "State",
-                "actions": "Manage",
-                "type_help": "Public, Single-use, or Capacity-limited. See strategy descriptions in the \"New access link\" dialog."
-            },
-            "status": {
-                "public": "Public",
-                "individual": "Individual",
-                "limited": "Limited"
-            },
-            "toasts": {
-                "created": "Recruitment links created successfully",
-                "failed": "Could not create recruitment links. Check the inputs and try again.",
-                "revoked": "Link revoked",
-                "revoke_failed": "Could not revoke this link. It may already be in use.",
-                "copied": "Copied to clipboard"
-            }
-        },
-        "analytics": {
-            "charts": {
-                "recruitment_funnel": {
-                    "title": "Recruitment funnel",
-                    "subtitle": "Aggregate conversion performance",
-                    "initial_contact": "Initial contact",
-                    "completion": "Completion",
-                    "started_study": "Started study",
-                    "submitted": "Submitted",
-                    "yield": "Yield",
-                    "success_rate": "Success rate",
-                    "completion_rate": "{{rate}}% of starters completed"
-                },
-                "link_performance": {
-                    "title": "Link performance tracking",
-                    "subtitle": "Monitor individual recruitment channel effectiveness",
-                    "volume": "Volume",
-                    "yield": "Yield",
-                    "conversion_rate": "Conversion rate",
-                    "total_responses": "responses"
-                }
-            }
-        },
-        "breadcrumbs": {
-            "admin": "Admin",
-            "dashboard": "Dashboard",
-            "study_dashboard": "Overview",
-            "design": "Design",
-            "participants": "Participants",
-            "team": "Team",
-            "recruitment": "Access",
-            "exports": "Data",
-            "data": "Data",
-            "privacy": "Data privacy",
-            "account": "Account settings",
-            "participant_n": "Participant {{code}}",
-            "analysis": "Analysis",
-            "settings": "Settings",
-            "concourse": "Concourse",
-            "members": "Team members"
-        },
-        "command_menu": {
-            "title": "Global command menu",
-            "placeholder": "Type a command or search...",
-            "no_results": "No results found.",
-            "switch_project": "Switch project",
-            "switch_study": "Switch study",
-            "study_actions": "Study actions",
-            "system": "System",
-            "no_studies": "No studies in this project.",
-            "open_dashboard": "Open dashboard",
-            "design_study": "Study design",
-            "collaborators": "Collaborators",
-            "copy_link": "Copy public link",
-            "toggle_theme": "Toggle theme",
-            "logout": "Log out",
-            "search_label": "Search or run commands",
-            "to_open": "To open",
-            "active": "Active",
-            "link_copied": "Study link copied!",
-            "logged_out": "Logged out successfully",
-            "switched_project": "Switched to {{name}}"
-        },
-        "dashboard": {
-            "title": "Project dashboard",
-            "welcome": "Welcome back,",
-            "snapshot": "Here's a snapshot of your research activity.",
-            "create_study": "Create study",
-            "total_studies": "Total studies",
-            "across_statuses": "Across all statuses",
-            "active_data_collection": "Active data collection",
-            "receiving_responses": "Studies receiving responses",
-            "total_participants": "Total participants",
-            "all_studies": "All studies",
-            "all_studies_description": "All studies in this project.",
-            "languages_count_one": "{{count}} language",
-            "languages_count_other": "{{count}} languages",
-            "n_participants_one": "{{count}} participant",
-            "n_participants_other": "{{count}} participants",
-            "n_studies_one": "{{count}} study",
-            "n_studies_other": "{{count}} studies",
-            "n_active_one": "{{count}} active",
-            "n_active_other": "{{count}} active",
-            "n_participants_total_one": "{{count}} participant",
-            "n_participants_total_other": "{{count}} participants",
-            "concourse_n_items_one": "{{count}} statement",
-            "concourse_n_items_other": "{{count}} statements",
-            "concourse_open_hint": "Curate candidate statements",
-            "created": "Created",
-            "no_studies": "No studies found. Create your first study to get started!",
-            "import_study": "Import study",
-            "get_started": "Get started with your research project",
-            "onboarding_title": "First steps",
-            "step_create_project": "Create your project",
-            "step_create_project_desc": "Your project is ready.",
-            "step_concourse": "Collect statements in the concourse",
-            "step_concourse_desc": "Add the candidate statements from your literature review.",
-            "step_qset": "Select the Q-set",
-            "step_qset_desc": "Review and accept the items that will form your Q-set.",
-            "step_study": "Create a study",
-            "step_study_desc": "Define the sorting grid for your Q-sort.",
-            "step_import": "Import the Q-set into your study",
-            "step_import_desc": "Import the accepted concourse items as study statements.",
-            "step_configure": "Configure the participant flow",
-            "step_configure_desc": "Set up instructions, presort, and postsort questions.",
-            "step_launch": "Launch recruitment",
-            "step_launch_desc": "Generate participation links and share them.",
-            "go_to_concourse": "Open concourse",
-            "go_to_qset": "Open Q-set",
-            "concourse": "Concourse",
-            "concourse_empty": "No items yet. Start building your statement collection.",
-            "team": "Team",
-            "team_loading": "Loading...",
-            "studies": "Studies",
-            "active_studies": "Active",
-            "paused_studies": "Paused",
-            "draft_studies": "Drafts",
-            "closed_studies": "Completed",
-            "attention": "Needs attention",
-            "alert_deadline": "{{study}}: closing in {{days}} days with {{count}} participants",
-            "view": "View",
-            "open_study": "Open study",
-            "add_study": "Add study",
-            "closes": "Closes",
-            "timeline": {
-                "title": "Submissions timeline",
-                "subtitle": "Daily participation trends",
-                "started": "Started",
-                "completed": "Completed"
-            },
-            "devices": {
-                "title": "Device distribution",
-                "subtitle": "How participants access your study",
-                "types": {
-                    "desktop": "Desktop",
-                    "mobile": "Mobile",
-                    "tablet": "Tablet",
-                    "unknown": "Unknown"
-                }
-            },
-            "n_studies_help": "Total number of studies in this project, including drafts and closed.",
-            "n_active_help": "Studies currently accepting participant submissions (state = active).",
-            "n_participants_total_help": "Sum of completed participants across all studies in this project.",
-            "tool_help": {
-                "design": "Configure the study: distribution grid, conditions of instruction, statements, consent.",
-                "recruit": "Recruitment links, access rules, and study URL settings.",
-                "data": "Participant responses and exports (CSV, Q-sort dumps).",
-                "analysis": "Factor analysis configuration and historical runs."
-            }
-        },
-        "export": {
-            "config": "Export configuration",
-            "exporting": "Exporting...",
-            "config_success": "Configuration exported successfully",
-            "config_error": "Could not export configuration. Try again.",
-            "label": "Export data",
-            "success": "Export successful",
-            "error": "Export failed. Try again.",
-            "csv": "Export CSV",
-            "json": "Export JSON",
-            "audio": "Export Audio (ZIP)",
-            "formats": {
-                "csv": "CSV",
-                "pqmethod": "PQMethod (ZIP)",
-                "rkit": "R-Kit (ZIP)",
-                "package": "Research Package (ZIP)",
-                "json": "JSON Dump"
-            },
-            "download": "Download",
-            "package_dialog": {
-                "title": "Download research package",
-                "description": "Bundles all study data into a single ZIP for OSF / pre-registration.",
-                "discussion_hint": "Adds memo/memo-discussion.md with all comment threads (signed and dated). Off by default; keep your export clean unless you want the deliberation trail."
-            }
-        },
-        "import": {
-            "title": "Import study configuration",
-            "config": "Import Configuration",
-            "upload_desc": "Upload a previously exported study configuration file",
-            "validate_desc": "Review configuration and provide a unique slug",
-            "creating_desc": "Creating study...",
-            "file_upload": "File upload",
-            "paste_json": "Paste JSON",
-            "drop_here": "Drop file here",
-            "drag_drop": "Drag & drop JSON file or click to browse",
-            "supported": "Supported format: .json",
-            "paste_label": "Paste JSON configuration",
-            "validate": "Validate & continue",
-            "valid": "Configuration is valid",
-            "invalid": "Configuration has errors",
-            "errors": "Errors",
-            "warnings": "Warnings",
-            "summary": "Study summary",
-            "title_field": "Title",
-            "languages": "Languages",
-            "statements": "Statements",
-            "grid": "Grid range",
-            "new_slug": "New study slug",
-            "slug_help": "Must be unique, 3-100 characters, lowercase letters, numbers, and hyphens only",
-            "creating": "Creating study from configuration...",
-            "create_study": "Create study",
-            "invalid_json": "Invalid JSON file",
-            "validation_failed": "Configuration is invalid",
-            "success": "Study imported successfully",
-            "redirecting": "Opening study designer...",
-            "failed": "Could not import study. See details below and retry.",
-            "validation": {
-                "errors": {
-                    "missing_version": "Missing version field",
-                    "unsupported_version": "Unsupported version: {{version}}",
-                    "missing_field": "Missing required field: {{field}}",
-                    "no_translations": "At least one translation required",
-                    "missing_translation_field": "Translation {{index}} missing required field: {{field}}",
-                    "invalid_lang_code": "Invalid language code: {{lang}}",
-                    "no_statements": "At least one statement required",
-                    "duplicate_codes": "Duplicate statement codes: {{codes}}",
-                    "missing_stmt_translations": "Statement {{index}} missing translations",
-                    "invalid_grid_config": "Invalid grid_config: must be a list",
-                    "invalid_grid_structure": "Invalid grid_config structure: {{error}}"
-                },
-                "warnings": {
-                    "grid_capacity_mismatch": "Statement count ({{count}}) doesn't match grid capacity ({{capacity}})",
-                    "missing_consent_draft": "Consent title or description missing (draft study)",
-                    "external_branding_logo": "Branding logo uses an external URL: {{url}}",
-                    "external_partner_logo": "Partner logo for '{{name}}' uses an external URL: {{url}}",
-                    "external_logo": "Logo URL references external resource - may not be accessible"
-                }
-            }
-        },
-        "dialogs": {
-            "create_study": {
-                "title": "Create new study",
-                "description": "Start a new q-methodology study. You can configure statements and settings later.",
-                "study_title": "Study title",
-                "study_title_placeholder": "E.g. Perspectives on AI",
-                "url_slug": "URL slug",
-                "url_slug_placeholder": "e.g. ai-perspectives-2025",
-                "cancel": "Cancel",
-                "create": "Create study",
-                "success": "Study created successfully",
-                "error": "Failed to create study",
-                "languages": "Languages",
-                "languages_desc": "Select the languages to enable. Content will be initialized with localized defaults."
-            }
-        },
+        "flexible": {
+          "label": "Elastyczny",
+          "tooltip": "Łączna liczba kart = rozmiar zbioru Q; pojemności kolumn są miękkimi wskazówkami (tylko ostrzeżenia)."
+        }
+      },
+      "rough_sort": {
+        "toggle_label": "Włącz wstępne sortowanie (triaż na 3 stosy)",
+        "lock_banner": "Przełącznik zablokowany. {{count}} uczestnik(-ów) rozpoczął(-ęło) ankietę; zarchiwizuj lub usuń te sesje przed zmianą tego ustawienia.",
+        "deck_mode_note": "Wyłączone. Uczestnicy widzą pełny zbiór Q jako przewijany poziomo talia kart."
+      }
+    },
+    "study": {
+      "activate_error": "Nie można aktywować badania. Sprawdź, czy projekt badania jest prawidłowy, i spróbuj ponownie.",
+      "save": {
+        "success": "Zmiany zapisane pomyślnie",
+        "save_success": "Zapisano pomyślnie",
+        "synced_warnings": "Zsynchronizowano z serwerem. Zachowano zmiany w: {{fields}}",
+        "synced_concurrent": "Zsynchronizowano ze zmianami wprowadzonymi przez innego użytkownika",
+        "conflict": "Wykryto konflikt. Niektórych zmian nie można było scalić.",
+        "error": "Nie udało się zapisać zmian"
+      },
+      "postsort": {
+        "missing": {
+          "title": "Brakujące stwierdzenia",
+          "desc": "Czy w zestawie stwierdzeń brakowało jakichś idei lub perspektyw?"
+        }
+      },
+      "state": {
+        "manage": "Zarządzaj przebiegiem badania"
+      }
+    },
+    "components": {
+      "markdown": {
+        "label": "Markdown",
+        "tooltip": "Obsługuje Markdown do bogatego formatowania",
+        "bold": "Pogrubienie",
+        "italic": "Kursywa",
+        "list": "Lista",
+        "link": "Link",
+        "edit": "Edytuj",
+        "preview": "Podgląd",
+        "empty": "Brak treści do podglądu"
+      },
+      "click_to_edit": "Kliknij, aby edytować"
+    },
+    "layout": {
+      "title": "Admin",
+      "back_home": "Wróć do strony głównej",
+      "beta": "Wersja badawcza beta",
+      "logout": "Wyloguj",
+      "account": "Ustawienia konta",
+      "admin_user": "Użytkownik administracyjny"
+    },
+    "account": {
+      "title": "Ustawienia konta",
+      "description": "Zarządzaj danymi osobowymi i bezpieczeństwem konta.",
+      "personal": {
+        "title": "Dane osobowe",
+        "email": "Adres e-mail",
+        "email_locked": "Zmiana adresu e-mail przez API będzie wkrótce dostępna na tej stronie; obsługa serwerowa jest już aktywna.",
+        "name": "Imię i nazwisko",
+        "save": "Zapisz",
+        "saving": "Zapisywanie...",
+        "success": "Profil zaktualizowany pomyślnie",
+        "error": "Nie udało się zaktualizować profilu",
+        "cannot_remove_self": "Nie można usunąć samego siebie",
+        "name_required": "Imię i nazwisko jest wymagane"
+      },
+      "security": {
+        "title": "Bezpieczeństwo",
+        "description": "Zarządzaj weryfikacją dwuetapową i hasłem.",
+        "tfa_subtitle": "Weryfikacja dwuetapowa",
+        "password_subtitle": "Hasło",
+        "enabled": "Włączone",
+        "setup_cta": "Skonfiguruj weryfikację dwuetapową",
+        "configure_title": "Konfiguruj aplikację uwierzytelniającą",
+        "scan_desc": "Zeskanuj ten kod QR aplikacją uwierzytelniającą (Google Authenticator, Authy itp.)",
+        "enter_code": "Wpisz 6-cyfrowy kod",
+        "enable_btn": "Włącz weryfikację dwuetapową",
+        "disable_btn": "Wyłącz weryfikację dwuetapową",
+        "confirm_disable": "Potwierdź wyłączenie",
+        "confirm_password_label": "Potwierdź hasłem",
+        "verifying": "Weryfikowanie...",
+        "cancel": "Anuluj",
+        "enabled_success": "Weryfikacja dwuetapowa włączona",
+        "disabled_success": "Weryfikacja dwuetapowa wyłączona",
+        "secret_copied": "Sekret skopiowany",
+        "invalid_token": "Nieprawidłowy kod weryfikacyjny",
+        "disable_error": "Nie udało się wyłączyć weryfikacji dwuetapowej",
+        "channel_select_label": "Jak dostarczać kody weryfikacji dwuetapowej?",
+        "channel_app": "Aplikacja uwierzytelniająca (zalecane)",
+        "channel_email": "E-mail",
+        "channel_email_desc": "Będziemy wysyłać 6-cyfrowy kod e-mailem przy każdym logowaniu. Przydatne, gdy nie można zainstalować aplikacji uwierzytelniającej.",
+        "enable_email_btn": "Włącz weryfikację dwuetapową przez e-mail",
+        "enable_email_pending": "Włączanie…"
+      },
+      "password": {
+        "title": "Zarządzanie hasłem",
+        "current": "Aktualne hasło",
+        "new": "Nowe hasło",
+        "change_btn": "Zmień hasło",
+        "updating": "Aktualizowanie...",
+        "success": "Hasło zmienione pomyślnie",
+        "error": "Nie udało się zmienić hasła. Sprawdź aktualne hasło.",
         "validation": {
-            "required": "Required",
-            "slug_min": "Slug must be at least 3 characters",
-            "slug_regex": "Slug must contain only lowercase letters, numbers, and hyphens"
+          "required": "Wymagane",
+          "min_length": "Min. 8 znaków"
+        }
+      }
+    },
+    "sidebar": {
+      "home": "Panel",
+      "add_study": "Dodaj badanie",
+      "create_project": "UTWÓRZ NOWY PROJEKT",
+      "dashboard": "Panel",
+      "overview": "Przegląd",
+      "design": "Projekt",
+      "recruit": "Dostęp",
+      "data": "Dane",
+      "analysis": "Analiza",
+      "privacy": "Prywatność danych",
+      "team": "Zespół",
+      "settings": "Ustawienia badania",
+      "project_settings": "Ustawienia projektu",
+      "study_tools": "Narzędzia badania",
+      "project": "Projekt",
+      "documentation": "Dokumentacja",
+      "support": "Wsparcie",
+      "study_management": "Zarządzanie badaniem",
+      "search": "Szukaj...",
+      "studies": "Badania",
+      "select_study": "Wybierz badanie",
+      "select_study_msg": "Wybierz lub utwórz badanie, aby rozpocząć.",
+      "view_all_studies": "Wszystkie badania",
+      "study": "Badanie",
+      "select_project": "Wybierz projekt",
+      "concourses": "Konkursy",
+      "concourse": "Konkurs",
+      "members": "Członkowie zespołu"
+    },
+    "concourse": {
+      "title": "Konkurs",
+      "description": "Zarządzaj stwierdzeniami kandydatów do badania metodologią Q",
+      "default_title": "Konkurs",
+      "default_title_for_project": "Konkurs {{project}}",
+      "create": "Nowy konkurs",
+      "create_success": "Konkurs utworzony",
+      "create_error": "Nie udało się utworzyć konkursu",
+      "create_dialog_title": "Utwórz konkurs",
+      "create_dialog_desc": "Konkurs to zbiór stwierdzień kandydatów, spośród których zostanie wybrany zbiór Q.",
+      "field_title": "Tytuł",
+      "field_title_placeholder": "np. Postawy wobec zmian klimatu",
+      "field_description": "Opis",
+      "field_description_placeholder": "Krótki opis tego konkursu...",
+      "field_code": "Kod",
+      "field_text": "Tekst stwierdzenia",
+      "field_text_placeholder": "Wpisz tekst stwierdzenia...",
+      "field_source": "Źródło",
+      "items_label": "elementów",
+      "updated": "Zaktualizowano",
+      "empty_title": "Brak konkursów",
+      "empty_desc": "Utwórz konkurs, aby zacząć zbierać i porządkować stwierdzenia kandydatów do badań metodologią Q.",
+      "add_item": "Dodaj element",
+      "bulk_import": "Import zbiorczy",
+      "import_desc": "Wklej stwierdzenia oddzielone nową linią. Każda linia staje się jednym elementem.",
+      "import_prefix": "Prefiks kodu",
+      "import_statements": "Stwierdzenia",
+      "import_placeholder": "Jedno stwierdzenie na wiersz...",
+      "items_to_import": "stwierdzeń do importu",
+      "import_button": "Importuj",
+      "import_success": "Zaimportowano {{count}} elementów",
+      "import_error": "Import nie powiódł się",
+      "item_created": "Element dodany",
+      "item_create_error": "Nie udało się dodać elementu",
+      "item_updated": "Element zaktualizowany",
+      "item_update_error": "Nie udało się zaktualizować elementu",
+      "item_deleted": "Element usunięty",
+      "item_delete_error": "Nie udało się usunąć elementu",
+      "status_error": "Nie udało się zmienić statusu",
+      "search_placeholder": "Szukaj elementów...",
+      "source_placeholder": "np. Wywiad nr 3, Przegląd literatury",
+      "no_items": "Brak elementów. Dodaj pierwsze stwierdzenie.",
+      "no_matches": "Żaden element nie pasuje do filtrów.",
+      "danger_zone": "Strefa zagrożenia",
+      "delete": "Usuń konkurs",
+      "delete_confirm": "Czy na pewno chcesz usunąć ten konkurs i wszystkie jego elementy?",
+      "deleted": "Konkurs usunięty",
+      "delete_error": "Nie udało się usunąć konkursu",
+      "delete_item_title": "Usuń element",
+      "delete_item_confirm": "Usunąć ten element? Tego działania nie można cofnąć.",
+      "status": {
+        "proposed": "Proponowane",
+        "accepted": "Zaakceptowane",
+        "rejected": "Odrzucone"
+      },
+      "change_note_placeholder": "Uwaga do zmiany (opcjonalnie)",
+      "history": "Historia",
+      "comments": "Komentarze",
+      "no_history": "Brak historii edycji.",
+      "no_comments": "Brak komentarzy.",
+      "add_comment": "Napisz komentarz...",
+      "send_comment": "Wyślij",
+      "comment_added": "Komentarz dodany",
+      "comment_error": "Nie udało się dodać komentarza. Proszę spróbować ponownie.",
+      "version_label": "v{{n}}",
+      "item_detail_desc": "Historia i komentarze dla tego elementu",
+      "manage_tags": "Tagi",
+      "tag_name_placeholder": "Nazwa tagu",
+      "tag_color": "Kolor tagu",
+      "tag_created": "Tag utworzony",
+      "tag_create_error": "Nie udało się utworzyć tagu",
+      "tag_deleted": "Tag usunięty",
+      "tag_delete_error": "Nie udało się usunąć tagu",
+      "no_tags": "Brak tagów. Utwórz pierwszy tag powyżej.",
+      "field_tags": "Tagi",
+      "export_csv": "Eksportuj CSV",
+      "select_language": "Język",
+      "add_language": "Dodaj język",
+      "add_language_desc": "Wpisz kod języka (np. en, fr, fi).",
+      "add_language_desc_v2": "Wybierz język tłumaczeń stwierdzeń.",
+      "add_language_tooltip": "Dodaj język tłumaczenia",
+      "field_language": "Język",
+      "import_language": "Język",
+      "select_all": "Zaznacz wszystko",
+      "bulk_selected": "Zaznaczono {{count}}",
+      "bulk_set_status": "Ustaw status:",
+      "bulk_clear": "Wyczyść",
+      "bulk_status_success": "Zaktualizowano {{count}} elementów",
+      "bulk_status_error": "Nie udało się zaktualizować niektórych elementów",
+      "qset_title": "Kuracja",
+      "qset_pending": "{{count}} elementów do przejrzenia",
+      "qset_complete": "Wszystkie elementy przejrzane",
+      "show_pending": "Do przejrzenia",
+      "bulk_confirm_title": "Potwierdź zmianę statusu",
+      "bulk_confirm_desc": "Ustawić {{count}} elementów na \"{{status}}\"?",
+      "no_translation": "Brak tekstu",
+      "language_tooltip": "Język tekstów stwierdzeń",
+      "loading": "Konfigurowanie konkursu...",
+      "diff_code": "kod",
+      "diff_status": "status",
+      "diff_text": "tekst",
+      "diff_tags": "tagi",
+      "diff_changed": "Zmieniono:",
+      "methodological_context": {
+        "title": "Kontekst metodologiczny",
+        "subtitle": "Opcjonalne pola dokumentacyjne. Wypełnij to, co istotne dla projektu; pozostałe pozostaw puste."
+      },
+      "import_from_csv": "Importuj CSV/TSV…",
+      "import_csv_hint": "CSV/TSV wymaga kolumn: code, language, text.",
+      "import_csv_no_match": "Żaden wiersz nie pasuje do wybranego języka ({{lang}}).",
+      "import_csv_skipped": "Pominięto {{count}} wiersz(-y) w innych językach: {{langs}}.",
+      "import_csv_more_errors": "{{count}} więcej problemów"
+    },
+    "concourse_import": {
+      "title": "Importuj z konkursu",
+      "desc": "Wybierz elementy z konkursu, aby zaimportować je jako stwierdzenia badania. Elementy są kopiowane; zmiany w konkursie nie wpłyną na badanie.",
+      "button_label": "Importuj z konkursu",
+      "select_concourse": "Konkurs",
+      "select_placeholder": "Wybierz konkurs...",
+      "code_prefix": "Prefiks kodu",
+      "code_prefix_placeholder": "np. S",
+      "only_accepted": "Tylko zaakceptowane",
+      "replace_existing": "Zastąp istniejące stwierdzenia",
+      "replace_warning": "Wszystkie istniejące stwierdzenia zostaną trwale usunięte i zastąpione wybranymi elementami.",
+      "selected": "Wybrano: {{count}}",
+      "select_all": "Zaznacz wszystkie",
+      "import_button": "Importuj {{count}} stwierdzenia(-n)",
+      "success": "Zaimportowano {{count}} stwierdzenia(-n)",
+      "error": "Nie można zaimportować elementów z konkursu. Spróbuj ponownie.",
+      "no_accepted": "Brak zaakceptowanych elementów w tym konkursie. Odznacz opcję \"Tylko zaakceptowane\", aby zobaczyć wszystkie.",
+      "no_items": "Ten konkurs nie ma żadnych elementów.",
+      "no_concourses": "Brak konkursów w tym projekcie. Najpierw utwórz konkurs."
+    },
+    "concourse_sync": {
+      "update_available": "Aktualizacja",
+      "source_deleted": "Źródło usunięte",
+      "source_deleted_tip": "Element źródłowy konkursu został usunięty.",
+      "new_version": "Nowa wersja w konkursie:",
+      "synced": "Stwierdzenie zaktualizowane z konkursu",
+      "error": "Nie można zsynchronizować z konkursem. Spróbuj ponownie.",
+      "stale_banner": "{{count}} stwierdzenie(-n) ma dostępne aktualizacje z konkursu."
+    },
+    "analysis": {
+      "title": "Analiza",
+      "description": "Analiza czynnikowa danych z sortowania Q: wyodrębnianie punktów widzenia z odpowiedzi uczestników",
+      "configuration": "Konfiguracja",
+      "configuration_description": "Wybierz metodę ekstrakcji, liczbę czynników i rotację",
+      "extraction_method": "Ekstrakcja",
+      "centroid": "Centroid",
+      "n_factors": "Czynniki",
+      "rotation_method": "Rotacja",
+      "none": "Brak",
+      "run": "Uruchom analizę",
+      "run_will_replace": "Ponowne uruchomienie zastąpi bieżący widok wyników. Użyj panelu historii, aby porównać przebiegi.",
+      "running": "Analizowanie...",
+      "reanalyzing": "Ponowne analizowanie...",
+      "success": "Analiza zakończona. Wyodrębniono {{n}} czynników.",
+      "error": "Analiza nie powiodła się: {{message}}",
+      "scree_hint": "Każdy słupek pokazuje, ile wariancji wyjaśnia dany czynnik (jego wartość własna). Przerywana linia oznacza wartość własną = 1 (kryterium Kaisera). Kliknij słupek, aby wybrać liczbę czynników do wyodrębnienia.",
+      "kaiser_suggestion": "{{n}} czynnik(-ów) ma wartości własne powyżej 1 (kryterium Kaisera)",
+      "factor": "Czynnik",
+      "factor_n": "Czynnik {{n}}",
+      "eigenvalue": "Wartość własna",
+      "too_few_participants": "Do uruchomienia analizy potrzebne są co najmniej 2 ukończone sortowania.",
+      "eigenvalue_error": "Nie udało się wczytać danych analizy. Proszę spróbować ponownie.",
+      "scree_plot_label": "Wykres osypiska pokazujący wartości własne dla {{n}} czynników",
+      "loading_eigenvalues": "Wczytywanie wartości własnych...",
+      "empty_state": "Ustaw parametry i uruchom analizę.",
+      "empty": {
+        "contract_title": "Za mało danych z sortowania Q",
+        "contract_body": "Analiza czynnikowa metodologii Q wymaga co najmniej 2 uczestników, którzy ukończyli sortowanie. Opcje konfiguracji (ekstrakcja, czynniki, rotacja, oznaczanie) nabierają znaczenia po zgromadzeniu danych. Udostępnij link do badania z widoku ogólnego, aby zacząć zbierać odpowiedzi.",
+        "contract_cta": "Otwórz widok ogólny badania"
+      },
+      "advanced": {
+        "title": "Ustawienia zaawansowane",
+        "summary": "Rotacja: {{rotation}} · Oznaczanie: {{flagging}} · Bootstrap: {{bootstrap}}",
+        "bootstrap_off": "wyłączony",
+        "bootstrap_on": "{{n}} iteracji"
+      },
+      "tab_loadings": "Ładunki",
+      "tab_factor_arrays": "Tablice czynnikowe",
+      "tab_statements": "Stwierdzenia",
+      "tab_summary": "Podsumowanie",
+      "participant": "Uczestnik",
+      "flagged": "Oznaczony",
+      "significance_threshold": "Próg istotności (p<0,05): ±{{threshold}}",
+      "sorts": "sortowania",
+      "distinguishing_legend": "Stwierdzenie różnicujące",
+      "code": "Kod",
+      "statement": "Stwierdzenie",
+      "type": "Typ",
+      "distinguishing": "Różnicujące",
+      "consensus": "Konsensusowe",
+      "variance_explained": "Wyjaśniona wariancja (%)",
+      "cumulative_variance": "Skumulowana wariancja (%)",
+      "n_flagged": "Liczba oznaczonych sortowań",
+      "composite_reliability": "Rzetelność złożona",
+      "se_factor_scores": "Błąd standardowy wyników czynnikowych",
+      "factor_correlations": "Korelacje czynników",
+      "high_correlation": "Wysoka korelacja",
+      "total_variance": "Łączna wyjaśniona wariancja",
+      "method_used": "Metoda",
+      "statements_label": "stwierdzenia",
+      "pca": "PCA",
+      "varimax": "Varimax",
+      "metric": "Metryka",
+      "caption_loadings": "Ładunki czynnikowe na uczestnika",
+      "caption_statements": "Wyniki z i tablice czynnikowe na czynnik",
+      "caption_characteristics": "Charakterystyki czynników i statystyki rzetelności",
+      "caption_correlations": "Macierz korelacji między czynnikami",
+      "retry": "Spróbuj ponownie",
+      "flagging_method": "Oznaczanie",
+      "auto": "Auto",
+      "manual": "Ręczny",
+      "manual_flag_hint": "Kliknij komórkę ładunku, aby oznaczyć/odznaczyć uczestnika dla danego czynnika. Uruchom ponownie analizę, aby zaktualizować wyniki.",
+      "no_flagged_participants": "Żaden uczestnik nie jest oznaczony dla żadnego czynnika. Spróbuj dostosować liczbę czynników lub metodę oznaczania.",
+      "no_statement_scores": "Brak dostępnych wyników stwierdzeń. Upewnij się, że uczestnicy są oznaczeni dla co najmniej jednego czynnika.",
+      "no_characteristics": "Brak dostępnych charakterystyk czynników.",
+      "export": "Eksportuj",
+      "export_loadings": "Ładunki czynnikowe (CSV)",
+      "export_scores": "Wyniki stwierdzeń (CSV)",
+      "export_xlsx": "Pełna analiza (XLSX)",
+      "export_error": "Nie udało się wygenerować eksportu XLSX.",
+      "select_factors": "Wybierz liczbę czynników",
+      "loadings_help": "Ładunki czynnikowe pokazują, jak silnie sortowanie każdego uczestnika koreluje z każdym czynnikiem. Wyróżnione komórki przekraczają próg istotności podany powyżej.",
+      "factor_array_help": "Złożone sortowanie Q pokazujące wyidealizowany wzorzec sortowania dla tego czynnika. Stwierdzenia są rozmieszczone w rozkładzie na podstawie ważonych wyników z.",
+      "factor_array_label": "Złożone sortowanie czynnika {{n}}",
+      "factor_arrays": {
+        "toggle_narratives": "Pokaż interpretacje czynników",
+        "toggle_narratives_aria": "Przełącz interpretacje poszczególnych czynników"
+      },
+      "statements_help": "Wyniki z pokazują standardową pozycję każdego czynnika na każdym stwierdzeniu. D = różnicujące (istotnie różne między czynnikami), C = konsensusowe (brak istotnych różnic).",
+      "z_scores_description": "Wyniki z i pozycje tablicy czynnikowej na stwierdzenie",
+      "factor_statistics": "Statystyki czynników",
+      "characteristics_help": "Wartości własne odzwierciedlają ilość wyjaśnionej wariancji. Rzetelność złożona odzwierciedla wewnętrzną spójność oznaczonych sortowań. Błąd standardowy wyników czynnikowych odzwierciedla precyzję estymacji złożonej.",
+      "help_extraction": "PCA maksymalizuje wyjaśnianą wariancję. Centroid jest mniej ograniczony matematycznie.",
+      "help_n_factors": "Każdy czynnik reprezentuje odrębny punkt widzenia.",
+      "help_rotation": "Varimax rozdziela czynniki dla prostszej struktury.",
+      "help_flagging": "Auto: oznaczaj uczestników ładujących się na dokładnie jeden czynnik. Ręczny: nadpisuj ręcznie dla każdego uczestnika.",
+      "guide_loadings_title": "Odczytywanie ładunków czynnikowych",
+      "guide_loadings_1": "Każdy ładunek to korelacja (od −1 do +1) między uczestnikiem a czynnikiem (wspólnym punktem widzenia).",
+      "guide_loadings_2": "Wyróżnione wartości przekraczają próg istotności pokazany powyżej tabeli.",
+      "guide_arrays_title": "Interpretacja tablic czynnikowych",
+      "guide_arrays_1": "Każda tablica czynnikowa to złożone sortowanie Q reprezentujące jeden wspólny punkt widzenia.",
+      "guide_arrays_2": "Czytaj od lewej do prawej: od największego braku zgody do największej zgody. Pozycje skrajne niosą najsilniejszy sygnał interpretacyjny.",
+      "guide_statements_title": "Rozumienie wyników stwierdzeń",
+      "guide_statements_1": "Wyniki z pokazują, jak silnie każdy czynnik zgadza się lub nie zgadza z każdym stwierdzeniem (0 = neutralnie).",
+      "guide_statements_2": "D = różnicujące (umieszczone istotnie różnie między czynnikami). Gwiazdki wskazują poziom istotności.",
+      "guide_summary_title": "Ocena rozwiązania",
+      "guide_summary_1": "Wartości własne mierzą, ile wariancji wyjaśnia dany czynnik. Kryterium Kaisera (wartość własna > 1) to jedna z popularnych heurystyk decydowania o liczbie czynników do zachowania.",
+      "guide_summary_2": "Rzetelność złożona odzwierciedla, jak spójnie oznaczone sortowania definiują dany czynnik. Wyższe wartości oznaczają, że estymacja czynnika opiera się na większej zgodności sortowań go definiujących.",
+      "benchmark_above": "Powyżej progu",
+      "benchmark_below": "Poniżej progu",
+      "history": {
+        "title": "Historia analiz",
+        "loading": "Wczytywanie historii…",
+        "fetch_error": "Nie udało się wczytać historii analiz.",
+        "empty": "Brak poprzednich analiz dla tego badania. Uruchom jedną, aby rozpocząć ślad audytu.",
+        "empty_explainer": "Każde uruchomienie jest tutaj rejestrowane, aby można było dokumentować i ponownie przeglądać każdą decyzję.",
+        "load_error": "Nie udało się wczytać tego przebiegu analizy. Odśwież stronę, aby spróbować ponownie.",
+        "load_run_aria": "Wczytaj przebieg analizy z {{date}}",
+        "loading_run": "Wczytywanie…",
+        "current_tag": "bieżący",
+        "n_factors_label": "{{n}}C",
+        "edit_notes": "Edytuj notatki",
+        "edit_notes_aria": "Edytuj notatki dla tego przebiegu",
+        "notes_placeholder": "Dodaj notatkę o tym przebiegu…",
+        "notes_aria": "Edytuj notatki dla tego przebiegu",
+        "save_notes_aria": "Zapisz notatki",
+        "cancel_edit_aria": "Anuluj edycję",
+        "notes_saved": "Notatki zapisane.",
+        "notes_error": "Nie udało się zapisać notatek. Sprawdź połączenie i spróbuj ponownie.",
+        "delete_run": "Usuń przebieg",
+        "delete_run_aria": "Usuń ten przebieg analizy",
+        "delete_dialog_title": "Usunąć przebieg analizy?",
+        "delete_dialog_description": "Usunięcie przebiegu analizy usuwa dowód analitycznego wyboru ze śladu audytu. Czy na pewno?",
+        "cancel": "Anuluj",
+        "delete_confirm": "Usuń",
+        "deleted": "Przebieg analizy usunięty.",
+        "delete_error": "Nie udało się usunąć przebiegu.",
+        "viewing_banner": "Podgląd przebiegu z {{date}}: {{extraction}} · {{n}}C · {{rotation}}",
+        "back_to_current": "Wróć do bieżącego"
+      },
+      "factor_voices": {
+        "title": "Głosy przy czynniku {{n}}",
+        "no_audio": "Brak nagrań audio po sortowaniu od uczestników oznaczonych dla tego czynnika.",
+        "no_material": "Brak nagrań audio po sortowaniu ani pisemnych komentarzy od uczestników oznaczonych dla tego czynnika.",
+        "loading": "Wczytywanie nagrań…",
+        "error": "Nie udało się wczytać nagrań audio. Proszę spróbować ponownie.",
+        "context": "Osadź interpretację czynnika we własnych słowach uczestników: ich uzasadnieniach audio i pisemnych komentarzach do kart.",
+        "context_aria": "O tym panelu",
+        "audio_label": "Nagranie: {{key}} — {{participant}}",
+        "url_unavailable": "URL audio niedostępny.",
+        "comments_label": "Komentarze do kart"
+      },
+      "factor_note": {
+        "label": "Interpretacja czynnika",
+        "placeholder": "Napisz interpretację tego czynnika: dyskurs, głosy i napięcia, które eksponuje.",
+        "empty_hint": "Dodaj interpretację dla tego czynnika",
+        "char_count": "{{n}}/{{max}}",
+        "edit_aria": "Edytuj interpretację czynnika {{n}}",
+        "save_aria": "Zapisz interpretację czynnika",
+        "cancel_aria": "Anuluj edycję",
+        "aria": "Edytuj interpretację czynnika {{n}}",
+        "saved": "Interpretacja czynnika zapisana.",
+        "error": "Nie udało się zapisać interpretacji czynnika."
+      },
+      "rotation": {
+        "judgmental": {
+          "label": "Ekspercka (ręczna)",
+          "short": "Ekspercka",
+          "tooltip": "Ręcznie obracaj pary czynników o wybrane kąty, aby ustawić je w merytorycznie sensownych pozycjach."
+        }
+      },
+      "manual_rotations": {
+        "title": "Rotacje ręczne",
+        "helper": "Podaj rotacje w formie: 'obróć czynnik F o Δ° wokół czynnika G'. Rotacje są stosowane w kolejności.",
+        "add": "Dodaj rotację",
+        "remove_aria": "Usuń rotację",
+        "empty": "Dodaj co najmniej jedną rotację, aby uruchomić analizę.",
+        "factor_a_label": "Obróć czynnik",
+        "angle_label": "o",
+        "factor_b_label": "wokół czynnika"
+      },
+      "bootstrap": {
+        "toggle_label": "Uruchom bootstrap stabilności",
+        "iterations_label": "Iteracje (B)",
+        "helper": "Opcjonalnie. Próbkuje sortowania Q B razy, aby oszacować przedziały ufności dla wyników czynnikowych.",
+        "running": "Trwa bootstrap…",
+        "se_column": "Średni błąd standardowy (z)",
+        "tooltip": "Nieparametryczny bootstrap sortowań Q (próbkowanie ze zwracaniem); analiza jest powtarzana B razy, aby oszacować 95% przedziały ufności dla wyników z."
+      },
+      "explore": {
+        "diagnostics_title": "Diagnostyka",
+        "kaiser": "Kaiser",
+        "parallel": "Analiza równoległa",
+        "map": "MAP Velicera",
+        "advisory": "Wyłącznie orientacyjne. Decyzja o liczbie czynników w metodologii Q zależy też od interpretowalności i stabilności (Watts i Stenner 2012).",
+        "preview_range_title": "Podgląd zakresu",
+        "preview_range_disabled": "Podgląd zakresu obsługuje tylko PCA + varimax. Ekstrakcja centroidów i rotacja ekspercka są zależne od ścieżki; zatwierdź rzeczywisty przebieg, aby sprawdzić.",
+        "select_k": "{{k}} czynników",
+        "empty_factor": "Pusty czynnik (nadmierna faktoryzacja)",
+        "cumvar": "skum. war. %",
+        "pct_flagged": "% oznaczonych",
+        "n_distinguishing": "# różnicujące",
+        "n_cross_loaders": "# wieloczynnikowe",
+        "min_def_sorts": "min. sortowań def.",
+        "advanced_title": "Konfiguracja zaawansowana",
+        "commit_cta": "Zatwierdź i interpretuj"
+      },
+      "interpret": {
+        "def_sorts": "Sortowania definiujące: {{n}}",
+        "statements_title": "Stwierdzenia",
+        "narrative_title": "Interpretacja C{{n}}",
+        "insert_comment_quote": "Wstaw komentarz jako cytat",
+        "focus_mode": "Fokus na czynnik",
+        "overview_mode": "Widok ogólny",
+        "mode_toggle": "Tryb widoku"
+      },
+      "compare": {
+        "pin_cta": "Przypnij do porównania",
+        "no_other_runs": "Brak innych dostępnych przebiegów",
+        "run_label": "Przebieg #{{id}} ({{n}} czynników)",
+        "pinned": "Porównanie z przebiegiem #{{id}}",
+        "phi": "φ = {{phi}}",
+        "ambiguous": "niejednoznaczne dopasowanie (interpretuj różnice ostrożnie)",
+        "unpin": "Odepnij",
+        "delta_z_aria": "Δz {{delta}} vs przebieg porównawczy",
+        "delta_loading_aria": "Δładunek {{delta}} vs przebieg porównawczy"
+      },
+      "quote_insert_format": "> {{text}}\n> {{p}}, o stwierdzeniu {{code}}: \"{{stmt}}\""
+    },
+    "project": {
+      "remove_member": "Usuń członka",
+      "table_caption": "Członkowie projektu",
+      "switcher": {
+        "settings": "Ustawienia projektu",
+        "settings_desc": "Członkowie i profile",
+        "new_project": "Nowy projekt",
+        "new_project_desc": "Utwórz nowy projekt"
+      },
+      "roles": {
+        "owner": "Właściciel",
+        "admin": "Administrator",
+        "viewer": "Obserwator",
+        "member": "Członek"
+      },
+      "study_states": {
+        "active": "Aktywne",
+        "draft": "Szkic",
+        "paused": "Wstrzymane",
+        "closed": "Zamknięte"
+      },
+      "create": {
+        "title": "Utwórz projekt",
+        "card_title": "Szczegóły projektu",
+        "name_label": "Nazwa projektu",
+        "name_placeholder": "Badanie Q postaw wobec klimatu",
+        "url_label": "URL projektu",
+        "url_placeholder": "badanie-q-postawy-klimat",
+        "url_description": "To staje sie sciezka projektu pod /app/.",
+        "cancel": "Anuluj",
+        "create_button": "Utwórz projekt",
+        "creating": "Tworzenie...",
+        "success": "Projekt został pomyślnie utworzony",
+        "error": "Nie udało się utworzyć projektu"
+      }
+    },
+    "recruitment": {
+      "title": "Dostęp",
+      "description": "Skonfiguruj URL badania, zarządzaj dostępem uczestników i śledź efektywność rekrutacji.",
+      "study_url": {
+        "title": "URL badania",
+        "description": "Publiczny adres, pod którym uczestnicy mają dostęp do badania.",
+        "full_url_label": "Pełny URL",
+        "slug_label": "URL slug",
+        "slug_description": "Unikalny identyfikator używany w URL badania. Tylko małe litery, cyfry i myślniki.",
+        "slug_locked": "Slug URL można zmieniać tylko w trybie szkicu."
+      },
+      "state_draft": "Tryb szkicu. Linki będą działać po aktywowaniu badania.",
+      "state_closed": "To badanie jest zamknięte. Istniejące linki pozostają widoczne, ale nowi uczestnicy nie mogą rozpocząć.",
+      "state_archived": "To badanie jest zarchiwizowane. Wszystkie dane rekrutacji są tylko do odczytu.",
+      "empty_title": "Brak linków rekrutacyjnych",
+      "empty_description": "Utwórz pierwszy link, aby zacząć zapraszać uczestników.",
+      "empty_cta": "Utwórz link dostępu",
+      "stats_summary": {
+        "links": "linków",
+        "started": "rozpoczętych",
+        "submitted": "przesłanych"
+      },
+      "access_rules": {
+        "title": "Reguły dostępu",
+        "description": "Kontroluj, kiedy i jak uczestnicy mają dostęp do badania.",
+        "password_toggle": "Wymagaj hasła",
+        "password_toggle_desc": "Uczestnicy muszą wpisać hasło przed rozpoczęciem badania.",
+        "password_label": "Hasło dostępu",
+        "password_placeholder": "Wpisz hasło dostępu",
+        "password_locked": "Ochrona hasłem może być zmieniana tylko w trybie szkicu.",
+        "password_set": "Hasło jest aktualnie ustawione. Wpisz nową wartość, aby je zmienić, lub wyłącz przełącznik, aby je usunąć.",
+        "collection_window": "Okno zbierania danych",
+        "window_toggle": "Ogranicz okno zbierania danych",
+        "window_toggle_help": "Ogranicz dostęp uczestników do określonego zakresu czasu.",
+        "start_date_label": "Otwiera się o",
+        "end_date_label": "Zamyka się o",
+        "date_hint": "Pozostaw puste, aby nie ograniczać czasu.",
+        "clear_date": "Wyczyść datę",
+        "save_button": "Zapisz reguły dostępu",
+        "save_success": "Reguły dostępu zaktualizowane",
+        "save_error": "Nie udało się zaktualizować reguł dostępu",
+        "non_draft_notice": "Poza trybem szkicu można edytować tylko okno zbierania danych. Przełącz badanie z powrotem na szkic, aby zmienić inne reguły dostępu.",
+        "archived_notice": "To badanie jest zarchiwizowane. Reguły dostępu są tylko do odczytu."
+      },
+      "new_link": "Nowy link dostępu",
+      "create_title": "Utwórz linki dostępu",
+      "link_type": "Strategia dostępu",
+      "select_type": "Wybierz typ rekrutacji...",
+      "campaign_name": "Kanał / nazwa kampanii",
+      "name_placeholder": "Np. LinkedIn, e-mail partia a, lista studentów...",
+      "link_count": "Rozmiar partii",
+      "capacity_label": "Maks. zgłoszeń",
+      "generate_links": "Generuj linki",
+      "no_links": "Nie wygenerowano jeszcze żadnych linków rekrutacyjnych.",
+      "unnamed": "Kanał bez nazwy",
+      "revoked": "Dostęp odwołany",
+      "qr_title": "Udostępnij przez QR",
+      "copy_link": "Kopiuj URL",
+      "table_title": "Linki rekrutacyjne",
+      "share_title": "Udostępnij badanie",
+      "share_desc": "Rozprowadź URL badania, aby zaprosić uczestników.",
+      "public_url_label": "Publiczny URL uczestnictwa",
+      "hide_qr": "Ukryj QR",
+      "show_qr": "Pokaż kod QR",
+      "delete_link": "Usuń link",
+      "qr_alt": "Kod QR dla {{url}}",
+      "table_caption": "Linki rekrutacyjne",
+      "progress_label": "{{count}} z {{max}} odpowiedzi",
+      "usage": {
+        "started": "rozpoczęte",
+        "submitted": "przesłane",
+        "completed": "Ukończone",
+        "in_progress": "W toku",
+        "unused": "Nieużyte"
+      },
+      "live_study": "Badanie na żywo",
+      "download_qr": "Pobierz obraz",
+      "qr_print_hint": "Zeskanuj lub wydrukuj ten kod do fizycznych materiałów rekrutacyjnych (ulotki, plakaty).",
+      "analytics_title": "Analityka kampanii",
+      "analytics_desc": "Bezpośrednie linki i skany QR są automatycznie śledzone w panelu zdrowia powyżej.",
+      "copy_success": "Link do badania skopiowany do schowka",
+      "types": {
+        "public": "Dostęp otwarty (publiczny)",
+        "individual": "Jednorazowy kod dostępu",
+        "limited": "Ograniczone uczestnictwo"
+      },
+      "guidance": {
+        "public": "Najlepszy do rekrutacji na dużą skalę. Jeden URL dla wszystkich uczestników.",
+        "individual": "Maksymalne bezpieczeństwo. Generuje unikalne linki wygasające po jednym pomyślnym ukończeniu.",
+        "limited": "Kontrolowany dostęp. Jeden link, który przestaje działać po określonej liczbie zgłoszeń."
+      },
+      "stats": {
+        "total_links": "Łącznie kanałów",
+        "active_channels": "Aktywne partie rekrutacyjne",
+        "started": "Łącznie sesji",
+        "engagements": "Uczestnicy, którzy rozpoczęli",
+        "submitted": "Prawidłowe dane",
+        "completions": "Ukończone zgłoszenia",
+        "conversion": "Wskaźnik przechwycenia",
+        "efficiency": "Ostateczny wynik danych"
+      },
+      "table": {
+        "name": "Kampania / partia",
+        "type": "Typ wejścia",
+        "token": "Token bezpieczeństwa",
+        "usage": "Pojemność",
+        "status": "Stan",
+        "actions": "Zarządzaj",
+        "type_help": "Publiczny, jednorazowy lub z ograniczoną pojemnością. Patrz opisy strategii w oknie dialogowym 'Nowy link dostępu'."
+      },
+      "status": {
+        "public": "Publiczny",
+        "individual": "Indywidualny",
+        "limited": "Ograniczony"
+      },
+      "toasts": {
+        "created": "Linki rekrutacyjne utworzone pomyślnie",
+        "failed": "Nie udało się utworzyć linków rekrutacyjnych. Sprawdź dane wejściowe i spróbuj ponownie.",
+        "revoked": "Link odwołany",
+        "revoke_failed": "Nie udało się odwołać tego linku. Możliwe, że jest już w użyciu.",
+        "copied": "Skopiowano do schowka"
+      }
+    },
+    "analytics": {
+      "charts": {
+        "recruitment_funnel": {
+          "title": "Lejek rekrutacyjny",
+          "subtitle": "Łączna wydajność konwersji",
+          "initial_contact": "Pierwszy kontakt",
+          "completion": "Ukończenie",
+          "started_study": "Rozpoczęto badanie",
+          "submitted": "Przesłano",
+          "yield": "Wynik",
+          "success_rate": "Wskaźnik sukcesu",
+          "completion_rate": "{{rate}}% uczestników ukończyło badanie"
         },
-        "study_overview": {
-            "title": "Overview",
-            "back_to_overview": "Back to overview",
-            "sample_size": "Number of participants (P-Set)",
-            "valid": "valid",
-            "completion_rate": "Completion rate",
-            "active": "active",
-            "mobile": "mobile",
-            "median_duration": "Median duration",
-            "suspect": "Suspect",
-            "recent_activity": "Recent activity",
-            "latest_participants": "Latest participants (last {{count}} of {{total}})",
-            "recently_completed": "Recently completed",
-            "in_progress": "In progress",
-            "discarded": "Discarded",
-            "started": "Started",
-            "view_all": "View all participants and data details",
-            "no_participants": "No participants yet.",
-            "view_data": "View",
-            "submitted": "Submitted",
-            "edit_design": "Edit design",
-            "export_csv": "Download CSV",
-            "export_json": "Download JSON",
-            "steps": {
-                "welcome": "Welcome",
-                "consent": "Consent",
-                "rough_sort": "Rough sort",
-                "fine_sort": "Q-sort",
-                "final": "Final steps"
-            }
+        "link_performance": {
+          "title": "Śledzenie skuteczności linków",
+          "subtitle": "Monitorowanie efektywności poszczególnych kanałów rekrutacyjnych",
+          "volume": "Wolumen",
+          "yield": "Wynik",
+          "conversion_rate": "Wskaźnik konwersji",
+          "total_responses": "odpowiedzi"
+        }
+      }
+    },
+    "breadcrumbs": {
+      "admin": "Admin",
+      "dashboard": "Dashboard",
+      "study_dashboard": "Overview",
+      "design": "Design",
+      "participants": "Participants",
+      "team": "Team",
+      "recruitment": "Access",
+      "exports": "Data",
+      "data": "Data",
+      "privacy": "Data privacy",
+      "account": "Account settings",
+      "participant_n": "Participant {{code}}",
+      "analysis": "Analysis",
+      "settings": "Settings",
+      "concourse": "Concourse",
+      "members": "Team members"
+    },
+    "command_menu": {
+      "title": "Globalne menu poleceń",
+      "placeholder": "Wpisz polecenie lub wyszukaj...",
+      "no_results": "Brak wyników.",
+      "switch_project": "Przełącz projekt",
+      "switch_study": "Przełącz badanie",
+      "study_actions": "Akcje badania",
+      "system": "System",
+      "no_studies": "Brak badań w tym projekcie.",
+      "open_dashboard": "Otwórz panel",
+      "design_study": "Projekt badania",
+      "collaborators": "Współpracownicy",
+      "copy_link": "Kopiuj publiczny link",
+      "toggle_theme": "Przełącz motyw",
+      "logout": "Wyloguj",
+      "search_label": "Szukaj lub uruchom polecenia",
+      "to_open": "Otwórz",
+      "active": "Aktywne",
+      "link_copied": "Link do badania skopiowany!",
+      "logged_out": "Wylogowano pomyślnie",
+      "switched_project": "Przełączono na {{name}}"
+    },
+    "dashboard": {
+      "title": "Panel projektu",
+      "welcome": "Witamy z powrotem,",
+      "snapshot": "Oto migawka aktywności badawczej.",
+      "create_study": "Utwórz badanie",
+      "total_studies": "Łącznie badań",
+      "across_statuses": "Wszystkich statusów",
+      "active_data_collection": "Aktywne zbieranie danych",
+      "receiving_responses": "Badania przyjmujące odpowiedzi",
+      "total_participants": "Łącznie uczestników",
+      "all_studies": "Wszystkie badania",
+      "all_studies_description": "Wszystkie badania w tym projekcie.",
+      "languages_count_one": "{{count}} język",
+      "languages_count_other": "{{count}} języków",
+      "n_participants_one": "{{count}} uczestnik",
+      "n_participants_other": "{{count}} uczestników",
+      "n_studies_one": "{{count}} badanie",
+      "n_studies_other": "{{count}} badań",
+      "n_active_one": "{{count}} aktywne",
+      "n_active_other": "{{count}} aktywnych",
+      "n_participants_total_one": "{{count}} uczestnik",
+      "n_participants_total_other": "{{count}} uczestników",
+      "concourse_n_items_one": "{{count}} stwierdzenie",
+      "concourse_n_items_other": "{{count}} stwierdzeń",
+      "concourse_open_hint": "Kuracja stwierdzeń kandydatów",
+      "created": "Utworzono",
+      "no_studies": "Nie znaleziono badań. Utwórz pierwsze badanie, aby zacząć!",
+      "import_study": "Importuj badanie",
+      "get_started": "Zacznij swój projekt badawczy",
+      "onboarding_title": "Pierwsze kroki",
+      "step_create_project": "Utwórz projekt",
+      "step_create_project_desc": "Projekt jest gotowy.",
+      "step_concourse": "Zbierz stwierdzenia w konkursie",
+      "step_concourse_desc": "Dodaj stwierdzenia kandydatów z przeglądu literatury.",
+      "step_qset": "Wybierz zbiór Q",
+      "step_qset_desc": "Przejrzyj i zaakceptuj elementy tworzące zbiór Q.",
+      "step_study": "Utwórz badanie",
+      "step_study_desc": "Zdefiniuj siatkę sortowania Q.",
+      "step_import": "Zaimportuj zbiór Q do badania",
+      "step_import_desc": "Zaimportuj zaakceptowane elementy konkursu jako stwierdzenia badania.",
+      "step_configure": "Skonfiguruj przepływ uczestnika",
+      "step_configure_desc": "Skonfiguruj instrukcje, wstępne sortowanie i pytania końcowe.",
+      "step_launch": "Uruchom rekrutację",
+      "step_launch_desc": "Generuj linki uczestnictwa i udostępniaj je.",
+      "go_to_concourse": "Otwórz konkurs",
+      "go_to_qset": "Otwórz zbiór Q",
+      "concourse": "Konkurs",
+      "concourse_empty": "Brak elementów. Zacznij budować kolekcję stwierdzeń.",
+      "team": "Zespół",
+      "team_loading": "Ładowanie...",
+      "studies": "Badania",
+      "active_studies": "Aktywne",
+      "paused_studies": "Wstrzymane",
+      "draft_studies": "Szkice",
+      "closed_studies": "Ukończone",
+      "attention": "Wymaga uwagi",
+      "alert_deadline": "{{study}}: zamknięcie za {{days}} dni, {{count}} uczestników",
+      "view": "Pokaż",
+      "open_study": "Otwórz badanie",
+      "add_study": "Dodaj badanie",
+      "closes": "Zamknięcie",
+      "timeline": {
+        "title": "Oś czasu zgłoszeń",
+        "subtitle": "Dzienne trendy uczestnictwa",
+        "started": "Rozpoczęto",
+        "completed": "Ukończono"
+      },
+      "devices": {
+        "title": "Rozkład urządzeń",
+        "subtitle": "Jak uczestnicy korzystają z badania",
+        "types": {
+          "desktop": "Komputer",
+          "mobile": "Telefon",
+          "tablet": "Tablet",
+          "unknown": "Nieznane"
+        }
+      },
+      "n_studies_help": "Łączna liczba badań w tym projekcie, w tym szkice i zamknięte.",
+      "n_active_help": "Badania aktualnie przyjmujące zgłoszenia uczestników (stan = aktywne).",
+      "n_participants_total_help": "Suma ukończonych uczestników we wszystkich badaniach tego projektu.",
+      "tool_help": {
+        "design": "Konfiguruj badanie: siatka rozkładu, warunki instrukcji, stwierdzenia, zgoda.",
+        "recruit": "Linki rekrutacyjne, reguły dostępu i ustawienia URL badania.",
+        "data": "Odpowiedzi uczestników i eksporty (CSV, zrzuty sortowania Q).",
+        "analysis": "Konfiguracja analizy czynnikowej i historia przebiegów."
+      }
+    },
+    "export": {
+      "config": "Eksportuj konfigurację",
+      "exporting": "Eksportowanie...",
+      "config_success": "Konfiguracja wyeksportowana pomyślnie",
+      "config_error": "Nie można wyeksportować konfiguracji. Spróbuj ponownie.",
+      "label": "Eksportuj dane",
+      "success": "Eksport zakończony pomyślnie",
+      "error": "Eksport nie powiódł się. Spróbuj ponownie.",
+      "csv": "Eksportuj CSV",
+      "json": "Eksportuj JSON",
+      "audio": "Eksportuj nagrania audio (ZIP)",
+      "formats": {
+        "csv": "CSV",
+        "pqmethod": "PQMethod (ZIP)",
+        "rkit": "R-Kit (ZIP)",
+        "package": "Pakiet badawczy (ZIP)",
+        "json": "Zrzut JSON"
+      },
+      "download": "Pobierz",
+      "package_dialog": {
+        "title": "Pobierz pakiet badawczy",
+        "description": "Łączy wszystkie dane badania w jeden plik ZIP do OSF lub rejestracji wstępnej.",
+        "discussion_hint": "Dodaje plik memo/memo-discussion.md ze wszystkimi wątkami komentarzy (podpisanymi i opatrzonymi datą). Domyślnie wyłączone; zachowaj czysty eksport, chyba że potrzebna jest ścieżka deliberacji."
+      }
+    },
+    "import": {
+      "title": "Importuj konfigurację badania",
+      "config": "Importuj konfigurację",
+      "upload_desc": "Prześlij wcześniej wyeksportowany plik konfiguracji badania",
+      "validate_desc": "Przejrzyj konfigurację i podaj unikalny slug",
+      "creating_desc": "Tworzenie badania...",
+      "file_upload": "Prześlij plik",
+      "paste_json": "Wklej JSON",
+      "drop_here": "Upuść plik tutaj",
+      "drag_drop": "Przeciągnij i upuść plik JSON lub kliknij, aby przeglądać",
+      "supported": "Obsługiwany format: .json",
+      "paste_label": "Wklej konfigurację JSON",
+      "validate": "Sprawdź poprawność i kontynuuj",
+      "valid": "Konfiguracja jest prawidłowa",
+      "invalid": "Konfiguracja zawiera błędy",
+      "errors": "Błędy",
+      "warnings": "Ostrzeżenia",
+      "summary": "Podsumowanie badania",
+      "title_field": "Tytuł",
+      "languages": "Języki",
+      "statements": "Stwierdzenia",
+      "grid": "Zakres siatki",
+      "new_slug": "Nowy slug badania",
+      "slug_help": "Musi być unikalny, 3–100 znaków, tylko małe litery, cyfry i myślniki",
+      "creating": "Tworzenie badania z konfiguracji...",
+      "create_study": "Utwórz badanie",
+      "invalid_json": "Nieprawidłowy plik JSON",
+      "validation_failed": "Konfiguracja jest nieprawidłowa",
+      "success": "Badanie zaimportowane pomyślnie",
+      "redirecting": "Otwieranie projektanta badania...",
+      "failed": "Nie udało się zaimportować badania. Zapoznaj się ze szczegółami poniżej i spróbuj ponownie.",
+      "validation": {
+        "errors": {
+          "missing_version": "Brak pola wersji",
+          "unsupported_version": "Nieobsługiwana wersja: {{version}}",
+          "missing_field": "Brak wymaganego pola: {{field}}",
+          "no_translations": "Wymagane jest co najmniej jedno tłumaczenie",
+          "missing_translation_field": "Tłumaczeniu {{index}} brakuje wymaganego pola: {{field}}",
+          "invalid_lang_code": "Nieprawidłowy kod języka: {{lang}}",
+          "no_statements": "Wymagane jest co najmniej jedno stwierdzenie",
+          "duplicate_codes": "Zduplikowane kody stwierdzeń: {{codes}}",
+          "missing_stmt_translations": "Stwierdzeniu {{index}} brakuje tłumaczeń",
+          "invalid_grid_config": "Nieprawidłowy grid_config: musi być listą",
+          "invalid_grid_structure": "Nieprawidłowa struktura grid_config: {{error}}"
         },
-        "overview": {
-            "copy_id": "Copy participant ID"
+        "warnings": {
+          "grid_capacity_mismatch": "Liczba stwierdzeń ({{count}}) nie odpowiada pojemności siatki ({{capacity}})",
+          "missing_consent_draft": "Brak tytułu lub opisu formularza zgody (badanie w szkicu)",
+          "external_branding_logo": "Logo marki używa zewnętrznego URL: {{url}}",
+          "external_partner_logo": "Logo partnera '{{name}}' używa zewnętrznego URL: {{url}}",
+          "external_logo": "URL logo odwołuje się do zasobu zewnętrznego — może być niedostępny"
+        }
+      }
+    },
+    "dialogs": {
+      "create_study": {
+        "title": "Utwórz nowe badanie",
+        "description": "Rozpocznij nowe badanie metodologią Q. Stwierdzenia i ustawienia można skonfigurować później.",
+        "study_title": "Tytuł badania",
+        "study_title_placeholder": "Np. Perspektywy dotyczące AI",
+        "url_slug": "URL slug",
+        "url_slug_placeholder": "np. perspektywy-ai-2025",
+        "cancel": "Anuluj",
+        "create": "Utwórz badanie",
+        "success": "Badanie zostało pomyślnie utworzone",
+        "error": "Nie udało się utworzyć badania",
+        "languages": "Języki",
+        "languages_desc": "Wybierz języki do włączenia. Treść zostanie zainicjowana zlokalizowanymi wartościami domyślnymi."
+      }
+    },
+    "validation": {
+      "required": "Wymagane",
+      "slug_min": "Slug musi mieć co najmniej 3 znaki",
+      "slug_regex": "Slug może zawierać tylko małe litery, cyfry i myślniki"
+    },
+    "study_overview": {
+      "title": "Przegląd",
+      "back_to_overview": "Wróć do przeglądu",
+      "sample_size": "Liczba uczestników (P-Set)",
+      "valid": "prawidłowe",
+      "completion_rate": "Wskaźnik ukończenia",
+      "active": "aktywne",
+      "mobile": "mobilne",
+      "median_duration": "Mediana czasu trwania",
+      "suspect": "Podejrzane",
+      "recent_activity": "Ostatnia aktywność",
+      "latest_participants": "Ostatni uczestnicy ({{count}} z {{total}})",
+      "recently_completed": "Ostatnio ukończone",
+      "in_progress": "W toku",
+      "discarded": "Odrzucone",
+      "started": "Rozpoczęto",
+      "view_all": "Zobacz wszystkich uczestników i szczegóły danych",
+      "no_participants": "Brak uczestników.",
+      "view_data": "Pokaż",
+      "submitted": "Przesłano",
+      "edit_design": "Edytuj projekt",
+      "export_csv": "Pobierz CSV",
+      "export_json": "Pobierz JSON",
+      "steps": {
+        "welcome": "Powitanie",
+        "consent": "Zgoda",
+        "rough_sort": "Sortowanie zgrubne",
+        "fine_sort": "Sortowanie Q",
+        "final": "Ostatnie kroki"
+      }
+    },
+    "overview": {
+      "copy_id": "Copy participant ID"
+    },
+    "study_status": {
+      "dialog": {
+        "draft": {
+          "title": "Przywrócić do szkicu?",
+          "desc": "Spowoduje to zatrzymanie zbierania danych, ale umożliwi modyfikację projektu badania. Istniejące dane zostaną zachowane.",
+          "action": "Przywróć do szkicu"
         },
-        "study_status": {
-            "dialog": {
-                "draft": {
-                    "title": "Revert to draft?",
-                    "desc": "This will stop data collection but allow you to modify the study design. Existing data is preserved.",
-                    "action": "Revert to draft"
-                },
-                "active": {
-                    "title": "Launch study?",
-                    "desc": "Activating the study will open it to participants.",
-                    "action": "Set to active"
-                },
-                "paused": {
-                    "title": "Pause study?",
-                    "desc": "Participants will not be able to enter the study while it is paused. You can resume later.",
-                    "action": "Pause study"
-                },
-                "closed": {
-                    "title": "Close study?",
-                    "desc": "This will prevent new participants from entering. Existing sessions can still finish. You can reopen later.",
-                    "action": "Close study"
-                }
-            },
-            "steps": {
-                "draft": {
-                    "label": "Draft",
-                    "description": "Configuration & design"
-                },
-                "active": {
-                    "label": "Active",
-                    "description": "Collecting responses"
-                },
-                "paused": {
-                    "label": "Paused",
-                    "description": "On hold"
-                },
-                "closed": {
-                    "label": "Closed",
-                    "description": "Analysis & export"
-                }
-            },
-            "state": {
-                "activate": "Activate study",
-                "switch_to_draft": "Draft Mode",
-                "manage": "Manage status"
-            },
-            "notifications": {
-                "success": {
-                    "draft": "Study reverted to draft successfully",
-                    "active": "Study launched successfully",
-                    "paused": "Study paused successfully",
-                    "closed": "Study closed successfully"
-                },
-                "error": "Could not change study state. Check your permissions and try again.",
-                "state_changed_active": "Study is now active!"
-            }
+        "active": {
+          "title": "Uruchomić badanie?",
+          "desc": "Aktywowanie badania otworzy je dla uczestników.",
+          "action": "Ustaw jako aktywne"
         },
-        "design": {
-            "title": "Study design",
-            "translation_needed": "Review required (copy)",
-            "reset_defaults": "Reset to defaults",
-            "editing_language_banner": "Editing the {{language}} version. Use the language selector in the toolbar to switch.",
-            "multilang": {
-                "view_others": "View in other languages",
-                "other_formulations": "Other Formulations"
-            },
-            "guidance": {
-                "title": "Design guidance",
-                "intro_title": "Welcome to the studio",
-                "intro_desc": "Start by defining the purpose of your study. This information will be shown to participants before they begin the sorting process.",
-                "qsort_title": "Statement & grid balance",
-                "qsort_desc": "Ensure your grid capacity exactly matches the number of statements. A balanced Q-set usually follows a quasi-normal (bell curve) distribution."
-            },
-            "checklist": {
-                "title": "Checklist",
-                "statements": "Statements",
-                "grid_balance": "Grid balanced",
-                "branding": "Logo & colors",
-                "instructions": "Instructions",
-                "ready": "All essential parts are ready. You can now launch your study!",
-                "pending": "Complete the required steps above to enable study activation.",
-                "study_title": "Study title",
-                "consent_defined": "Consent form",
-                "progress": "Progress",
-                "languages": "Languages",
-                "status_ready": "Ready",
-                "status_pending": "Pending",
-                "required": "Required",
-                "reset_defaults": "Reset to defaults"
-            },
-            "unsaved_changes": {
-                "title": "Unsaved changes",
-                "description": "You have unsaved changes in your study design. If you leave now, these changes will be lost.",
-                "confirm": "Leave without saving",
-                "cancel": "Keep editing"
-            },
-            "tips": {
-                "title": "Quick tip",
-                "pilot": "Always run a test sort yourself before sharing the link with participants."
-            },
-            "toolbar": {
-                "title": "Design",
-                "back": "Back",
-                "preview": "Show preview",
-                "hide_preview": "Hide preview",
-                "popout": "Pop out preview",
-                "discard": "Discard unsaved changes",
-                "test_run": "Test run",
-                "save": "Save",
-                "saved": "Saved",
-                "closed": "Closed",
-                "back_to_study": "Back to study",
-                "editing_language": "Editing language",
-                "manage_langs": "Manage languages",
-                "select_lang": "Select language",
-                "test_run_help": "Preview as a participant. These runs aren't included in your data.",
-                "more_actions": "More actions"
-            },
-            "sync": {
-                "saving": "Saving...",
-                "error": "Save error",
-                "modified": "Unsaved changes",
-                "synced": "Changes saved",
-                "wait_save": "Saving in progress... Please wait a moment.",
-                "recovered": "Draft recovered from local backup!",
-                "recovery_title": "Unsaved changes found",
-                "recovery_desc": "We found a local version of this study that is more recent than the one on the server. Would you like to restore it?",
-                "recovery_restore": "Restore local version",
-                "recovery_discard": "Discard local version"
-            },
-            "validation": {
-                "failed_title": "Configuration incomplete",
-                "failed_desc": "Fix these issues to activate:",
-                "errors": {
-                    "no_statements": "Study must have at least one statement.",
-                    "no_grid": "Grid configuration is missing.",
-                    "capacity_mismatch": "Grid capacity ({{total}}) does not match statement count ({{count}}).",
-                    "no_translations": "Study must have at least one language translation.",
-                    "missing_default_lang": "Default language ({{lang}}) translation is missing.",
-                    "missing_title": "Title is missing for language '{{lang}}'.",
-                    "missing_consent_title": "Consent title is missing for language '{{lang}}'.",
-                    "missing_consent_description": "Consent description is missing for language '{{lang}}'.",
-                    "missing_grid_instructions": "Q-Sort instructions are missing for language '{{lang}}'.",
-                    "missing_step_title": "Step {{index}} title is missing for language '{{lang}}'.",
-                    "missing_statement_translation": "Statement '{{code}}' is missing translations for: {{missing}}.",
-                    "empty_statement_text": "Statement '{{code}}' has empty text for language '{{lang}}'.",
-                    "missing_question_label": "Question '{{id}}' is missing a label for language '{{lang}}' ({{section}}).",
-                    "missing_option_label": "Option {{index}} of question '{{id}}' is missing a label for language '{{lang}}' ({{section}})."
-                }
-            },
-            "languages": {
-                "manage_title": "Manage languages",
-                "manage_desc": "Enable or disable languages available for participants to see in this study.",
-                "auto_translate": "Automatic translation",
-                "auto_translate_desc": "Soon you will be able to use AI to automatically translate your study into 30+ languages.",
-                "activate_title": "Activate language",
-                "activate_desc": "Choose a source language to copy translations from. This prevents empty fields for participants.",
-                "source_label": "Source language",
-                "copy_notice": "All fields will be copied. You will see a visual indicator on fields that still need your translation.",
-                "confirm_activate": "Activate & copy"
-            },
-            "tabs": {
-                "welcome": "General",
-                "presort": "Pre-sort",
-                "condition": "Condition",
-                "qsort": "Q-sort",
-                "postsort": "Post-sort",
-                "interface": "Interface",
-                "theme": "Theme",
-                "general": "General",
-                "statements": "Statements",
-                "grid": "Grid",
-                "survey": "Survey",
-                "branding": "Branding"
-            },
-            "view_mode": {
-                "mobile": "Mobile view",
-                "desktop": "Desktop view"
-            },
-            "intro": {
-                "general_settings": "General Settings",
-                "welcome_title": "Welcome message",
-                "process_title": "Study steps overview",
-                "process_steps": {
-                    "title": "Study steps overview",
-                    "desc": "Define the phases shown to participants on the welcome page. If left empty, default steps will be used.",
-                    "add_step": "Add step",
-                    "empty": {
-                        "title": "No custom steps defined",
-                        "desc": "The study will use the standard q-methodology workflow (meet, first impressions, perspective, why)."
-                    },
-                    "fields": {
-                        "title": "Step title",
-                        "description": "Short description",
-                        "icon": "Icon",
-                        "toggle": "Toggle"
-                    },
-                    "defaults": {
-                        "new_step": "New study step",
-                        "new_desc": "Explain what the participant will do in this phase."
-                    },
-                    "reset": {
-                        "instructions": "Reset instructions",
-                        "consent_title": "Reset consent title",
-                        "consent_description": "Reset consent description",
-                        "process_steps": "Reset process steps",
-                        "process_steps_confirm": "Are you sure you want to reset all process steps to defaults? This will replace your custom steps."
-                    },
-                    "inconsistent": {
-                        "banner_title": "Inconsistent process steps",
-                        "rough_disabled": "The 'First impressions' (rough sort) step is in this list but the study has rough sort disabled. Participants will not see it.",
-                        "presort_disabled": "The 'Let's meet' (pre-sort survey) step is in this list but the study has the pre-sort survey disabled. Participants will not see it.",
-                        "remove_action": "Remove"
-                    }
-                },
-                "consent_title": "Consent form",
-                "reset": "Reset instruction",
-                "consent_details": "Consent form details",
-                "fields": {
-                    "default_lang": "Default Language",
-                    "default_lang_help": "This language will be shown to participants by default if their browser language is not supported.",
-                    "title": "Study title",
-                    "title_placeholder": "Enter public title...",
-                    "subtitle": "Subtitle (optional)",
-                    "subtitle_placeholder": "A brief catchphrase...",
-                    "objective": "Study objective",
-                    "objective_placeholder": "What is the research question or purpose of this study?",
-                    "task_overview": "Introduction",
-                    "task_placeholder": "Describe the study process here (number of steps, estimated duration, etc.). This field is optional if you use the custom steps above.",
-                    "consent_title_label": "Consent title",
-                    "legal_text": "Legal text / agreement",
-                    "legal_placeholder": "Enter the full legal agreement text..."
-                },
-                "consent_desc": "Participants must agree to these terms before starting."
-            },
-            "condition": {
-                "title": "Condition of instruction",
-                "label": "Define condition of instruction",
-                "desc": "This is the core prompt that guides participants throughout the sorting process.",
-                "field_label": "Instruction text",
-                "placeholder": "E.g. Please rank the following statements from those you most agree with to those you most disagree with",
-                "grid_title": "Q-Sort instruction",
-                "grid_desc": "This is the core instruction guiding participants during the Q-Sort process.",
-                "pre_title": "Preliminary sort instruction",
-                "pre_desc": "Instruction given to participants during the initial rough sort.",
-                "pre_field_label": "Instruction text",
-                "pre_placeholder": "E.g. Based on your personal point of view; divide the cards into three piles...",
-                "enable_pre": "Enable pre-instruction step",
-                "pre_label": "Pre-instruction content",
-                "tips": {
-                    "title": "Why is this important?",
-                    "desc": "In q-methodology, the 'condition of instruction' determines the point of view from which the participant sorts the items. It should be clear and consistent across all sorting phases."
-                }
-            },
-            "questions": {
-                "enable_presort": "Enable pre-sort survey",
-                "enable_presort_desc": "Collect demographic information or other data before the sorting task.",
-                "add_field": "Add a new field",
-                "basic_fields": "Basic fields",
-                "choice_fields": "Choice fields",
-                "scale_fields": "Scale fields",
-                "labels": {
-                    "question": "Question label",
-                    "required": "Required field",
-                    "options": "Options",
-                    "multiple": "(Multiple selection allowed)",
-                    "single": "(Single selection)",
-                    "placeholder": "Enter your question here...",
-                    "scale": "Rating scale",
-                    "scale_points": "Number of points",
-                    "scale_left": "Left endpoint label",
-                    "scale_right": "Right endpoint label"
-                },
-                "types": {
-                    "text": "Text",
-                    "long_text": "Long text",
-                    "number": "Number",
-                    "date": "Date",
-                    "email": "Email",
-                    "dropdown": "Dropdown",
-                    "radio": "Radio",
-                    "checkboxes": "Checkboxes",
-                    "text_audio": "Text + Audio",
-                    "rating": "Rating scale"
-                },
-                "empty": {
-                    "title": "No questions yet",
-                    "desc": "Click above to add your first question"
-                },
-                "defaults": {
-                    "new_question": "New question",
-                    "option": "Option",
-                    "enter_answer": "Enter your answer...",
-                    "untitled": "Untitled question",
-                    "scale_left": "Strongly disagree",
-                    "scale_right": "Strongly agree"
-                },
-                "actions": {
-                    "add_option": "Add option",
-                    "copy_from": "Import from language",
-                    "copy_success": "Imported"
-                },
-                "logic": {
-                    "title": "Visibility logic",
-                    "enable": "Add visibility condition",
-                    "depends_on": "Show this question only if...",
-                    "select_placeholder": "Select a parent question",
-                    "operator": "Operator",
-                    "value": "Comparison value",
-                    "operators": {
-                        "equals": "Equals",
-                        "not_equals": "Does not equal",
-                        "contains": "Includes",
-                        "greater_than": "Greater than",
-                        "less_than": "Less than"
-                    }
-                }
-            },
-            "qsort": {
-                "tabs": {
-                    "statements": "Statements",
-                    "distribution": "Distribution"
-                },
-                "bulk": {
-                    "title": "Bulk editor (quick paste)",
-                    "desc": "One statement per line. Supports \"code: text\" and excel copy-paste (multi-language).",
-                    "replace_all": "Replace all",
-                    "append": "Append to list",
-                    "sync_by_code": "Sync/Merge by code",
-                    "placeholder": "Simple:. My statement",
-                    "detected": "{{count}} statements detected",
-                    "process_replace": "Process & replace statements",
-                    "process_append": "Process & append statements",
-                    "process_sync": "Process & sync translations",
-                    "detected_format": {
-                        "excel": "Excel format detected (tabs)",
-                        "list": "List format detected (code: text)",
-                        "simple": "Simple list detected (one per line)",
-                        "multi_lang": "Multi-language: {{langs}}",
-                        "with_codes": "With custom codes"
-                    }
-                },
-                "set": {
-                    "title": "Q-set",
-                    "clear": "Clear all",
-                    "confirm_clear": "Are you sure you want to delete ALL statements? This cannot be undone.",
-                    "updated": "Statement updated",
-                    "cleared": "All statements cleared",
-                    "imported": "Successfully imported {{count}} statements",
-                    "reset_codes": "Reset codes",
-                    "confirm_reset_codes": "Are you sure you want to re-sequence all statement codes (s1, s2, s3...)?",
-                    "codes_reset": "Statement codes re-sequenced"
-                },
-                "settings": {
-                    "title": "Research settings",
-                    "desc": "Configure how statements are presented to participants",
-                    "show_codes": "Show statement codes",
-                    "show_codes_desc": "Display statement codes (e.g., \"S1\", \"S2\") alongside the text.",
-                    "randomize": "Randomize statement order",
-                    "randomize_desc": "Present statements in random order to each participant (consistent within session)"
-                },
-                "grid": {
-                    "title": "Q-Sort distribution grid",
-                    "desc": "The grid shape forces participants to discriminate between statements, approximating a normal distribution.",
-                    "slot_count": "{{count}} slots allocated",
-                    "stat_count": "{{count}} statements",
-                    "perfect": "Perfect balance",
-                    "too_many": "{{count}} too many statements",
-                    "too_few": "{{count}} statements missing",
-                    "min_reached": "Minimum range reached (±2)",
-                    "max_reached": "Maximum range reached (±6)",
-                    "remove_extreme_columns": "Remove extreme columns",
-                    "add_extreme_columns": "Add extreme columns",
-                    "symmetry_lock": "Symmetry lock",
-                    "symmetry_lock_desc": "Automatically apply changes to opposite columns to maintain a balanced distribution.",
-                    "auto_balance": "Auto-Balance",
-                    "auto_balance_desc": "Reshape grid to a balanced semi-normal distribution",
-                    "reshaped": "Grid reshaped to a balanced distribution",
-                    "balanced": "Grid balanced to standard distribution",
-                    "no_statements": "Add statements first to auto-shape the grid",
-                    "statements": "statements",
-                    "ideal_shape": "Ideal shape",
-                    "symmetric": "Symmetric",
-                    "asymmetric": "Asymmetric",
-                    "tooltip_title": "Why forced distribution?",
-                    "tooltip_desc": "Q-methodology uses a quasi-normal distribution (kurtosis > 0) to ensure participants make meaningful distinctions. The pyramid shape prevents central tendency bias.",
-                    "locked": "Design locked",
-                    "locked_desc": "Structural changes (statement codes, grid) are disabled because the study has collected data or is no longer in draft mode. You can still edit text translations.",
-                    "locked_active": "This study is active. Switch to draft mode to edit.",
-                    "locked_paused": "This study is paused. Switch to draft mode to edit.",
-                    "locked_closed": "This study is closed. The design is archived.",
-                    "mismatch_title": "Grid capacity mismatch",
-                    "mismatch_desc": "You have {{statements}} statements but the grid only has slots for {{slots}} items. Please adjust the columns below to match.",
-                    "unlock_hint": "Go to data explorer to purge sessions and unlock structure"
-                }
-            },
-            "postsort": {
-                "extreme": {
-                    "title": "Targeted columns",
-                    "desc": "Select columns that trigger follow-up questions.",
-                    "no_columns": "No columns selected.",
-                    "add_label": "Add column:",
-                    "prompt_label": "Prompt for statements",
-                    "prompt_placeholder": "Why did you place this statement here?",
-                    "add": "Add",
-                    "add_defaults": "Add default extremes",
-                    "select_placeholder": "Select..."
-                },
-                "random_comments": {
-                    "title": "Allow random comments",
-                    "desc": "Allow participants to add comments to any statement in the grid."
-                },
-                "custom": {
-                    "title": "Custom questions",
-                    "desc": "Add custom questions to the post-sort survey."
-                },
-                "missing": {
-                    "title": "Ask about missing statements",
-                    "desc": "If yes, please describe them briefly.",
-                    "prompt_label": "Prompt text",
-                    "prompt_placeholder": "Please feel free to suggest and explain."
-                },
-                "steps": {
-                    "step1": "Step 1: feedback",
-                    "step2": "Step 2: questions"
-                },
-                "email": {
-                    "title": "Participant follow-up",
-                    "desc": "Collect email addresses for follow-up or research results.",
-                    "interview": "Offer follow-up",
-                    "results": "Offer to subscribe to a mailing list about study outcomes",
-                    "interview_warning": "Note: agreeing to be contacted lifts anonymity for the researcher.",
-                    "results_hint": "Email solely for results, anonymity preserved."
-                },
-                "audio": {
-                    "title": "Audio Recording",
-                    "desc": "Allow participants to record audio responses instead of text.",
-                    "max_duration": "Maximum Duration",
-                    "seconds": "seconds",
-                    "max_duration_help": "Maximum recording time per question (30–600 seconds).",
-                    "participant_choice_info": "Participants can respond with text, audio, or both for each question."
-                }
-            },
-            "interface": {
-                "title": "Interface customization",
-                "desc": "Customize the buttons and labels of the interface to match your study's tone (e.g., changing \"agree/disagree\" to \"like/dislike\").",
-                "nav": {
-                    "title": "Navigation buttons",
-                    "start": "Start button",
-                    "next": "Next step button",
-                    "submit": "Submit button",
-                    "confirm": "Confirm sort button",
-                    "tooltips": {
-                        "start": "Button that starts the study",
-                        "next": "Move to the next step",
-                        "submit": "Submit results at the end",
-                        "confirm": "Generic validation button"
-                    }
-                },
-                "terms": {
-                    "title": "Sorting terminology",
-                    "desc": "Define the labels for the spontaneous sort and the grid spectrum.",
-                    "rough": "Rough sort labels",
-                    "agree": "Agree",
-                    "neutral": "Neutral",
-                    "disagree": "Disagree",
-                    "grid": "Grid legends (extremes)",
-                    "most_agree": "Most agree",
-                    "most_disagree": "Most disagree"
-                },
-                "hints": {
-                    "title": "Methodology tips",
-                    "desc": "Add or modify floating hints to help participants during the grid sort phase.",
-                    "placeholder": "Enter a methodology tip...",
-                    "add": "Add tip",
-                    "reset": "Reset to defaults"
-                },
-                "help": {
-                    "title": "Step guidance (what/why)",
-                    "desc": "Customize the context-sensitive help available to participants at each step via the '?' overlay.",
-                    "step_disabled": "(step disabled)"
-                }
-            },
-            "theme": {
-                "title": "Visual branding",
-                "accent": {
-                    "title": "Accent color",
-                    "desc": "This color will be used for buttons, links, and highlights throughout the study.",
-                    "pick": "Pick a color",
-                    "reset": "Reset to default"
-                },
-                "logo": {
-                    "title": "Study logo",
-                    "desc": "Upload a custom logo to replace the default Open-Q branding.",
-                    "label": "Logo URL",
-                    "hint": "Recommended size: 200x50px. Supports PNG, SVG, JPG.",
-                    "preview": "Logo preview",
-                    "help_title": "Where does this logo appear?",
-                    "help_desc": "The logo is displayed at the top of every study page (navigation bar) and on the welcome page. It reinforces your project's visual identity."
-                },
-                "partners": {
-                    "title": "Institutional partners",
-                    "desc": "Add logos of supporting institutions or partners.",
-                    "add": "Add partner",
-                    "name_label": "Partner name",
-                    "name_placeholder": "Institution name",
-                    "logo_label": "Logo URL",
-                    "url_label": "Website (optional)",
-                    "url_placeholder": "Https://...",
-                    "help_title": "Display of logos",
-                    "help_desc": "Partner logos are displayed on the landing page as well as in the study header, next to the main logo."
-                },
-                "upload": {
-                    "upload": "Upload",
-                    "recommended": "Recommended",
-                    "invalid_type": "Invalid file type. Use PNG, JPG, or SVG.",
-                    "file_too_large": "File too large. Maximum size: {{size}}kb.",
-                    "conversion_error": "Failed to process image.",
-                    "processing": "Processing image...",
-                    "drag_drop": "Drag & drop or click to upload",
-                    "max": "Max"
-                }
-            },
-            "activate_dialog": {
-                "title": "Activate this study?",
-                "description": "Activating opens recruitment and unlocks public links. Real participants can begin submitting.",
-                "checklist_title": "Pre-flight checks",
-                "languages_title": "Languages",
-                "lang_ready": "Ready",
-                "lang_incomplete": "Incomplete",
-                "required": "(required)",
-                "attestation": "I have reviewed the consent text, the retention policy, and confirm this study is ready to receive real participants.",
-                "confirm": "Activate study"
-            }
+        "paused": {
+          "title": "Wstrzymać badanie?",
+          "desc": "Uczestnicy nie będą mogli wziąć udziału w badaniu, gdy jest ono wstrzymane. Można je wznowić później.",
+          "action": "Wstrzymaj badanie"
         },
-        "data": {
-            "title": "Data",
-            "description": "Monitor real-time participation, analyze data quality, and manage research sessions.",
-            "sections": {
-                "key_indicators": "Key indicators",
-                "responses": "Responses",
-                "key_statistics": "Key statistics"
-            },
-            "stats": {
-                "email_collection": "Email collection",
-                "participants": "total",
-                "newsletter": "Wants results",
-                "opt_in": "Response rate",
-                "follow_up": "Follow-up potential",
-                "interested": "interested",
-                "click_to_filter": "Click to filter",
-                "click_to_export": "Click to export list",
-                "completed": "Completed",
-                "in_progress": "In progress",
-                "abandoned_count": "{{count}} abandoned",
-                "interview_interested": "Accepts follow-up",
-                "interview": "Accepts follow-up",
-                "email": "Emails"
-            },
-            "tabs": {
-                "live": "Live participants",
-                "test": "Test sessions",
-                "browse": "Interactive view",
-                "export": "Export hub"
-            },
-            "status": {
-                "started": "started",
-                "completed": "Completed",
-                "in_progress": "In progress",
-                "abandoned": "Abandoned",
-                "discarded": "discarded"
-            },
-            "step": {
-                "consent": "Consent",
-                "presort": "Pre-sort survey",
-                "rough": "Preliminary sort",
-                "fine": "Q-sort",
-                "post": "Post-sort survey"
-            },
-            "actions": {
-                "discard": "Discard",
-                "restore": "Restore",
-                "export": "Export",
-                "clear_all": "Reset all data",
-                "clear_all_confirm": "DANGER: This will permanently delete ALL participant data for this study. This cannot be undone.",
-                "clear_all_success": "All data cleared",
-                "clear_all_error": "Could not clear data. Check your permissions and try again."
-            },
-            "confirm_discard": {
-                "title": "Discard participant?",
-                "description": "This participant will be excluded from exports and analysis. You can restore them later.",
-                "reason_label": "Reason (optional)",
-                "reason_placeholder": "Why is this participant being discarded?"
-            },
-            "confirm_restore": {
-                "title": "Restore participant?",
-                "description": "This participant will be included in exports and analysis again."
-            },
-            "guide": {
-                "title": "Format guide",
-                "csv": {
-                    "title": "Universal CSV",
-                    "desc": "Raw rectangular data. Best for r, python, SPSS, or excel analysis. Includes all metadata."
-                },
-                "json": {
-                    "title": "KenQ JSON",
-                    "desc": "Optimized for the web-kenq analysis tool. Contains study definition and sorts."
-                },
-                "zip": {
-                    "title": "PQMethod bundle (ZIP)",
-                    "desc": "Contains legacy .DAT and .STA files for DOS PQMethod analysis."
-                }
-            },
-            "table": {
-                "participant": "Participant",
-                "lang": "Lang",
-                "status": "Status",
-                "consent": "Consent",
-                "flags": "Flags",
-                "duration": "Duration",
-                "submitted": "Submitted",
-                "last_step": "Last step",
-                "current_step": "Current step",
-                "view": "View",
-                "actions": "Details",
-                "duplicate_ip": "Duplicate IP",
-                "duplicate_ip_hint": "Shares IP hash with other participants"
-            },
-            "tooltips": {
-                "suspect": "Potentially suspect: session duration < 2 minutes",
-                "has_comments": "Contains participant comments on cards",
-                "has_audio": "Has audio responses",
-                "email_provided": "Email provided",
-                "newsletter_consent": "Wants results",
-                "interview_consent": "Accepts follow-up"
-            },
-            "toast": {
-                "discarded": "Participant discarded",
-                "restored": "Participant restored",
-                "error": "Could not update participant. Check your connection and try again."
-            },
-            "detail": {
-                "participant": "Participant",
-                "participant_n": "Participant {{code}}",
-                "not_found": "Participant not found",
-                "title": "Participant profile",
-                "session": "Session",
-                "discarded_badge": "Discarded",
-                "description": "Comprehensive Q-sort results and metadata.",
-                "stats": {
-                    "duration": "Total duration",
-                    "language": "Language used"
-                },
-                "actions": {
-                    "discard": "Discard participant",
-                    "restore": "Restore participant"
-                },
-                "sort_config": "Sort configuration",
-                "survey": {
-                    "title": "Questionnaire responses",
-                    "csv_note": "Full responses available in CSV export."
-                }
-            },
-            "filter": {
-                "show_discarded": "Include discarded records",
-                "all_states": "All states",
-                "only_active": "Only active",
-                "only_flagged": "Flagged quality"
-            },
-            "filters": {
-                "active": "Active filters",
-                "has_email": "Email provided",
-                "newsletter": "Wants results",
-                "interview": "Accepts follow-up",
-                "flagged": "Flagged only",
-                "clear_all": "Clear filters",
-                "remove_filter": "Remove filter",
-                "all_statuses": "All statuses",
-                "all_consents": "All",
-                "all_indicators": "All",
-                "all_steps": "All steps",
-                "has_comments": "Has comments",
-                "has_audio": "Has audio",
-                "has_recruitment": "Has recruitment link"
-            },
-            "charts": {
-                "section_title": "Response Distributions",
-                "distribution_label": "Distribution for {{question}}",
-                "multi_select_note": "Multiple selections allowed",
-                "responses_count": "{{count}} responses",
-                "no_answer": "No answer",
-                "option": "Option",
-                "count": "Count"
-            },
-            "search": {
-                "placeholder": "Search by ID or recruitment token...",
-                "records_found": "Records detected",
-                "no_results": "No records match your query"
-            },
-            "errors": {
-                "load_failed": "Cloud sync interrupted. Please check your connection."
-            },
-            "export_emails_success": "Emails exported successfully",
-            "empty": {
-                "no_participants_title": "No participants yet",
-                "no_participants_desc": "Share your study link to start collecting responses.",
-                "contract_title": "No submissions yet",
-                "contract_body": "Submissions and exports will appear here. Share the study link to start collecting.",
-                "contract_cta": "Open study overview"
-            },
-            "pagination": {
-                "showing": "Showing {{from}}–{{to}} of {{total}}"
-            }
+        "closed": {
+          "title": "Zamknąć badanie?",
+          "desc": "Uniemożliwi to nowym uczestnikom wejście do badania. Trwające sesje mogą zostać ukończone. Można je ponownie otworzyć później.",
+          "action": "Zamknij badanie"
+        }
+      },
+      "steps": {
+        "draft": {
+          "label": "Szkic",
+          "description": "Konfiguracja i projekt"
         },
-        "team": {
-            "title": "Study team",
-            "description": "Manage collaborators and study-level access control.",
-            "invite_title": "Invite collaborator",
-            "invite_description": "Generate a secure link to invite a new member to this study.",
-            "email_label": "Email address",
-            "role_label": "Role",
-            "select_role": "Select a role",
-            "generate_link": "Generate link",
-            "invite_success": "Invitation link generated!",
-            "invite_error": "Failed to generate invitation",
-            "copy_success": "Link copied to clipboard",
-            "share_label": "Share this link with the invitee:",
-            "collab_overview": "Collaboration overview",
-            "active_members": "Active members",
-            "permissions_info": "Permissions info",
-            "list_title": "Research team",
-            "list_description": "Manage access for existing collaborators.",
-            "added_on": "Added on",
-            "headers": {
-                "collaborator": "Collaborator",
-                "role": "Role",
-                "actions": "Actions"
-            },
-            "roles": {
-                "owner": "Owner (full control)",
-                "editor": "Editor (design & analysis)",
-                "viewer": "Viewer (read-only)",
-                "owner_badge": "OWNER",
-                "editor_badge": "EDITOR",
-                "viewer_badge": "VIEWER"
-            },
-            "permissions": {
-                "owner": "Can delete the study and manage team.",
-                "editor": "Can modify design and view results.",
-                "viewer": "Read-only access to all modules."
-            }
+        "active": {
+          "label": "Aktywne",
+          "description": "Zbieranie odpowiedzi"
         },
-        "empty_states": {
-            "participants": {
-                "title": "Ready to launch?",
-                "desc": "Share your study link to start collecting responses. Your first participant is just a click away.",
-                "action": "Copy study link",
-                "hint": "Or scan the QR code",
-                "copy_success": "Study link copied to clipboard!"
-            },
-            "team": {
-                "title": "You're flying solo",
-                "desc": "Invite collaborators to help manage this study. They can view data, edit the design, or just observe.",
-                "action": "Invite your first collaborator"
-            },
-            "designer": {
-                "title": "Tabula rasa",
-                "desc": "This study has no statements yet. Add your Q-set items to begin designing your sort.",
-                "action": "Load example Q-set"
-            }
+        "paused": {
+          "label": "Wstrzymane",
+          "description": "Wstrzymano"
         },
-        "status": {
-            "active": "Active",
-            "paused": "Paused",
-            "closed": "Closed",
-            "draft": "Draft"
+        "closed": {
+          "label": "Zamknięte",
+          "description": "Analiza i eksport"
+        }
+      },
+      "state": {
+        "activate": "Aktywuj badanie",
+        "switch_to_draft": "Tryb szkicu",
+        "manage": "Zarządzaj statusem"
+      },
+      "notifications": {
+        "success": {
+          "draft": "Badanie pomyślnie przywrócono do szkicu",
+          "active": "Badanie zostało pomyślnie uruchomione",
+          "paused": "Badanie zostało pomyślnie wstrzymane",
+          "closed": "Badanie zostało pomyślnie zamknięte"
+        },
+        "error": "Nie można zmienić stanu badania. Sprawdź swoje uprawnienia i spróbuj ponownie.",
+        "state_changed_active": "Badanie jest teraz aktywne!"
+      }
+    },
+    "design": {
+      "title": "Projekt badania",
+      "translation_needed": "Wymaga weryfikacji (kopia)",
+      "reset_defaults": "Przywróć wartości domyślne",
+      "editing_language_banner": "Edytowanie wersji {{language}}. Aby przełączyć, użyj selektora języka na pasku narzędzi.",
+      "multilang": {
+        "view_others": "Pokaż w innych językach",
+        "other_formulations": "Inne sformułowania"
+      },
+      "guidance": {
+        "title": "Wskazówki projektowe",
+        "intro_title": "Witamy w studiu",
+        "intro_desc": "Zacznij od określenia celu badania. Informacje te będą widoczne dla uczestników przed rozpoczęciem sortowania.",
+        "qsort_title": "Równowaga stwierdzeń i siatki",
+        "qsort_desc": "Upewnij się, że pojemność siatki dokładnie odpowiada liczbie stwierdzeń. Wyważony zbiór Q zwykle podąża za rozkładem quasi-normalnym (w kształcie krzywej dzwonowej)."
+      },
+      "checklist": {
+        "title": "Lista kontrolna",
+        "statements": "Stwierdzenia",
+        "grid_balance": "Siatka wyważona",
+        "branding": "Logo i kolory",
+        "instructions": "Instrukcje",
+        "ready": "Wszystkie niezbędne elementy są gotowe. Możesz teraz uruchomić badanie!",
+        "pending": "Wykonaj wymagane kroki powyżej, aby umożliwić aktywację badania.",
+        "study_title": "Tytuł badania",
+        "consent_defined": "Formularz zgody",
+        "progress": "Postęp",
+        "languages": "Języki",
+        "status_ready": "Gotowe",
+        "status_pending": "Oczekuje",
+        "required": "Wymagane",
+        "reset_defaults": "Przywróć wartości domyślne"
+      },
+      "unsaved_changes": {
+        "title": "Niezapisane zmiany",
+        "description": "W projekcie badania są niezapisane zmiany. Opuszczenie strony spowoduje ich utratę.",
+        "confirm": "Opuść bez zapisywania",
+        "cancel": "Kontynuuj edycję"
+      },
+      "tips": {
+        "title": "Szybka wskazówka",
+        "pilot": "Zawsze przeprowadź testowe sortowanie samodzielnie przed udostępnieniem linku uczestnikom."
+      },
+      "toolbar": {
+        "title": "Projekt",
+        "back": "Wstecz",
+        "preview": "Pokaż podgląd",
+        "hide_preview": "Ukryj podgląd",
+        "popout": "Otwórz podgląd w oknie",
+        "discard": "Odrzuć niezapisane zmiany",
+        "test_run": "Uruchomienie testowe",
+        "save": "Zapisz",
+        "saved": "Zapisano",
+        "closed": "Zamknięte",
+        "back_to_study": "Wróć do badania",
+        "editing_language": "Edytowany język",
+        "manage_langs": "Zarządzaj językami",
+        "select_lang": "Wybierz język",
+        "test_run_help": "Podgląd z perspektywy uczestnika. Te sesje nie są uwzględniane w danych.",
+        "more_actions": "Więcej działań"
+      },
+      "sync": {
+        "saving": "Zapisywanie...",
+        "error": "Błąd zapisu",
+        "modified": "Niezapisane zmiany",
+        "synced": "Zmiany zapisane",
+        "wait_save": "Trwa zapisywanie... Proszę chwilę poczekać.",
+        "recovered": "Szkic przywrócony z lokalnej kopii zapasowej!",
+        "recovery_title": "Znaleziono niezapisane zmiany",
+        "recovery_desc": "Znaleziono lokalną wersję tego badania nowszą niż wersja na serwerze. Czy chcesz ją przywrócić?",
+        "recovery_restore": "Przywróć wersję lokalną",
+        "recovery_discard": "Odrzuć wersję lokalną"
+      },
+      "validation": {
+        "failed_title": "Konfiguracja niekompletna",
+        "failed_desc": "Proszę poprawić te problemy, aby aktywować:",
+        "errors": {
+          "no_statements": "Badanie musi zawierać co najmniej jedno stwierdzenie.",
+          "no_grid": "Brak konfiguracji siatki.",
+          "capacity_mismatch": "Pojemność siatki ({{total}}) nie odpowiada liczbie stwierdzeń ({{count}}).",
+          "no_translations": "Badanie musi mieć co najmniej jedno tłumaczenie językowe.",
+          "missing_default_lang": "Brak tłumaczenia dla języka domyślnego ({{lang}}).",
+          "missing_title": "Brak tytułu dla języka '{{lang}}'.",
+          "missing_consent_title": "Brak tytułu formularza zgody dla języka '{{lang}}'.",
+          "missing_consent_description": "Brak opisu formularza zgody dla języka '{{lang}}'.",
+          "missing_grid_instructions": "Brak instrukcji sortowania Q dla języka '{{lang}}'.",
+          "missing_step_title": "Brak tytułu kroku {{index}} dla języka '{{lang}}'.",
+          "missing_statement_translation": "Stwierdzenie '{{code}}' nie ma tłumaczeń dla: {{missing}}.",
+          "empty_statement_text": "Stwierdzenie '{{code}}' ma pusty tekst dla języka '{{lang}}'.",
+          "missing_question_label": "Pytanie '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}}).",
+          "missing_option_label": "Opcja {{index}} pytania '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}})."
+        }
+      },
+      "languages": {
+        "manage_title": "Zarządzaj językami",
+        "manage_desc": "Włącz lub wyłącz języki dostępne dla uczestników w tym badaniu.",
+        "auto_translate": "Automatyczne tłumaczenie",
+        "auto_translate_desc": "Wkrótce będzie można używać AI do automatycznego tłumaczenia badania na ponad 30 języków.",
+        "activate_title": "Aktywuj język",
+        "activate_desc": "Wybierz język źródłowy, z którego zostaną skopiowane tłumaczenia. Zapobiega to pustym polom widocznym dla uczestników.",
+        "source_label": "Język źródłowy",
+        "copy_notice": "Wszystkie pola zostaną skopiowane. Pola wymagające tłumaczenia będą oznaczone wizualnie.",
+        "confirm_activate": "Aktywuj i skopiuj"
+      },
+      "tabs": {
+        "welcome": "Ogólne",
+        "presort": "Wstępne sortowanie",
+        "condition": "Warunek",
+        "qsort": "Sortowanie Q",
+        "postsort": "Sortowanie końcowe",
+        "interface": "Interfejs",
+        "theme": "Motyw",
+        "general": "Ogólne",
+        "statements": "Stwierdzenia",
+        "grid": "Siatka",
+        "survey": "Ankieta",
+        "branding": "Identyfikacja wizualna"
+      },
+      "view_mode": {
+        "mobile": "Widok mobilny",
+        "desktop": "Widok komputerowy"
+      },
+      "intro": {
+        "general_settings": "Ustawienia ogólne",
+        "welcome_title": "Wiadomość powitalna",
+        "process_title": "Przegląd kroków badania",
+        "process_steps": {
+          "title": "Przegląd kroków badania",
+          "desc": "Zdefiniuj etapy wyświetlane uczestnikom na stronie powitalnej. Jeśli pozostawione puste, zostaną użyte domyślne kroki.",
+          "add_step": "Dodaj krok",
+          "empty": {
+            "title": "Brak niestandardowych kroków",
+            "desc": "Badanie użyje standardowego przepływu metodologii Q (poznajmy się, pierwsze wrażenia, perspektywa, dlaczego)."
+          },
+          "fields": {
+            "title": "Tytuł kroku",
+            "description": "Krótki opis",
+            "icon": "Ikona",
+            "toggle": "Przełącznik"
+          },
+          "defaults": {
+            "new_step": "Nowy krok badania",
+            "new_desc": "Wyjaśnij, co uczestnik będzie robił na tym etapie."
+          },
+          "reset": {
+            "instructions": "Przywróć instrukcje",
+            "consent_title": "Przywróć tytuł zgody",
+            "consent_description": "Przywróć opis zgody",
+            "process_steps": "Przywróć kroki procesu",
+            "process_steps_confirm": "Czy na pewno chcesz przywrócić wszystkie kroki procesu do wartości domyślnych? Zastąpi to niestandardowe kroki."
+          },
+          "inconsistent": {
+            "banner_title": "Niespójne kroki procesu",
+            "rough_disabled": "Krok 'Pierwsze wrażenia' (sortowanie zgrubne) jest na tej liście, ale sortowanie zgrubne jest w badaniu wyłączone. Uczestnicy go nie zobaczą.",
+            "presort_disabled": "Krok 'Poznajmy się' (ankieta wstępna) jest na tej liście, ale ankieta wstępna jest wyłączona. Uczestnicy go nie zobaczą.",
+            "remove_action": "Usuń"
+          }
+        },
+        "consent_title": "Formularz zgody",
+        "reset": "Przywróć instrukcję",
+        "consent_details": "Szczegóły formularza zgody",
+        "fields": {
+          "default_lang": "Język domyślny",
+          "default_lang_help": "Ten język będzie domyślnie wyświetlany uczestnikom, jeśli język przeglądarki nie jest obsługiwany.",
+          "title": "Tytuł badania",
+          "title_placeholder": "Wpisz tytuł publiczny...",
+          "subtitle": "Podtytuł (opcjonalnie)",
+          "subtitle_placeholder": "Krótkie hasło...",
+          "objective": "Cel badania",
+          "objective_placeholder": "Jakie jest pytanie badawcze lub cel tego badania?",
+          "task_overview": "Wprowadzenie",
+          "task_placeholder": "Opisz tutaj przebieg badania (liczba kroków, szacowany czas itp.). To pole jest opcjonalne, jeśli używasz niestandardowych kroków powyżej.",
+          "consent_title_label": "Tytuł zgody",
+          "legal_text": "Tekst prawny / umowa",
+          "legal_placeholder": "Wpisz pełny tekst umowy prawnej..."
+        },
+        "consent_desc": "Uczestnicy muszą zaakceptować te warunki przed rozpoczęciem."
+      },
+      "condition": {
+        "title": "Warunek instrukcji",
+        "label": "Zdefiniuj warunek instrukcji",
+        "desc": "To jest główna instrukcja, która prowadzi uczestników przez cały proces sortowania.",
+        "field_label": "Treść instrukcji",
+        "placeholder": "Np. Proszę uszeregować poniższe stwierdzenia od tych, z którymi najbardziej się Pan/Pani zgadza, do tych, z którymi najbardziej się nie zgadza",
+        "grid_title": "Instrukcja sortowania Q",
+        "grid_desc": "To jest główna instrukcja prowadząca uczestników podczas procesu sortowania Q.",
+        "pre_title": "Instrukcja wstępnego sortowania",
+        "pre_desc": "Instrukcja podawana uczestnikom podczas wstępnego sortowania zgrubnego.",
+        "pre_field_label": "Treść instrukcji",
+        "pre_placeholder": "Np. Na podstawie własnego punktu widzenia podziel karty na trzy stosy...",
+        "enable_pre": "Włącz etap wstępnej instrukcji",
+        "pre_label": "Treść wstępnej instrukcji",
+        "tips": {
+          "title": "Dlaczego to ważne?",
+          "desc": "W metodologii Q 'warunek instrukcji' określa punkt widzenia, z którego uczestnik sortuje stwierdzenia. Powinien być jasny i spójny we wszystkich fazach sortowania."
+        }
+      },
+      "questions": {
+        "enable_presort": "Włącz ankietę wstępną",
+        "enable_presort_desc": "Zbierz dane demograficzne lub inne informacje przed zadaniem sortowania.",
+        "add_field": "Dodaj nowe pole",
+        "basic_fields": "Pola podstawowe",
+        "choice_fields": "Pola wyboru",
+        "scale_fields": "Pola skali",
+        "labels": {
+          "question": "Etykieta pytania",
+          "required": "Pole wymagane",
+          "options": "Opcje",
+          "multiple": "(Dozwolony wielokrotny wybór)",
+          "single": "(Pojedynczy wybór)",
+          "placeholder": "Wpisz tutaj swoje pytanie...",
+          "scale": "Skala ocen",
+          "scale_points": "Liczba punktów",
+          "scale_left": "Etykieta lewego krańca",
+          "scale_right": "Etykieta prawego krańca"
+        },
+        "types": {
+          "text": "Tekst",
+          "long_text": "Tekst długi",
+          "number": "Liczba",
+          "date": "Data",
+          "email": "E-mail",
+          "dropdown": "Lista rozwijana",
+          "radio": "Przycisk radiowy",
+          "checkboxes": "Pola wyboru",
+          "text_audio": "Tekst + audio",
+          "rating": "Skala ocen"
+        },
+        "empty": {
+          "title": "Brak pytań",
+          "desc": "Kliknij powyżej, aby dodać pierwsze pytanie"
+        },
+        "defaults": {
+          "new_question": "Nowe pytanie",
+          "option": "Opcja",
+          "enter_answer": "Wpisz swoją odpowiedź...",
+          "untitled": "Pytanie bez tytułu",
+          "scale_left": "Zdecydowanie się nie zgadzam",
+          "scale_right": "Zdecydowanie się zgadzam"
+        },
+        "actions": {
+          "add_option": "Dodaj opcję",
+          "copy_from": "Importuj z języka",
+          "copy_success": "Zaimportowano"
+        },
+        "logic": {
+          "title": "Logika widoczności",
+          "enable": "Dodaj warunek widoczności",
+          "depends_on": "Pokaż to pytanie tylko jeśli...",
+          "select_placeholder": "Wybierz pytanie nadrzędne",
+          "operator": "Operator",
+          "value": "Wartość porównania",
+          "operators": {
+            "equals": "Równa się",
+            "not_equals": "Nie równa się",
+            "contains": "Zawiera",
+            "greater_than": "Większe niż",
+            "less_than": "Mniejsze niż"
+          }
+        }
+      },
+      "qsort": {
+        "tabs": {
+          "statements": "Stwierdzenia",
+          "distribution": "Rozkład"
+        },
+        "bulk": {
+          "title": "Edytor zbiorczy (szybkie wklejanie)",
+          "desc": "Jedno stwierdzenie w każdym wierszu. Obsługuje format 'kod: tekst' i kopiowanie z Excela (wielojęzyczne).",
+          "replace_all": "Zastąp wszystko",
+          "append": "Dołącz do listy",
+          "sync_by_code": "Synchronizuj/scal wg kodu",
+          "placeholder": "Proste: Moje stwierdzenie",
+          "detected": "Wykryto {{count}} stwierdzeń",
+          "process_replace": "Przetwórz i zastąp stwierdzenia",
+          "process_append": "Przetwórz i dołącz stwierdzenia",
+          "process_sync": "Przetwórz i synchronizuj tłumaczenia",
+          "detected_format": {
+            "excel": "Wykryto format Excel (tabulatory)",
+            "list": "Wykryto format listy (kod: tekst)",
+            "simple": "Wykryto prostą listę (jeden wiersz = jedno stwierdzenie)",
+            "multi_lang": "Wielojęzyczne: {{langs}}",
+            "with_codes": "Z niestandardowymi kodami"
+          }
+        },
+        "set": {
+          "title": "Zbiór Q",
+          "clear": "Wyczyść wszystko",
+          "confirm_clear": "Czy na pewno chcesz usunąć WSZYSTKIE stwierdzenia? Tego działania nie można cofnąć.",
+          "updated": "Stwierdzenie zaktualizowane",
+          "cleared": "Wszystkie stwierdzenia wyczyszczone",
+          "imported": "Pomyślnie zaimportowano {{count}} stwierdzeń",
+          "reset_codes": "Resetuj kody",
+          "confirm_reset_codes": "Czy na pewno chcesz ponownie nadać numery wszystkim kodom stwierdzeń (s1, s2, s3...)?",
+          "codes_reset": "Kody stwierdzeń ponownie ponumerowane"
         },
         "settings": {
-            "title": "Settings",
-            "description": "Data retention, archiving, and study deletion.",
-            "lifecycle": {
-                "title": "Archiving",
-                "description": "Archive the study to make it read-only for everyone.",
-                "notice": "To archive a study, it must first be closed. Once archived, no further changes can be made.",
-                "archived_status": "Study is archived",
-                "archive_button": "Archive study",
-                "current_state": "Current state"
-            },
-            "danger": {
-                "title": "Danger zone",
-                "description": "Actions here are irreversible.",
-                "notice": "Deleting a study removes ALL data (participants, answers, config) permanently. Study must be archived before deletion.",
-                "delete_button": "Delete study",
-                "delete_confirm": "Are you sure? This action is IRREVERSIBLE.",
-                "delete_dialog_title": "Delete this study?",
-                "delete_dialog_intro": "Permanently deletes sorts, audio, and analysis runs.",
-                "delete_dialog_typed_label": "Type the study slug to confirm",
-                "delete_dialog_action": "Delete permanently"
-            },
-            "save_button": "Save",
-            "save_success": "Settings updated",
-            "save_success_desc": "Study settings have been saved.",
-            "save_error": "Could not save settings. Verify the values and try again.",
-            "save_error_desc": "Failed to update settings. Slug might be taken.",
-            "archive_success": "Study archived",
-            "archive_success_desc": "The study is now archived and read-only.",
-            "archive_error": "Error archiving study",
-            "archive_error_desc": "Failed to archive study. Is it closed?",
-            "delete_success": "Study deleted",
-            "delete_success_desc": "The study has been permanently removed.",
-            "delete_error": "Could not delete study. Make sure all data has been cleared first.",
-            "delete_error_desc": "Failed to delete study.",
-            "storage": {
-                "title": "Audio Storage Usage",
-                "used": "Storage Used",
-                "quota": "Quota",
-                "quota_label": "Storage Quota",
-                "quota_help": "Maximum total audio storage for this study (10–1000 MB).",
-                "error": "Failed to load storage usage.",
-                "warning_high_usage": "Storage usage is high. Consider increasing the quota or removing old recordings.",
-                "save_success": "Storage quota updated",
-                "save_error": "Could not update storage quota. Try again."
-            },
-            "retention": {
-                "title": "Data retention",
-                "months_label": "Retention (months)",
-                "help": "Common values: 6, 12, 24, 60 months. Leave empty for system default (12).",
-                "save_success": "Data retention policy updated",
-                "save_error": "Failed to update data retention policy",
-                "range_error": "Retention must be an integer between 1 and 240 months."
-            }
+          "title": "Ustawienia badawcze",
+          "desc": "Skonfiguruj sposób prezentacji stwierdzeń uczestnikom",
+          "show_codes": "Pokaż kody stwierdzeń",
+          "show_codes_desc": "Wyświetlaj kody stwierdzeń (np. 'S1', 'S2') obok tekstu.",
+          "randomize": "Losuj kolejność stwierdzeń",
+          "randomize_desc": "Prezentuj stwierdzenia w losowej kolejności każdemu uczestnikowi (spójnie w ramach sesji)"
         },
-        "privacy": {
-            "title": "Data privacy",
-            "header_desc": "Consent, inventory & anonymisation",
-            "load_error": "Failed to load data inventory.",
-            "participants_title": "Participants snapshot",
-            "stat_started": "Started",
-            "stat_completed": "Completed",
-            "stat_discarded": "Discarded",
-            "stat_anonymised": "Anonymised",
-            "older_1y": "Older than 1 year (not anonymised)",
-            "older_2y": "Older than 2 years (not anonymised)",
-            "audio_title": "Audio storage",
-            "audio_count": "Recordings",
-            "audio_mb": "Total size",
-            "locale_title": "Locale breakdown",
-            "locale_col": "Language",
-            "locale_count_col": "Participants",
-            "locale_empty": "No locale data yet.",
-            "timeline_title": "Timeline",
-            "tl_first": "First submission",
-            "tl_last": "Last submission",
-            "tl_anon": "Last anonymisation",
-            "bulk_title": "Bulk anonymisation",
-            "bulk_desc": "Remove personal data from completed participants submitted before a cutoff date. Q-sort rankings are preserved.",
-            "cutoff_label": "Cutoff date",
-            "cutoff_help": "Only completed participants submitted strictly before this date will be anonymised.",
-            "preview_label": "Candidates:",
-            "preview_zero": "No participants qualify for this cutoff. Try an earlier date.",
-            "anonymise_button": "Anonymise",
-            "anonymise_success": "Anonymisation complete",
-            "anonymise_success_desc": "{{n}} participant(s) anonymised, {{s}} already anonymous.",
-            "anonymise_error": "Anonymisation failed",
-            "confirm_title": "Anonymise participant data?",
-            "confirm_candidates": "{{count}} completed participant(s) submitted before {{date}} will be anonymised.",
-            "confirm_preserved": "Q-sort rankings are kept; identity is removed.",
-            "confirm_irreversible": "This action is immediate and cannot be undone.",
-            "confirm_in_progress": "Anonymising…",
-            "confirm_action": "Yes, anonymise",
-            "cutoff_from_policy": "Default derived from study retention policy ({{months}} months).",
-            "empty": {
-                "title": "No participant data yet",
-                "body": "This page activates once participants submit. Share the study link first.",
-                "cta": "Open study overview"
-            },
-            "consent": {
-                "title": "Consent form",
-                "description": "What participants see before they enter the study. Edited in Study design.",
-                "no_text": "No consent text set yet.",
-                "no_title": "(no title)",
-                "no_body": "(empty)",
-                "edit_in_design": "Edit in Study design",
-                "view": "View"
-            }
-        },
-        "projects": {
-            "title": "Projects",
-            "settings": {
-                "title": "Project settings",
-                "identity_desc": "Manage project identity.",
-                "general": {
-                    "title": "General settings",
-                    "desc": "Identity and primary identification of your project.",
-                    "label_title": "Project title",
-                    "placeholder_title": "My awesome lab",
-                    "label_slug": "URL slug",
-                    "placeholder_slug": "My-lab",
-                    "slug_hint": "Changing the slug will update all your research dashboard links.",
-                    "save": "Save",
-                    "save_success": "Project updated successfully",
-                    "save_error": "Failed to update project."
-                },
-                "team_growth_title": "Team management",
-                "team_growth_desc": "Need more researchers? You can invite collaborators to your project. They will be able to manage all studies within this project.",
-                "team": {
-                    "title": "Team members",
-                    "desc": "List of users with access to this project.",
-                    "col_user": "User",
-                    "col_role": "Role",
-                    "col_joined": "Joined",
-                    "col_actions": "Actions",
-                    "remove_confirm": "Are you sure you want to remove this member?",
-                    "remove_dialog_title": "Remove team member?",
-                    "remove_dialog_body": "{{name}} will lose access to this project. They can be re-invited later.",
-                    "remove_dialog_action": "Remove",
-                    "remove_member_aria": "Remove {{name}}",
-                    "remove_success": "Member removed successfully",
-                    "remove_error": "Failed to remove member",
-                    "growth_title": "Team growth",
-                    "growth_desc": "Need more researchers? You can invite collaborators to your project. They will be able to manage all studies within this project.",
-                    "invite_button": "Invite collaborator",
-                    "permissions_matrix": {
-                        "title": "Permissions matrix",
-                        "admin": {
-                            "label": "Admin",
-                            "desc": "Can manage project settings, members, and all studies."
-                        },
-                        "owner": {
-                            "label": "Owner",
-                            "desc": "Full project, member, and study control."
-                        },
-                        "member": {
-                            "label": "Member",
-                            "desc": "Can create and manage all studies. Restricted from project settings."
-                        },
-                        "viewer": {
-                            "label": "Viewer",
-                            "desc": "Read-only access to all studies and data in the project."
-                        }
-                    },
-                    "coming_soon": "Coming soon",
-                    "invite_modal": {
-                        "title": "Invite collaborator",
-                        "email_label": "Collaborator email",
-                        "role_label": "Assigned role",
-                        "success": "Invitation link generated!",
-                        "error": "Failed to create invitation.",
-                        "send": "Create & send invitation",
-                        "copy_success": "Link copied to clipboard!"
-                    }
-                }
-            },
-            "members": {
-                "quota": "{{count}}/{{limit}} seats used",
-                "quota_full_tooltip": "Member limit reached. Increase MAX_MEMBERS_PER_PROJECT or remove a member."
-            },
-            "create": {
-                "quota": "{{count}}/{{limit}} owned projects",
-                "quota_full_tooltip": "You've reached your owned-project limit."
-            }
-        },
-        "members": {
-            "title": "Team members",
-            "description": "Manage who can access this project and what they can do."
-        },
-        "participants": {
-            "title": "Participants",
-            "description": "Manage participants and explore submitted data.",
-            "table": {
-                "id": "ID",
-                "status": "Status",
-                "started": "Started at",
-                "completed": "Completed at",
-                "duration": "Duration",
-                "actions": "Actions"
-            }
-        },
-        "participant": {
-            "tabs": {
-                "session": "Metadata",
-                "presort": "Pre-Sort",
-                "grid": "Q-Sort Grid",
-                "postsort": "Post-Sort"
-            },
-            "grid": {
-                "detail_view": "Card Details",
-                "no_comment": "No comment provided.",
-                "select_instruction": "Select a card on the grid to view details.",
-                "read_only_mode": "Viewer Mode",
-                "score": "Score"
-            },
-            "metadata": {
-                "title": "Session Metadata",
-                "technology": "Technology",
-                "browser": "Browser",
-                "session": "Session Details",
-                "duration": "Total Duration",
-                "started": "Started",
-                "submitted": "Submitted",
-                "id": "Internal ID",
-                "ip_hash": "IP Hash",
-                "recruitment_token": "Recruitment Token",
-                "device": {
-                    "mobile": "Mobile",
-                    "tablet": "Tablet",
-                    "desktop": "Desktop"
-                }
-            },
-            "status": {
-                "started": "Started",
-                "completed": "Completed",
-                "discarded": "Discarded",
-                "in_progress": "In Progress"
-            },
-            "survey": {
-                "presort": "Pre-Sort Questions",
-                "postsort": "Post-Sort Questions",
-                "no_answers": "No answers recorded for this section.",
-                "categories": {
-                    "identity": "Identity & Contact",
-                    "questions": "Questionnaire Responses",
-                    "comments": "Card Comments",
-                    "feedback": "General Feedback"
-                }
-            }
+        "grid": {
+          "title": "Siatka rozkładu sortowania Q",
+          "desc": "Kształt siatki zmusza uczestników do różnicowania stwierdzeń, przybliżając rozkład normalny.",
+          "slot_count": "Przydzielono {{count}} miejsc",
+          "stat_count": "{{count}} stwierdzeń",
+          "perfect": "Idealna równowaga",
+          "too_many": "{{count}} stwierdzeń za dużo",
+          "too_few": "Brakuje {{count}} stwierdzeń",
+          "min_reached": "Osiągnięto minimalny zakres (±2)",
+          "max_reached": "Osiągnięto maksymalny zakres (±6)",
+          "remove_extreme_columns": "Usuń skrajne kolumny",
+          "add_extreme_columns": "Dodaj skrajne kolumny",
+          "symmetry_lock": "Blokada symetrii",
+          "symmetry_lock_desc": "Automatycznie stosuj zmiany do kolumn przeciwnych, aby zachować wyważony rozkład.",
+          "auto_balance": "Auto-wyważenie",
+          "auto_balance_desc": "Przekształć siatkę w wyważony rozkład półnormalny",
+          "reshaped": "Siatka przekształcona do wyważonego rozkładu",
+          "balanced": "Siatka wyważona do standardowego rozkładu",
+          "no_statements": "Najpierw dodaj stwierdzenia, aby automatycznie ukształtować siatkę",
+          "statements": "stwierdzenia",
+          "ideal_shape": "Idealny kształt",
+          "symmetric": "Symetryczna",
+          "asymmetric": "Asymetryczna",
+          "tooltip_title": "Dlaczego rozkład wymuszony?",
+          "tooltip_desc": "Metodologia Q używa rozkładu quasi-normalnego (kurtoza > 0), aby zapewnić, że uczestnicy dokonują znaczących rozróżnień. Kształt piramidy zapobiega błędowi tendencji centralnej.",
+          "locked": "Projekt zablokowany",
+          "locked_desc": "Zmiany strukturalne (kody stwierdzeń, siatka) są wyłączone, ponieważ badanie zebrało dane lub nie jest już w trybie szkicu. Nadal można edytować tłumaczenia tekstowe.",
+          "locked_active": "To badanie jest aktywne. Przełącz na tryb szkicu, aby edytować.",
+          "locked_paused": "To badanie jest wstrzymane. Przełącz na tryb szkicu, aby edytować.",
+          "locked_closed": "To badanie jest zamknięte. Projekt jest zarchiwizowany.",
+          "mismatch_title": "Niezgodność pojemności siatki",
+          "mismatch_desc": "Masz {{statements}} stwierdzeń, ale siatka ma tylko miejsca dla {{slots}} elementów. Dostosuj kolumny poniżej.",
+          "unlock_hint": "Przejdź do eksploratora danych, aby wyczyścić sesje i odblokować strukturę"
         }
+      },
+      "postsort": {
+        "extreme": {
+          "title": "Kolumny docelowe",
+          "desc": "Wybierz kolumny, które wyzwalają pytania uzupełniające.",
+          "no_columns": "Nie wybrano żadnych kolumn.",
+          "add_label": "Dodaj kolumnę:",
+          "prompt_label": "Pytanie o stwierdzenia",
+          "prompt_placeholder": "Dlaczego umieścił/a Pan/Pani to stwierdzenie w tym miejscu?",
+          "add": "Dodaj",
+          "add_defaults": "Dodaj domyślne skrajności",
+          "select_placeholder": "Wybierz..."
+        },
+        "random_comments": {
+          "title": "Zezwalaj na swobodne komentarze",
+          "desc": "Pozwól uczestnikom dodawać komentarze do dowolnego stwierdzenia na siatce."
+        },
+        "custom": {
+          "title": "Pytania niestandardowe",
+          "desc": "Dodaj niestandardowe pytania do ankiety po sortowaniu."
+        },
+        "missing": {
+          "title": "Pytaj o brakujące stwierdzenia",
+          "desc": "Jeśli tak, proszę opisać je krótko.",
+          "prompt_label": "Treść pytania",
+          "prompt_placeholder": "Proszę śmiało sugerować i wyjaśniać."
+        },
+        "steps": {
+          "step1": "Krok 1: informacja zwrotna",
+          "step2": "Krok 2: pytania"
+        },
+        "email": {
+          "title": "Kontakt uzupełniający z uczestnikiem",
+          "desc": "Zbieraj adresy e-mail do celów kontaktu uzupełniającego lub przekazania wyników badania.",
+          "interview": "Zaproponuj kontakt uzupełniający",
+          "results": "Zaproponuj zapis na listę mailingową z wynikami badania",
+          "interview_warning": "Uwaga: zgoda na kontakt znosi anonimowość wobec badacza.",
+          "results_hint": "E-mail wyłącznie do celów przekazania wyników, anonimowość zachowana."
+        },
+        "audio": {
+          "title": "Nagranie audio",
+          "desc": "Pozwól uczestnikom nagrywać odpowiedzi audio zamiast tekstu.",
+          "max_duration": "Maksymalny czas trwania",
+          "seconds": "sekund",
+          "max_duration_help": "Maksymalny czas nagrywania na pytanie (30–600 sekund).",
+          "participant_choice_info": "Uczestnicy mogą odpowiadać tekstem, nagraniem audio lub obydwoma sposobami na każde pytanie."
+        }
+      },
+      "interface": {
+        "title": "Dostosowanie interfejsu",
+        "desc": "Dostosuj przyciski i etykiety interfejsu do tonu badania (np. zastępując 'zgadzam się/nie zgadzam się' słowami 'lubię/nie lubię').",
+        "nav": {
+          "title": "Przyciski nawigacyjne",
+          "start": "Przycisk start",
+          "next": "Przycisk następnego kroku",
+          "submit": "Przycisk wyślij",
+          "confirm": "Przycisk potwierdzenia sortowania",
+          "tooltips": {
+            "start": "Przycisk rozpoczynający badanie",
+            "next": "Przejście do następnego kroku",
+            "submit": "Wyślij wyniki na końcu",
+            "confirm": "Ogólny przycisk zatwierdzania"
+          }
+        },
+        "terms": {
+          "title": "Terminologia sortowania",
+          "desc": "Zdefiniuj etykiety dla sortowania spontanicznego i spektrum siatki.",
+          "rough": "Etykiety sortowania zgrubnego",
+          "agree": "Zgadzam się",
+          "neutral": "Neutralnie",
+          "disagree": "Nie zgadzam się",
+          "grid": "Legendy siatki (skrajności)",
+          "most_agree": "Najbardziej zgadzam się",
+          "most_disagree": "Najbardziej nie zgadzam się"
+        },
+        "hints": {
+          "title": "Wskazówki metodologiczne",
+          "desc": "Dodaj lub zmodyfikuj pływające wskazówki pomagające uczestnikom podczas fazy sortowania na siatce.",
+          "placeholder": "Wpisz wskazówkę metodologiczną...",
+          "add": "Dodaj wskazówkę",
+          "reset": "Przywróć wartości domyślne"
+        },
+        "help": {
+          "title": "Wskazówki dla kroków (co/dlaczego)",
+          "desc": "Dostosuj kontekstową pomoc dostępną dla uczestników na każdym kroku przez nakładkę '?'.",
+          "step_disabled": "(krok wyłączony)"
+        }
+      },
+      "theme": {
+        "title": "Identyfikacja wizualna",
+        "accent": {
+          "title": "Kolor akcentu",
+          "desc": "Ten kolor będzie używany dla przycisków, linków i wyróżnień w całym badaniu.",
+          "pick": "Wybierz kolor",
+          "reset": "Przywróć domyślny"
+        },
+        "logo": {
+          "title": "Logo badania",
+          "desc": "Prześlij niestandardowe logo zastępujące domyślną markę Open-Q.",
+          "label": "URL logo",
+          "hint": "Zalecany rozmiar: 200×50 px. Obsługiwane formaty: PNG, SVG, JPG.",
+          "preview": "Podgląd logo",
+          "help_title": "Gdzie pojawia się to logo?",
+          "help_desc": "Logo jest wyświetlane na górze każdej strony badania (pasek nawigacyjny) i na stronie powitalnej. Wzmacnia identyfikację wizualną projektu."
+        },
+        "partners": {
+          "title": "Partnerzy instytucjonalni",
+          "desc": "Dodaj logo wspierających instytucji lub partnerów.",
+          "add": "Dodaj partnera",
+          "name_label": "Nazwa partnera",
+          "name_placeholder": "Nazwa instytucji",
+          "logo_label": "URL logo",
+          "url_label": "Strona internetowa (opcjonalnie)",
+          "url_placeholder": "https://...",
+          "help_title": "Wyświetlanie logo",
+          "help_desc": "Logo partnerów są wyświetlane na stronie startowej oraz w nagłówku badania, obok głównego logo."
+        },
+        "upload": {
+          "upload": "Prześlij",
+          "recommended": "Zalecane",
+          "invalid_type": "Nieprawidłowy typ pliku. Użyj PNG, JPG lub SVG.",
+          "file_too_large": "Plik jest za duży. Maksymalny rozmiar: {{size}} kB.",
+          "conversion_error": "Nie udało się przetworzyć obrazu.",
+          "processing": "Przetwarzanie obrazu...",
+          "drag_drop": "Przeciągnij i upuść lub kliknij, aby przesłać",
+          "max": "Maks."
+        }
+      },
+      "activate_dialog": {
+        "title": "Aktywować to badanie?",
+        "description": "Aktywacja otwiera rekrutację i odblokowuje publiczne linki. Prawdziwi uczestnicy będą mogli zacząć przesyłać odpowiedzi.",
+        "checklist_title": "Kontrola przed startem",
+        "languages_title": "Języki",
+        "lang_ready": "Gotowe",
+        "lang_incomplete": "Niekompletne",
+        "required": "(wymagane)",
+        "attestation": "Zapoznałem/am się z tekstem zgody i polityką przechowywania danych i potwierdzam, że badanie jest gotowe do przyjęcia prawdziwych uczestników.",
+        "confirm": "Aktywuj badanie"
+      }
+    },
+    "data": {
+      "title": "Dane",
+      "description": "Monitoruj uczestnictwo w czasie rzeczywistym, analizuj jakość danych i zarządzaj sesjami badawczymi.",
+      "sections": {
+        "key_indicators": "Kluczowe wskaźniki",
+        "responses": "Odpowiedzi",
+        "key_statistics": "Kluczowe statystyki"
+      },
+      "stats": {
+        "email_collection": "Zbieranie e-maili",
+        "participants": "łącznie",
+        "newsletter": "Chce wyniki",
+        "opt_in": "Wskaźnik odpowiedzi",
+        "follow_up": "Potencjał kontaktu uzupełniającego",
+        "interested": "zainteresowanych",
+        "click_to_filter": "Kliknij, aby filtrować",
+        "click_to_export": "Kliknij, aby eksportować listę",
+        "completed": "Ukończone",
+        "in_progress": "W toku",
+        "abandoned_count": "{{count}} porzuconych",
+        "interview_interested": "Akceptuje kontakt uzupełniający",
+        "interview": "Akceptuje kontakt uzupełniający",
+        "email": "E-maile"
+      },
+      "tabs": {
+        "live": "Uczestnicy na żywo",
+        "test": "Sesje testowe",
+        "browse": "Widok interaktywny",
+        "export": "Centrum eksportu"
+      },
+      "status": {
+        "started": "rozpoczęte",
+        "completed": "Ukończone",
+        "in_progress": "W toku",
+        "abandoned": "Porzucone",
+        "discarded": "odrzucone"
+      },
+      "step": {
+        "consent": "Zgoda",
+        "presort": "Ankieta wstępna",
+        "rough": "Sortowanie zgrubne",
+        "fine": "Sortowanie Q",
+        "post": "Ankieta końcowa"
+      },
+      "actions": {
+        "discard": "Odrzuć",
+        "restore": "Przywróć",
+        "export": "Eksportuj",
+        "clear_all": "Resetuj wszystkie dane",
+        "clear_all_confirm": "UWAGA: Spowoduje to trwałe usunięcie WSZYSTKICH danych uczestników dla tego badania. Tego działania nie można cofnąć.",
+        "clear_all_success": "Wszystkie dane wyczyszczone",
+        "clear_all_error": "Nie udało się wyczyścić danych. Sprawdź uprawnienia i spróbuj ponownie."
+      },
+      "confirm_discard": {
+        "title": "Odrzucić uczestnika?",
+        "description": "Ten uczestnik zostanie wykluczony z eksportów i analiz. Można go przywrócić później.",
+        "reason_label": "Powód (opcjonalnie)",
+        "reason_placeholder": "Dlaczego ten uczestnik jest odrzucany?"
+      },
+      "confirm_restore": {
+        "title": "Przywrócić uczestnika?",
+        "description": "Ten uczestnik zostanie ponownie uwzględniony w eksportach i analizach."
+      },
+      "guide": {
+        "title": "Przewodnik formatów",
+        "csv": {
+          "title": "Uniwersalny CSV",
+          "desc": "Surowe dane prostokątne. Najlepsze do analizy w R, Pythonie, SPSS lub Excelu. Zawiera wszystkie metadane."
+        },
+        "json": {
+          "title": "KenQ JSON",
+          "desc": "Zoptymalizowane dla narzędzia web-kenq. Zawiera definicję badania i sortowania."
+        },
+        "zip": {
+          "title": "Pakiet PQMethod (ZIP)",
+          "desc": "Zawiera starsze pliki .DAT i .STA do analizy DOS PQMethod."
+        }
+      },
+      "table": {
+        "participant": "Uczestnik",
+        "lang": "Język",
+        "status": "Status",
+        "consent": "Zgoda",
+        "flags": "Oznaczenia",
+        "duration": "Czas trwania",
+        "submitted": "Przesłano",
+        "last_step": "Ostatni krok",
+        "current_step": "Aktualny krok",
+        "view": "Pokaż",
+        "actions": "Szczegóły",
+        "duplicate_ip": "Duplikat IP",
+        "duplicate_ip_hint": "Współdzieli hash IP z innymi uczestnikami"
+      },
+      "tooltips": {
+        "suspect": "Potencjalnie podejrzane: czas trwania sesji < 2 minuty",
+        "has_comments": "Zawiera komentarze uczestnika do kart",
+        "has_audio": "Ma odpowiedzi audio",
+        "email_provided": "Podano e-mail",
+        "newsletter_consent": "Chce wyniki",
+        "interview_consent": "Akceptuje kontakt uzupełniający"
+      },
+      "toast": {
+        "discarded": "Uczestnik odrzucony",
+        "restored": "Uczestnik przywrócony",
+        "error": "Nie udało się zaktualizować uczestnika. Sprawdź połączenie i spróbuj ponownie."
+      },
+      "detail": {
+        "participant": "Uczestnik",
+        "participant_n": "Uczestnik {{code}}",
+        "not_found": "Uczestnik nie znaleziony",
+        "title": "Profil uczestnika",
+        "session": "Sesja",
+        "discarded_badge": "Odrzucony",
+        "description": "Pełne wyniki sortowania Q i metadane.",
+        "stats": {
+          "duration": "Łączny czas trwania",
+          "language": "Użyty język"
+        },
+        "actions": {
+          "discard": "Odrzuć uczestnika",
+          "restore": "Przywróć uczestnika"
+        },
+        "sort_config": "Konfiguracja sortowania",
+        "survey": {
+          "title": "Odpowiedzi ankietowe",
+          "csv_note": "Pełne odpowiedzi dostępne w eksporcie CSV."
+        }
+      },
+      "filter": {
+        "show_discarded": "Uwzględnij odrzucone rekordy",
+        "all_states": "Wszystkie stany",
+        "only_active": "Tylko aktywne",
+        "only_flagged": "Oznaczona jakość"
+      },
+      "filters": {
+        "active": "Aktywne filtry",
+        "has_email": "Podano e-mail",
+        "newsletter": "Chce wyniki",
+        "interview": "Akceptuje kontakt uzupełniający",
+        "flagged": "Tylko oznaczone",
+        "clear_all": "Wyczyść filtry",
+        "remove_filter": "Usuń filtr",
+        "all_statuses": "Wszystkie statusy",
+        "all_consents": "Wszystkie",
+        "all_indicators": "Wszystkie",
+        "all_steps": "Wszystkie kroki",
+        "has_comments": "Ma komentarze",
+        "has_audio": "Ma audio",
+        "has_recruitment": "Ma link rekrutacyjny"
+      },
+      "charts": {
+        "section_title": "Rozkłady odpowiedzi",
+        "distribution_label": "Rozkład dla {{question}}",
+        "multi_select_note": "Dozwolony wielokrotny wybór",
+        "responses_count": "{{count}} odpowiedzi",
+        "no_answer": "Brak odpowiedzi",
+        "option": "Opcja",
+        "count": "Liczba"
+      },
+      "search": {
+        "placeholder": "Szukaj po ID lub tokenie rekrutacyjnym...",
+        "records_found": "Wykryte rekordy",
+        "no_results": "Żaden rekord nie pasuje do zapytania"
+      },
+      "errors": {
+        "load_failed": "Synchronizacja z chmurą przerwana. Proszę sprawdzić połączenie."
+      },
+      "export_emails_success": "E-maile wyeksportowane pomyślnie",
+      "empty": {
+        "no_participants_title": "Brak uczestników",
+        "no_participants_desc": "Udostępnij link do badania, aby zacząć zbierać odpowiedzi.",
+        "contract_title": "Brak zgłoszeń",
+        "contract_body": "Zgłoszenia i eksporty pojawią się tutaj. Udostępnij link do badania, aby zacząć zbierać dane.",
+        "contract_cta": "Otwórz widok ogólny badania"
+      },
+      "pagination": {
+        "showing": "Pokazuję {{from}}–{{to}} z {{total}}"
+      }
+    },
+    "team": {
+      "title": "Zespół badania",
+      "description": "Zarządzaj współpracownikami i kontrolą dostępu na poziomie badania.",
+      "invite_title": "Zaproś współpracownika",
+      "invite_description": "Wygeneruj bezpieczny link, aby zaprosić nowego członka do tego badania.",
+      "email_label": "Adres e-mail",
+      "role_label": "Rola",
+      "select_role": "Wybierz rolę",
+      "generate_link": "Generuj link",
+      "invite_success": "Link zaproszenia wygenerowany!",
+      "invite_error": "Nie udało się wygenerować zaproszenia",
+      "copy_success": "Link skopiowany do schowka",
+      "share_label": "Udostępnij ten link zaproszonej osobie:",
+      "collab_overview": "Przegląd współpracy",
+      "active_members": "Aktywni członkowie",
+      "permissions_info": "Informacje o uprawnieniach",
+      "list_title": "Zespół badawczy",
+      "list_description": "Zarządzaj dostępem dla istniejących współpracowników.",
+      "added_on": "Dodano",
+      "headers": {
+        "collaborator": "Współpracownik",
+        "role": "Rola",
+        "actions": "Akcje"
+      },
+      "roles": {
+        "owner": "Właściciel (pełna kontrola)",
+        "editor": "Redaktor (projekt i analiza)",
+        "viewer": "Obserwator (tylko odczyt)",
+        "owner_badge": "WŁAŚCICIEL",
+        "editor_badge": "REDAKTOR",
+        "viewer_badge": "OBSERWATOR"
+      },
+      "permissions": {
+        "owner": "Może usunąć badanie i zarządzać zespołem.",
+        "editor": "Może modyfikować projekt i przeglądać wyniki.",
+        "viewer": "Dostęp tylko do odczytu do wszystkich modułów."
+      }
+    },
+    "empty_states": {
+      "participants": {
+        "title": "Gotowe do uruchomienia?",
+        "desc": "Udostępnij link do badania, aby rozpocząć zbieranie odpowiedzi. Pierwszy uczestnik jest o jedno kliknięcie.",
+        "action": "Kopiuj link do badania",
+        "hint": "Lub zeskanuj kod QR",
+        "copy_success": "Link do badania skopiowany do schowka!"
+      },
+      "team": {
+        "title": "Działasz samodzielnie",
+        "desc": "Zaproś współpracowników, aby pomogli zarządzać tym badaniem. Mogą przeglądać dane, edytować projekt lub jedynie obserwować.",
+        "action": "Zaproś pierwszego współpracownika"
+      },
+      "designer": {
+        "title": "Tabula rasa",
+        "desc": "To badanie nie ma jeszcze żadnych stwierdzeń. Dodaj elementy zbioru Q, aby rozpocząć projektowanie sortowania.",
+        "action": "Wczytaj przykładowy zbiór Q"
+      }
+    },
+    "status": {
+      "active": "Active",
+      "paused": "Paused",
+      "closed": "Closed",
+      "draft": "Draft"
+    },
+    "settings": {
+      "title": "Ustawienia",
+      "description": "Przechowywanie danych, archiwizacja i usuwanie badania.",
+      "lifecycle": {
+        "title": "Archiwizacja",
+        "description": "Zarchiwizuj badanie, aby uczynić je tylko do odczytu dla wszystkich.",
+        "notice": "Aby zarchiwizować badanie, należy je najpierw zamknąć. Po archiwizacji nie można wprowadzać żadnych zmian.",
+        "archived_status": "Badanie jest zarchiwizowane",
+        "archive_button": "Archiwizuj badanie",
+        "current_state": "Aktualny stan"
+      },
+      "danger": {
+        "title": "Strefa zagrożenia",
+        "description": "Działania tutaj są nieodwracalne.",
+        "notice": "Usunięcie badania trwale usuwa WSZYSTKIE dane (uczestników, odpowiedzi, konfigurację). Badanie musi być zarchiwizowane przed usunięciem.",
+        "delete_button": "Usuń badanie",
+        "delete_confirm": "Czy na pewno? To działanie jest NIEODWRACALNE.",
+        "delete_dialog_title": "Usunąć to badanie?",
+        "delete_dialog_intro": "Trwale usuwa sortowania, nagrania audio i przebiegi analiz.",
+        "delete_dialog_typed_label": "Wpisz slug badania, aby potwierdzić",
+        "delete_dialog_action": "Usuń trwale"
+      },
+      "save_button": "Zapisz",
+      "save_success": "Ustawienia zaktualizowane",
+      "save_success_desc": "Ustawienia badania zostały zapisane.",
+      "save_error": "Nie udało się zapisać ustawień. Sprawdź wartości i spróbuj ponownie.",
+      "save_error_desc": "Nie udało się zaktualizować ustawień. Możliwe, że slug jest już zajęty.",
+      "archive_success": "Badanie zarchiwizowane",
+      "archive_success_desc": "Badanie jest teraz zarchiwizowane i tylko do odczytu.",
+      "archive_error": "Błąd archiwizacji badania",
+      "archive_error_desc": "Nie udało się zarchiwizować badania. Czy zostało zamknięte?",
+      "delete_success": "Badanie usunięte",
+      "delete_success_desc": "Badanie zostało trwale usunięte.",
+      "delete_error": "Nie udało się usunąć badania. Upewnij się, że wszystkie dane zostały wcześniej wyczyszczone.",
+      "delete_error_desc": "Nie udało się usunąć badania.",
+      "storage": {
+        "title": "Użycie pamięci audio",
+        "used": "Używana pamięć",
+        "quota": "Limit",
+        "quota_label": "Limit pamięci",
+        "quota_help": "Maksymalna łączna pamięć audio dla tego badania (10–1000 MB).",
+        "error": "Nie udało się wczytać informacji o użyciu pamięci.",
+        "warning_high_usage": "Użycie pamięci jest wysokie. Rozważ zwiększenie limitu lub usunięcie starych nagrań.",
+        "save_success": "Limit pamięci zaktualizowany",
+        "save_error": "Nie udało się zaktualizować limitu pamięci. Proszę spróbować ponownie."
+      },
+      "retention": {
+        "title": "Przechowywanie danych",
+        "months_label": "Okres przechowywania (miesiące)",
+        "help": "Typowe wartości: 6, 12, 24, 60 miesięcy. Pozostaw puste, aby użyć wartości domyślnej systemu (12).",
+        "save_success": "Polityka przechowywania danych zaktualizowana",
+        "save_error": "Nie udało się zaktualizować polityki przechowywania danych",
+        "range_error": "Okres przechowywania musi być liczbą całkowitą od 1 do 240 miesięcy."
+      }
+    },
+    "privacy": {
+      "title": "Ochrona danych",
+      "header_desc": "Zgoda, inwentarz i anonimizacja",
+      "load_error": "Nie udało się wczytać inwentarza danych.",
+      "participants_title": "Migawka uczestników",
+      "stat_started": "Rozpoczętych",
+      "stat_completed": "Ukończonych",
+      "stat_discarded": "Odrzuconych",
+      "stat_anonymised": "Zanonimizowanych",
+      "older_1y": "Starsze niż 1 rok (niezanonimizowane)",
+      "older_2y": "Starsze niż 2 lata (niezanonimizowane)",
+      "audio_title": "Pamięć audio",
+      "audio_count": "Nagrania",
+      "audio_mb": "Łączny rozmiar",
+      "locale_title": "Podział według języka",
+      "locale_col": "Język",
+      "locale_count_col": "Uczestnicy",
+      "locale_empty": "Brak danych językowych.",
+      "timeline_title": "Oś czasu",
+      "tl_first": "Pierwsze zgłoszenie",
+      "tl_last": "Ostatnie zgłoszenie",
+      "tl_anon": "Ostatnia anonimizacja",
+      "bulk_title": "Anonimizacja zbiorcza",
+      "bulk_desc": "Usuń dane osobowe ukończonych uczestników, którzy przesłali zgłoszenia przed datą graniczną. Ranking sortowania Q jest zachowany.",
+      "cutoff_label": "Data graniczna",
+      "cutoff_help": "Zanonimizowani zostaną tylko ukończeni uczestnicy, którzy przesłali zgłoszenia ściśle przed tą datą.",
+      "preview_label": "Kandydaci:",
+      "preview_zero": "Żaden uczestnik nie kwalifikuje się do tej daty granicznej. Spróbuj wcześniejszej daty.",
+      "anonymise_button": "Anonimizuj",
+      "anonymise_success": "Anonimizacja zakończona",
+      "anonymise_success_desc": "Zanonimizowano {{n}} uczestnika(-ów), {{s}} już anonimowych.",
+      "anonymise_error": "Anonimizacja nie powiodła się",
+      "confirm_title": "Zanonimizować dane uczestników?",
+      "confirm_candidates": "Zostanie zanonimizowanych {{count}} ukończony(-ch) uczestnik(-ów), którzy przesłali zgłoszenia przed {{date}}.",
+      "confirm_preserved": "Ranking sortowania Q jest zachowany; tożsamość jest usuwana.",
+      "confirm_irreversible": "To działanie jest natychmiastowe i nie można go cofnąć.",
+      "confirm_in_progress": "Anonimizowanie…",
+      "confirm_action": "Tak, zanonimizuj",
+      "cutoff_from_policy": "Wartość domyślna wynikająca z polityki przechowywania badania ({{months}} miesięcy).",
+      "empty": {
+        "title": "Brak danych uczestników",
+        "body": "Ta strona aktywuje się po przesłaniu zgłoszeń przez uczestników. Najpierw udostępnij link do badania.",
+        "cta": "Otwórz widok ogólny badania"
+      },
+      "consent": {
+        "title": "Formularz zgody",
+        "description": "To, co uczestnicy widzą przed wejściem do badania. Edytowane w projekcie badania.",
+        "no_text": "Brak tekstu zgody.",
+        "no_title": "(brak tytułu)",
+        "no_body": "(puste)",
+        "edit_in_design": "Edytuj w projekcie badania",
+        "view": "Pokaż"
+      }
+    },
+    "projects": {
+      "title": "Projekty",
+      "settings": {
+        "title": "Ustawienia projektu",
+        "identity_desc": "Zarządzaj tożsamością projektu.",
+        "general": {
+          "title": "Ustawienia ogólne",
+          "desc": "Tożsamość i podstawowa identyfikacja projektu.",
+          "label_title": "Tytuł projektu",
+          "placeholder_title": "Moje świetne laboratorium",
+          "label_slug": "URL slug",
+          "placeholder_slug": "moje-laboratorium",
+          "slug_hint": "Zmiana slugu zaktualizuje wszystkie linki do panelu badawczego.",
+          "save": "Zapisz",
+          "save_success": "Projekt zaktualizowany pomyślnie",
+          "save_error": "Nie udało się zaktualizować projektu."
+        },
+        "team_growth_title": "Zarządzanie zespołem",
+        "team_growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
+        "team": {
+          "title": "Członkowie zespołu",
+          "desc": "Lista użytkowników mających dostęp do tego projektu.",
+          "col_user": "Użytkownik",
+          "col_role": "Rola",
+          "col_joined": "Dołączył/a",
+          "col_actions": "Działania",
+          "remove_confirm": "Czy na pewno chcesz usunąć tego członka?",
+          "remove_dialog_title": "Usunąć członka zespołu?",
+          "remove_dialog_body": "{{name}} straci dostęp do tego projektu. Można go zaprosić ponownie później.",
+          "remove_dialog_action": "Usuń",
+          "remove_member_aria": "Usuń {{name}}",
+          "remove_success": "Członek usunięty pomyślnie",
+          "remove_error": "Nie udało się usunąć członka",
+          "growth_title": "Rozwój zespołu",
+          "growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
+          "invite_button": "Zaproś współpracownika",
+          "permissions_matrix": {
+            "title": "Macierz uprawnień",
+            "admin": {
+              "label": "Administrator",
+              "desc": "Może zarządzać ustawieniami projektu, członkami i wszystkimi badaniami."
+            },
+            "owner": {
+              "label": "Właściciel",
+              "desc": "Pełna kontrola nad projektem, członkami i badaniami."
+            },
+            "member": {
+              "label": "Członek",
+              "desc": "Może tworzyć i zarządzać wszystkimi badaniami. Brak dostępu do ustawień projektu."
+            },
+            "viewer": {
+              "label": "Obserwator",
+              "desc": "Dostęp tylko do odczytu do wszystkich badań i danych w projekcie."
+            }
+          },
+          "coming_soon": "Wkrótce",
+          "invite_modal": {
+            "title": "Zaproś współpracownika",
+            "email_label": "E-mail współpracownika",
+            "role_label": "Przypisana rola",
+            "success": "Link zaproszenia wygenerowany!",
+            "error": "Nie udało się utworzyć zaproszenia.",
+            "send": "Utwórz i wyślij zaproszenie",
+            "copy_success": "Link skopiowany do schowka!"
+          }
+        }
+      },
+      "members": {
+        "quota": "{{count}}/{{limit}} miejsc zajętych",
+        "quota_full_tooltip": "Osiągnięto limit członków. Zwiększ MAX_MEMBERS_PER_PROJECT lub usuń członka."
+      },
+      "create": {
+        "quota": "{{count}}/{{limit}} posiadanych projektów",
+        "quota_full_tooltip": "Osiągnięto limit posiadanych projektów."
+      }
+    },
+    "members": {
+      "title": "Członkowie zespołu",
+      "description": "Zarządzaj dostępem do projektu i uprawnieniami."
+    },
+    "participants": {
+      "title": "Uczestnicy",
+      "description": "Zarządzaj uczestnikami i przeglądaj przesłane dane.",
+      "table": {
+        "id": "ID",
+        "status": "Status",
+        "started": "Rozpoczęto o",
+        "completed": "Ukończono o",
+        "duration": "Czas trwania",
+        "actions": "Akcje"
+      }
+    },
+    "participant": {
+      "tabs": {
+        "session": "Metadane",
+        "presort": "Wstępne sortowanie",
+        "grid": "Siatka sortowania Q",
+        "postsort": "Sortowanie końcowe"
+      },
+      "grid": {
+        "detail_view": "Szczegóły karty",
+        "no_comment": "Brak komentarza.",
+        "select_instruction": "Wybierz kartę na siatce, aby zobaczyć szczegóły.",
+        "read_only_mode": "Tryb obserwatora",
+        "score": "Wynik"
+      },
+      "metadata": {
+        "title": "Metadane sesji",
+        "technology": "Technologia",
+        "browser": "Przeglądarka",
+        "session": "Szczegóły sesji",
+        "duration": "Łączny czas",
+        "started": "Rozpoczęto",
+        "submitted": "Przesłano",
+        "id": "Wewnętrzny identyfikator",
+        "ip_hash": "Hash IP",
+        "recruitment_token": "Token rekrutacyjny",
+        "device": {
+          "mobile": "Telefon",
+          "tablet": "Tablet",
+          "desktop": "Komputer"
+        }
+      },
+      "status": {
+        "started": "Rozpoczęto",
+        "completed": "Ukończone",
+        "discarded": "Odrzucone",
+        "in_progress": "W toku"
+      },
+      "survey": {
+        "presort": "Pytania wstępne",
+        "postsort": "Pytania końcowe",
+        "no_answers": "Brak zapisanych odpowiedzi dla tej sekcji.",
+        "categories": {
+          "identity": "Tożsamość i kontakt",
+          "questions": "Odpowiedzi na pytania",
+          "comments": "Komentarze do kart",
+          "feedback": "Opinie ogólne"
+        }
+      }
     }
+  }
 }

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1,0 +1,2188 @@
+{
+    "auth": {
+        "login": {
+            "email_label": "Email address",
+            "password_label": "Password",
+            "submit": "Continue",
+            "cta": "Sign in",
+            "forgot_password": "Forgot?",
+            "loading": "Authenticating...",
+            "card_title": "Sign in",
+            "welcome_back": "Welcome back!",
+            "error_401": "Invalid email or password",
+            "error_generic": "Something went wrong. Please try again.",
+            "reason_session_expired": "Your session has expired. Please sign in again.",
+            "reason_auth_required": "Please sign in to continue.",
+            "forgot_password_link": "Forgot password?",
+            "reset_success_banner": "Password updated. You can now sign in with your new password.",
+            "two_factor_title": "Two-factor authentication",
+            "two_factor_app_prompt": "Enter the 6-digit code from your authenticator app.",
+            "two_factor_email_prompt": "We sent a 6-digit code to your email. Enter it below.",
+            "two_factor_submit": "Verify",
+            "two_factor_resend": "Resend code",
+            "two_factor_resend_cooldown": "Resend available in {{seconds}}s",
+            "two_factor_invalid": "Invalid code. Try again.",
+            "lost_2fa_link": "Lost access to your 2FA?"
+        },
+        "twofa": {
+            "recovery": {
+                "title": "Lost access to your two-factor authentication?",
+                "body": "Enter your account email. If two-factor is enabled on this account, we'll send you a link to disable it.",
+                "submit": "Send disable link",
+                "success": "If the email exists and has 2FA, a disable link is on its way."
+            },
+            "disable": {
+                "title": "Disable two-factor authentication",
+                "warning": "Clicking the button below will permanently remove the second factor from this account. You'll be able to sign in with just your password until you re-enable 2FA.",
+                "warning_attacker": "If you did NOT request this, close this page and change your password immediately.",
+                "confirm_button": "Yes, disable two-factor authentication",
+                "loading": "Disabling…",
+                "success": "Two-factor authentication is now disabled. You may sign in.",
+                "error_consumed": "This link has already been used.",
+                "error_expired": "This link has expired or is invalid.",
+                "missing_token": "No token in the URL."
+            }
+        },
+        "password_reset": {
+            "request_title": "Reset your password",
+            "request_body": "Enter your email and we'll send a reset link.",
+            "request_submit": "Send reset link",
+            "request_success": "If the email exists, a reset link is on its way.",
+            "confirm_title": "Choose a new password",
+            "confirm_submit": "Reset password",
+            "success_redirect": "Password updated. You can now sign in with your new password.",
+            "link_expired": "This link has expired or has already been used.",
+            "too_short": "Password must be at least 8 characters.",
+            "mismatch": "Passwords do not match.",
+            "missing_token": "No reset token in the URL.",
+            "new_password_placeholder": "New password",
+            "confirm_placeholder": "Confirm password"
+        },
+        "email": {
+            "verification_sent": {
+                "title": "Verify your email",
+                "body": "We sent a verification link to {{email}}. Click the link to activate your account.",
+                "resend": "Resend the email",
+                "cooldown": "Resend available in {{seconds}}s",
+                "error": "Could not resend. Try again later."
+            },
+            "verify": {
+                "verifying": "Verifying your email…",
+                "success": "Email verified. You can now sign in.",
+                "expired": "This link has expired or is invalid.",
+                "resend_link": "Request a new verification email"
+            }
+        },
+        "register": {
+            "title": "Create account",
+            "subtitle": "Join the research project",
+            "secure_invitation": "Secure invitation",
+            "invitation_to": "Invitation to:",
+            "study_label": "Study",
+            "role_label": "Role",
+            "email_label": "Email address",
+            "password_label": "Choose password",
+            "confirm_password_label": "Confirm password",
+            "placeholder_password": "••••••••",
+            "submit": "Complete registration",
+            "loading": "Creating account...",
+            "success_title": "Welcome aboard!",
+            "success_desc": "Your account has been created and linked to the study.",
+            "success_cta": "Go to dashboard",
+            "success_hint": "You can now log in to the administrative dashboard to begin collaborating.",
+            "invalid_title": "Invalid invitation",
+            "invalid_desc": "This invitation link is invalid or has expired.",
+            "missing_token_title": "Missing token",
+            "missing_token_desc": "This page requires a valid invitation token. Please check the link you received.",
+            "verifying": "Verifying your invitation...",
+            "privacy_hint": "By registering, you agree to follow the research ethics guidelines configured for this study.",
+            "errors": {
+                "password_mismatch": "Passwords do not match",
+                "generic_fail": "Registration failed"
+            }
+        }
+    },
+    "admin": {
+        "hub": {
+            "title": "Researcher Hub",
+            "welcome": "Welcome back,",
+            "new_project": "New project",
+            "your_projects": "Your projects",
+            "studies_count": "studies",
+            "recent_studies": "Recent studies",
+            "n_studies_one": "{{count}} study",
+            "n_studies_other": "{{count}} studies",
+            "n_active_one": "{{count}} active",
+            "n_active_other": "{{count}} active",
+            "collecting": "Collecting data",
+            "no_studies": "No studies yet",
+            "no_projects": "No projects yet. Create your first project to get started.",
+            "no_projects_title": "Start your first research project",
+            "no_projects_body": "Create a project before adding concourses, Q-sets, or studies."
+        },
+        "memo": {
+            "title_concourse": "Selection notes",
+            "title_study": "Methodology memo",
+            "summary_empty_concourse": "How and why you built this concourse",
+            "summary_empty_study": "Optional · for replication & pre-registration",
+            "summary_filled_one": "{{n}} entry · click to view",
+            "summary_filled_other": "{{n}} entries · click to view",
+            "summary_unread": "{{n}} unread",
+            "add_entry": "Add entry",
+            "insert_template": "Insert from template",
+            "entry_title_placeholder": "Section title…",
+            "entry_body_placeholder": "Document your rationale…",
+            "comments_count_one": "{{n}} comment",
+            "comments_count_other": "{{n}} comments",
+            "show_resolved": "Show resolved ({{n}})",
+            "hide_resolved": "Hide resolved",
+            "comment_placeholder": "Write a comment. Use @ to mention.",
+            "post_comment": "Post",
+            "edit": "Edit",
+            "delete": "Delete",
+            "deleted_body": "[deleted comment]",
+            "resolve": "Resolve",
+            "unresolve": "Unresolve",
+            "resolved_label": "[resolved]",
+            "save": "Save",
+            "cancel": "Cancel",
+            "saved": "Saved",
+            "save_error": "Could not save memo. Try again.",
+            "load_error": "Could not load memo. Refresh the page to retry.",
+            "mentions_for_you": "Mentions for you",
+            "mention_user_not_found": "Unknown user",
+            "delete_entry_confirm": "Delete this entry and all its comments?",
+            "include_discussion_in_export": "Include memo discussion threads",
+            "templates": {
+                "concourse": {
+                    "sources_canvassed": {
+                        "title": "Sources canvassed"
+                    },
+                    "voices_retained": {
+                        "title": "Voices retained"
+                    },
+                    "voices_excluded": {
+                        "title": "Voices excluded"
+                    },
+                    "sampling_rationale": {
+                        "title": "Sampling rationale"
+                    },
+                    "version_notes": {
+                        "title": "Version notes"
+                    }
+                },
+                "study": {
+                    "distribution_rationale": {
+                        "title": "Distribution rationale"
+                    },
+                    "conditions_of_instruction": {
+                        "title": "Conditions of instruction"
+                    },
+                    "qset_size": {
+                        "title": "Q-set size"
+                    },
+                    "pre_post_design": {
+                        "title": "Pre/post-sort design choices"
+                    },
+                    "limitations": {
+                        "title": "Limitations"
+                    }
+                }
+            }
+        },
+        "study_design": {
+            "distribution_mode": {
+                "title": "Distribution mode",
+                "helper": "Choose how strictly the Q-sort grid is enforced. Forced: each column must be filled to its declared capacity (the most common choice). Free: any number of cards per column, total = Q-set size. Flexible: total enforced, columns are soft hints.",
+                "forced": {
+                    "label": "Forced",
+                    "tooltip": "Each column must hold exactly its declared capacity."
+                },
+                "free": {
+                    "label": "Free",
+                    "tooltip": "Total cards = Q-set size; per-column count is unconstrained."
+                },
+                "flexible": {
+                    "label": "Flexible",
+                    "tooltip": "Total cards = Q-set size; per-column capacities are soft hints (warnings only)."
+                }
+            },
+            "rough_sort": {
+                "toggle_label": "Enable preliminary sort (3-pile triage)",
+                "lock_banner": "Toggle locked. {{count}} participant(s) have started the survey; archive or delete those sessions before changing this setting.",
+                "deck_mode_note": "Disabled. Participants see the full Q-set as a horizontally-scrollable deck."
+            }
+        },
+        "study": {
+            "activate_error": "Could not activate study. Verify the design is valid and try again.",
+            "save": {
+                "success": "Changes saved successfully",
+                "save_success": "Saved successfully",
+                "synced_warnings": "Synced with server. Kept your changes in: {{fields}}",
+                "synced_concurrent": "Synced with concurrent changes from another user",
+                "conflict": "Conflict detected. Some changes could not be merged.",
+                "error": "Failed to save changes"
+            },
+            "postsort": {
+                "missing": {
+                    "title": "Missing statements",
+                    "desc": "Are there any ideas or perspectives that you felt were missing from the set of statements?"
+                }
+            },
+            "state": {
+                "manage": "Manage study flow"
+            }
+        },
+        "components": {
+            "markdown": {
+                "label": "Markdown",
+                "tooltip": "Supports Markdown for rich formatting",
+                "bold": "Bold",
+                "italic": "Italic",
+                "list": "List",
+                "link": "Link",
+                "edit": "Edit",
+                "preview": "Preview",
+                "empty": "Nothing to preview"
+            },
+            "click_to_edit": "Click to edit"
+        },
+        "layout": {
+            "title": "Admin",
+            "back_home": "Back to home",
+            "beta": "Research beta",
+            "logout": "Log out",
+            "account": "Account settings",
+            "admin_user": "Admin user"
+        },
+        "account": {
+            "title": "Account settings",
+            "description": "Manage your personal information and account security.",
+            "personal": {
+                "title": "Personal information",
+                "email": "Email address",
+                "email_locked": "Email changes via the API are coming soon to this page; backend support is live.",
+                "name": "Full name",
+                "save": "Save",
+                "saving": "Saving...",
+                "success": "Profile updated successfully",
+                "error": "Failed to update profile",
+                "cannot_remove_self": "You cannot remove yourself",
+                "name_required": "Full name is required"
+            },
+            "security": {
+                "title": "Security",
+                "description": "Manage two-factor authentication and your password.",
+                "tfa_subtitle": "Two-factor authentication",
+                "password_subtitle": "Password",
+                "enabled": "Enabled",
+                "setup_cta": "Setup 2FA now",
+                "configure_title": "Configure authenticator app",
+                "scan_desc": "Scan this QR code with your authenticator app (google authenticator, authy, etc.)",
+                "enter_code": "Enter 6-digit code",
+                "enable_btn": "Enable 2FA",
+                "disable_btn": "Disable 2FA",
+                "confirm_disable": "Confirm disable",
+                "confirm_password_label": "Confirm with your password",
+                "verifying": "Verifying...",
+                "cancel": "Cancel",
+                "enabled_success": "Two-factor authentication enabled",
+                "disabled_success": "Two-factor authentication disabled",
+                "secret_copied": "Secret copied",
+                "invalid_token": "Invalid verification code",
+                "disable_error": "Failed to disable 2FA",
+                "channel_select_label": "How should we deliver your 2FA codes?",
+                "channel_app": "Authenticator app (recommended)",
+                "channel_email": "Email",
+                "channel_email_desc": "We'll email you a 6-digit code each time you log in. Useful if you can't install an authenticator app.",
+                "enable_email_btn": "Enable email-based 2FA",
+                "enable_email_pending": "Enabling…"
+            },
+            "password": {
+                "title": "Password management",
+                "current": "Current password",
+                "new": "New password",
+                "change_btn": "Change password",
+                "updating": "Updating...",
+                "success": "Password changed successfully",
+                "error": "Failed to change password. Check current password.",
+                "validation": {
+                    "required": "Required",
+                    "min_length": "Min 8 characters"
+                }
+            }
+        },
+        "sidebar": {
+            "home": "Dashboard",
+            "add_study": "Add study",
+            "create_project": "CREATE NEW PROJECT",
+            "dashboard": "Dashboard",
+            "overview": "Overview",
+            "design": "Design",
+            "recruit": "Access",
+            "data": "Data",
+            "analysis": "Analysis",
+            "privacy": "Data privacy",
+            "team": "Team",
+            "settings": "Study settings",
+            "project_settings": "Project settings",
+            "study_tools": "Study tools",
+            "project": "Project",
+            "documentation": "Documentation",
+            "support": "Support",
+            "study_management": "Study management",
+            "search": "Search...",
+            "studies": "Studies",
+            "select_study": "Select study",
+            "select_study_msg": "Please select or create a study to begin.",
+            "view_all_studies": "All studies",
+            "study": "Study",
+            "select_project": "Select project",
+            "concourses": "Concourses",
+            "concourse": "Concourse",
+            "members": "Team members"
+        },
+        "concourse": {
+            "title": "Concourse",
+            "description": "Manage candidate statements for your Q-methodology study",
+            "default_title": "Concourse",
+            "default_title_for_project": "{{project}} concourse",
+            "create": "New Concourse",
+            "create_success": "Concourse created",
+            "create_error": "Failed to create concourse",
+            "create_dialog_title": "Create Concourse",
+            "create_dialog_desc": "A concourse is a collection of candidate statements from which you will select your Q-set.",
+            "field_title": "Title",
+            "field_title_placeholder": "e.g. Climate Change Attitudes",
+            "field_description": "Description",
+            "field_description_placeholder": "Brief description of this concourse...",
+            "field_code": "Code",
+            "field_text": "Statement text",
+            "field_text_placeholder": "Enter the statement text...",
+            "field_source": "Source",
+            "items_label": "items",
+            "updated": "Updated",
+            "empty_title": "No concourses yet",
+            "empty_desc": "Create a concourse to start collecting and organizing candidate statements for your Q-methodology research.",
+            "add_item": "Add Item",
+            "bulk_import": "Bulk Import",
+            "import_desc": "Paste statements separated by newlines. Each line becomes one item.",
+            "import_prefix": "Code prefix",
+            "import_statements": "Statements",
+            "import_placeholder": "One statement per line...",
+            "items_to_import": "statements to import",
+            "import_button": "Import",
+            "import_success": "{{count}} items imported",
+            "import_error": "Import failed",
+            "item_created": "Item added",
+            "item_create_error": "Failed to add item",
+            "item_updated": "Item updated",
+            "item_update_error": "Failed to update item",
+            "item_deleted": "Item deleted",
+            "item_delete_error": "Failed to delete item",
+            "status_error": "Failed to change status",
+            "search_placeholder": "Search items...",
+            "source_placeholder": "e.g. Interview #3, Literature review",
+            "no_items": "No items yet. Add your first statement.",
+            "no_matches": "No items match your filters.",
+            "danger_zone": "Danger Zone",
+            "delete": "Delete Concourse",
+            "delete_confirm": "Are you sure you want to delete this concourse and all its items?",
+            "deleted": "Concourse deleted",
+            "delete_error": "Failed to delete concourse",
+            "delete_item_title": "Delete Item",
+            "delete_item_confirm": "Delete this item? Cannot be undone.",
+            "status": {
+                "proposed": "Proposed",
+                "accepted": "Accepted",
+                "rejected": "Rejected"
+            },
+            "change_note_placeholder": "Change note (optional)",
+            "history": "History",
+            "comments": "Comments",
+            "no_history": "No edit history yet.",
+            "no_comments": "No comments yet.",
+            "add_comment": "Write a comment...",
+            "send_comment": "Send",
+            "comment_added": "Comment added",
+            "comment_error": "Could not add comment. Try again.",
+            "version_label": "v{{n}}",
+            "item_detail_desc": "History and comments for this item",
+            "manage_tags": "Tags",
+            "tag_name_placeholder": "Tag name",
+            "tag_color": "Tag color",
+            "tag_created": "Tag created",
+            "tag_create_error": "Failed to create tag",
+            "tag_deleted": "Tag deleted",
+            "tag_delete_error": "Failed to delete tag",
+            "no_tags": "No tags yet. Create your first tag above.",
+            "field_tags": "Tags",
+            "export_csv": "Export CSV",
+            "select_language": "Language",
+            "add_language": "Add language",
+            "add_language_desc": "Enter a language code (e.g. en, fr, fi).",
+            "add_language_desc_v2": "Select a language for statement translations.",
+            "add_language_tooltip": "Add a translation language",
+            "field_language": "Language",
+            "import_language": "Language",
+            "select_all": "Select all",
+            "bulk_selected": "{{count}} selected",
+            "bulk_set_status": "Set status:",
+            "bulk_clear": "Clear",
+            "bulk_status_success": "{{count}} items updated",
+            "bulk_status_error": "Failed to update some items",
+            "qset_title": "Curation",
+            "qset_pending": "{{count}} items still to review",
+            "qset_complete": "All items reviewed",
+            "show_pending": "To review",
+            "bulk_confirm_title": "Confirm status change",
+            "bulk_confirm_desc": "Set {{count}} items to \"{{status}}\"?",
+            "no_translation": "No text",
+            "language_tooltip": "Language of statement texts",
+            "loading": "Setting up concourse...",
+            "diff_code": "code",
+            "diff_status": "status",
+            "diff_text": "text",
+            "diff_tags": "tags",
+            "diff_changed": "Changed:",
+            "methodological_context": {
+                "title": "Methodological context",
+                "subtitle": "Optional documentation fields. Fill in what's relevant to your design; leave others blank."
+            },
+            "import_from_csv": "Import CSV/TSV…",
+            "import_csv_hint": "CSV/TSV needs columns: code, language, text.",
+            "import_csv_no_match": "No rows match the selected language ({{lang}}).",
+            "import_csv_skipped": "Skipped {{count}} row(s) in other languages: {{langs}}.",
+            "import_csv_more_errors": "{{count}} more issues"
+        },
+        "concourse_import": {
+            "title": "Import from Concourse",
+            "desc": "Select items from a concourse to import as study statements. Items are copied; changes to the concourse will not affect the study.",
+            "button_label": "Import from Concourse",
+            "select_concourse": "Concourse",
+            "select_placeholder": "Choose a concourse...",
+            "code_prefix": "Code prefix",
+            "code_prefix_placeholder": "e.g. S",
+            "only_accepted": "Only accepted",
+            "replace_existing": "Replace existing statements",
+            "replace_warning": "All existing statements will be permanently deleted and replaced by the selected items.",
+            "selected": "{{count}} selected",
+            "select_all": "Select all",
+            "import_button": "Import {{count}} statements",
+            "success": "{{count}} statements imported",
+            "error": "Could not import items from the concourse. Try again.",
+            "no_accepted": "No accepted items in this concourse. Uncheck \"Only accepted\" to see all.",
+            "no_items": "This concourse has no items.",
+            "no_concourses": "No concourses in this project. Create one first."
+        },
+        "concourse_sync": {
+            "update_available": "Update",
+            "source_deleted": "Source deleted",
+            "source_deleted_tip": "The source concourse item has been deleted.",
+            "new_version": "New version in concourse:",
+            "synced": "Statement updated from concourse",
+            "error": "Could not sync from the concourse. Try again.",
+            "stale_banner": "{{count}} statement(s) have updates available from the concourse."
+        },
+        "analysis": {
+            "title": "Analysis",
+            "description": "Factor analysis of Q-sort data: extract viewpoints from participant responses",
+            "configuration": "Configuration",
+            "configuration_description": "Select extraction method, number of factors, and rotation",
+            "extraction_method": "Extraction",
+            "centroid": "Centroid",
+            "n_factors": "Factors",
+            "rotation_method": "Rotation",
+            "none": "None",
+            "run": "Run Analysis",
+            "run_will_replace": "Running again will replace the current results view. Use the history panel to compare runs.",
+            "running": "Analyzing...",
+            "reanalyzing": "Re-analyzing...",
+            "success": "Analysis complete. {{n}} factors extracted.",
+            "error": "Analysis failed: {{message}}",
+            "scree_hint": "Each bar shows how much variance a factor explains (its eigenvalue). The dashed line marks eigenvalue = 1 (Kaiser criterion). Click a bar to select the number of factors to extract.",
+            "kaiser_suggestion": "{{n}} factor(s) have eigenvalues above 1 (Kaiser criterion)",
+            "factor": "Factor",
+            "factor_n": "Factor {{n}}",
+            "eigenvalue": "Eigenvalue",
+            "too_few_participants": "Need at least 2 completed participants to run analysis.",
+            "eigenvalue_error": "Failed to load analysis data. Please try again.",
+            "scree_plot_label": "Scree plot showing eigenvalues for {{n}} factors",
+            "loading_eigenvalues": "Loading eigenvalues...",
+            "empty_state": "Set parameters and run the analysis.",
+            "empty": {
+                "contract_title": "Not enough Q-sort data yet",
+                "contract_body": "Q-methodology factor analysis requires at least 2 participants who have completed the sort. Configuration choices (extraction, factors, rotation, flagging) carry meaning once data exists. Share the study link from the overview to start collecting responses.",
+                "contract_cta": "Open study overview"
+            },
+            "advanced": {
+                "title": "Advanced settings",
+                "summary": "Rotation: {{rotation}} · Flagging: {{flagging}} · Bootstrap: {{bootstrap}}",
+                "bootstrap_off": "off",
+                "bootstrap_on": "{{n}} iterations"
+            },
+            "tab_loadings": "Loadings",
+            "tab_factor_arrays": "Factor Arrays",
+            "tab_statements": "Statements",
+            "tab_summary": "Summary",
+            "participant": "Participant",
+            "flagged": "Flagged",
+            "significance_threshold": "Significance threshold (p<0.05): ±{{threshold}}",
+            "sorts": "sorts",
+            "distinguishing_legend": "Distinguishing statement",
+            "code": "Code",
+            "statement": "Statement",
+            "type": "Type",
+            "distinguishing": "Distinguishing",
+            "consensus": "Consensus",
+            "variance_explained": "Variance Explained (%)",
+            "cumulative_variance": "Cumulative Variance (%)",
+            "n_flagged": "N Flagged Sorts",
+            "composite_reliability": "Composite Reliability",
+            "se_factor_scores": "SE of Factor Scores",
+            "factor_correlations": "Factor Correlations",
+            "high_correlation": "High correlation",
+            "total_variance": "Total Variance Explained",
+            "method_used": "Method",
+            "statements_label": "statements",
+            "pca": "PCA",
+            "varimax": "Varimax",
+            "metric": "Metric",
+            "caption_loadings": "Factor loadings per participant",
+            "caption_statements": "Statement z-scores and factor arrays per factor",
+            "caption_characteristics": "Factor characteristics and reliability statistics",
+            "caption_correlations": "Factor-to-factor correlation matrix",
+            "retry": "Retry",
+            "flagging_method": "Flagging",
+            "auto": "Auto",
+            "manual": "Manual",
+            "manual_flag_hint": "Click a loading cell to flag/unflag a participant for that factor. Re-run analysis to update results.",
+            "no_flagged_participants": "No participants flagged for any factor. Try adjusting the number of factors or flagging method.",
+            "no_statement_scores": "No statement scores available. Ensure participants are flagged for at least one factor.",
+            "no_characteristics": "No factor characteristics available.",
+            "export": "Export",
+            "export_loadings": "Factor loadings (CSV)",
+            "export_scores": "Statement scores (CSV)",
+            "export_xlsx": "Complete analysis (XLSX)",
+            "export_error": "Failed to generate XLSX export.",
+            "select_factors": "Select number of factors",
+            "loadings_help": "Factor loadings show how strongly each participant's sort correlates with each factor. Highlighted cells exceed the significance threshold shown above.",
+            "factor_array_help": "Composite Q-sort showing the idealized sort pattern for this factor. Statements are placed in the distribution based on their weighted z-scores.",
+            "factor_array_label": "Factor {{n}} composite sort",
+            "factor_arrays": {
+                "toggle_narratives": "Show factor narratives",
+                "toggle_narratives_aria": "Toggle per-factor interpretive narratives"
+            },
+            "statements_help": "Z-scores show each factor's standardized position on each statement. D = distinguishing (significantly different between factors), C = consensus (no significant differences).",
+            "z_scores_description": "Z-scores and factor array positions per statement",
+            "factor_statistics": "Factor Statistics",
+            "characteristics_help": "Eigenvalues reflect the amount of variance explained. Composite reliability reflects internal consistency among flagged sorts. SE of factor scores reflects the precision of the composite estimate.",
+            "help_extraction": "PCA maximises explained variance. Centroid is less mathematically constrained.",
+            "help_n_factors": "Each factor represents a distinct viewpoint.",
+            "help_rotation": "Varimax separates factors for simpler structure.",
+            "help_flagging": "Auto: flag participants loading on exactly one factor. Manual: override per participant.",
+            "guide_loadings_title": "Reading Factor Loadings",
+            "guide_loadings_1": "Each loading is a correlation (-1 to +1) between a participant and a factor (shared viewpoint).",
+            "guide_loadings_2": "Highlighted values exceed the significance threshold shown above the table.",
+            "guide_arrays_title": "Interpreting Factor Arrays",
+            "guide_arrays_1": "Each factor array is the composite Q-sort representing one shared viewpoint.",
+            "guide_arrays_2": "Read left-to-right as most disagreed to most agreed. Extreme positions carry the strongest signal for interpretation.",
+            "guide_statements_title": "Understanding Statement Scores",
+            "guide_statements_1": "Z-scores show how strongly each factor agrees or disagrees with each statement (0 = neutral).",
+            "guide_statements_2": "D = distinguishing (placed significantly differently across factors). Stars indicate significance level.",
+            "guide_summary_title": "Evaluating Your Solution",
+            "guide_summary_1": "Eigenvalues measure how much variance a factor explains. The Kaiser criterion (eigenvalue > 1) is one common heuristic for deciding how many factors to retain.",
+            "guide_summary_2": "Composite reliability reflects how consistently the flagged sorts define each factor. Higher values mean the factor estimate is based on more agreement among its defining sorts.",
+            "benchmark_above": "Above threshold",
+            "benchmark_below": "Below threshold",
+            "history": {
+                "title": "Analysis history",
+                "loading": "Loading history…",
+                "fetch_error": "Could not load analysis history.",
+                "empty": "No previous analyses for this study yet. Run one to start the audit trail.",
+                "empty_explainer": "Each run is logged here so you can document and revisit every decision.",
+                "load_error": "Could not load this analysis run. Refresh the page to retry.",
+                "load_run_aria": "Load analysis run from {{date}}",
+                "loading_run": "Loading…",
+                "current_tag": "current",
+                "n_factors_label": "{{n}}F",
+                "edit_notes": "Edit notes",
+                "edit_notes_aria": "Edit notes for this run",
+                "notes_placeholder": "Add a note about this run…",
+                "notes_aria": "Edit notes for this run",
+                "save_notes_aria": "Save notes",
+                "cancel_edit_aria": "Cancel editing",
+                "notes_saved": "Notes saved.",
+                "notes_error": "Could not save notes. Check your connection and try again.",
+                "delete_run": "Delete run",
+                "delete_run_aria": "Delete this analysis run",
+                "delete_dialog_title": "Delete analysis run?",
+                "delete_dialog_description": "Deleting an analysis run removes evidence of an analytical choice from the audit trail. Are you sure?",
+                "cancel": "Cancel",
+                "delete_confirm": "Delete",
+                "deleted": "Analysis run deleted.",
+                "delete_error": "Failed to delete the run.",
+                "viewing_banner": "Viewing run from {{date}}: {{extraction}} · {{n}}F · {{rotation}}",
+                "back_to_current": "Back to current"
+            },
+            "factor_voices": {
+                "title": "Voices on Factor {{n}}",
+                "no_audio": "No post-sort audio recordings from participants flagged on this factor.",
+                "no_material": "No post-sort audio recordings or written comments from participants flagged on this factor.",
+                "loading": "Loading recordings…",
+                "error": "Could not load audio recordings. Please try again.",
+                "context": "Ground factor interpretation in participants' own words: their audio rationales and their written card comments.",
+                "context_aria": "About this panel",
+                "audio_label": "Recording: {{key}} by {{participant}}",
+                "url_unavailable": "Audio URL not available.",
+                "comments_label": "Card comments"
+            },
+            "factor_note": {
+                "label": "Factor narrative",
+                "placeholder": "Write the interpretive narrative for this factor: the discourse, voices, and tensions it foregrounds.",
+                "empty_hint": "Add an interpretive narrative for this factor",
+                "char_count": "{{n}}/{{max}}",
+                "edit_aria": "Edit factor {{n}} narrative",
+                "save_aria": "Save factor narrative",
+                "cancel_aria": "Cancel editing",
+                "aria": "Edit factor {{n}} narrative",
+                "saved": "Factor narrative saved.",
+                "error": "Failed to save the factor narrative."
+            },
+            "rotation": {
+                "judgmental": {
+                    "label": "Judgmental (manual)",
+                    "short": "Judgmental",
+                    "tooltip": "Manually rotate factor pairs by chosen angles to align factors with substantively-meaningful positions."
+                }
+            },
+            "manual_rotations": {
+                "title": "Manual rotations",
+                "helper": "Specify rotations as 'rotate factor F by Δ° around factor G'. Rotations are applied in order.",
+                "add": "Add rotation",
+                "remove_aria": "Remove rotation",
+                "empty": "Add at least one rotation to run the analysis.",
+                "factor_a_label": "Rotate factor",
+                "angle_label": "by",
+                "factor_b_label": "around factor"
+            },
+            "bootstrap": {
+                "toggle_label": "Run bootstrap stability",
+                "iterations_label": "Iterations (B)",
+                "helper": "Optional. Resamples Q-sorts B times to estimate confidence intervals on factor scores.",
+                "running": "Running bootstrap…",
+                "se_column": "Mean SE (z)",
+                "tooltip": "Non-parametric bootstrap of Q-sorts (resampled with replacement); analysis is repeated B times to estimate 95% CIs on z-scores."
+            },
+            "explore": {
+                "diagnostics_title": "Diagnostics",
+                "kaiser": "Kaiser",
+                "parallel": "Parallel analysis",
+                "map": "Velicer's MAP",
+                "advisory": "Advisory only. Q-method retention also depends on interpretability and stability (Watts & Stenner 2012).",
+                "preview_range_title": "Preview range",
+                "preview_range_disabled": "Preview range supports PCA + varimax only. Centroid extraction and judgmental rotation are path-dependent; commit a real run to inspect.",
+                "select_k": "{{k}} factors",
+                "empty_factor": "Empty factor (over-factorisation)",
+                "cumvar": "cumvar %",
+                "pct_flagged": "% flagged",
+                "n_distinguishing": "# distinguishing",
+                "n_cross_loaders": "# cross-loaders",
+                "min_def_sorts": "min defining sorts",
+                "advanced_title": "Advanced configuration",
+                "commit_cta": "Commit and interpret"
+            },
+            "interpret": {
+                "def_sorts": "Defining sorts: {{n}}",
+                "statements_title": "Statements",
+                "narrative_title": "F{{n}} narrative",
+                "insert_comment_quote": "Insert comment as quote",
+                "focus_mode": "Per-factor focus",
+                "overview_mode": "Overview",
+                "mode_toggle": "View mode"
+            },
+            "compare": {
+                "pin_cta": "Pin compare",
+                "no_other_runs": "No other runs available",
+                "run_label": "Run #{{id}} ({{n}} factors)",
+                "pinned": "Comparing with run #{{id}}",
+                "phi": "φ = {{phi}}",
+                "ambiguous": "ambiguous match (interpret deltas with care)",
+                "unpin": "Unpin",
+                "delta_z_aria": "Δz {{delta}} vs compare run",
+                "delta_loading_aria": "Δloading {{delta}} vs compare run"
+            },
+            "quote_insert_format": "> {{text}}\n> {{p}}, on statement {{code}}: \"{{stmt}}\""
+        },
+        "project": {
+            "remove_member": "Remove member",
+            "table_caption": "Project members",
+            "switcher": {
+                "settings": "Project settings",
+                "settings_desc": "Members & profiles",
+                "new_project": "New project",
+                "new_project_desc": "Create a new project"
+            },
+            "roles": {
+                "owner": "Owner",
+                "admin": "Administrator",
+                "viewer": "Viewer",
+                "member": "Member"
+            },
+            "study_states": {
+                "active": "Active",
+                "draft": "Draft",
+                "paused": "Paused",
+                "closed": "Closed"
+            },
+            "create": {
+                "title": "Create project",
+                "card_title": "Project details",
+                "name_label": "Project name",
+                "name_placeholder": "Climate attitudes Q study",
+                "url_label": "Project URL",
+                "url_placeholder": "climate-attitudes-q-study",
+                "url_description": "This becomes the project path under /app/.",
+                "cancel": "Cancel",
+                "create_button": "Create project",
+                "creating": "Creating...",
+                "success": "Project created successfully",
+                "error": "Failed to create project"
+            }
+        },
+        "recruitment": {
+            "title": "Access",
+            "description": "Configure the study URL, manage participant access, and track recruitment efficiency.",
+            "study_url": {
+                "title": "Study URL",
+                "description": "The public address where participants access your study.",
+                "full_url_label": "Full URL",
+                "slug_label": "URL slug",
+                "slug_description": "The unique identifier used in the study URL. Lowercase letters, numbers, and hyphens only.",
+                "slug_locked": "The URL slug can only be changed while the study is in draft mode."
+            },
+            "state_draft": "Draft mode. Links will work once you activate the study.",
+            "state_closed": "This study is closed. Existing links remain visible but new participants cannot start.",
+            "state_archived": "This study is archived. All recruitment data is read-only.",
+            "empty_title": "No recruitment links yet",
+            "empty_description": "Create your first link to start inviting participants.",
+            "empty_cta": "Create access link",
+            "stats_summary": {
+                "links": "links",
+                "started": "started",
+                "submitted": "submitted"
+            },
+            "access_rules": {
+                "title": "Access rules",
+                "description": "Control when and how participants can access the study.",
+                "password_toggle": "Require a password",
+                "password_toggle_desc": "Participants must enter a password before starting the study.",
+                "password_label": "Access password",
+                "password_placeholder": "Enter access password",
+                "password_locked": "Password protection can only be changed while the study is in draft mode.",
+                "password_set": "A password is currently set. Enter a new value to change it, or toggle off to remove.",
+                "collection_window": "Collection window",
+                "window_toggle": "Limit collection window",
+                "window_toggle_help": "Restrict participant access to a specific time range.",
+                "start_date_label": "Opens at",
+                "end_date_label": "Closes at",
+                "date_hint": "Leave empty for no time restriction.",
+                "clear_date": "Clear date",
+                "save_button": "Save access rules",
+                "save_success": "Access rules updated",
+                "save_error": "Failed to update access rules",
+                "non_draft_notice": "Outside draft, only the collection window can be edited. Switch the study back to draft to change other access rules.",
+                "archived_notice": "This study is archived. Access rules are read-only."
+            },
+            "new_link": "New access link",
+            "create_title": "Create access links",
+            "link_type": "Access strategy",
+            "select_type": "Choose a recruitment type...",
+            "campaign_name": "Channel / campaign name",
+            "name_placeholder": "E.g. LinkedIn, email batch a, student list...",
+            "link_count": "Batch size",
+            "capacity_label": "Max submissions",
+            "generate_links": "Provision links",
+            "no_links": "No recruitment links generated yet.",
+            "unnamed": "Unnamed channel",
+            "revoked": "Access revoked",
+            "qr_title": "Share via QR",
+            "copy_link": "Copy URL",
+            "table_title": "Recruitment links",
+            "share_title": "Share study",
+            "share_desc": "Distribute your study URL to invite participants.",
+            "public_url_label": "Public participation URL",
+            "hide_qr": "Hide QR",
+            "show_qr": "Show QR code",
+            "delete_link": "Delete link",
+            "qr_alt": "QR code for {{url}}",
+            "table_caption": "Recruitment links",
+            "progress_label": "{{count}} of {{max}} responses",
+            "usage": {
+                "started": "started",
+                "submitted": "submitted",
+                "completed": "Completed",
+                "in_progress": "In progress",
+                "unused": "Unused"
+            },
+            "live_study": "Live study",
+            "download_qr": "Download image",
+            "qr_print_hint": "Scan or print this code for physical recruitment materials (flyers, posters).",
+            "analytics_title": "Campaign analytics",
+            "analytics_desc": "Direct links and QR scans are automatically tracked in the health dashboard above.",
+            "copy_success": "Study link copied to clipboard",
+            "types": {
+                "public": "Open access (public)",
+                "individual": "Single-Use passcode",
+                "limited": "Capped participation"
+            },
+            "guidance": {
+                "public": "Best for high-volume recruitment. A single URL for all participants.",
+                "individual": "Maximum security. Generates unique links that expire after one successful completion.",
+                "limited": "Controlled access. One link that stops working after a fixed number of submissions."
+            },
+            "stats": {
+                "total_links": "Total channels",
+                "active_channels": "Active recruitment lots",
+                "started": "Total sessions",
+                "engagements": "Participants who started",
+                "submitted": "Valid data",
+                "completions": "Finished submissions",
+                "conversion": "Capture rate",
+                "efficiency": "Final data yield"
+            },
+            "table": {
+                "name": "Campaign / lot",
+                "type": "Entry type",
+                "token": "Security token",
+                "usage": "Capacity",
+                "status": "State",
+                "actions": "Manage",
+                "type_help": "Public, Single-use, or Capacity-limited. See strategy descriptions in the \"New access link\" dialog."
+            },
+            "status": {
+                "public": "Public",
+                "individual": "Individual",
+                "limited": "Limited"
+            },
+            "toasts": {
+                "created": "Recruitment links created successfully",
+                "failed": "Could not create recruitment links. Check the inputs and try again.",
+                "revoked": "Link revoked",
+                "revoke_failed": "Could not revoke this link. It may already be in use.",
+                "copied": "Copied to clipboard"
+            }
+        },
+        "analytics": {
+            "charts": {
+                "recruitment_funnel": {
+                    "title": "Recruitment funnel",
+                    "subtitle": "Aggregate conversion performance",
+                    "initial_contact": "Initial contact",
+                    "completion": "Completion",
+                    "started_study": "Started study",
+                    "submitted": "Submitted",
+                    "yield": "Yield",
+                    "success_rate": "Success rate",
+                    "completion_rate": "{{rate}}% of starters completed"
+                },
+                "link_performance": {
+                    "title": "Link performance tracking",
+                    "subtitle": "Monitor individual recruitment channel effectiveness",
+                    "volume": "Volume",
+                    "yield": "Yield",
+                    "conversion_rate": "Conversion rate",
+                    "total_responses": "responses"
+                }
+            }
+        },
+        "breadcrumbs": {
+            "admin": "Admin",
+            "dashboard": "Dashboard",
+            "study_dashboard": "Overview",
+            "design": "Design",
+            "participants": "Participants",
+            "team": "Team",
+            "recruitment": "Access",
+            "exports": "Data",
+            "data": "Data",
+            "privacy": "Data privacy",
+            "account": "Account settings",
+            "participant_n": "Participant {{code}}",
+            "analysis": "Analysis",
+            "settings": "Settings",
+            "concourse": "Concourse",
+            "members": "Team members"
+        },
+        "command_menu": {
+            "title": "Global command menu",
+            "placeholder": "Type a command or search...",
+            "no_results": "No results found.",
+            "switch_project": "Switch project",
+            "switch_study": "Switch study",
+            "study_actions": "Study actions",
+            "system": "System",
+            "no_studies": "No studies in this project.",
+            "open_dashboard": "Open dashboard",
+            "design_study": "Study design",
+            "collaborators": "Collaborators",
+            "copy_link": "Copy public link",
+            "toggle_theme": "Toggle theme",
+            "logout": "Log out",
+            "search_label": "Search or run commands",
+            "to_open": "To open",
+            "active": "Active",
+            "link_copied": "Study link copied!",
+            "logged_out": "Logged out successfully",
+            "switched_project": "Switched to {{name}}"
+        },
+        "dashboard": {
+            "title": "Project dashboard",
+            "welcome": "Welcome back,",
+            "snapshot": "Here's a snapshot of your research activity.",
+            "create_study": "Create study",
+            "total_studies": "Total studies",
+            "across_statuses": "Across all statuses",
+            "active_data_collection": "Active data collection",
+            "receiving_responses": "Studies receiving responses",
+            "total_participants": "Total participants",
+            "all_studies": "All studies",
+            "all_studies_description": "All studies in this project.",
+            "languages_count_one": "{{count}} language",
+            "languages_count_other": "{{count}} languages",
+            "n_participants_one": "{{count}} participant",
+            "n_participants_other": "{{count}} participants",
+            "n_studies_one": "{{count}} study",
+            "n_studies_other": "{{count}} studies",
+            "n_active_one": "{{count}} active",
+            "n_active_other": "{{count}} active",
+            "n_participants_total_one": "{{count}} participant",
+            "n_participants_total_other": "{{count}} participants",
+            "concourse_n_items_one": "{{count}} statement",
+            "concourse_n_items_other": "{{count}} statements",
+            "concourse_open_hint": "Curate candidate statements",
+            "created": "Created",
+            "no_studies": "No studies found. Create your first study to get started!",
+            "import_study": "Import study",
+            "get_started": "Get started with your research project",
+            "onboarding_title": "First steps",
+            "step_create_project": "Create your project",
+            "step_create_project_desc": "Your project is ready.",
+            "step_concourse": "Collect statements in the concourse",
+            "step_concourse_desc": "Add the candidate statements from your literature review.",
+            "step_qset": "Select the Q-set",
+            "step_qset_desc": "Review and accept the items that will form your Q-set.",
+            "step_study": "Create a study",
+            "step_study_desc": "Define the sorting grid for your Q-sort.",
+            "step_import": "Import the Q-set into your study",
+            "step_import_desc": "Import the accepted concourse items as study statements.",
+            "step_configure": "Configure the participant flow",
+            "step_configure_desc": "Set up instructions, presort, and postsort questions.",
+            "step_launch": "Launch recruitment",
+            "step_launch_desc": "Generate participation links and share them.",
+            "go_to_concourse": "Open concourse",
+            "go_to_qset": "Open Q-set",
+            "concourse": "Concourse",
+            "concourse_empty": "No items yet. Start building your statement collection.",
+            "team": "Team",
+            "team_loading": "Loading...",
+            "studies": "Studies",
+            "active_studies": "Active",
+            "paused_studies": "Paused",
+            "draft_studies": "Drafts",
+            "closed_studies": "Completed",
+            "attention": "Needs attention",
+            "alert_deadline": "{{study}}: closing in {{days}} days with {{count}} participants",
+            "view": "View",
+            "open_study": "Open study",
+            "add_study": "Add study",
+            "closes": "Closes",
+            "timeline": {
+                "title": "Submissions timeline",
+                "subtitle": "Daily participation trends",
+                "started": "Started",
+                "completed": "Completed"
+            },
+            "devices": {
+                "title": "Device distribution",
+                "subtitle": "How participants access your study",
+                "types": {
+                    "desktop": "Desktop",
+                    "mobile": "Mobile",
+                    "tablet": "Tablet",
+                    "unknown": "Unknown"
+                }
+            },
+            "n_studies_help": "Total number of studies in this project, including drafts and closed.",
+            "n_active_help": "Studies currently accepting participant submissions (state = active).",
+            "n_participants_total_help": "Sum of completed participants across all studies in this project.",
+            "tool_help": {
+                "design": "Configure the study: distribution grid, conditions of instruction, statements, consent.",
+                "recruit": "Recruitment links, access rules, and study URL settings.",
+                "data": "Participant responses and exports (CSV, Q-sort dumps).",
+                "analysis": "Factor analysis configuration and historical runs."
+            }
+        },
+        "export": {
+            "config": "Export configuration",
+            "exporting": "Exporting...",
+            "config_success": "Configuration exported successfully",
+            "config_error": "Could not export configuration. Try again.",
+            "label": "Export data",
+            "success": "Export successful",
+            "error": "Export failed. Try again.",
+            "csv": "Export CSV",
+            "json": "Export JSON",
+            "audio": "Export Audio (ZIP)",
+            "formats": {
+                "csv": "CSV",
+                "pqmethod": "PQMethod (ZIP)",
+                "rkit": "R-Kit (ZIP)",
+                "package": "Research Package (ZIP)",
+                "json": "JSON Dump"
+            },
+            "download": "Download",
+            "package_dialog": {
+                "title": "Download research package",
+                "description": "Bundles all study data into a single ZIP for OSF / pre-registration.",
+                "discussion_hint": "Adds memo/memo-discussion.md with all comment threads (signed and dated). Off by default; keep your export clean unless you want the deliberation trail."
+            }
+        },
+        "import": {
+            "title": "Import study configuration",
+            "config": "Import Configuration",
+            "upload_desc": "Upload a previously exported study configuration file",
+            "validate_desc": "Review configuration and provide a unique slug",
+            "creating_desc": "Creating study...",
+            "file_upload": "File upload",
+            "paste_json": "Paste JSON",
+            "drop_here": "Drop file here",
+            "drag_drop": "Drag & drop JSON file or click to browse",
+            "supported": "Supported format: .json",
+            "paste_label": "Paste JSON configuration",
+            "validate": "Validate & continue",
+            "valid": "Configuration is valid",
+            "invalid": "Configuration has errors",
+            "errors": "Errors",
+            "warnings": "Warnings",
+            "summary": "Study summary",
+            "title_field": "Title",
+            "languages": "Languages",
+            "statements": "Statements",
+            "grid": "Grid range",
+            "new_slug": "New study slug",
+            "slug_help": "Must be unique, 3-100 characters, lowercase letters, numbers, and hyphens only",
+            "creating": "Creating study from configuration...",
+            "create_study": "Create study",
+            "invalid_json": "Invalid JSON file",
+            "validation_failed": "Configuration is invalid",
+            "success": "Study imported successfully",
+            "redirecting": "Opening study designer...",
+            "failed": "Could not import study. See details below and retry.",
+            "validation": {
+                "errors": {
+                    "missing_version": "Missing version field",
+                    "unsupported_version": "Unsupported version: {{version}}",
+                    "missing_field": "Missing required field: {{field}}",
+                    "no_translations": "At least one translation required",
+                    "missing_translation_field": "Translation {{index}} missing required field: {{field}}",
+                    "invalid_lang_code": "Invalid language code: {{lang}}",
+                    "no_statements": "At least one statement required",
+                    "duplicate_codes": "Duplicate statement codes: {{codes}}",
+                    "missing_stmt_translations": "Statement {{index}} missing translations",
+                    "invalid_grid_config": "Invalid grid_config: must be a list",
+                    "invalid_grid_structure": "Invalid grid_config structure: {{error}}"
+                },
+                "warnings": {
+                    "grid_capacity_mismatch": "Statement count ({{count}}) doesn't match grid capacity ({{capacity}})",
+                    "missing_consent_draft": "Consent title or description missing (draft study)",
+                    "external_branding_logo": "Branding logo uses an external URL: {{url}}",
+                    "external_partner_logo": "Partner logo for '{{name}}' uses an external URL: {{url}}",
+                    "external_logo": "Logo URL references external resource - may not be accessible"
+                }
+            }
+        },
+        "dialogs": {
+            "create_study": {
+                "title": "Create new study",
+                "description": "Start a new q-methodology study. You can configure statements and settings later.",
+                "study_title": "Study title",
+                "study_title_placeholder": "E.g. Perspectives on AI",
+                "url_slug": "URL slug",
+                "url_slug_placeholder": "e.g. ai-perspectives-2025",
+                "cancel": "Cancel",
+                "create": "Create study",
+                "success": "Study created successfully",
+                "error": "Failed to create study",
+                "languages": "Languages",
+                "languages_desc": "Select the languages to enable. Content will be initialized with localized defaults."
+            }
+        },
+        "validation": {
+            "required": "Required",
+            "slug_min": "Slug must be at least 3 characters",
+            "slug_regex": "Slug must contain only lowercase letters, numbers, and hyphens"
+        },
+        "study_overview": {
+            "title": "Overview",
+            "back_to_overview": "Back to overview",
+            "sample_size": "Number of participants (P-Set)",
+            "valid": "valid",
+            "completion_rate": "Completion rate",
+            "active": "active",
+            "mobile": "mobile",
+            "median_duration": "Median duration",
+            "suspect": "Suspect",
+            "recent_activity": "Recent activity",
+            "latest_participants": "Latest participants (last {{count}} of {{total}})",
+            "recently_completed": "Recently completed",
+            "in_progress": "In progress",
+            "discarded": "Discarded",
+            "started": "Started",
+            "view_all": "View all participants and data details",
+            "no_participants": "No participants yet.",
+            "view_data": "View",
+            "submitted": "Submitted",
+            "edit_design": "Edit design",
+            "export_csv": "Download CSV",
+            "export_json": "Download JSON",
+            "steps": {
+                "welcome": "Welcome",
+                "consent": "Consent",
+                "rough_sort": "Rough sort",
+                "fine_sort": "Q-sort",
+                "final": "Final steps"
+            }
+        },
+        "overview": {
+            "copy_id": "Copy participant ID"
+        },
+        "study_status": {
+            "dialog": {
+                "draft": {
+                    "title": "Revert to draft?",
+                    "desc": "This will stop data collection but allow you to modify the study design. Existing data is preserved.",
+                    "action": "Revert to draft"
+                },
+                "active": {
+                    "title": "Launch study?",
+                    "desc": "Activating the study will open it to participants.",
+                    "action": "Set to active"
+                },
+                "paused": {
+                    "title": "Pause study?",
+                    "desc": "Participants will not be able to enter the study while it is paused. You can resume later.",
+                    "action": "Pause study"
+                },
+                "closed": {
+                    "title": "Close study?",
+                    "desc": "This will prevent new participants from entering. Existing sessions can still finish. You can reopen later.",
+                    "action": "Close study"
+                }
+            },
+            "steps": {
+                "draft": {
+                    "label": "Draft",
+                    "description": "Configuration & design"
+                },
+                "active": {
+                    "label": "Active",
+                    "description": "Collecting responses"
+                },
+                "paused": {
+                    "label": "Paused",
+                    "description": "On hold"
+                },
+                "closed": {
+                    "label": "Closed",
+                    "description": "Analysis & export"
+                }
+            },
+            "state": {
+                "activate": "Activate study",
+                "switch_to_draft": "Draft Mode",
+                "manage": "Manage status"
+            },
+            "notifications": {
+                "success": {
+                    "draft": "Study reverted to draft successfully",
+                    "active": "Study launched successfully",
+                    "paused": "Study paused successfully",
+                    "closed": "Study closed successfully"
+                },
+                "error": "Could not change study state. Check your permissions and try again.",
+                "state_changed_active": "Study is now active!"
+            }
+        },
+        "design": {
+            "title": "Study design",
+            "translation_needed": "Review required (copy)",
+            "reset_defaults": "Reset to defaults",
+            "editing_language_banner": "Editing the {{language}} version. Use the language selector in the toolbar to switch.",
+            "multilang": {
+                "view_others": "View in other languages",
+                "other_formulations": "Other Formulations"
+            },
+            "guidance": {
+                "title": "Design guidance",
+                "intro_title": "Welcome to the studio",
+                "intro_desc": "Start by defining the purpose of your study. This information will be shown to participants before they begin the sorting process.",
+                "qsort_title": "Statement & grid balance",
+                "qsort_desc": "Ensure your grid capacity exactly matches the number of statements. A balanced Q-set usually follows a quasi-normal (bell curve) distribution."
+            },
+            "checklist": {
+                "title": "Checklist",
+                "statements": "Statements",
+                "grid_balance": "Grid balanced",
+                "branding": "Logo & colors",
+                "instructions": "Instructions",
+                "ready": "All essential parts are ready. You can now launch your study!",
+                "pending": "Complete the required steps above to enable study activation.",
+                "study_title": "Study title",
+                "consent_defined": "Consent form",
+                "progress": "Progress",
+                "languages": "Languages",
+                "status_ready": "Ready",
+                "status_pending": "Pending",
+                "required": "Required",
+                "reset_defaults": "Reset to defaults"
+            },
+            "unsaved_changes": {
+                "title": "Unsaved changes",
+                "description": "You have unsaved changes in your study design. If you leave now, these changes will be lost.",
+                "confirm": "Leave without saving",
+                "cancel": "Keep editing"
+            },
+            "tips": {
+                "title": "Quick tip",
+                "pilot": "Always run a test sort yourself before sharing the link with participants."
+            },
+            "toolbar": {
+                "title": "Design",
+                "back": "Back",
+                "preview": "Show preview",
+                "hide_preview": "Hide preview",
+                "popout": "Pop out preview",
+                "discard": "Discard unsaved changes",
+                "test_run": "Test run",
+                "save": "Save",
+                "saved": "Saved",
+                "closed": "Closed",
+                "back_to_study": "Back to study",
+                "editing_language": "Editing language",
+                "manage_langs": "Manage languages",
+                "select_lang": "Select language",
+                "test_run_help": "Preview as a participant. These runs aren't included in your data.",
+                "more_actions": "More actions"
+            },
+            "sync": {
+                "saving": "Saving...",
+                "error": "Save error",
+                "modified": "Unsaved changes",
+                "synced": "Changes saved",
+                "wait_save": "Saving in progress... Please wait a moment.",
+                "recovered": "Draft recovered from local backup!",
+                "recovery_title": "Unsaved changes found",
+                "recovery_desc": "We found a local version of this study that is more recent than the one on the server. Would you like to restore it?",
+                "recovery_restore": "Restore local version",
+                "recovery_discard": "Discard local version"
+            },
+            "validation": {
+                "failed_title": "Configuration incomplete",
+                "failed_desc": "Fix these issues to activate:",
+                "errors": {
+                    "no_statements": "Study must have at least one statement.",
+                    "no_grid": "Grid configuration is missing.",
+                    "capacity_mismatch": "Grid capacity ({{total}}) does not match statement count ({{count}}).",
+                    "no_translations": "Study must have at least one language translation.",
+                    "missing_default_lang": "Default language ({{lang}}) translation is missing.",
+                    "missing_title": "Title is missing for language '{{lang}}'.",
+                    "missing_consent_title": "Consent title is missing for language '{{lang}}'.",
+                    "missing_consent_description": "Consent description is missing for language '{{lang}}'.",
+                    "missing_grid_instructions": "Q-Sort instructions are missing for language '{{lang}}'.",
+                    "missing_step_title": "Step {{index}} title is missing for language '{{lang}}'.",
+                    "missing_statement_translation": "Statement '{{code}}' is missing translations for: {{missing}}.",
+                    "empty_statement_text": "Statement '{{code}}' has empty text for language '{{lang}}'.",
+                    "missing_question_label": "Question '{{id}}' is missing a label for language '{{lang}}' ({{section}}).",
+                    "missing_option_label": "Option {{index}} of question '{{id}}' is missing a label for language '{{lang}}' ({{section}})."
+                }
+            },
+            "languages": {
+                "manage_title": "Manage languages",
+                "manage_desc": "Enable or disable languages available for participants to see in this study.",
+                "auto_translate": "Automatic translation",
+                "auto_translate_desc": "Soon you will be able to use AI to automatically translate your study into 30+ languages.",
+                "activate_title": "Activate language",
+                "activate_desc": "Choose a source language to copy translations from. This prevents empty fields for participants.",
+                "source_label": "Source language",
+                "copy_notice": "All fields will be copied. You will see a visual indicator on fields that still need your translation.",
+                "confirm_activate": "Activate & copy"
+            },
+            "tabs": {
+                "welcome": "General",
+                "presort": "Pre-sort",
+                "condition": "Condition",
+                "qsort": "Q-sort",
+                "postsort": "Post-sort",
+                "interface": "Interface",
+                "theme": "Theme",
+                "general": "General",
+                "statements": "Statements",
+                "grid": "Grid",
+                "survey": "Survey",
+                "branding": "Branding"
+            },
+            "view_mode": {
+                "mobile": "Mobile view",
+                "desktop": "Desktop view"
+            },
+            "intro": {
+                "general_settings": "General Settings",
+                "welcome_title": "Welcome message",
+                "process_title": "Study steps overview",
+                "process_steps": {
+                    "title": "Study steps overview",
+                    "desc": "Define the phases shown to participants on the welcome page. If left empty, default steps will be used.",
+                    "add_step": "Add step",
+                    "empty": {
+                        "title": "No custom steps defined",
+                        "desc": "The study will use the standard q-methodology workflow (meet, first impressions, perspective, why)."
+                    },
+                    "fields": {
+                        "title": "Step title",
+                        "description": "Short description",
+                        "icon": "Icon",
+                        "toggle": "Toggle"
+                    },
+                    "defaults": {
+                        "new_step": "New study step",
+                        "new_desc": "Explain what the participant will do in this phase."
+                    },
+                    "reset": {
+                        "instructions": "Reset instructions",
+                        "consent_title": "Reset consent title",
+                        "consent_description": "Reset consent description",
+                        "process_steps": "Reset process steps",
+                        "process_steps_confirm": "Are you sure you want to reset all process steps to defaults? This will replace your custom steps."
+                    },
+                    "inconsistent": {
+                        "banner_title": "Inconsistent process steps",
+                        "rough_disabled": "The 'First impressions' (rough sort) step is in this list but the study has rough sort disabled. Participants will not see it.",
+                        "presort_disabled": "The 'Let's meet' (pre-sort survey) step is in this list but the study has the pre-sort survey disabled. Participants will not see it.",
+                        "remove_action": "Remove"
+                    }
+                },
+                "consent_title": "Consent form",
+                "reset": "Reset instruction",
+                "consent_details": "Consent form details",
+                "fields": {
+                    "default_lang": "Default Language",
+                    "default_lang_help": "This language will be shown to participants by default if their browser language is not supported.",
+                    "title": "Study title",
+                    "title_placeholder": "Enter public title...",
+                    "subtitle": "Subtitle (optional)",
+                    "subtitle_placeholder": "A brief catchphrase...",
+                    "objective": "Study objective",
+                    "objective_placeholder": "What is the research question or purpose of this study?",
+                    "task_overview": "Introduction",
+                    "task_placeholder": "Describe the study process here (number of steps, estimated duration, etc.). This field is optional if you use the custom steps above.",
+                    "consent_title_label": "Consent title",
+                    "legal_text": "Legal text / agreement",
+                    "legal_placeholder": "Enter the full legal agreement text..."
+                },
+                "consent_desc": "Participants must agree to these terms before starting."
+            },
+            "condition": {
+                "title": "Condition of instruction",
+                "label": "Define condition of instruction",
+                "desc": "This is the core prompt that guides participants throughout the sorting process.",
+                "field_label": "Instruction text",
+                "placeholder": "E.g. Please rank the following statements from those you most agree with to those you most disagree with",
+                "grid_title": "Q-Sort instruction",
+                "grid_desc": "This is the core instruction guiding participants during the Q-Sort process.",
+                "pre_title": "Preliminary sort instruction",
+                "pre_desc": "Instruction given to participants during the initial rough sort.",
+                "pre_field_label": "Instruction text",
+                "pre_placeholder": "E.g. Based on your personal point of view; divide the cards into three piles...",
+                "enable_pre": "Enable pre-instruction step",
+                "pre_label": "Pre-instruction content",
+                "tips": {
+                    "title": "Why is this important?",
+                    "desc": "In q-methodology, the 'condition of instruction' determines the point of view from which the participant sorts the items. It should be clear and consistent across all sorting phases."
+                }
+            },
+            "questions": {
+                "enable_presort": "Enable pre-sort survey",
+                "enable_presort_desc": "Collect demographic information or other data before the sorting task.",
+                "add_field": "Add a new field",
+                "basic_fields": "Basic fields",
+                "choice_fields": "Choice fields",
+                "scale_fields": "Scale fields",
+                "labels": {
+                    "question": "Question label",
+                    "required": "Required field",
+                    "options": "Options",
+                    "multiple": "(Multiple selection allowed)",
+                    "single": "(Single selection)",
+                    "placeholder": "Enter your question here...",
+                    "scale": "Rating scale",
+                    "scale_points": "Number of points",
+                    "scale_left": "Left endpoint label",
+                    "scale_right": "Right endpoint label"
+                },
+                "types": {
+                    "text": "Text",
+                    "long_text": "Long text",
+                    "number": "Number",
+                    "date": "Date",
+                    "email": "Email",
+                    "dropdown": "Dropdown",
+                    "radio": "Radio",
+                    "checkboxes": "Checkboxes",
+                    "text_audio": "Text + Audio",
+                    "rating": "Rating scale"
+                },
+                "empty": {
+                    "title": "No questions yet",
+                    "desc": "Click above to add your first question"
+                },
+                "defaults": {
+                    "new_question": "New question",
+                    "option": "Option",
+                    "enter_answer": "Enter your answer...",
+                    "untitled": "Untitled question",
+                    "scale_left": "Strongly disagree",
+                    "scale_right": "Strongly agree"
+                },
+                "actions": {
+                    "add_option": "Add option",
+                    "copy_from": "Import from language",
+                    "copy_success": "Imported"
+                },
+                "logic": {
+                    "title": "Visibility logic",
+                    "enable": "Add visibility condition",
+                    "depends_on": "Show this question only if...",
+                    "select_placeholder": "Select a parent question",
+                    "operator": "Operator",
+                    "value": "Comparison value",
+                    "operators": {
+                        "equals": "Equals",
+                        "not_equals": "Does not equal",
+                        "contains": "Includes",
+                        "greater_than": "Greater than",
+                        "less_than": "Less than"
+                    }
+                }
+            },
+            "qsort": {
+                "tabs": {
+                    "statements": "Statements",
+                    "distribution": "Distribution"
+                },
+                "bulk": {
+                    "title": "Bulk editor (quick paste)",
+                    "desc": "One statement per line. Supports \"code: text\" and excel copy-paste (multi-language).",
+                    "replace_all": "Replace all",
+                    "append": "Append to list",
+                    "sync_by_code": "Sync/Merge by code",
+                    "placeholder": "Simple:. My statement",
+                    "detected": "{{count}} statements detected",
+                    "process_replace": "Process & replace statements",
+                    "process_append": "Process & append statements",
+                    "process_sync": "Process & sync translations",
+                    "detected_format": {
+                        "excel": "Excel format detected (tabs)",
+                        "list": "List format detected (code: text)",
+                        "simple": "Simple list detected (one per line)",
+                        "multi_lang": "Multi-language: {{langs}}",
+                        "with_codes": "With custom codes"
+                    }
+                },
+                "set": {
+                    "title": "Q-set",
+                    "clear": "Clear all",
+                    "confirm_clear": "Are you sure you want to delete ALL statements? This cannot be undone.",
+                    "updated": "Statement updated",
+                    "cleared": "All statements cleared",
+                    "imported": "Successfully imported {{count}} statements",
+                    "reset_codes": "Reset codes",
+                    "confirm_reset_codes": "Are you sure you want to re-sequence all statement codes (s1, s2, s3...)?",
+                    "codes_reset": "Statement codes re-sequenced"
+                },
+                "settings": {
+                    "title": "Research settings",
+                    "desc": "Configure how statements are presented to participants",
+                    "show_codes": "Show statement codes",
+                    "show_codes_desc": "Display statement codes (e.g., \"S1\", \"S2\") alongside the text.",
+                    "randomize": "Randomize statement order",
+                    "randomize_desc": "Present statements in random order to each participant (consistent within session)"
+                },
+                "grid": {
+                    "title": "Q-Sort distribution grid",
+                    "desc": "The grid shape forces participants to discriminate between statements, approximating a normal distribution.",
+                    "slot_count": "{{count}} slots allocated",
+                    "stat_count": "{{count}} statements",
+                    "perfect": "Perfect balance",
+                    "too_many": "{{count}} too many statements",
+                    "too_few": "{{count}} statements missing",
+                    "min_reached": "Minimum range reached (±2)",
+                    "max_reached": "Maximum range reached (±6)",
+                    "remove_extreme_columns": "Remove extreme columns",
+                    "add_extreme_columns": "Add extreme columns",
+                    "symmetry_lock": "Symmetry lock",
+                    "symmetry_lock_desc": "Automatically apply changes to opposite columns to maintain a balanced distribution.",
+                    "auto_balance": "Auto-Balance",
+                    "auto_balance_desc": "Reshape grid to a balanced semi-normal distribution",
+                    "reshaped": "Grid reshaped to a balanced distribution",
+                    "balanced": "Grid balanced to standard distribution",
+                    "no_statements": "Add statements first to auto-shape the grid",
+                    "statements": "statements",
+                    "ideal_shape": "Ideal shape",
+                    "symmetric": "Symmetric",
+                    "asymmetric": "Asymmetric",
+                    "tooltip_title": "Why forced distribution?",
+                    "tooltip_desc": "Q-methodology uses a quasi-normal distribution (kurtosis > 0) to ensure participants make meaningful distinctions. The pyramid shape prevents central tendency bias.",
+                    "locked": "Design locked",
+                    "locked_desc": "Structural changes (statement codes, grid) are disabled because the study has collected data or is no longer in draft mode. You can still edit text translations.",
+                    "locked_active": "This study is active. Switch to draft mode to edit.",
+                    "locked_paused": "This study is paused. Switch to draft mode to edit.",
+                    "locked_closed": "This study is closed. The design is archived.",
+                    "mismatch_title": "Grid capacity mismatch",
+                    "mismatch_desc": "You have {{statements}} statements but the grid only has slots for {{slots}} items. Please adjust the columns below to match.",
+                    "unlock_hint": "Go to data explorer to purge sessions and unlock structure"
+                }
+            },
+            "postsort": {
+                "extreme": {
+                    "title": "Targeted columns",
+                    "desc": "Select columns that trigger follow-up questions.",
+                    "no_columns": "No columns selected.",
+                    "add_label": "Add column:",
+                    "prompt_label": "Prompt for statements",
+                    "prompt_placeholder": "Why did you place this statement here?",
+                    "add": "Add",
+                    "add_defaults": "Add default extremes",
+                    "select_placeholder": "Select..."
+                },
+                "random_comments": {
+                    "title": "Allow random comments",
+                    "desc": "Allow participants to add comments to any statement in the grid."
+                },
+                "custom": {
+                    "title": "Custom questions",
+                    "desc": "Add custom questions to the post-sort survey."
+                },
+                "missing": {
+                    "title": "Ask about missing statements",
+                    "desc": "If yes, please describe them briefly.",
+                    "prompt_label": "Prompt text",
+                    "prompt_placeholder": "Please feel free to suggest and explain."
+                },
+                "steps": {
+                    "step1": "Step 1: feedback",
+                    "step2": "Step 2: questions"
+                },
+                "email": {
+                    "title": "Participant follow-up",
+                    "desc": "Collect email addresses for follow-up or research results.",
+                    "interview": "Offer follow-up",
+                    "results": "Offer to subscribe to a mailing list about study outcomes",
+                    "interview_warning": "Note: agreeing to be contacted lifts anonymity for the researcher.",
+                    "results_hint": "Email solely for results, anonymity preserved."
+                },
+                "audio": {
+                    "title": "Audio Recording",
+                    "desc": "Allow participants to record audio responses instead of text.",
+                    "max_duration": "Maximum Duration",
+                    "seconds": "seconds",
+                    "max_duration_help": "Maximum recording time per question (30–600 seconds).",
+                    "participant_choice_info": "Participants can respond with text, audio, or both for each question."
+                }
+            },
+            "interface": {
+                "title": "Interface customization",
+                "desc": "Customize the buttons and labels of the interface to match your study's tone (e.g., changing \"agree/disagree\" to \"like/dislike\").",
+                "nav": {
+                    "title": "Navigation buttons",
+                    "start": "Start button",
+                    "next": "Next step button",
+                    "submit": "Submit button",
+                    "confirm": "Confirm sort button",
+                    "tooltips": {
+                        "start": "Button that starts the study",
+                        "next": "Move to the next step",
+                        "submit": "Submit results at the end",
+                        "confirm": "Generic validation button"
+                    }
+                },
+                "terms": {
+                    "title": "Sorting terminology",
+                    "desc": "Define the labels for the spontaneous sort and the grid spectrum.",
+                    "rough": "Rough sort labels",
+                    "agree": "Agree",
+                    "neutral": "Neutral",
+                    "disagree": "Disagree",
+                    "grid": "Grid legends (extremes)",
+                    "most_agree": "Most agree",
+                    "most_disagree": "Most disagree"
+                },
+                "hints": {
+                    "title": "Methodology tips",
+                    "desc": "Add or modify floating hints to help participants during the grid sort phase.",
+                    "placeholder": "Enter a methodology tip...",
+                    "add": "Add tip",
+                    "reset": "Reset to defaults"
+                },
+                "help": {
+                    "title": "Step guidance (what/why)",
+                    "desc": "Customize the context-sensitive help available to participants at each step via the '?' overlay.",
+                    "step_disabled": "(step disabled)"
+                }
+            },
+            "theme": {
+                "title": "Visual branding",
+                "accent": {
+                    "title": "Accent color",
+                    "desc": "This color will be used for buttons, links, and highlights throughout the study.",
+                    "pick": "Pick a color",
+                    "reset": "Reset to default"
+                },
+                "logo": {
+                    "title": "Study logo",
+                    "desc": "Upload a custom logo to replace the default Open-Q branding.",
+                    "label": "Logo URL",
+                    "hint": "Recommended size: 200x50px. Supports PNG, SVG, JPG.",
+                    "preview": "Logo preview",
+                    "help_title": "Where does this logo appear?",
+                    "help_desc": "The logo is displayed at the top of every study page (navigation bar) and on the welcome page. It reinforces your project's visual identity."
+                },
+                "partners": {
+                    "title": "Institutional partners",
+                    "desc": "Add logos of supporting institutions or partners.",
+                    "add": "Add partner",
+                    "name_label": "Partner name",
+                    "name_placeholder": "Institution name",
+                    "logo_label": "Logo URL",
+                    "url_label": "Website (optional)",
+                    "url_placeholder": "Https://...",
+                    "help_title": "Display of logos",
+                    "help_desc": "Partner logos are displayed on the landing page as well as in the study header, next to the main logo."
+                },
+                "upload": {
+                    "upload": "Upload",
+                    "recommended": "Recommended",
+                    "invalid_type": "Invalid file type. Use PNG, JPG, or SVG.",
+                    "file_too_large": "File too large. Maximum size: {{size}}kb.",
+                    "conversion_error": "Failed to process image.",
+                    "processing": "Processing image...",
+                    "drag_drop": "Drag & drop or click to upload",
+                    "max": "Max"
+                }
+            },
+            "activate_dialog": {
+                "title": "Activate this study?",
+                "description": "Activating opens recruitment and unlocks public links. Real participants can begin submitting.",
+                "checklist_title": "Pre-flight checks",
+                "languages_title": "Languages",
+                "lang_ready": "Ready",
+                "lang_incomplete": "Incomplete",
+                "required": "(required)",
+                "attestation": "I have reviewed the consent text, the retention policy, and confirm this study is ready to receive real participants.",
+                "confirm": "Activate study"
+            }
+        },
+        "data": {
+            "title": "Data",
+            "description": "Monitor real-time participation, analyze data quality, and manage research sessions.",
+            "sections": {
+                "key_indicators": "Key indicators",
+                "responses": "Responses",
+                "key_statistics": "Key statistics"
+            },
+            "stats": {
+                "email_collection": "Email collection",
+                "participants": "total",
+                "newsletter": "Wants results",
+                "opt_in": "Response rate",
+                "follow_up": "Follow-up potential",
+                "interested": "interested",
+                "click_to_filter": "Click to filter",
+                "click_to_export": "Click to export list",
+                "completed": "Completed",
+                "in_progress": "In progress",
+                "abandoned_count": "{{count}} abandoned",
+                "interview_interested": "Accepts follow-up",
+                "interview": "Accepts follow-up",
+                "email": "Emails"
+            },
+            "tabs": {
+                "live": "Live participants",
+                "test": "Test sessions",
+                "browse": "Interactive view",
+                "export": "Export hub"
+            },
+            "status": {
+                "started": "started",
+                "completed": "Completed",
+                "in_progress": "In progress",
+                "abandoned": "Abandoned",
+                "discarded": "discarded"
+            },
+            "step": {
+                "consent": "Consent",
+                "presort": "Pre-sort survey",
+                "rough": "Preliminary sort",
+                "fine": "Q-sort",
+                "post": "Post-sort survey"
+            },
+            "actions": {
+                "discard": "Discard",
+                "restore": "Restore",
+                "export": "Export",
+                "clear_all": "Reset all data",
+                "clear_all_confirm": "DANGER: This will permanently delete ALL participant data for this study. This cannot be undone.",
+                "clear_all_success": "All data cleared",
+                "clear_all_error": "Could not clear data. Check your permissions and try again."
+            },
+            "confirm_discard": {
+                "title": "Discard participant?",
+                "description": "This participant will be excluded from exports and analysis. You can restore them later.",
+                "reason_label": "Reason (optional)",
+                "reason_placeholder": "Why is this participant being discarded?"
+            },
+            "confirm_restore": {
+                "title": "Restore participant?",
+                "description": "This participant will be included in exports and analysis again."
+            },
+            "guide": {
+                "title": "Format guide",
+                "csv": {
+                    "title": "Universal CSV",
+                    "desc": "Raw rectangular data. Best for r, python, SPSS, or excel analysis. Includes all metadata."
+                },
+                "json": {
+                    "title": "KenQ JSON",
+                    "desc": "Optimized for the web-kenq analysis tool. Contains study definition and sorts."
+                },
+                "zip": {
+                    "title": "PQMethod bundle (ZIP)",
+                    "desc": "Contains legacy .DAT and .STA files for DOS PQMethod analysis."
+                }
+            },
+            "table": {
+                "participant": "Participant",
+                "lang": "Lang",
+                "status": "Status",
+                "consent": "Consent",
+                "flags": "Flags",
+                "duration": "Duration",
+                "submitted": "Submitted",
+                "last_step": "Last step",
+                "current_step": "Current step",
+                "view": "View",
+                "actions": "Details",
+                "duplicate_ip": "Duplicate IP",
+                "duplicate_ip_hint": "Shares IP hash with other participants"
+            },
+            "tooltips": {
+                "suspect": "Potentially suspect: session duration < 2 minutes",
+                "has_comments": "Contains participant comments on cards",
+                "has_audio": "Has audio responses",
+                "email_provided": "Email provided",
+                "newsletter_consent": "Wants results",
+                "interview_consent": "Accepts follow-up"
+            },
+            "toast": {
+                "discarded": "Participant discarded",
+                "restored": "Participant restored",
+                "error": "Could not update participant. Check your connection and try again."
+            },
+            "detail": {
+                "participant": "Participant",
+                "participant_n": "Participant {{code}}",
+                "not_found": "Participant not found",
+                "title": "Participant profile",
+                "session": "Session",
+                "discarded_badge": "Discarded",
+                "description": "Comprehensive Q-sort results and metadata.",
+                "stats": {
+                    "duration": "Total duration",
+                    "language": "Language used"
+                },
+                "actions": {
+                    "discard": "Discard participant",
+                    "restore": "Restore participant"
+                },
+                "sort_config": "Sort configuration",
+                "survey": {
+                    "title": "Questionnaire responses",
+                    "csv_note": "Full responses available in CSV export."
+                }
+            },
+            "filter": {
+                "show_discarded": "Include discarded records",
+                "all_states": "All states",
+                "only_active": "Only active",
+                "only_flagged": "Flagged quality"
+            },
+            "filters": {
+                "active": "Active filters",
+                "has_email": "Email provided",
+                "newsletter": "Wants results",
+                "interview": "Accepts follow-up",
+                "flagged": "Flagged only",
+                "clear_all": "Clear filters",
+                "remove_filter": "Remove filter",
+                "all_statuses": "All statuses",
+                "all_consents": "All",
+                "all_indicators": "All",
+                "all_steps": "All steps",
+                "has_comments": "Has comments",
+                "has_audio": "Has audio",
+                "has_recruitment": "Has recruitment link"
+            },
+            "charts": {
+                "section_title": "Response Distributions",
+                "distribution_label": "Distribution for {{question}}",
+                "multi_select_note": "Multiple selections allowed",
+                "responses_count": "{{count}} responses",
+                "no_answer": "No answer",
+                "option": "Option",
+                "count": "Count"
+            },
+            "search": {
+                "placeholder": "Search by ID or recruitment token...",
+                "records_found": "Records detected",
+                "no_results": "No records match your query"
+            },
+            "errors": {
+                "load_failed": "Cloud sync interrupted. Please check your connection."
+            },
+            "export_emails_success": "Emails exported successfully",
+            "empty": {
+                "no_participants_title": "No participants yet",
+                "no_participants_desc": "Share your study link to start collecting responses.",
+                "contract_title": "No submissions yet",
+                "contract_body": "Submissions and exports will appear here. Share the study link to start collecting.",
+                "contract_cta": "Open study overview"
+            },
+            "pagination": {
+                "showing": "Showing {{from}}–{{to}} of {{total}}"
+            }
+        },
+        "team": {
+            "title": "Study team",
+            "description": "Manage collaborators and study-level access control.",
+            "invite_title": "Invite collaborator",
+            "invite_description": "Generate a secure link to invite a new member to this study.",
+            "email_label": "Email address",
+            "role_label": "Role",
+            "select_role": "Select a role",
+            "generate_link": "Generate link",
+            "invite_success": "Invitation link generated!",
+            "invite_error": "Failed to generate invitation",
+            "copy_success": "Link copied to clipboard",
+            "share_label": "Share this link with the invitee:",
+            "collab_overview": "Collaboration overview",
+            "active_members": "Active members",
+            "permissions_info": "Permissions info",
+            "list_title": "Research team",
+            "list_description": "Manage access for existing collaborators.",
+            "added_on": "Added on",
+            "headers": {
+                "collaborator": "Collaborator",
+                "role": "Role",
+                "actions": "Actions"
+            },
+            "roles": {
+                "owner": "Owner (full control)",
+                "editor": "Editor (design & analysis)",
+                "viewer": "Viewer (read-only)",
+                "owner_badge": "OWNER",
+                "editor_badge": "EDITOR",
+                "viewer_badge": "VIEWER"
+            },
+            "permissions": {
+                "owner": "Can delete the study and manage team.",
+                "editor": "Can modify design and view results.",
+                "viewer": "Read-only access to all modules."
+            }
+        },
+        "empty_states": {
+            "participants": {
+                "title": "Ready to launch?",
+                "desc": "Share your study link to start collecting responses. Your first participant is just a click away.",
+                "action": "Copy study link",
+                "hint": "Or scan the QR code",
+                "copy_success": "Study link copied to clipboard!"
+            },
+            "team": {
+                "title": "You're flying solo",
+                "desc": "Invite collaborators to help manage this study. They can view data, edit the design, or just observe.",
+                "action": "Invite your first collaborator"
+            },
+            "designer": {
+                "title": "Tabula rasa",
+                "desc": "This study has no statements yet. Add your Q-set items to begin designing your sort.",
+                "action": "Load example Q-set"
+            }
+        },
+        "status": {
+            "active": "Active",
+            "paused": "Paused",
+            "closed": "Closed",
+            "draft": "Draft"
+        },
+        "settings": {
+            "title": "Settings",
+            "description": "Data retention, archiving, and study deletion.",
+            "lifecycle": {
+                "title": "Archiving",
+                "description": "Archive the study to make it read-only for everyone.",
+                "notice": "To archive a study, it must first be closed. Once archived, no further changes can be made.",
+                "archived_status": "Study is archived",
+                "archive_button": "Archive study",
+                "current_state": "Current state"
+            },
+            "danger": {
+                "title": "Danger zone",
+                "description": "Actions here are irreversible.",
+                "notice": "Deleting a study removes ALL data (participants, answers, config) permanently. Study must be archived before deletion.",
+                "delete_button": "Delete study",
+                "delete_confirm": "Are you sure? This action is IRREVERSIBLE.",
+                "delete_dialog_title": "Delete this study?",
+                "delete_dialog_intro": "Permanently deletes sorts, audio, and analysis runs.",
+                "delete_dialog_typed_label": "Type the study slug to confirm",
+                "delete_dialog_action": "Delete permanently"
+            },
+            "save_button": "Save",
+            "save_success": "Settings updated",
+            "save_success_desc": "Study settings have been saved.",
+            "save_error": "Could not save settings. Verify the values and try again.",
+            "save_error_desc": "Failed to update settings. Slug might be taken.",
+            "archive_success": "Study archived",
+            "archive_success_desc": "The study is now archived and read-only.",
+            "archive_error": "Error archiving study",
+            "archive_error_desc": "Failed to archive study. Is it closed?",
+            "delete_success": "Study deleted",
+            "delete_success_desc": "The study has been permanently removed.",
+            "delete_error": "Could not delete study. Make sure all data has been cleared first.",
+            "delete_error_desc": "Failed to delete study.",
+            "storage": {
+                "title": "Audio Storage Usage",
+                "used": "Storage Used",
+                "quota": "Quota",
+                "quota_label": "Storage Quota",
+                "quota_help": "Maximum total audio storage for this study (10–1000 MB).",
+                "error": "Failed to load storage usage.",
+                "warning_high_usage": "Storage usage is high. Consider increasing the quota or removing old recordings.",
+                "save_success": "Storage quota updated",
+                "save_error": "Could not update storage quota. Try again."
+            },
+            "retention": {
+                "title": "Data retention",
+                "months_label": "Retention (months)",
+                "help": "Common values: 6, 12, 24, 60 months. Leave empty for system default (12).",
+                "save_success": "Data retention policy updated",
+                "save_error": "Failed to update data retention policy",
+                "range_error": "Retention must be an integer between 1 and 240 months."
+            }
+        },
+        "privacy": {
+            "title": "Data privacy",
+            "header_desc": "Consent, inventory & anonymisation",
+            "load_error": "Failed to load data inventory.",
+            "participants_title": "Participants snapshot",
+            "stat_started": "Started",
+            "stat_completed": "Completed",
+            "stat_discarded": "Discarded",
+            "stat_anonymised": "Anonymised",
+            "older_1y": "Older than 1 year (not anonymised)",
+            "older_2y": "Older than 2 years (not anonymised)",
+            "audio_title": "Audio storage",
+            "audio_count": "Recordings",
+            "audio_mb": "Total size",
+            "locale_title": "Locale breakdown",
+            "locale_col": "Language",
+            "locale_count_col": "Participants",
+            "locale_empty": "No locale data yet.",
+            "timeline_title": "Timeline",
+            "tl_first": "First submission",
+            "tl_last": "Last submission",
+            "tl_anon": "Last anonymisation",
+            "bulk_title": "Bulk anonymisation",
+            "bulk_desc": "Remove personal data from completed participants submitted before a cutoff date. Q-sort rankings are preserved.",
+            "cutoff_label": "Cutoff date",
+            "cutoff_help": "Only completed participants submitted strictly before this date will be anonymised.",
+            "preview_label": "Candidates:",
+            "preview_zero": "No participants qualify for this cutoff. Try an earlier date.",
+            "anonymise_button": "Anonymise",
+            "anonymise_success": "Anonymisation complete",
+            "anonymise_success_desc": "{{n}} participant(s) anonymised, {{s}} already anonymous.",
+            "anonymise_error": "Anonymisation failed",
+            "confirm_title": "Anonymise participant data?",
+            "confirm_candidates": "{{count}} completed participant(s) submitted before {{date}} will be anonymised.",
+            "confirm_preserved": "Q-sort rankings are kept; identity is removed.",
+            "confirm_irreversible": "This action is immediate and cannot be undone.",
+            "confirm_in_progress": "Anonymising…",
+            "confirm_action": "Yes, anonymise",
+            "cutoff_from_policy": "Default derived from study retention policy ({{months}} months).",
+            "empty": {
+                "title": "No participant data yet",
+                "body": "This page activates once participants submit. Share the study link first.",
+                "cta": "Open study overview"
+            },
+            "consent": {
+                "title": "Consent form",
+                "description": "What participants see before they enter the study. Edited in Study design.",
+                "no_text": "No consent text set yet.",
+                "no_title": "(no title)",
+                "no_body": "(empty)",
+                "edit_in_design": "Edit in Study design",
+                "view": "View"
+            }
+        },
+        "projects": {
+            "title": "Projects",
+            "settings": {
+                "title": "Project settings",
+                "identity_desc": "Manage project identity.",
+                "general": {
+                    "title": "General settings",
+                    "desc": "Identity and primary identification of your project.",
+                    "label_title": "Project title",
+                    "placeholder_title": "My awesome lab",
+                    "label_slug": "URL slug",
+                    "placeholder_slug": "My-lab",
+                    "slug_hint": "Changing the slug will update all your research dashboard links.",
+                    "save": "Save",
+                    "save_success": "Project updated successfully",
+                    "save_error": "Failed to update project."
+                },
+                "team_growth_title": "Team management",
+                "team_growth_desc": "Need more researchers? You can invite collaborators to your project. They will be able to manage all studies within this project.",
+                "team": {
+                    "title": "Team members",
+                    "desc": "List of users with access to this project.",
+                    "col_user": "User",
+                    "col_role": "Role",
+                    "col_joined": "Joined",
+                    "col_actions": "Actions",
+                    "remove_confirm": "Are you sure you want to remove this member?",
+                    "remove_dialog_title": "Remove team member?",
+                    "remove_dialog_body": "{{name}} will lose access to this project. They can be re-invited later.",
+                    "remove_dialog_action": "Remove",
+                    "remove_member_aria": "Remove {{name}}",
+                    "remove_success": "Member removed successfully",
+                    "remove_error": "Failed to remove member",
+                    "growth_title": "Team growth",
+                    "growth_desc": "Need more researchers? You can invite collaborators to your project. They will be able to manage all studies within this project.",
+                    "invite_button": "Invite collaborator",
+                    "permissions_matrix": {
+                        "title": "Permissions matrix",
+                        "admin": {
+                            "label": "Admin",
+                            "desc": "Can manage project settings, members, and all studies."
+                        },
+                        "owner": {
+                            "label": "Owner",
+                            "desc": "Full project, member, and study control."
+                        },
+                        "member": {
+                            "label": "Member",
+                            "desc": "Can create and manage all studies. Restricted from project settings."
+                        },
+                        "viewer": {
+                            "label": "Viewer",
+                            "desc": "Read-only access to all studies and data in the project."
+                        }
+                    },
+                    "coming_soon": "Coming soon",
+                    "invite_modal": {
+                        "title": "Invite collaborator",
+                        "email_label": "Collaborator email",
+                        "role_label": "Assigned role",
+                        "success": "Invitation link generated!",
+                        "error": "Failed to create invitation.",
+                        "send": "Create & send invitation",
+                        "copy_success": "Link copied to clipboard!"
+                    }
+                }
+            },
+            "members": {
+                "quota": "{{count}}/{{limit}} seats used",
+                "quota_full_tooltip": "Member limit reached. Increase MAX_MEMBERS_PER_PROJECT or remove a member."
+            },
+            "create": {
+                "quota": "{{count}}/{{limit}} owned projects",
+                "quota_full_tooltip": "You've reached your owned-project limit."
+            }
+        },
+        "members": {
+            "title": "Team members",
+            "description": "Manage who can access this project and what they can do."
+        },
+        "participants": {
+            "title": "Participants",
+            "description": "Manage participants and explore submitted data.",
+            "table": {
+                "id": "ID",
+                "status": "Status",
+                "started": "Started at",
+                "completed": "Completed at",
+                "duration": "Duration",
+                "actions": "Actions"
+            }
+        },
+        "participant": {
+            "tabs": {
+                "session": "Metadata",
+                "presort": "Pre-Sort",
+                "grid": "Q-Sort Grid",
+                "postsort": "Post-Sort"
+            },
+            "grid": {
+                "detail_view": "Card Details",
+                "no_comment": "No comment provided.",
+                "select_instruction": "Select a card on the grid to view details.",
+                "read_only_mode": "Viewer Mode",
+                "score": "Score"
+            },
+            "metadata": {
+                "title": "Session Metadata",
+                "technology": "Technology",
+                "browser": "Browser",
+                "session": "Session Details",
+                "duration": "Total Duration",
+                "started": "Started",
+                "submitted": "Submitted",
+                "id": "Internal ID",
+                "ip_hash": "IP Hash",
+                "recruitment_token": "Recruitment Token",
+                "device": {
+                    "mobile": "Mobile",
+                    "tablet": "Tablet",
+                    "desktop": "Desktop"
+                }
+            },
+            "status": {
+                "started": "Started",
+                "completed": "Completed",
+                "discarded": "Discarded",
+                "in_progress": "In Progress"
+            },
+            "survey": {
+                "presort": "Pre-Sort Questions",
+                "postsort": "Post-Sort Questions",
+                "no_answers": "No answers recorded for this section.",
+                "categories": {
+                    "identity": "Identity & Contact",
+                    "questions": "Questionnaire Responses",
+                    "comments": "Card Comments",
+                    "feedback": "General Feedback"
+                }
+            }
+        }
+    }
+}

--- a/frontend/public/locales/pl/participant.json
+++ b/frontend/public/locales/pl/participant.json
@@ -1,0 +1,461 @@
+{
+    "common": {
+        "placeholders": {
+            "text_response": "Enter your answer..."
+        },
+        "add": "Add",
+        "confirm": "Confirm",
+        "all": "All",
+        "agree": "Somewhat agree",
+        "disagree": "Somewhat disagree",
+        "neutral": "Neutral",
+        "reset_to_default": "Reset to default",
+        "reset_to_default_success": "Restored to default",
+        "reset_to_default_confirm": "Are you sure you want to reset this field to its default value? Any custom changes will be lost.",
+        "undo": "Undo",
+        "next": "Next step",
+        "submit": "Share my perspective",
+        "continue": "Continue",
+        "loading": "Loading...",
+        "lang_code": "en",
+        "attention": "Attention",
+        "error": "Error",
+        "submitting": "Submitting...",
+        "cards": "statements",
+        "close": "Close",
+        "unknown_card": "Unknown Card",
+        "unknown": "Unknown",
+        "duration_short": "{{m}}m {{s}}s",
+        "duration_long": "{{h}}h {{m}}m {{s}}s",
+        "optional": "Optional",
+        "processing": "Processing...",
+        "statement": "Statement",
+        "step": "Step",
+        "back": "Back",
+        "cancel": "Cancel",
+        "delete": "Delete",
+        "slots": "slots",
+        "project_label": "Project",
+        "read_full": "Read full statement",
+        "reduce": "Reduce",
+        "expand": "Expand",
+        "yes": "Yes",
+        "no": "No",
+        "score": "Score",
+        "comment": "Comment",
+        "errors": {
+            "network": "Network connection error. Please check your internet connection.",
+            "not_found": "Study not found.",
+            "validation": "System error: data validation failed.",
+            "unknown": "An unexpected error occurred.",
+            "retry": "Retry",
+            "min": "Value must be at least {{min}}",
+            "max": "Value must be at most {{max}}",
+            "email": "Please enter a valid email address",
+            "min_length": "Minimum {{count}} characters required",
+            "max_length": "Maximum {{count}} characters allowed",
+            "404": {
+                "title": "Page not found",
+                "message": "The page or study you are looking for does not exist."
+            },
+            "429": {
+                "title": "Too many requests",
+                "message": "You are doing that too fast. Please wait a moment."
+            },
+            "500": {
+                "title": "Server error",
+                "message": "Our servers encountered an issue. Please try again later."
+            },
+            "network_title": "Connection lost",
+            "home": "Go to home",
+            "reset": "Reset session",
+            "default_title": "Oops! Something went wrong.",
+            "study_not_found": {
+                "title": "Study not found",
+                "message": "We couldn't find a study with that name. Please check the URL or contact the researcher.",
+                "action": "Go to home"
+            }
+        },
+        "status": {
+            "draft": {
+                "title": "Study under preparation",
+                "message": "This study is not available for participation yet. Please check back later.",
+                "action": "Back to home"
+            },
+            "steps": {
+                "draft": {
+                    "label": "Draft",
+                    "description": "Configuration & design"
+                },
+                "active": {
+                    "label": "Active",
+                    "description": "Collecting responses"
+                },
+                "paused": {
+                    "label": "Paused",
+                    "description": "On hold"
+                },
+                "closed": {
+                    "label": "Closed",
+                    "description": "Analysis & export"
+                }
+            },
+            "paused": {
+                "title": "Maintenance in progress",
+                "message": "Data collection is temporarily paused for maintenance. We will be back shortly.",
+                "action": "Retry"
+            },
+            "closed": {
+                "title": "Data collection closed",
+                "message": "This study is now closed. Participation is no longer possible.",
+                "action": "Back to home"
+            }
+        }
+    },
+    "layout": {
+        "title": "Open-Q",
+        "preparing": "Preparing your study session...",
+        "pilot_mode": "Pilot mode: changes are temporary & data will not be saved",
+        "default_study_title": "Q-Method study",
+        "loading_content": "Loading study content...",
+        "change_lang_title": "Change language",
+        "steps": {
+            "welcome": "Welcome",
+            "consent": "Privacy & Consent",
+            "rough": "First impressions",
+            "fine": "Q-sort",
+            "post": "Final questions"
+        },
+        "mobile_step": "Step",
+        "navigation": "Navigation",
+        "language": "English"
+    },
+    "study": {
+        "help": {
+            "title": "Help & information",
+            "trigger": "Help",
+            "what": "What we ask",
+            "why": "Why it matters",
+            "step_welcome": {
+                "what": "Read the research objectives and the specific instructions for participation.",
+                "why": "Beyond standard ethical consent, you need to grasp the 'condition of instruction': the precise lens or scenario you adopt to evaluate the statements. This matters for data validity."
+            },
+            "step_presort": {
+                "what": "Provide background information to help characterize your participant profile.",
+                "why": "This context allows the research team to analyze how distinct viewpoints (factors) may or may not correlate with specific demographic variables or professional backgrounds within the participant group."
+            },
+            "step_rough": {
+                "what": "Sort the deck of statements into three initial piles based on your immediate reaction.",
+                "why": "This preparatory step is designed to reduce cognitive load; it allows you to familiarize yourself with the full range of the topic (the Q-set) before the more demanding task of comparative ranking begins."
+            },
+            "step_fine": {
+                "what": "Place the statements on the grid by ranking them relative to one another, from those you most agree with (to the right) to those you most disagree with (to the left). Starting with the extremes might help you in this task.",
+                "why": "The grid's structure imposes a 'forced distribution' that prevents you from rating everything as equally important; it compels you to make trade-offs, thereby modelling the relative significance of each idea in your specific belief system."
+            },
+            "step_post": {
+                "what": "Confirm your grid arrangement and add comments explaining your strongest choices.",
+                "why": "Your qualitative explanations are critical for validating the statistical analysis; they help the researchers interpret the data through your logic rather than imposing their own assumptions on your choices."
+            }
+        },
+        "steps": {
+            "presort": "Pre-sort survey",
+            "rough": "Preliminary sort",
+            "fine": "Grid placement",
+            "post": "Post-sort stage"
+        }
+    },
+    "welcome": {
+        "start": "Get started",
+        "consent": {
+            "label": "I confirm that i have read the above information and consent to the processing of my data for the purposes of this study.",
+            "error": "Please accept the terms to continue."
+        },
+        "reset_confirm": "Are you sure you want to start a new session? This will clear your current progress.",
+        "restart": "Start a new session",
+        "preview_title": "Preview",
+        "conducted_by": "Conducted by",
+        "how_it_works": "Process",
+        "objective_label": "Study objective",
+        "instructions_label": "Process",
+        "default_instructions": "1. **Let's meet:** First, you will be asked a few short, preliminary questions.\n2. **First impressions:** You will read through the different statements and roughly sort them according to your personal viewpoint: whether you tend to agree, feel neutral, or disagree with them.\n3. **Your perspective:** During the sorting stage, you will place the statements on a grid to refine your viewpoint. You will sort and rank the statements from “most agree” to “most disagree” by placing each statement in the corresponding box.\n4. **Why:** Before the session ends, you will be asked a few clarifying questions to help us better understand your most significant choices.",
+        "steps": {
+            "profile": {
+                "title": "Let's meet",
+                "description": "First, you will be asked a few short, preliminary questions."
+            },
+            "rough": {
+                "title": "First impressions",
+                "description": "You will read through the different statements and roughly sort them according to your personal viewpoint: whether you tend to agree, feel neutral, or disagree with them. It will make the next task easier."
+            },
+            "fine": {
+                "title": "Your perspective",
+                "description": "During the sorting stage, you will place the statements on a grid to refine your viewpoint. You will sort and rank the statements from “most agree” to “most disagree” by placing each statement in the corresponding box. There are no right or wrong answers. The best answer is the one that reflects your opinion, or beliefs."
+            },
+            "post": {
+                "title": "Why",
+                "description": "Before the session ends, you will be asked a few clarifying questions to help us better understand your most significant choices, as well as a few questions about your background."
+            }
+        }
+    },
+    "consent": {
+        "title": "Informed consent and data processing agreement",
+        "subtitle": "Please read the following information carefully.",
+        "record_error": "Could not save consent record. You may continue.",
+        "default_text": "1. Nature of the study and participant understanding. You understand that this exercise employs q-methodology, a research technique designed to model subjective viewpoints. The task requires you to sort statements according to their significance relative to your personal perspective; consequently, there are no objective \"right\" or \"wrong\" answers.\n\n2. Data processing and pseudonymization (GDPR compliance).\n\nDe-identification and retention:. This technical process ensures that your digital footprint cannot be used to re-identify you once the session ends.\n\nException for follow-up: if you voluntarily provide your contact details at the end of the study for a follow-up contact, the link between your identity (email) and your response will be maintained strictly for the duration of that specific follow-up phase.\n\nReporting: the final results will be presented in an anonymized format. Data will be aggregated to reveal shared social perspectives (factors). Qualitative comments may be quoted to contextualize these factors but will be screened to remove revealing details.\n\n3. Voluntary participation and right to withdraw. You maintain the right to discontinue the sorting process and close your browser at any time prior to submission without penalty.\n\nPre-submission: if you withdraw before finalizing your sort, no partial data will be retained.\n\nPost-submission: due to the statistical nature of q-methodology (factor analysis), once your data has been submitted and aggregated into the dataset, individual withdrawal may not be feasible.\n\n4. Data retention and rights"
+    },
+    "presort": {
+        "title": "Before we start",
+        "description": "Please answer a few questions to help us situate your viewpoint.",
+        "submit": "Continue to sorting",
+        "select_placeholder": "Select...",
+        "error_required": "Please answer this question."
+    },
+    "rough": {
+        "header": {
+            "subtitle": "Swipe **left** to disagree, **right** to agree, or **down** to be neutral.",
+            "hint": "This is spontaneous. You can change your mind right after."
+        },
+        "tip": {
+            "close": "Close tip"
+        },
+        "complete": {
+            "title": "First step complete",
+            "subtitle": "We will now refine the nuances.",
+            "button": "Continue to fine sort"
+        },
+        "instructions": {
+            "desktop_tip": "Drag, press, or use keyboard ( ← ↓ → ) to sort"
+        },
+        "progress_label": "Rough sort progress: {{percent}}% complete"
+    },
+    "fine": {
+        "deck": {
+            "title": "Available statements",
+            "all_placed": "All statements in this pile are sorted"
+        },
+        "toolbar": {
+            "preview": "Statement",
+            "zoom_in": "Zoom in",
+            "zoom_out": "Zoom out",
+            "fit_screen": "Fit to screen",
+            "label": "Grid controls"
+        },
+        "grid": {
+            "label": "Q-Sort grid",
+            "column": "Column",
+            "slot": "Slot",
+            "in_column": "In column"
+        },
+        "legend": {
+            "disagree": "Most disagree",
+            "neutral": "Neutral",
+            "agree": "Most agree",
+            "label": "Grid legend"
+        },
+        "actions": {
+            "validate": "Confirm sort",
+            "finish": "Finish sorting",
+            "ready": "Review overview",
+            "not_ready": "Place all statements to continue"
+        },
+        "header": {
+            "title": "Place statements on the grid",
+            "instruction_label": "Instruction",
+            "expand_instructions": "Expand instructions",
+            "minimize_instructions": "Minimize instructions"
+        },
+        "workbench": {
+            "active_card": "Active statement",
+            "place_on_grid": "Tap grid to place",
+            "drag_or_tap": "Drag to grid or tap slot",
+            "initial_instruction": "Tap (or drag) statement",
+            "initial_instruction_mobile": "Tap statement",
+            "cancel_selection": "Cancel selection",
+            "help": "How does it work?",
+            "previous_tip": "Previous tip",
+            "next_tip": "Next tip",
+            "go_to_tip": "Go to tip {{number}}",
+            "methodology": {
+                "extremes": "Tip: start with what is most obvious to you (the extremes).",
+                "vertical": "In the same column, the order from top to bottom doesn't matter.",
+                "constraint": "You have to fit everything! It can be a puzzle, but that's how we prioritize choices.",
+                "relative": "Reminder: items are sorted relative to each other (relative agreement).",
+                "zoom": "Feel free to zoom in on different parts of the grid for better visibility.",
+                "flexibility": "Nothing is final: you can move cards or put them back in the deck at any time."
+            }
+        }
+    },
+    "post": {
+        "title": "Your perspective & feedback",
+        "description": "You're almost done! Your comments on the most significant statements are crucial for our analysis.",
+        "step2_title": "Almost done!",
+        "step2_description": "Please answer these final questions to complete the study.",
+        "extreme": {
+            "title": "Key Choices",
+            "why": "Why did you choose to place this statement here? How is it significant to you?",
+            "placeholder": "E.g., a specific event, a strong belief, or a particular word in the statement...",
+            "min_chars": "A few words are enough to help us understand the context.",
+            "label_agree": "Strongest agreement",
+            "label_disagree": "Strongest disagreement",
+            "label_neutral": "Neutral",
+            "missing_statement": "Missing Statement",
+            "general_comment": "General Comment"
+        },
+        "optional": {
+            "title": "Did any statements feel particularly surprising, unclear, or confusing to you? If so, why?",
+            "description": "You are also welcome to add comments to any other statement if you would like to further explain your choices.",
+            "select_placeholder": "Select a statement to comment...",
+            "placeholder": "Your comment here..."
+        },
+        "submit": "Share my perspective",
+        "validation_error": "Please fill in all required fields.",
+        "text_audio_info": "For text + audio questions, you can respond with text, an audio recording, or both.",
+        "text_audio_required": "A few words or an audio recording will help us understand your viewpoint.",
+        "success": {
+            "title": "Thank you for your participation!",
+            "message": "Your contribution to the study has been saved.",
+            "id_label": "Confirmation code",
+            "share": {
+                "title": "Spread the word",
+                "copy_link": "Copy link",
+                "copy_success": "Link copied!",
+                "message": "I just participated in this study: \"{{title}}\". I thought it might interest you. You can access it here:",
+                "email": "Email",
+                "email_subject": "Participate in this study: {{title}}",
+                "native": "Share"
+            }
+        },
+        "submit_error": {
+            "title": "Submission failed",
+            "message": "Please check your connection and try again."
+        },
+        "score": "Score",
+        "back": "Back to sort",
+        "contact": {
+            "title": "Results & contact",
+            "email_label": "Your email address (optional)",
+            "email_placeholder": "Example@email.com",
+            "interview_consent": "I agree to be contacted by the researcher for follow-up.",
+            "newsletter_consent": "I wish to be informed about the study results.",
+            "gdpr_note": "Your email will never be publicly shared. Providing it ensures pseudonymization: your data remains identifiable only for research purposes by the investigator.",
+            "pseudonymization_note": "Agreeing to be contacted implies that the researcher can link your perspective to your email (pseudonymization) for this specific follow-up.",
+            "error_invalid_email": "Please enter a valid email address"
+        },
+        "audio": {
+            "info": "For each question, you can respond with text, an audio recording, or both.",
+            "section_label": "Audio response (optional)"
+        }
+    },
+    "audio": {
+        "record_prompt": "Record audio response if you prefer",
+        "recording": "Recording...",
+        "recorded": "Recorded",
+        "playing": "Playing...",
+        "uploading": "Uploading...",
+        "ready": "Ready to record",
+        "start_recording": "Start recording",
+        "stop_recording": "Stop",
+        "pause": "Pause",
+        "play": "Play",
+        "delete": "Delete",
+        "deleted": "Audio deleted",
+        "delete_failed": "Could not delete the recording. Try again.",
+        "file_size": "File size",
+        "upload_success": "Audio uploaded successfully",
+        "upload_failed": "Upload failed. Please try again.",
+        "upload_cancelled": "Recording cancelled",
+        "recording_error": "Recording error - please try again",
+        "invalid_recording": "Recording failed - no audio data captured",
+        "permission_denied": "Microphone permission denied",
+        "unsupported": "Audio recording is not supported in this browser.",
+        "permission_revoked": "Microphone access lost - recording stopped",
+        "refresh_failed": "Could not refresh audio. Your recording is still saved.",
+        "refreshing": "Refreshing audio...",
+        "playback_failed": "Could not play audio. Refresh the page and try again.",
+        "error": {
+            "no_token": "Session token missing",
+            "quota_exceeded": "Storage quota exceeded. Please delete an existing recording or use text instead.",
+            "file_too_large": "Recording file is too large. Try a shorter recording.",
+            "server_error": "Server error. Please try again in a moment.",
+            "upload_in_progress": "Please wait for audio upload to finish.",
+            "security": "Recording blocked by browser security settings",
+            "invalid_state": "Recording encountered an internal error"
+        },
+        "fallback": {
+            "toast": "Audio has been disabled due to repeated errors. Please use text.",
+            "banner_title": "Audio unavailable",
+            "banner_description": "Audio recording encountered repeated errors. You can continue with text responses.",
+            "try_again": "Try again",
+            "inline": "Audio temporarily unavailable."
+        },
+        "permission_denied_with_guidance": "Microphone permission denied. Check your browser settings to allow microphone access, then try again.",
+        "retry_upload": "Retry upload",
+        "space_shortcut": "or press Space",
+        "waveform": {
+            "recording": "Audio waveform - recording in progress",
+            "playing": "Audio waveform - playing back recording"
+        }
+    },
+    "resume": {
+        "continue_later": "Continue later",
+        "copy_link": "Copy link",
+        "copy_failed": "Unable to copy. Please select the link manually.",
+        "link_copied": "Link copied!",
+        "instruction": "To continue on a different device, save this link:",
+        "instruction_same_browser": "If you return on this browser, your progress will be saved automatically.",
+        "instruction_detail": "Keep this link private. It gives access to your session.",
+        "resume_url": "Resume URL",
+        "saving": "Saving...",
+        "saved": "Saved",
+        "save_failed": "Not saved",
+        "loading": "Restoring your session...",
+        "restored": "Welcome back! Your progress has been restored.",
+        "welcome_back": "Welcome back! Your progress has been restored.",
+        "not_found": "This link is no longer valid. If you haven't completed the study, please contact the researcher for a new link.",
+        "already_completed": "You've already submitted your responses. Thank you for your participation!",
+        "study_closed": "This study is no longer accepting responses. Please contact the researcher if you have questions.",
+        "rate_limited": "Too many attempts. Please wait a moment and try again.",
+        "error": "Something went wrong while restoring your session. Please try again.",
+        "share": "Send to myself",
+        "share_title": "My study session",
+        "go_to_study": "Start a new session"
+    },
+    "landing": {
+        "page_title": "Qualis study access",
+        "instruction": "Enter your study code to begin.",
+        "study_code_label": "Study Code",
+        "study_code_placeholder": "e.g. my-study",
+        "go_to_study": "Go to Study",
+        "resetting_session": "Resetting study session…"
+    },
+    "erasure": {
+        "section_title": "Your right to erasure (GDPR Art. 17)",
+        "section_intro": "You can request the removal of your personal data at any time. Your anonymous statement rankings will be kept as research data; everything that could identify you will be removed.",
+        "button": "Request my data deletion",
+        "confirm_title": "Erase your personal data?",
+        "confirm_what_erased": "The following will be permanently removed: any IP address logged with your session, your browser identifier, your written answers (pre- and post-sort), and any audio recording you provided.",
+        "confirm_what_kept": "Your statement rankings will be preserved as anonymous research data. They no longer link to you.",
+        "confirm_irreversible": "This action is immediate and cannot be undone.",
+        "confirm_action": "Yes, erase my data",
+        "confirm_in_progress": "Erasing…",
+        "success": "Your personal data has been removed. Your anonymous Q-sort rankings remain in the study.",
+        "error": "We could not process your request. Please try again or contact the researcher.",
+        "already_erased": "Your personal data has been removed for this session."
+    },
+    "footer": {
+        "powered_by": "Powered by Qualis",
+        "license": "AGPLv3",
+        "github_aria": "View source on GitHub"
+    },
+    "errors": {
+        "member_limit_reached": "Project member limit reached.",
+        "owner_project_limit_reached": "You can't own any more projects.",
+        "owner_role_immutable": "The Owner role can only be assigned at project creation.",
+        "access_denied_title": "Access denied",
+        "access_denied_description": "You do not have permission to perform this action.",
+        "rate_limited_title": "Too many requests",
+        "rate_limited_description": "Please wait a moment before trying again.",
+        "conflict_title": "Conflict",
+        "conflict_description": "The resource has been modified or already exists."
+    }
+}

--- a/frontend/public/locales/pl/participant.json
+++ b/frontend/public/locales/pl/participant.json
@@ -1,461 +1,461 @@
 {
     "common": {
         "placeholders": {
-            "text_response": "Enter your answer..."
+            "text_response": "Wpisz swoją odpowiedź..."
         },
-        "add": "Add",
-        "confirm": "Confirm",
-        "all": "All",
-        "agree": "Somewhat agree",
-        "disagree": "Somewhat disagree",
-        "neutral": "Neutral",
-        "reset_to_default": "Reset to default",
-        "reset_to_default_success": "Restored to default",
-        "reset_to_default_confirm": "Are you sure you want to reset this field to its default value? Any custom changes will be lost.",
-        "undo": "Undo",
-        "next": "Next step",
-        "submit": "Share my perspective",
-        "continue": "Continue",
-        "loading": "Loading...",
-        "lang_code": "en",
-        "attention": "Attention",
-        "error": "Error",
-        "submitting": "Submitting...",
-        "cards": "statements",
-        "close": "Close",
-        "unknown_card": "Unknown Card",
-        "unknown": "Unknown",
+        "add": "Dodaj",
+        "confirm": "Potwierdź",
+        "all": "Wszystkie",
+        "agree": "Raczej zgadzam się",
+        "disagree": "Raczej nie zgadzam się",
+        "neutral": "Neutralnie",
+        "reset_to_default": "Przywróć domyślne",
+        "reset_to_default_success": "Przywrócono domyślne",
+        "reset_to_default_confirm": "Czy na pewno chcesz przywrócić domyślną wartość tego pola? Wszelkie własne zmiany zostaną utracone.",
+        "undo": "Cofnij",
+        "next": "Następny krok",
+        "submit": "Podziel się swoją perspektywą",
+        "continue": "Kontynuuj",
+        "loading": "Ładowanie...",
+        "lang_code": "pl",
+        "attention": "Uwaga",
+        "error": "Błąd",
+        "submitting": "Wysyłanie...",
+        "cards": "stwierdzenia",
+        "close": "Zamknij",
+        "unknown_card": "Nieznana karta",
+        "unknown": "Nieznane",
         "duration_short": "{{m}}m {{s}}s",
         "duration_long": "{{h}}h {{m}}m {{s}}s",
-        "optional": "Optional",
-        "processing": "Processing...",
-        "statement": "Statement",
-        "step": "Step",
-        "back": "Back",
-        "cancel": "Cancel",
-        "delete": "Delete",
-        "slots": "slots",
-        "project_label": "Project",
-        "read_full": "Read full statement",
-        "reduce": "Reduce",
-        "expand": "Expand",
-        "yes": "Yes",
-        "no": "No",
-        "score": "Score",
-        "comment": "Comment",
+        "optional": "Opcjonalnie",
+        "processing": "Przetwarzanie...",
+        "statement": "Stwierdzenie",
+        "step": "Krok",
+        "back": "Wstecz",
+        "cancel": "Anuluj",
+        "delete": "Usuń",
+        "slots": "miejsca",
+        "project_label": "Projekt",
+        "read_full": "Przeczytaj całe stwierdzenie",
+        "reduce": "Zwiń",
+        "expand": "Rozwiń",
+        "yes": "Tak",
+        "no": "Nie",
+        "score": "Wynik",
+        "comment": "Komentarz",
         "errors": {
-            "network": "Network connection error. Please check your internet connection.",
-            "not_found": "Study not found.",
-            "validation": "System error: data validation failed.",
-            "unknown": "An unexpected error occurred.",
-            "retry": "Retry",
-            "min": "Value must be at least {{min}}",
-            "max": "Value must be at most {{max}}",
-            "email": "Please enter a valid email address",
-            "min_length": "Minimum {{count}} characters required",
-            "max_length": "Maximum {{count}} characters allowed",
+            "network": "Błąd połączenia sieciowego. Proszę sprawdzić połączenie z Internetem.",
+            "not_found": "Nie znaleziono badania.",
+            "validation": "Błąd systemu: weryfikacja danych nie powiodła się.",
+            "unknown": "Wystąpił nieoczekiwany błąd.",
+            "retry": "Spróbuj ponownie",
+            "min": "Wartość musi wynosić co najmniej {{min}}",
+            "max": "Wartość musi wynosić co najwyżej {{max}}",
+            "email": "Proszę podać prawidłowy adres e-mail",
+            "min_length": "Wymagana minimalna liczba znaków: {{count}}",
+            "max_length": "Dozwolona maksymalna liczba znaków: {{count}}",
             "404": {
-                "title": "Page not found",
-                "message": "The page or study you are looking for does not exist."
+                "title": "Nie znaleziono strony",
+                "message": "Strona lub badanie, którego szukasz, nie istnieje."
             },
             "429": {
-                "title": "Too many requests",
-                "message": "You are doing that too fast. Please wait a moment."
+                "title": "Zbyt wiele żądań",
+                "message": "Działanie zbyt szybkie. Proszę chwilę poczekać."
             },
             "500": {
-                "title": "Server error",
-                "message": "Our servers encountered an issue. Please try again later."
+                "title": "Błąd serwera",
+                "message": "Nasze serwery napotkały problem. Proszę spróbować ponownie później."
             },
-            "network_title": "Connection lost",
-            "home": "Go to home",
-            "reset": "Reset session",
-            "default_title": "Oops! Something went wrong.",
+            "network_title": "Utracono połączenie",
+            "home": "Przejdź do strony głównej",
+            "reset": "Zresetuj sesję",
+            "default_title": "Ups! Coś poszło nie tak.",
             "study_not_found": {
-                "title": "Study not found",
-                "message": "We couldn't find a study with that name. Please check the URL or contact the researcher.",
-                "action": "Go to home"
+                "title": "Nie znaleziono badania",
+                "message": "Nie mogliśmy znaleźć badania o tej nazwie. Proszę sprawdzić adres URL lub skontaktować się z badaczem.",
+                "action": "Przejdź do strony głównej"
             }
         },
         "status": {
             "draft": {
-                "title": "Study under preparation",
-                "message": "This study is not available for participation yet. Please check back later.",
-                "action": "Back to home"
+                "title": "Badanie w przygotowaniu",
+                "message": "To badanie nie jest jeszcze dostępne do uczestnictwa. Proszę wrócić później.",
+                "action": "Wróć do strony głównej"
             },
             "steps": {
                 "draft": {
-                    "label": "Draft",
-                    "description": "Configuration & design"
+                    "label": "Szkic",
+                    "description": "Konfiguracja i projekt"
                 },
                 "active": {
-                    "label": "Active",
-                    "description": "Collecting responses"
+                    "label": "Aktywne",
+                    "description": "Zbieranie odpowiedzi"
                 },
                 "paused": {
-                    "label": "Paused",
-                    "description": "On hold"
+                    "label": "Wstrzymane",
+                    "description": "Wstrzymane"
                 },
                 "closed": {
-                    "label": "Closed",
-                    "description": "Analysis & export"
+                    "label": "Zamknięte",
+                    "description": "Analiza i eksport"
                 }
             },
             "paused": {
-                "title": "Maintenance in progress",
-                "message": "Data collection is temporarily paused for maintenance. We will be back shortly.",
-                "action": "Retry"
+                "title": "Trwa konserwacja",
+                "message": "Zbieranie danych zostało tymczasowo wstrzymane ze względu na konserwację. Wrócimy wkrótce.",
+                "action": "Spróbuj ponownie"
             },
             "closed": {
-                "title": "Data collection closed",
-                "message": "This study is now closed. Participation is no longer possible.",
-                "action": "Back to home"
+                "title": "Zbieranie danych zakończone",
+                "message": "To badanie jest już zamknięte. Uczestnictwo nie jest już możliwe.",
+                "action": "Wróć do strony głównej"
             }
         }
     },
     "layout": {
         "title": "Open-Q",
-        "preparing": "Preparing your study session...",
-        "pilot_mode": "Pilot mode: changes are temporary & data will not be saved",
-        "default_study_title": "Q-Method study",
-        "loading_content": "Loading study content...",
-        "change_lang_title": "Change language",
+        "preparing": "Przygotowywanie sesji badania...",
+        "pilot_mode": "Tryb pilotażowy: zmiany są tymczasowe i dane nie zostaną zapisane",
+        "default_study_title": "Badanie metodologią Q",
+        "loading_content": "Ładowanie treści badania...",
+        "change_lang_title": "Zmień język",
         "steps": {
-            "welcome": "Welcome",
-            "consent": "Privacy & Consent",
-            "rough": "First impressions",
-            "fine": "Q-sort",
-            "post": "Final questions"
+            "welcome": "Powitanie",
+            "consent": "Prywatność i zgoda",
+            "rough": "Pierwsze wrażenia",
+            "fine": "Sortowanie Q",
+            "post": "Pytania końcowe"
         },
-        "mobile_step": "Step",
-        "navigation": "Navigation",
-        "language": "English"
+        "mobile_step": "Krok",
+        "navigation": "Nawigacja",
+        "language": "Polski"
     },
     "study": {
         "help": {
-            "title": "Help & information",
-            "trigger": "Help",
-            "what": "What we ask",
-            "why": "Why it matters",
+            "title": "Pomoc i informacje",
+            "trigger": "Pomoc",
+            "what": "Co prosimy zrobić",
+            "why": "Dlaczego to ważne",
             "step_welcome": {
-                "what": "Read the research objectives and the specific instructions for participation.",
-                "why": "Beyond standard ethical consent, you need to grasp the 'condition of instruction': the precise lens or scenario you adopt to evaluate the statements. This matters for data validity."
+                "what": "Proszę przeczytać cele badania oraz szczegółowe instrukcje dotyczące uczestnictwa.",
+                "why": "Poza standardową zgodą etyczną konieczne jest zrozumienie „warunku instrukcji”: precyzyjnego punktu widzenia lub scenariusza, który przyjmuje Pan/Pani przy ocenie stwierdzeń. Ma to znaczenie dla trafności danych."
             },
             "step_presort": {
-                "what": "Provide background information to help characterize your participant profile.",
-                "why": "This context allows the research team to analyze how distinct viewpoints (factors) may or may not correlate with specific demographic variables or professional backgrounds within the participant group."
+                "what": "Proszę podać informacje ogólne, które pomogą scharakteryzować profil uczestnika.",
+                "why": "Ten kontekst pozwala zespołowi badawczemu analizować, w jaki sposób odmienne punkty widzenia (czynniki) mogą — lub nie — korelować z określonymi zmiennymi demograficznymi lub zawodowymi wewnątrz grupy uczestników."
             },
             "step_rough": {
-                "what": "Sort the deck of statements into three initial piles based on your immediate reaction.",
-                "why": "This preparatory step is designed to reduce cognitive load; it allows you to familiarize yourself with the full range of the topic (the Q-set) before the more demanding task of comparative ranking begins."
+                "what": "Proszę podzielić zestaw stwierdzeń na trzy wstępne stosy na podstawie pierwszego wrażenia.",
+                "why": "Ten krok przygotowawczy ma na celu zmniejszenie obciążenia poznawczego; pozwala zapoznać się z pełnym zakresem tematu (zbiorem Q) przed bardziej wymagającym zadaniem porównawczego rangowania."
             },
             "step_fine": {
-                "what": "Place the statements on the grid by ranking them relative to one another, from those you most agree with (to the right) to those you most disagree with (to the left). Starting with the extremes might help you in this task.",
-                "why": "The grid's structure imposes a 'forced distribution' that prevents you from rating everything as equally important; it compels you to make trade-offs, thereby modelling the relative significance of each idea in your specific belief system."
+                "what": "Proszę umieścić stwierdzenia na siatce, rangując je względem siebie — od tych, z którymi Pan/Pani najbardziej się zgadza (po prawej), do tych, z którymi najbardziej się nie zgadza (po lewej). Pomocne może być rozpoczęcie od skrajności.",
+                "why": "Struktura siatki narzuca „wymuszony rozkład”, który uniemożliwia ocenę wszystkiego jako równie ważnego; zmusza do dokonywania kompromisów, modelując w ten sposób względne znaczenie każdej idei w indywidualnym systemie przekonań."
             },
             "step_post": {
-                "what": "Confirm your grid arrangement and add comments explaining your strongest choices.",
-                "why": "Your qualitative explanations are critical for validating the statistical analysis; they help the researchers interpret the data through your logic rather than imposing their own assumptions on your choices."
+                "what": "Proszę potwierdzić układ siatki i dodać komentarze wyjaśniające najbardziej znaczące wybory.",
+                "why": "Jakościowe wyjaśnienia są niezbędne do walidacji analizy statystycznej; pomagają badaczom interpretować dane zgodnie z logiką uczestnika, zamiast narzucać własne założenia na jego wybory."
             }
         },
         "steps": {
-            "presort": "Pre-sort survey",
-            "rough": "Preliminary sort",
-            "fine": "Grid placement",
-            "post": "Post-sort stage"
+            "presort": "Ankieta wstępna",
+            "rough": "Sortowanie wstępne",
+            "fine": "Umiejscowienie na siatce",
+            "post": "Etap po sortowaniu"
         }
     },
     "welcome": {
-        "start": "Get started",
+        "start": "Rozpocznij",
         "consent": {
-            "label": "I confirm that i have read the above information and consent to the processing of my data for the purposes of this study.",
-            "error": "Please accept the terms to continue."
+            "label": "Potwierdzam, że zapoznałem/am się z powyższymi informacjami i wyrażam zgodę na przetwarzanie moich danych na potrzeby tego badania.",
+            "error": "Proszę zaakceptować warunki, aby kontynuować."
         },
-        "reset_confirm": "Are you sure you want to start a new session? This will clear your current progress.",
-        "restart": "Start a new session",
-        "preview_title": "Preview",
-        "conducted_by": "Conducted by",
-        "how_it_works": "Process",
-        "objective_label": "Study objective",
-        "instructions_label": "Process",
-        "default_instructions": "1. **Let's meet:** First, you will be asked a few short, preliminary questions.\n2. **First impressions:** You will read through the different statements and roughly sort them according to your personal viewpoint: whether you tend to agree, feel neutral, or disagree with them.\n3. **Your perspective:** During the sorting stage, you will place the statements on a grid to refine your viewpoint. You will sort and rank the statements from “most agree” to “most disagree” by placing each statement in the corresponding box.\n4. **Why:** Before the session ends, you will be asked a few clarifying questions to help us better understand your most significant choices.",
+        "reset_confirm": "Czy na pewno chcesz rozpocząć nową sesję? Spowoduje to usunięcie bieżącego postępu.",
+        "restart": "Rozpocznij nową sesję",
+        "preview_title": "Podgląd",
+        "conducted_by": "Prowadzone przez",
+        "how_it_works": "Przebieg",
+        "objective_label": "Cel badania",
+        "instructions_label": "Przebieg",
+        "default_instructions": "1. **Poznajmy się:** Na początku zostanie zadanych kilka krótkich pytań wstępnych.\n2. **Pierwsze wrażenia:** Proszę przeczytać różne stwierdzenia i wstępnie posortować je według własnego punktu widzenia: czy raczej się Pan/Pani z nimi zgadza, jest neutralny/a, czy też się nie zgadza.\n3. **Twoja perspektywa:** Na etapie sortowania proszę umieścić stwierdzenia na siatce, aby doprecyzować swój punkt widzenia. Proszę posortować i uszeregować stwierdzenia od „najbardziej zgadzam się” do „najbardziej nie zgadzam się”, umieszczając każde stwierdzenie w odpowiednim polu.\n4. **Dlaczego:** Przed zakończeniem sesji zostanie zadanych kilka pytań wyjaśniających, które pomogą nam lepiej zrozumieć najbardziej znaczące wybory.",
         "steps": {
             "profile": {
-                "title": "Let's meet",
-                "description": "First, you will be asked a few short, preliminary questions."
+                "title": "Poznajmy się",
+                "description": "Na początku zostanie zadanych kilka krótkich pytań wstępnych."
             },
             "rough": {
-                "title": "First impressions",
-                "description": "You will read through the different statements and roughly sort them according to your personal viewpoint: whether you tend to agree, feel neutral, or disagree with them. It will make the next task easier."
+                "title": "Pierwsze wrażenia",
+                "description": "Proszę przeczytać różne stwierdzenia i wstępnie posortować je według własnego punktu widzenia: czy raczej się Pan/Pani z nimi zgadza, jest neutralny/a, czy też się nie zgadza. Ułatwi to kolejne zadanie."
             },
             "fine": {
-                "title": "Your perspective",
-                "description": "During the sorting stage, you will place the statements on a grid to refine your viewpoint. You will sort and rank the statements from “most agree” to “most disagree” by placing each statement in the corresponding box. There are no right or wrong answers. The best answer is the one that reflects your opinion, or beliefs."
+                "title": "Twoja perspektywa",
+                "description": "Na etapie sortowania proszę umieścić stwierdzenia na siatce, aby doprecyzować swój punkt widzenia. Proszę posortować i uszeregować stwierdzenia od „najbardziej zgadzam się” do „najbardziej nie zgadzam się”, umieszczając każde stwierdzenie w odpowiednim polu. Nie ma odpowiedzi prawidłowych ani błędnych. Najlepsza odpowiedź to ta, która odzwierciedla opinię lub przekonania uczestnika."
             },
             "post": {
-                "title": "Why",
-                "description": "Before the session ends, you will be asked a few clarifying questions to help us better understand your most significant choices, as well as a few questions about your background."
+                "title": "Dlaczego",
+                "description": "Przed zakończeniem sesji zostanie zadanych kilka pytań wyjaśniających, które pomogą nam lepiej zrozumieć najbardziej znaczące wybory, a także kilka pytań dotyczących Pana/Pani tła."
             }
         }
     },
     "consent": {
-        "title": "Informed consent and data processing agreement",
-        "subtitle": "Please read the following information carefully.",
-        "record_error": "Could not save consent record. You may continue.",
-        "default_text": "1. Nature of the study and participant understanding. You understand that this exercise employs q-methodology, a research technique designed to model subjective viewpoints. The task requires you to sort statements according to their significance relative to your personal perspective; consequently, there are no objective \"right\" or \"wrong\" answers.\n\n2. Data processing and pseudonymization (GDPR compliance).\n\nDe-identification and retention:. This technical process ensures that your digital footprint cannot be used to re-identify you once the session ends.\n\nException for follow-up: if you voluntarily provide your contact details at the end of the study for a follow-up contact, the link between your identity (email) and your response will be maintained strictly for the duration of that specific follow-up phase.\n\nReporting: the final results will be presented in an anonymized format. Data will be aggregated to reveal shared social perspectives (factors). Qualitative comments may be quoted to contextualize these factors but will be screened to remove revealing details.\n\n3. Voluntary participation and right to withdraw. You maintain the right to discontinue the sorting process and close your browser at any time prior to submission without penalty.\n\nPre-submission: if you withdraw before finalizing your sort, no partial data will be retained.\n\nPost-submission: due to the statistical nature of q-methodology (factor analysis), once your data has been submitted and aggregated into the dataset, individual withdrawal may not be feasible.\n\n4. Data retention and rights"
+        "title": "Świadoma zgoda i umowa o przetwarzaniu danych",
+        "subtitle": "Proszę uważnie przeczytać poniższe informacje.",
+        "record_error": "Nie udało się zapisać zgody. Można kontynuować.",
+        "default_text": "1. Charakter badania i zrozumienie uczestnika. Rozumie Pan/Pani, że ćwiczenie to wykorzystuje metodologię Q — technikę badawczą zaprojektowaną do modelowania subiektywnych punktów widzenia. Zadanie polega na sortowaniu stwierdzeń według ich znaczenia względem osobistej perspektywy uczestnika; w związku z tym nie istnieją obiektywnie „prawidłowe” ani „błędne” odpowiedzi.\n\n2. Przetwarzanie danych i pseudonimizacja (zgodność z RODO).\n\nDe-identyfikacja i okres przechowywania: Ten techniczny proces zapewnia, że cyfrowy ślad uczestnika nie może zostać użyty do jego ponownej identyfikacji po zakończeniu sesji.\n\nWyjątek dotyczący badania uzupełniającego: jeśli uczestnik dobrowolnie poda dane kontaktowe na końcu badania w celu kontaktu uzupełniającego, powiązanie między tożsamością (e-mail) a odpowiedzią będzie utrzymywane wyłącznie przez czas trwania tej konkretnej fazy uzupełniającej.\n\nRaportowanie: ostateczne wyniki zostaną przedstawione w formie zanonimizowanej. Dane zostaną zagregowane w celu ujawnienia wspólnych perspektyw społecznych (czynników). Komentarze jakościowe mogą być cytowane w celu kontekstualizacji tych czynników, ale zostaną sprawdzone pod kątem usunięcia ujawniających szczegółów.\n\n3. Dobrowolne uczestnictwo i prawo do wycofania się. Uczestnik zachowuje prawo do przerwania procesu sortowania i zamknięcia przeglądarki w dowolnym momencie przed przesłaniem danych bez żadnych konsekwencji.\n\nPrzed przesłaniem: jeśli uczestnik wycofa się przed sfinalizowaniem sortowania, żadne częściowe dane nie zostaną zachowane.\n\nPo przesłaniu: ze względu na statystyczny charakter metodologii Q (analiza czynnikowa), po przesłaniu i zagregowaniu danych w zbiorze danych indywidualne wycofanie może nie być możliwe.\n\n4. Przechowywanie danych i prawa"
     },
     "presort": {
-        "title": "Before we start",
-        "description": "Please answer a few questions to help us situate your viewpoint.",
-        "submit": "Continue to sorting",
-        "select_placeholder": "Select...",
-        "error_required": "Please answer this question."
+        "title": "Zanim zaczniemy",
+        "description": "Proszę odpowiedzieć na kilka pytań, które pomogą nam zlokalizować Pana/Pani punkt widzenia.",
+        "submit": "Przejdź do sortowania",
+        "select_placeholder": "Wybierz...",
+        "error_required": "Proszę odpowiedzieć na to pytanie."
     },
     "rough": {
         "header": {
-            "subtitle": "Swipe **left** to disagree, **right** to agree, or **down** to be neutral.",
-            "hint": "This is spontaneous. You can change your mind right after."
+            "subtitle": "Przesuń **w lewo**, aby nie zgadzać się, **w prawo**, aby zgadzać się, lub **w dół**, aby być neutralnym.",
+            "hint": "To jest spontaniczne. Można zmienić zdanie od razu po."
         },
         "tip": {
-            "close": "Close tip"
+            "close": "Zamknij wskazówkę"
         },
         "complete": {
-            "title": "First step complete",
-            "subtitle": "We will now refine the nuances.",
-            "button": "Continue to fine sort"
+            "title": "Pierwszy krok ukończony",
+            "subtitle": "Teraz doprecyzujemy niuanse.",
+            "button": "Przejdź do sortowania szczegółowego"
         },
         "instructions": {
-            "desktop_tip": "Drag, press, or use keyboard ( ← ↓ → ) to sort"
+            "desktop_tip": "Przeciągnij, naciśnij lub użyj klawiatury ( ← ↓ → ), aby sortować"
         },
-        "progress_label": "Rough sort progress: {{percent}}% complete"
+        "progress_label": "Postęp sortowania zgrubnego: {{percent}}% ukończone"
     },
     "fine": {
         "deck": {
-            "title": "Available statements",
-            "all_placed": "All statements in this pile are sorted"
+            "title": "Dostępne stwierdzenia",
+            "all_placed": "Wszystkie stwierdzenia w tym stosie są posortowane"
         },
         "toolbar": {
-            "preview": "Statement",
-            "zoom_in": "Zoom in",
-            "zoom_out": "Zoom out",
-            "fit_screen": "Fit to screen",
-            "label": "Grid controls"
+            "preview": "Stwierdzenie",
+            "zoom_in": "Powiększ",
+            "zoom_out": "Pomniejsz",
+            "fit_screen": "Dopasuj do ekranu",
+            "label": "Sterowanie siatką"
         },
         "grid": {
-            "label": "Q-Sort grid",
-            "column": "Column",
-            "slot": "Slot",
-            "in_column": "In column"
+            "label": "Siatka sortowania Q",
+            "column": "Kolumna",
+            "slot": "Miejsce",
+            "in_column": "W kolumnie"
         },
         "legend": {
-            "disagree": "Most disagree",
-            "neutral": "Neutral",
-            "agree": "Most agree",
-            "label": "Grid legend"
+            "disagree": "Najbardziej nie zgadzam się",
+            "neutral": "Neutralnie",
+            "agree": "Najbardziej zgadzam się",
+            "label": "Legenda siatki"
         },
         "actions": {
-            "validate": "Confirm sort",
-            "finish": "Finish sorting",
-            "ready": "Review overview",
-            "not_ready": "Place all statements to continue"
+            "validate": "Potwierdź sortowanie",
+            "finish": "Zakończ sortowanie",
+            "ready": "Przejrzyj zestawienie",
+            "not_ready": "Umieść wszystkie stwierdzenia, aby kontynuować"
         },
         "header": {
-            "title": "Place statements on the grid",
-            "instruction_label": "Instruction",
-            "expand_instructions": "Expand instructions",
-            "minimize_instructions": "Minimize instructions"
+            "title": "Umieść stwierdzenia na siatce",
+            "instruction_label": "Instrukcja",
+            "expand_instructions": "Rozwiń instrukcje",
+            "minimize_instructions": "Zwiń instrukcje"
         },
         "workbench": {
-            "active_card": "Active statement",
-            "place_on_grid": "Tap grid to place",
-            "drag_or_tap": "Drag to grid or tap slot",
-            "initial_instruction": "Tap (or drag) statement",
-            "initial_instruction_mobile": "Tap statement",
-            "cancel_selection": "Cancel selection",
-            "help": "How does it work?",
-            "previous_tip": "Previous tip",
-            "next_tip": "Next tip",
-            "go_to_tip": "Go to tip {{number}}",
+            "active_card": "Aktywne stwierdzenie",
+            "place_on_grid": "Dotkniąć siatki, aby umieścić",
+            "drag_or_tap": "Przeciągnij na siatkę lub dotknięcie miejsca",
+            "initial_instruction": "Dotkniąć (lub przeciągnąć) stwierdzenie",
+            "initial_instruction_mobile": "Dotkniąć stwierdzenie",
+            "cancel_selection": "Anuluj wybór",
+            "help": "Jak to działa?",
+            "previous_tip": "Poprzednia wskazówka",
+            "next_tip": "Następna wskazówka",
+            "go_to_tip": "Przejdź do wskazówki {{number}}",
             "methodology": {
-                "extremes": "Tip: start with what is most obvious to you (the extremes).",
-                "vertical": "In the same column, the order from top to bottom doesn't matter.",
-                "constraint": "You have to fit everything! It can be a puzzle, but that's how we prioritize choices.",
-                "relative": "Reminder: items are sorted relative to each other (relative agreement).",
-                "zoom": "Feel free to zoom in on different parts of the grid for better visibility.",
-                "flexibility": "Nothing is final: you can move cards or put them back in the deck at any time."
+                "extremes": "Wskazówka: zacznij od tego, co jest najbardziej oczywiste (skrajności).",
+                "vertical": "W tej samej kolumnie kolejność od góry do dołu nie ma znaczenia.",
+                "constraint": "Trzeba dopasować wszystko! To może być jak układanka, ale właśnie w ten sposób ustalamy priorytety wyborów.",
+                "relative": "Przypomnienie: elementy są sortowane względem siebie (względna zgoda).",
+                "zoom": "Można swobodnie powiększać różne części siatki, aby lepiej widzieć.",
+                "flexibility": "Nic nie jest ostateczne: można w dowolnym momencie przenosić karty lub odkładać je z powrotem do stosu."
             }
         }
     },
     "post": {
-        "title": "Your perspective & feedback",
-        "description": "You're almost done! Your comments on the most significant statements are crucial for our analysis.",
-        "step2_title": "Almost done!",
-        "step2_description": "Please answer these final questions to complete the study.",
+        "title": "Twoja perspektywa i opinia",
+        "description": "Prawie gotowe! Komentarze dotyczące najbardziej znaczących stwierdzeń są kluczowe dla naszej analizy.",
+        "step2_title": "Prawie gotowe!",
+        "step2_description": "Proszę odpowiedzieć na te ostatnie pytania, aby ukończyć badanie.",
         "extreme": {
-            "title": "Key Choices",
-            "why": "Why did you choose to place this statement here? How is it significant to you?",
-            "placeholder": "E.g., a specific event, a strong belief, or a particular word in the statement...",
-            "min_chars": "A few words are enough to help us understand the context.",
-            "label_agree": "Strongest agreement",
-            "label_disagree": "Strongest disagreement",
-            "label_neutral": "Neutral",
-            "missing_statement": "Missing Statement",
-            "general_comment": "General Comment"
+            "title": "Kluczowe wybory",
+            "why": "Dlaczego zdecydował/a się Pan/Pani umieścić to stwierdzenie w tym miejscu? Jakie ma ono dla Pana/Pani znaczenie?",
+            "placeholder": "Np. konkretne zdarzenie, mocne przekonanie lub szczególne słowo w stwierdzeniu...",
+            "min_chars": "Kilka słów wystarczy, aby pomóc nam zrozumieć kontekst.",
+            "label_agree": "Najsilniejsza zgoda",
+            "label_disagree": "Najsilniejszy sprzeciw",
+            "label_neutral": "Neutralnie",
+            "missing_statement": "Brakujące stwierdzenie",
+            "general_comment": "Komentarz ogólny"
         },
         "optional": {
-            "title": "Did any statements feel particularly surprising, unclear, or confusing to you? If so, why?",
-            "description": "You are also welcome to add comments to any other statement if you would like to further explain your choices.",
-            "select_placeholder": "Select a statement to comment...",
-            "placeholder": "Your comment here..."
+            "title": "Czy któreś stwierdzenia wydały się Panu/Pani szczególnie zaskakujące, niejasne lub mylące? Jeśli tak, dlaczego?",
+            "description": "Można również dodać komentarze do innych stwierdzeń, jeśli chce Pan/Pani bliżej wyjaśnić swoje wybory.",
+            "select_placeholder": "Wybierz stwierdzenie do skomentowania...",
+            "placeholder": "Komentarz tutaj..."
         },
-        "submit": "Share my perspective",
-        "validation_error": "Please fill in all required fields.",
-        "text_audio_info": "For text + audio questions, you can respond with text, an audio recording, or both.",
-        "text_audio_required": "A few words or an audio recording will help us understand your viewpoint.",
+        "submit": "Podziel się swoją perspektywą",
+        "validation_error": "Proszę wypełnić wszystkie wymagane pola.",
+        "text_audio_info": "W przypadku pytań tekstowych i dźwiękowych można odpowiedzieć tekstem, nagraniem audio lub obydwoma.",
+        "text_audio_required": "Kilka słów lub nagranie audio pomoże nam zrozumieć Pana/Pani punkt widzenia.",
         "success": {
-            "title": "Thank you for your participation!",
-            "message": "Your contribution to the study has been saved.",
-            "id_label": "Confirmation code",
+            "title": "Dziękujemy za uczestnictwo!",
+            "message": "Pana/Pani wkład w badanie został zapisany.",
+            "id_label": "Kod potwierdzenia",
             "share": {
-                "title": "Spread the word",
-                "copy_link": "Copy link",
-                "copy_success": "Link copied!",
-                "message": "I just participated in this study: \"{{title}}\". I thought it might interest you. You can access it here:",
-                "email": "Email",
-                "email_subject": "Participate in this study: {{title}}",
-                "native": "Share"
+                "title": "Podziel się z innymi",
+                "copy_link": "Skopiuj link",
+                "copy_success": "Link skopiowany!",
+                "message": "Właśnie wziąłem/wzięłam udział w tym badaniu: „{{title}}”. Może to zainteresować i innych. Można do niego przejść tutaj:",
+                "email": "E-mail",
+                "email_subject": "Weź udział w tym badaniu: {{title}}",
+                "native": "Udostępnij"
             }
         },
         "submit_error": {
-            "title": "Submission failed",
-            "message": "Please check your connection and try again."
+            "title": "Wysyłanie nie powiodło się",
+            "message": "Proszę sprawdzić połączenie i spróbować ponownie."
         },
-        "score": "Score",
-        "back": "Back to sort",
+        "score": "Wynik",
+        "back": "Wróć do sortowania",
         "contact": {
-            "title": "Results & contact",
-            "email_label": "Your email address (optional)",
-            "email_placeholder": "Example@email.com",
-            "interview_consent": "I agree to be contacted by the researcher for follow-up.",
-            "newsletter_consent": "I wish to be informed about the study results.",
-            "gdpr_note": "Your email will never be publicly shared. Providing it ensures pseudonymization: your data remains identifiable only for research purposes by the investigator.",
-            "pseudonymization_note": "Agreeing to be contacted implies that the researcher can link your perspective to your email (pseudonymization) for this specific follow-up.",
-            "error_invalid_email": "Please enter a valid email address"
+            "title": "Wyniki i kontakt",
+            "email_label": "Adres e-mail (opcjonalnie)",
+            "email_placeholder": "Przykład@email.com",
+            "interview_consent": "Zgadzam się na kontakt ze strony badacza w celu dalszego badania.",
+            "newsletter_consent": "Chcę być informowany/a o wynikach badania.",
+            "gdpr_note": "Adres e-mail nigdy nie będzie publicznie udostępniany. Jego podanie zapewnia pseudonimizację: dane pozostają możliwe do zidentyfikowania wyłącznie na potrzeby badań przez badacza.",
+            "pseudonymization_note": "Zgoda na kontakt oznacza, że badacz może powiązać Pana/Pani perspektywę z adresem e-mail (pseudonimizacja) na potrzeby tej konkretnej fazy uzupełniającej.",
+            "error_invalid_email": "Proszę podać prawidłowy adres e-mail"
         },
         "audio": {
-            "info": "For each question, you can respond with text, an audio recording, or both.",
-            "section_label": "Audio response (optional)"
+            "info": "Dla każdego pytania można odpowiedzieć tekstem, nagraniem audio lub obydwoma.",
+            "section_label": "Odpowiedź audio (opcjonalnie)"
         }
     },
     "audio": {
-        "record_prompt": "Record audio response if you prefer",
-        "recording": "Recording...",
-        "recorded": "Recorded",
-        "playing": "Playing...",
-        "uploading": "Uploading...",
-        "ready": "Ready to record",
-        "start_recording": "Start recording",
-        "stop_recording": "Stop",
-        "pause": "Pause",
-        "play": "Play",
-        "delete": "Delete",
-        "deleted": "Audio deleted",
-        "delete_failed": "Could not delete the recording. Try again.",
-        "file_size": "File size",
-        "upload_success": "Audio uploaded successfully",
-        "upload_failed": "Upload failed. Please try again.",
-        "upload_cancelled": "Recording cancelled",
-        "recording_error": "Recording error - please try again",
-        "invalid_recording": "Recording failed - no audio data captured",
-        "permission_denied": "Microphone permission denied",
-        "unsupported": "Audio recording is not supported in this browser.",
-        "permission_revoked": "Microphone access lost - recording stopped",
-        "refresh_failed": "Could not refresh audio. Your recording is still saved.",
-        "refreshing": "Refreshing audio...",
-        "playback_failed": "Could not play audio. Refresh the page and try again.",
+        "record_prompt": "Nagraj odpowiedź audio, jeśli wolisz",
+        "recording": "Nagrywanie...",
+        "recorded": "Nagrano",
+        "playing": "Odtwarzanie...",
+        "uploading": "Przesyłanie...",
+        "ready": "Gotowe do nagrywania",
+        "start_recording": "Rozpocznij nagrywanie",
+        "stop_recording": "Zatrzymaj",
+        "pause": "Pauza",
+        "play": "Odtwórz",
+        "delete": "Usuń",
+        "deleted": "Audio usunięte",
+        "delete_failed": "Nie udało się usunąć nagrania. Spróbuj ponownie.",
+        "file_size": "Rozmiar pliku",
+        "upload_success": "Audio przesłane pomyślnie",
+        "upload_failed": "Przesyłanie nie powiodło się. Proszę spróbować ponownie.",
+        "upload_cancelled": "Nagrywanie anulowane",
+        "recording_error": "Błąd nagrywania — proszę spróbować ponownie",
+        "invalid_recording": "Nagrywanie nie powiodło się — nie przechwycono danych audio",
+        "permission_denied": "Odmówiono dostępu do mikrofonu",
+        "unsupported": "Nagrywanie audio nie jest obsługiwane w tej przeglądarce.",
+        "permission_revoked": "Utracono dostęp do mikrofonu — nagrywanie zatrzymane",
+        "refresh_failed": "Nie udało się odświeżyć audio. Nagranie jest nadal zapisane.",
+        "refreshing": "Odświeżanie audio...",
+        "playback_failed": "Nie udało się odtworzyć audio. Proszę odświeżyć stronę i spróbować ponownie.",
         "error": {
-            "no_token": "Session token missing",
-            "quota_exceeded": "Storage quota exceeded. Please delete an existing recording or use text instead.",
-            "file_too_large": "Recording file is too large. Try a shorter recording.",
-            "server_error": "Server error. Please try again in a moment.",
-            "upload_in_progress": "Please wait for audio upload to finish.",
-            "security": "Recording blocked by browser security settings",
-            "invalid_state": "Recording encountered an internal error"
+            "no_token": "Brak tokenu sesji",
+            "quota_exceeded": "Przekroczono limit miejsca. Proszę usunąć istniejące nagranie lub zamiast tego użyć tekstu.",
+            "file_too_large": "Plik nagrania jest zbyt duży. Proszę spróbować krótszego nagrania.",
+            "server_error": "Błąd serwera. Proszę spróbować ponownie za chwilę.",
+            "upload_in_progress": "Proszę poczekać na zakończenie przesyłania audio.",
+            "security": "Nagrywanie zablokowane przez ustawienia zabezpieczeń przeglądarki",
+            "invalid_state": "Nagrywanie napotkało błąd wewnętrzny"
         },
         "fallback": {
-            "toast": "Audio has been disabled due to repeated errors. Please use text.",
-            "banner_title": "Audio unavailable",
-            "banner_description": "Audio recording encountered repeated errors. You can continue with text responses.",
-            "try_again": "Try again",
-            "inline": "Audio temporarily unavailable."
+            "toast": "Audio zostało wyłączone z powodu powtarzających się błędów. Proszę używać tekstu.",
+            "banner_title": "Audio niedostępne",
+            "banner_description": "Nagrywanie audio napotkało powtarzające się błędy. Można kontynuować z odpowiedziami tekstowymi.",
+            "try_again": "Spróbuj ponownie",
+            "inline": "Audio tymczasowo niedostępne."
         },
-        "permission_denied_with_guidance": "Microphone permission denied. Check your browser settings to allow microphone access, then try again.",
-        "retry_upload": "Retry upload",
-        "space_shortcut": "or press Space",
+        "permission_denied_with_guidance": "Odmówiono dostępu do mikrofonu. Proszę sprawdzić ustawienia przeglądarki, aby zezwolić na dostęp do mikrofonu, a następnie spróbować ponownie.",
+        "retry_upload": "Prześlij ponownie",
+        "space_shortcut": "lub naciśnij Spację",
         "waveform": {
-            "recording": "Audio waveform - recording in progress",
-            "playing": "Audio waveform - playing back recording"
+            "recording": "Fala dźwiękowa — nagrywanie w toku",
+            "playing": "Fala dźwiękowa — odtwarzanie nagrania"
         }
     },
     "resume": {
-        "continue_later": "Continue later",
-        "copy_link": "Copy link",
-        "copy_failed": "Unable to copy. Please select the link manually.",
-        "link_copied": "Link copied!",
-        "instruction": "To continue on a different device, save this link:",
-        "instruction_same_browser": "If you return on this browser, your progress will be saved automatically.",
-        "instruction_detail": "Keep this link private. It gives access to your session.",
-        "resume_url": "Resume URL",
-        "saving": "Saving...",
-        "saved": "Saved",
-        "save_failed": "Not saved",
-        "loading": "Restoring your session...",
-        "restored": "Welcome back! Your progress has been restored.",
-        "welcome_back": "Welcome back! Your progress has been restored.",
-        "not_found": "This link is no longer valid. If you haven't completed the study, please contact the researcher for a new link.",
-        "already_completed": "You've already submitted your responses. Thank you for your participation!",
-        "study_closed": "This study is no longer accepting responses. Please contact the researcher if you have questions.",
-        "rate_limited": "Too many attempts. Please wait a moment and try again.",
-        "error": "Something went wrong while restoring your session. Please try again.",
-        "share": "Send to myself",
-        "share_title": "My study session",
-        "go_to_study": "Start a new session"
+        "continue_later": "Kontynuuj później",
+        "copy_link": "Skopiuj link",
+        "copy_failed": "Nie można skopiować. Proszę ręcznie wybrać link.",
+        "link_copied": "Link skopiowany!",
+        "instruction": "Aby kontynuować na innym urządzeniu, proszę zapisać ten link:",
+        "instruction_same_browser": "Jeśli wróci Pan/Pani w tej samej przeglądarce, postęp zostanie zapisany automatycznie.",
+        "instruction_detail": "Proszę zachować ten link w tajemnicy. Daje on dostęp do sesji.",
+        "resume_url": "URL wznowienia",
+        "saving": "Zapisywanie...",
+        "saved": "Zapisano",
+        "save_failed": "Nie zapisano",
+        "loading": "Przywracanie sesji...",
+        "restored": "Witamy z powrotem! Postęp został przywrócony.",
+        "welcome_back": "Witamy z powrotem! Postęp został przywrócony.",
+        "not_found": "Ten link jest już nieważny. Jeśli badanie nie zostało ukończone, proszę skontaktować się z badaczem w celu uzyskania nowego linku.",
+        "already_completed": "Odpowiedzi zostały już przesłane. Dziękujemy za uczestnictwo!",
+        "study_closed": "To badanie nie przyjmuje już odpowiedzi. Proszę skontaktować się z badaczem, jeśli mają Państwo pytania.",
+        "rate_limited": "Zbyt wiele prób. Proszę chwilę poczekać i spróbować ponownie.",
+        "error": "Coś poszło nie tak podczas przywracania sesji. Proszę spróbować ponownie.",
+        "share": "Wyślij do siebie",
+        "share_title": "Moja sesja badania",
+        "go_to_study": "Rozpocznij nową sesję"
     },
     "landing": {
-        "page_title": "Qualis study access",
-        "instruction": "Enter your study code to begin.",
-        "study_code_label": "Study Code",
-        "study_code_placeholder": "e.g. my-study",
-        "go_to_study": "Go to Study",
-        "resetting_session": "Resetting study session…"
+        "page_title": "Dostęp do badania Qualis",
+        "instruction": "Wpisz kod badania, aby rozpocząć.",
+        "study_code_label": "Kod badania",
+        "study_code_placeholder": "np. moje-badanie",
+        "go_to_study": "Przejdź do badania",
+        "resetting_session": "Resetowanie sesji badania…"
     },
     "erasure": {
-        "section_title": "Your right to erasure (GDPR Art. 17)",
-        "section_intro": "You can request the removal of your personal data at any time. Your anonymous statement rankings will be kept as research data; everything that could identify you will be removed.",
-        "button": "Request my data deletion",
-        "confirm_title": "Erase your personal data?",
-        "confirm_what_erased": "The following will be permanently removed: any IP address logged with your session, your browser identifier, your written answers (pre- and post-sort), and any audio recording you provided.",
-        "confirm_what_kept": "Your statement rankings will be preserved as anonymous research data. They no longer link to you.",
-        "confirm_irreversible": "This action is immediate and cannot be undone.",
-        "confirm_action": "Yes, erase my data",
-        "confirm_in_progress": "Erasing…",
-        "success": "Your personal data has been removed. Your anonymous Q-sort rankings remain in the study.",
-        "error": "We could not process your request. Please try again or contact the researcher.",
-        "already_erased": "Your personal data has been removed for this session."
+        "section_title": "Prawo do usunięcia danych (art. 17 RODO)",
+        "section_intro": "Można w każdej chwili zażądać usunięcia danych osobowych. Anonimowe rankingi stwierdzeń zostaną zachowane jako dane badawcze; wszystko, co mogłoby Pana/Panią zidentyfikować, zostanie usunięte.",
+        "button": "Zażądaj usunięcia moich danych",
+        "confirm_title": "Usunąć dane osobowe?",
+        "confirm_what_erased": "Następujące dane zostaną trwale usunięte: wszelkie adresy IP zarejestrowane w sesji, identyfikator przeglądarki, pisemne odpowiedzi (przed i po sortowaniu) oraz wszelkie nagrane nagrania audio.",
+        "confirm_what_kept": "Rankingi stwierdzeń zostaną zachowane jako anonimowe dane badawcze. Nie są już z Panem/Panią powiązane.",
+        "confirm_irreversible": "Działanie jest natychmiastowe i nieodwracalne.",
+        "confirm_action": "Tak, usuń moje dane",
+        "confirm_in_progress": "Usuwanie…",
+        "success": "Dane osobowe zostały usunięte. Anonimowe rankingi sortowania Q pozostają w badaniu.",
+        "error": "Nie udało się przetworzyć żądania. Proszę spróbować ponownie lub skontaktować się z badaczem.",
+        "already_erased": "Dane osobowe zostały już usunięte dla tej sesji."
     },
     "footer": {
         "powered_by": "Powered by Qualis",
         "license": "AGPLv3",
-        "github_aria": "View source on GitHub"
+        "github_aria": "Wyświetl kod źródłowy na GitHub"
     },
     "errors": {
-        "member_limit_reached": "Project member limit reached.",
-        "owner_project_limit_reached": "You can't own any more projects.",
-        "owner_role_immutable": "The Owner role can only be assigned at project creation.",
-        "access_denied_title": "Access denied",
-        "access_denied_description": "You do not have permission to perform this action.",
-        "rate_limited_title": "Too many requests",
-        "rate_limited_description": "Please wait a moment before trying again.",
-        "conflict_title": "Conflict",
-        "conflict_description": "The resource has been modified or already exists."
+        "member_limit_reached": "Osiągnięto limit członków projektu.",
+        "owner_project_limit_reached": "Nie można posiadać więcej projektów.",
+        "owner_role_immutable": "Rola właściciela może być przypisana wyłącznie podczas tworzenia projektu.",
+        "access_denied_title": "Odmowa dostępu",
+        "access_denied_description": "Brak uprawnień do wykonania tej czynności.",
+        "rate_limited_title": "Zbyt wiele żądań",
+        "rate_limited_description": "Proszę chwilę poczekać przed ponowną próbą.",
+        "conflict_title": "Konflikt",
+        "conflict_description": "Zasób został zmodyfikowany lub już istnieje."
     }
 }

--- a/frontend/scripts/i18n/glossaries/pl.yaml
+++ b/frontend/scripts/i18n/glossaries/pl.yaml
@@ -1,0 +1,154 @@
+# Q-methodology and product terminology for Polish (pl).
+# Used by Claude Code during translation. Edit before translating; treat as a contract.
+language: pl
+language_name: Polski
+
+terms:
+  # Q-methodology
+  concourse: konkurs
+  Q-methodology: metodologia Q
+  Q-sort: sortowanie Q
+  Q-set: zbiór Q
+  statement: stwierdzenie
+  factor: czynnik
+  factor analysis: analiza czynnikowa
+  factor loading: ładunek czynnikowy
+  factor array: tablica czynnikowa
+  eigenvalue: wartość własna
+  presort: wstępne sortowanie
+  rough sort: sortowanie zgrubne
+  fine sort: sortowanie szczegółowe
+  postsort: sortowanie końcowe
+
+  # Product entities
+  study: badanie
+  study design: projekt badania
+  recruitment: rekrutacja
+  participant: uczestnik
+  member: członek
+  owner: właściciel
+  viewer: obserwator
+  editor: redaktor
+  consent: zgoda
+  consent form: formularz zgody
+  audio recording: nagranie audio
+  memo: notatka
+  draft: szkic
+  resume code: kod wznowienia
+  invitation: zaproszenie
+  project: projekt
+
+  # UI primitives
+  grid: siatka
+  cancel: Anuluj
+  save: Zapisz
+  saving: Zapisywanie...
+  delete: Usuń
+  view (verb / button): Pokaż
+  view (noun): Widok
+  loading: Ładowanie
+  dashboard: Panel
+  slug: slug
+  share (verb / button): Udostępnij
+  flag (verb): oznacz
+  flag (noun): oznaczenie
+  narrative (factor): interpretacja
+
+  # State labels
+  draft (state): Szkic
+  active: Aktywne
+  paused: Wstrzymane
+  closed: Zamknięte
+  archived: Zarchiwizowane
+  completed: Ukończone
+  discarded: Odrzucone
+  in_progress: W toku
+  abandoned: Porzucone
+
+notes: |
+  # === REGISTER ===
+  - Tone: formal **"Pan/Pani"** form when addressing participants AND
+    researchers directly (e.g. consent forms, destructive admin actions:
+    "Czy na pewno?"). For impersonal UI labels (most of the codebase),
+    use the infinitive imperative or impersonal phrasings rather than
+    direct address — this is the most idiomatic Polish UI register.
+  - Avoid "ty/twój" (informal direct address) entirely.
+  - Imperative for buttons: "Zapisz", "Anuluj", "Kontynuuj", "Wstecz".
+    Capitalized first letter.
+
+  # === PLURALIZATION (CRITICAL FOR POLISH) ===
+  - Polish has FOUR plural categories driven by the number itself:
+    - `one`   → 1
+    - `few`   → 2-4, 22-24, 32-34, ... (numbers ending in 2/3/4 except 12-14)
+    - `many`  → 0, 5-21, 25-31, ... (everything else)
+    - `other` → fractions (1.5, etc.)
+  - i18next supports this via key suffixes: `key_one`, `key_few`,
+    `key_many`, `key_other`.
+  - The EN source currently has only `_one`/`_other` pairs. For most
+    count-bearing keys, this is a quality problem in Polish — e.g.
+    "{{count}} uczestników" (genitive plural, used for many) reads
+    wrong for "2 uczestników" (should be "2 uczestnicy", nominative
+    plural after 2-4).
+  - **HANDLING STRATEGY for this PR**: translate the existing
+    `_one`/`_other` keys with Polish forms that read acceptably across
+    the count range. Use the GENITIVE PLURAL form (used after numbers
+    5+) for `_other` since it's the most common case at the scale
+    Qualis works at (participant counts, statement counts typically > 4).
+    Example: `{{count}} uczestnik` (1) / `{{count}} uczestników` (5+).
+    For numbers 2-4, this reads slightly off but is widely tolerated.
+  - If a key reads catastrophically wrong, propose adding the full
+    4-form keyset to en.json (and all locales) as a follow-up PR per
+    the languages plan (Task 10, Step 8). Don't unilaterally add new
+    keys to en.json in this PR.
+
+  # === COMPOUND WORDS ===
+  - Polish doesn't agglutinate like German/Dutch but builds long
+    multi-word phrases. For DENSE UI slots (sidebar, badges, chips),
+    prefer single-word options or accepted English loanwords (e.g.
+    "Dashboard", "Slug").
+
+  # === CASES (declension) ===
+  - Polish has 7 grammatical cases. Common pitfalls:
+    - After "dla" → genitive ("dla uczestnika" not "dla uczestnik")
+    - After "z" → instrumental or genitive (context-dependent)
+    - Direct objects → accusative ("Usuń badanie" not "Usuń badania" if
+      single object intended)
+    - Subjects → nominative
+  - For UI labels (single nouns), default to NOMINATIVE unless the
+    context demands otherwise.
+
+  # === FALSE-FRIEND CHECKS ===
+  - "study" (research study) → "badanie", NOT "studium" (= academic
+    discipline / a course of studies).
+  - "close" (verb to close a study) → "zamknij", NOT a positional sense.
+  - "statement" (Q-item) → "stwierdzenie", NOT "oświadczenie" (legal
+    declaration) or "wypowiedź" (utterance/speech act, too informal).
+  - "grid" → "siatka", NOT "sieć" (= network).
+  - "share" (button) → "Udostępnij", NOT "Akcja" (= action/share certificate).
+  - "resume" (verb / URL) → "wznów" / "kod wznowienia", NOT "życiorys"
+    (= CV).
+  - "slug" → "slug" (kept English).
+  - "manual" (mode) → "ręczny", NOT "podręcznik" (= instruction booklet).
+  - "concourse" → "konkurs" (cognate, accepted). Polish Q-methodology
+    literature also uses "korpus", but "konkurs" matches the spirit of
+    other Romance locales.
+
+  # === GDPR / LEGAL ===
+  - GDPR → "RODO" (Rozporządzenie o Ochronie Danych Osobowych — Polish
+    official term). Use "RODO" in body text addressing Polish users.
+    EN's "GDPR" can also be kept verbatim if context demands.
+  - "right to erasure" (Art. 17) → "prawo do usunięcia"
+  - "pseudonymisation" → "pseudonimizacja"
+  - "data processing" → "przetwarzanie danych"
+
+  # === GENDER ===
+  - Polish has grammatical gender (masculine/feminine/neuter, with
+    masculine personal/non-personal subtypes for plurals). The codebase
+    uses generic masculine throughout other locales (es/it/de/pt); stay
+    consistent: "uczestnik" (m.) not "uczestnik/uczestniczka" splits.
+
+  # === NUMBERS / TYPOGRAPHY ===
+  - Decimal separator: comma (123,45). But don't edit numeric placeholder
+    tokens; Intl handles per-locale formatting.
+  - Polish quotation marks: „..." (low-9 open + high-9 close). Use for
+    quoted text in prose.

--- a/frontend/src/constants/languages.ts
+++ b/frontend/src/constants/languages.ts
@@ -21,6 +21,7 @@ export const SUPPORTED_LANGUAGES: Language[] = [
     { code: 'it', label: 'Italiano', flag: '🇮🇹', hasAdmin: true },
     { code: 'nl', label: 'Nederlands', flag: '🇳🇱', hasAdmin: true },
     { code: 'pt', label: 'Português', flag: '🇵🇹', hasAdmin: true },
+    { code: 'pl', label: 'Polski', flag: '🇵🇱', hasAdmin: true },
 ];
 
 /**

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -9,7 +9,7 @@ import HttpBackend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
-export const SUPPORTED_I18N_LANGUAGES = ['en', 'fr', 'fi', 'de', 'es', 'it', 'nl', 'pt'];
+export const SUPPORTED_I18N_LANGUAGES = ['en', 'fr', 'fi', 'de', 'es', 'it', 'nl', 'pt', 'pl'];
 
 i18n
     // load translation using http -> see /public/locales

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -24,7 +24,7 @@ vi.mock('./i18n', async () => {
     // This runs lazily when ./i18n is first imported
     const testI18n = await import('./test-utils/i18n-test');
     return {
-        SUPPORTED_I18N_LANGUAGES: ['en', 'fr', 'fi', 'de', 'es', 'it', 'nl', 'pt'],
+        SUPPORTED_I18N_LANGUAGES: ['en', 'fr', 'fi', 'de', 'es', 'it', 'nl', 'pt', 'pl'],
         default: testI18n.default,
     };
 });
@@ -32,7 +32,7 @@ vi.mock('./i18n', async () => {
 vi.mock('@/i18n', async () => {
     const testI18n = await import('./test-utils/i18n-test');
     return {
-        SUPPORTED_I18N_LANGUAGES: ['en', 'fr', 'fi', 'de', 'es', 'it', 'nl', 'pt'],
+        SUPPORTED_I18N_LANGUAGES: ['en', 'fr', 'fi', 'de', 'es', 'it', 'nl', 'pt', 'pl'],
         default: testI18n.default,
     };
 });


### PR DESCRIPTION
## Summary
Adds Polish (\`pl\`) as the 9th supported locale, with full translation of both namespaces:

- \`frontend/public/locales/pl/participant.json\` (15 namespaces)
- \`frontend/public/locales/pl/admin.json\` (auth + 36 admin sub-namespaces)

\`SUPPORTED_LANGUAGES\` gets \`{ code: 'pl', label: 'Polski', flag: '🇵🇱', hasAdmin: true }\`. **Completes the original 5-European-languages plan** (es, it, nl, pt, pl all shipped).

## Glossary
\`frontend/scripts/i18n/glossaries/pl.yaml\` — 30 Q-methodology + product terms (konkurs, sortowanie Q, stwierdzenie, czynnik, uczestnik, badanie, projekt, siatka, …). Tone: formal **Pan/Pani** for direct address; impersonal infinitive for most UI labels (idiomatic Polish UI register). RODO for GDPR.

## Pluralization caveat (Polish-specific)
Polish has 4 plural forms (one/few/many/other). The EN source has only \`_one\`/\`_other\` pairs. Per glossary strategy, \`_other\` uses GENITIVE PLURAL form (idiomatic for counts ≥ 5, the dominant case at Qualis scale). Counts 2–4 read slightly off (expected: nominative plural) but are widely tolerated.

Full 4-form keyset (\`_one\`/\`_few\`/\`_many\`/\`_other\`) is a follow-up per languages plan Task 10 Step 8 if/when a specific count-bearing key reads catastrophically wrong.

## Translation methodology
Four subagent passes (1 participant + 3 admin to stay within 32K output token limits).

Cross-file consistency verified: status labels (Szkic/Aktywne/Wstrzymane/Zamknięte/Zarchiwizowane/Ukończone/Odrzucone), button verbs (Zapisz/Anuluj/Kontynuuj/Usuń/Wstecz/Pokaż), role names (Właściciel/Redaktor/Członek/Obserwator), entity terms render identically across both files.

## Test plan
- [x] \`make ci-fast\` passes (backend 266 / frontend 1382)
- [x] \`npm run i18n-check\`: \`✓ pl/participant.json in sync\` + \`✓ pl/admin.json in sync\`
- [x] \`npm run check-interpolations\`: zero mismatches on \`pl\`
- [x] Automated scans: 0 English residue, 0 forbidden mistranslations, 0 informal pronouns (outside section-title convention)
- [x] \`languages.test.ts\` cross-consistency invariant passes
- [ ] Reviewer confirms participant flow renders fully in PL via \`?lang=pl\`
- [ ] Reviewer confirms admin sidebar offers PL and chrome renders fully

## Strings flagged for native-speaker review
- \`consent.default_text\` / \`erasure.*\` — RODO/legal phrasing (pseudonimizacja, prawo do usunięcia, przetwarzanie danych)
- \`post.success.share.message\` — uses first-person gendered split (wziąłem/wzięłam, Pomyślałem/am) — standard Polish gender-neutral approach but may feel clunky
- \`admin.analysis.*\` — psychometric terms (ładunek czynnikowy, wartość własna, wykres osypiska, rzetelność złożona)
- Polish quotation marks (\`„..."\`) used in prose; ASCII single quotes used inside JSON-context strings to avoid escape collisions

## References
- Glossary: \`frontend/scripts/i18n/glossaries/pl.yaml\`
- Pattern PRs: #161 (Spanish), #162 (Italian), #163 (Dutch), #167 (Portuguese), #165 (German rework)
- Completes plan: \`docs/superpowers/plans/2026-05-13-add-5-european-languages.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)