### PR TITLE
chore: sync release lockfiles to 0.6.8 (unblocks make ci)

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1523,7 +1523,7 @@ wheels = [
 
 [[package]]
 name = "qualis-backend"
-version = "0.6.6"
+version = "0.6.8"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "qualis",
-    "version": "0.6.7",
+    "version": "0.6.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "qualis",
-            "version": "0.6.7",
+            "version": "0.6.8",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",


### PR DESCRIPTION
## Summary

`make ci` has been red **repo-wide on every branch** (including `main`) because stale release-please artifacts lagged the bumped project version:

- `frontend/package-lock.json` — `0.6.7` vs `package.json` `0.6.8`
- `backend/uv.lock` — `qualis-backend 0.6.6` vs `pyproject.toml` `0.6.8`

`scripts/check_installation_docs.py` (run inside `make check`) fails on the frontend mismatch, aborting CI before tests/build run.

Regenerated both lockfiles canonically: `npm install --package-lock-only` (frontend) and `uv lock` (backend). **Version field only — zero dependency churn** (3 changed lines total).

## Test Plan

- [x] `python3 scripts/check_installation_docs.py` → `Installation docs are coherent.` exit 0 (was the failing gate)
- [x] `git diff main..HEAD` = exactly `backend/uv.lock` (1 line) + `frontend/package-lock.json` (2 lines), all `version` fields → `0.6.8`, no resolved-dependency changes
- [ ] `make ci` green (the `check` step that aborted CI now passes; nothing else in the diff affects lint/test/build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)