### PR TITLE
refactor(audio): fold useAudioRecorder ui-coupling (W3 follow-up)

### DIFF
--- a/docs/superpowers/plans/2026-05-16-w3-followup-uicoupling.md
+++ b/docs/superpowers/plans/2026-05-16-w3-followup-uicoupling.md
@@ -1,0 +1,339 @@
+# W3 follow-up — useAudioRecorder ui-coupling fold — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold the two imperative JSX→ref mutations in `AudioRecorder` into intent-named `useAudioRecorder` wrappers (`play()`, `applyPlaybackSpeed()`), removing `playbackRetryRef`/`audioPlayerRef` from the hook's public `ui` group, with no observable behaviour change.
+
+**Architecture:** Characterization-first (W4 model): pin the exact observable micro-behaviours on the W3 baseline, then fold. Behaviour-touching (first such in the program) — proof is the unchanged behaviour oracle (`AudioRecorder.test.tsx`), not code-identity.
+
+**Tech Stack:** React 19, TypeScript (strict via `tsc -b`/Biome), MediaRecorder/AudioContext/`new Audio()` Web APIs, Vitest + `@testing-library/react` (`renderHook`).
+
+**Branch:** `chore/code-quality-w3-followup-uicoupling`, **based on `chore/code-quality-wave3-useaudiorecorder`** (its tip; already created; spec committed there). PR diff framed vs the W3 branch; merge order **#179 → this**.
+
+**The real typecheck gate is `cd frontend && npm run type-check` (= `tsc -b`).** Never `npx tsc --noEmit` (false-green).
+
+---
+
+### Task 0: Baseline
+
+**Files:** none modified.
+
+- [ ] **Step 1: Record the green baseline**
+
+Run: `cd frontend && npm run type-check && npx vitest run 2>&1 | grep -E "Test Files|Tests " | tail -2`
+Expected: `tsc -b` exit 0; full suite green — **record the exact `Tests N passed | M skipped` line** (behaviour-preservation target for Tasks 2–3).
+
+- [ ] **Step 2: Record the oracle count + confirm consumers**
+
+Run: `cd frontend && npx vitest run src/components/audio/AudioRecorder.test.tsx 2>&1 | tail -3 && grep -rln "components/audio/AudioRecorder" src --include="*.tsx" --include="*.ts" | grep -vE "AudioRecorder\.(tsx|test)"`
+Expected: 45 passed; consumers exactly `src/components/postsort/Step1_Feedback.tsx` and `src/components/postsort/Step2_Questionnaire.tsx`. Anything else → STOP, report.
+
+No commit (read-only).
+
+---
+
+### Task 1: Characterization tests (pin behaviour BEFORE the fold)
+
+**Files:**
+- Modify: `frontend/src/components/audio/AudioRecorder.test.tsx` (append 1 `describe`, 3 tests; do NOT alter the existing 45)
+
+**Characterization tests: assert what the UNCHANGED W3 component does today. Snapshot reality; do not normalize.**
+
+- [ ] **Step 1: Append the characterization describe block**
+
+Read the existing file's harness first: `global.Audio` is mocked at ~line 108–116 as `vi.fn(function(){ … playbackRate: 1.0 … })`. To assert the live element's `playbackRate`, capture the constructed instance the same way the file captures `capturedMediaRecorder` (a module-scoped `let capturedAudio` assigned inside the mock factory, or read `(global.Audio as unknown as { mock: { results: { value: { playbackRate: number } }[] } }).mock.results.at(-1)?.value`). Mirror the existing tests' setup/`renderWithStore`/`userEvent`/`waitFor`/`act` and the `getUserMedia`+`MediaRecorder` capture pattern (read `'plays audio when play button is clicked'` ~L318 and `'shows speed control buttons in stopped state'` ~L342 and reuse their exact seeding/start-playback steps).
+
+Append:
+
+```tsx
+describe('Characterization — ui coupling (W3-followup oracle)', () => {
+    it('applies playbackRate to the live audio element when a speed button is clicked WHILE playing', async () => {
+        // Render an existing-recording AudioRecorder, start playback so the
+        // component is in state 'playing' (reuse the exact steps from
+        // 'plays audio when play button is clicked'). Capture the Audio
+        // instance the hook constructed (`new Audio()`), then click the 1.5x
+        // (or 2.0x) speed button. Assert the captured audio element's
+        // .playbackRate === the chosen speed (this is the L173-175 live poke,
+        // gated on state === 'playing'). Assert against the ELEMENT, not the
+        // button's rendered class.
+    });
+
+    it('does NOT imperatively set playbackRate when a speed button is clicked while NOT playing', async () => {
+        // Render an existing-recording AudioRecorder in 'stopped' state (do
+        // not start playback). Click a speed button. Assert: the displayed
+        // selected speed updates (state changed), AND the captured/last Audio
+        // element's playbackRate was NOT imperatively mutated by the click
+        // (it stays at its constructed default until a fresh playRecording
+        // applies it). Snapshot the current state==='playing' guard: when not
+        // playing, the click only sets state, no element poke.
+    });
+
+    it('user play button resets the retry guard so a load-failed existing recording can be re-played', async () => {
+        // Seed an existing recording with sessionToken so the hook's
+        // existing-recording retry path is reachable; drive the playback
+        // load-failure path that sets playbackRetryRef.current = true (mirror
+        // however the file already simulates an audio error / failed load —
+        // search the existing tests for an `onerror`/`reject` pattern; if
+        // none exists, trigger the audio element's error handler on the
+        // captured instance). Then click the user play button. Assert it
+        // re-attempts playback (playRecording invoked again / a new Audio
+        // constructed) — i.e. the L112 `playbackRetryRef.current = false`
+        // reset took effect. This is the observable behaviour the fold must
+        // preserve. If the load-failure path genuinely cannot be driven
+        // through the harness, STOP and report BLOCKED with what you tried
+        // (do not fake it, do not weaken to a tautology).
+    });
+});
+```
+
+Fill the bodies by reading the live component output + existing tests. Assertions target observed current behaviour (the live element's `playbackRate`; a re-attempt after guard reset) — not mock tautologies.
+
+- [ ] **Step 2: Run — characterization green on the unchanged W3 baseline**
+
+Run: `cd frontend && npx vitest run src/components/audio/AudioRecorder.test.tsx`
+Expected: 45 + 3 = **48 passed**, against the UNCHANGED component/hook. If a test can't pass against unchanged code, it's a setup bug or discovered real behaviour to encode faithfully — investigate; do NOT modify the hook/component (untouched in Task 1).
+
+- [ ] **Step 3: Lint/format the test file**
+
+Run: `cd frontend && npx @biomejs/biome check --write src/components/audio/AudioRecorder.test.tsx && npx @biomejs/biome check src/components/audio/AudioRecorder.test.tsx`
+Expected: formatting normalized; second run 0 errors/0 warnings. Re-run Step 2's vitest to confirm formatting didn't break a test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/audio/AudioRecorder.test.tsx
+git commit -m "test(audio): characterization for ui-coupling (W3-followup oracle)
+
+Pins observable behaviour of the 2 JSX->ref couplings (live playbackRate
+while playing; no poke when not playing; retry-guard reset re-enables
+play) on the unchanged W3 baseline BEFORE the fold. Existing 45 tests
+unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: The fold (hook wrappers + interface reduction + JSX simplification)
+
+**Files:**
+- Modify: `frontend/src/hooks/participant/useAudioRecorder.ts`
+- Modify: `frontend/src/components/audio/AudioRecorder.tsx`
+
+- [ ] **Step 1: Add the two wrappers in the hook**
+
+In `useAudioRecorder.ts`, immediately AFTER the `playRecording` definition ends (the `const playRecording = async () => { … };` block starting ~line 600) and after `setPlaybackSpeed` is in scope (the `useState` at ~line 173), add:
+
+```ts
+// Public play entry: resets the existing-recording retry guard, then plays.
+// Internal callers keep using `playRecording` directly (they must NOT reset
+// the guard — that is the guard's purpose).
+const play = () => {
+    playbackRetryRef.current = false;
+    return playRecording();
+};
+
+// Public speed setter: sets state, and — only while actually playing —
+// applies the rate to the live audio element (closure-safe via stateRef,
+// the hook's existing mirror of `state`).
+const applyPlaybackSpeed = (s: number) => {
+    setPlaybackSpeed(s);
+    if (audioPlayerRef.current && stateRef.current === 'playing') {
+        audioPlayerRef.current.playbackRate = s;
+    }
+};
+```
+
+Do NOT modify `playRecording`, the raw `setPlaybackSpeed` state setter, or any internal caller of either. (Verify: the only places that must keep raw `playRecording` are the internal retry path ~L703 and any other internal invocation — leave them.)
+
+- [ ] **Step 2: Change the returned bindings**
+
+In the hook's `return { … }` object: change `play: playRecording,` → `play: play,`; change the returned `setPlaybackSpeed,` (the raw setter, ~L821) → `setPlaybackSpeed: applyPlaybackSpeed,`.
+
+- [ ] **Step 3: Remove the two refs from the public interface + return**
+
+In `UseAudioRecorderResult.ui` (interface ~L126), delete the two members:
+`playbackRetryRef: MutableRef<boolean>;` (~L131) and
+`audioPlayerRef: RefObject<HTMLAudioElement | null>;` (~L132).
+In the hook's returned `ui: { … }` object (~L829), delete the `playbackRetryRef,` and `audioPlayerRef,` entries. If `MutableRef`/`RefObject` imports become unused, let `tsc -b`/Biome flag them and remove them.
+
+- [ ] **Step 4: Simplify the two JSX coupling sites in the component**
+
+In `AudioRecorder.tsx`:
+- Remove `playbackRetryRef,` and `audioPlayerRef,` from the `ui: { … }` destructure (~lines 34–35).
+- **Play button** (~L108–114): the `play` returned is destructured as `play: playRecording`. The onClick currently is:
+  ```tsx
+  onClick={
+      state === 'playing'
+          ? pausePlayback
+          : () => {
+                playbackRetryRef.current = false;
+                playRecording();
+            }
+  }
+  ```
+  Replace with (the reset is now inside the hook's `play`, which is the destructured `playRecording`):
+  ```tsx
+  onClick={state === 'playing' ? pausePlayback : playRecording}
+  ```
+- **Speed buttons** (~L172–177): replace:
+  ```tsx
+  onClick={() => {
+      setPlaybackSpeed(speed);
+      if (audioPlayerRef.current && state === 'playing') {
+          audioPlayerRef.current.playbackRate = speed;
+      }
+  }}
+  ```
+  with:
+  ```tsx
+  onClick={() => setPlaybackSpeed(speed)}
+  ```
+  (the live-element poke is now inside the hook's `applyPlaybackSpeed`, which is the destructured `setPlaybackSpeed`).
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `cd frontend && npm run type-check && npm run lint 2>&1 | tail -1`
+Expected: `tsc -b` exit 0 (fix any now-unused import — `MutableRef`/`RefObject` in the hook if no longer used; nothing in the component should newly need imports). Lint 0 errors; **no new `biome-ignore`**; no `any`. W3's pre-existing keyboard-effect suppression must be untouched.
+
+- [ ] **Step 6: The cardinal gate — oracle byte-unchanged since Task 1 + green**
+
+Run: `cd frontend && git diff --exit-code src/components/audio/AudioRecorder.test.tsx && npx vitest run src/components/audio/AudioRecorder.test.tsx 2>&1 | tail -3`
+Expected: `git diff --exit-code` exits 0 (the 48-test oracle is byte-UNMODIFIED since the Task-1 commit) AND all 48 pass. If a test had to change to pass, observable behaviour changed → STOP and escalate; do NOT edit the oracle.
+
+- [ ] **Step 7: Full suite + consumers**
+
+Run: `cd frontend && npx vitest run 2>&1 | grep -E "Tests " | tail -1`
+Expected: full suite green at the **Task-0 baseline count + 3** (the Task-1 characterization tests; no other delta yet). `Step1_Feedback.tsx`/`Step2_Questionnaire.tsx` unmodified; `tsc -b` (Step 5) proves their call sites still type-check against the unchanged `AudioRecorderProps`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/hooks/participant/useAudioRecorder.ts frontend/src/components/audio/AudioRecorder.tsx
+git commit -m "refactor(audio): fold ui coupling into useAudioRecorder wrappers
+
+play() resets the retry guard internally; setPlaybackSpeed applies the
+live playbackRate when playing (closure-safe via stateRef). ui no longer
+exposes playbackRetryRef/audioPlayerRef. Oracle (48) byte-unchanged and
+green — no observable behaviour change. playRecording + raw state setter
++ internal callers untouched.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Hook unit tests for the two wrappers
+
+**Files:**
+- Modify: `frontend/src/hooks/participant/useAudioRecorder.test.ts` (append ≥2 tests)
+
+- [ ] **Step 1: Append the wrapper unit tests**
+
+Reuse the Task-1-of-W3 mock pattern already in this file (it mocks `MediaRecorder`/`getUserMedia`/`AudioContext`; add a `new Audio()` mock if the file doesn't already have one — mirror the oracle's `global.Audio` factory). Append via `renderHook`:
+
+```ts
+describe('useAudioRecorder — play() wrapper', () => {
+    it('resets playbackRetryRef and invokes playback', async () => {
+        // renderHook(useAudioRecorder, props with an existingRecording so the
+        // retry path is meaningful). Force playbackRetryRef true by driving
+        // the retry path OR (if unreachable in unit context) assert the
+        // observable: call result.current.playback.play() inside act();
+        // assert a new Audio() was constructed (playback attempted) AND that
+        // a subsequent play() after a simulated failed-load still re-attempts
+        // (guard was reset). Assert behaviour, not the private ref.
+    });
+});
+
+describe('useAudioRecorder — setPlaybackSpeed wrapper', () => {
+    it('always updates state speed but pokes the live element ONLY while playing', async () => {
+        // Not playing: act(() => result.current.playback.setPlaybackSpeed(1.5));
+        // assert result.current.playback.playbackSpeed === 1.5 AND the
+        // constructed audio element's playbackRate was NOT set to 1.5 by the
+        // call (no element / not 'playing').
+        // Then start playback (state 'playing'); act setPlaybackSpeed(2.0);
+        // assert playbackSpeed === 2.0 AND the live audio element's
+        // playbackRate === 2.0 (the stateRef==='playing' branch).
+    });
+});
+```
+
+Fill bodies against the real hook surface. Assert real behaviour (state value, constructed-Audio `playbackRate`), not mock tautologies. If a path can't be driven cleanly at the hook unit level, substitute a different genuine assertion of the wrapper's contract and say so.
+
+- [ ] **Step 2: Run the hook test file**
+
+Run: `cd frontend && npx vitest run src/hooks/participant/useAudioRecorder.test.ts`
+Expected: all pass (the prior W3 hook tests + ≥2 new).
+
+- [ ] **Step 3: Lint/format**
+
+Run: `cd frontend && npx @biomejs/biome check --write src/hooks/participant/useAudioRecorder.test.ts && npx @biomejs/biome check src/hooks/participant/useAudioRecorder.test.ts`
+Expected: formatting normalized; 0 errors/0 warnings. Re-run Step 2's vitest to confirm.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/hooks/participant/useAudioRecorder.test.ts
+git commit -m "test(audio): unit-cover play()/setPlaybackSpeed wrappers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Final verification against the Definition of Done
+
+**Files:** none (verification only; fix inline if a gate fails).
+
+- [ ] **Step 1: Type + build + lint**
+
+Run: `cd frontend && npm run type-check && npm run build && npm run lint 2>&1 | tail -1`
+Expected: `tsc -b` exit 0; `vite build` succeeds; lint 0 errors, no new `biome-ignore`.
+
+- [ ] **Step 2: Oracle unchanged-since-Task-1 + full suite**
+
+Run: `cd frontend && git diff --exit-code <Task-1 commit SHA> -- src/components/audio/AudioRecorder.test.tsx; echo "oracle-vs-task1-exit:$?" && npx vitest run 2>&1 | grep -E "Test Files|Tests " | tail -2`
+Expected: `AudioRecorder.test.tsx` identical to its Task-1 committed state (no change in Tasks 2–3). Full suite green at Task-0 baseline + 3 characterization + ≥2 hook tests, no regression.
+
+- [ ] **Step 3: Interface reduction + scope discipline**
+
+Run: `cd frontend && grep -nE "playbackRetryRef|audioPlayerRef" src/components/audio/AudioRecorder.tsx || echo "component: refs gone (ok)"` and `grep -nE "playbackRetryRef:|audioPlayerRef:" src/hooks/participant/useAudioRecorder.ts` and `git diff chore/code-quality-wave3-useaudiorecorder...HEAD --name-only`
+Expected: the component no longer references either ref; the hook's interface no longer DECLARES `playbackRetryRef:`/`audioPlayerRef:` in `ui` (internal `const playbackRetryRef`/`audioPlayerRef` still exist — that's correct, only the public surface shrank). Changed files vs the W3 branch = the 2 docs + `useAudioRecorder.ts` + `useAudioRecorder.test.ts` + `AudioRecorder.tsx` + `AudioRecorder.test.tsx` ONLY. No consumers, no other wave's files.
+
+- [ ] **Step 4: No `any`; behaviour invariance restated**
+
+Run: `cd frontend && grep -nE ": any|as any|<any>" src/hooks/participant/useAudioRecorder.ts src/components/audio/AudioRecorder.tsx | grep -v "i18n\|'.*'" || echo "no any"`
+Expected: "no any". Behaviour-invariance is proven by Step 2's byte-unchanged 48-test oracle staying green — restate that in the final report.
+
+- [ ] **Step 5: Final commit if inline fixes were made**
+
+```bash
+git add -A
+git commit -m "chore(audio): w3-followup DoD fixups
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(Skip if Steps 1–4 were green with no edits.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Characterization-first, committed before any production change → Task 1 (both production files untouched; Tasks 2 only edits them). ✓
+- 3 exact micro-behaviours (live rate while playing / no poke when not playing / retry-guard reset re-enables play) → Task 1 Step 1, one `it` each. ✓
+- `play()` wrapper resets guard; internal `playRecording` + retry path untouched → Task 2 Step 1 (explicit "do NOT modify playRecording / internal callers") + Step 2. ✓
+- `applyPlaybackSpeed` sets state + pokes live element only when `stateRef.current==='playing'` → Task 2 Step 1. ✓
+- `ui` drops both refs (interface + return); component drops both → Task 2 Steps 3–4. ✓
+- Oracle byte-unchanged from the characterization commit through the fold → Task 2 Step 6 (`git diff --exit-code`), Task 4 Step 2. ✓
+- ≥2 hook unit tests for the wrappers → Task 3. ✓
+- DoD (type-check/build/lint/suite/no-any/no-new-biome-ignore/consumers/interface-reduction) → Task 4. ✓
+- No LOC-drop target (correctly absent — value = smell resolution + smaller surface). ✓
+- Stacked on W3; diff vs W3 branch; merge order #179 → this → header + Task 4 Step 3. ✓
+
+**Placeholder scan:** No TBD/TODO. The two wrapper bodies, the return-binding edits, the interface deletions, and both JSX before/after rewrites are shown in full (this change is small enough for complete code). The characterization + hook-test bodies are intentionally specified by *behaviour to assert + harness to reuse* (characterization tests are written against the live component/hook the engineer reads at impl time; the exact behaviours — element `playbackRate` value, re-attempt after guard reset, no-poke-when-not-playing — are concrete and falsifiable), with explicit STOP-if-unreachable for the one risky path (load-failure simulation).
+
+**Type consistency:** `play` / `applyPlaybackSpeed` are the only new identifiers; returned as `play:` / `setPlaybackSpeed:` (Task 2 Step 2) and consumed by the component via the existing `play: playRecording` / `setPlaybackSpeed` destructure aliases (Task 2 Step 4) — names consistent across hook definition, return, and component. `playbackRetryRef`/`audioPlayerRef` removed from `ui` in interface AND return AND component destructure (Task 2 Steps 3–4) — no dangling reference.
+
+**Open note for the reviewer:** the cardinal risk is the `stateRef.current === 'playing'` substitution for the JSX's `state === 'playing'` — behaviourally identical at click time (the hook keeps `stateRef.current = state` synced each render, ~L184), and the characterization test #1 (poke WHILE playing) + #2 (no poke when not) pin exactly this. The spec-reviewer should independently confirm `stateRef` is the synced mirror of `state` and that no internal `playRecording`/raw-`setPlaybackSpeed` caller was altered (only the *returned* bindings change).

--- a/docs/superpowers/specs/2026-05-16-w3-followup-uicoupling-design.md
+++ b/docs/superpowers/specs/2026-05-16-w3-followup-uicoupling-design.md
@@ -1,0 +1,145 @@
+# W3 follow-up — useAudioRecorder ui-coupling fold — design
+
+**Date:** 2026-05-16
+**Status:** Approved (design)
+**Scope:** Code-quality program — the deferred Wave-3 follow-up (not a new wave;
+the audit's true-monolith list is exhausted).
+
+## Background
+
+Wave 3 (`useAudioRecorder`, PR #179) was a strict verbatim relocation, so it
+could not fold the JSX→imperative coupling into the hook (that is a
+behaviour-touching change, forbidden in a verbatim wave). The W3 T1 review and
+final review flagged the residual coupling as a legitimate, explicitly-deferred
+follow-up. This spec is that follow-up.
+
+The W3 component still mutates two hook-internal refs directly from JSX
+(`AudioRecorder.tsx` on the W3 branch):
+- **L112–113** (play button): `playbackRetryRef.current = false; playRecording();`
+- **L173–175** (speed button): `setPlaybackSpeed(speed); if (audioPlayerRef.current
+  && state === 'playing') audioPlayerRef.current.playbackRate = speed;`
+
+These are the **only** two consumers of the hook's `ui.playbackRetryRef` and
+`ui.audioPlayerRef`. Folding them into intent-named hook methods removes both
+raw refs from the public surface, fully resolving the boundary smell.
+
+This is the program's **first behaviour-touching refactor** (W1/W3/W4 were
+verbatim relocations; W2 was type-only). Observable behaviour must be
+preserved, but the proof cannot be code-identity (JSX changes, hook gains
+logic) — it is the **unchanged behaviour oracle**.
+
+Decisions taken at brainstorm:
+- **Characterization-first** (W4 model): pin the exact observable
+  micro-behaviours on the W3 baseline before the fold.
+- Stacked on the W3 branch; merge order **#179 → this**.
+
+## Goal
+
+Move the two imperative JSX mutations into intent-named `useAudioRecorder`
+methods, remove `playbackRetryRef`/`audioPlayerRef` from the hook's public
+`ui` group, with **no observable behaviour change**.
+
+## Architecture & boundary
+
+Stacked on `chore/code-quality-wave3-useaudiorecorder` (base = its tip).
+Modifies only `frontend/src/hooks/participant/useAudioRecorder.ts` and
+`frontend/src/components/audio/AudioRecorder.tsx`.
+
+**Two folds (behaviour-preserving):**
+
+1. **`play()` wrapper.** Add `const play = () => { playbackRetryRef.current =
+   false; return playRecording(); };`. Return `play: play` instead of
+   `play: playRecording`. **Invariant:** `playRecording` is unchanged and all
+   internal callers keep calling it directly — in particular the
+   existing-recording retry path (hook ~L703) must NOT reset the guard (that
+   is the guard's purpose). Only the public entry resets it — exactly what the
+   JSX did at L112–113.
+2. **`applyPlaybackSpeed(s)` wrapper.** Add `const applyPlaybackSpeed = (s:
+   number) => { setPlaybackSpeed(s); if (audioPlayerRef.current &&
+   stateRef.current === 'playing') audioPlayerRef.current.playbackRate = s; };`.
+   Return `setPlaybackSpeed: applyPlaybackSpeed` instead of the raw state
+   setter. The raw `setPlaybackSpeed` state setter stays internal-only;
+   `playRecording`'s existing `audio.playbackRate = playbackSpeed` (~L618,
+   fresh-play applies current speed) is unaffected. **Closure nuance:** the JSX
+   read `state === 'playing'` (render state); the behaviourally-identical
+   closure-safe equivalent inside the hook is the existing `stateRef.current`
+   mirror — use that, not `state`.
+
+**Interface change:** `UseAudioRecorderResult.ui` **drops**
+`playbackRetryRef` and `audioPlayerRef` (no remaining consumers). This is a
+*reduction* of the public surface — no fabrication; the W3-flagged smell is
+eliminated.
+
+**Component:** drop both refs from the `ui` destructure; L112–113 → call the
+play handler (which is now `play()` with the reset folded in); L173–175 →
+`setPlaybackSpeed(speed)`. JSX edits are minimal and targeted (remove 2
+mutation lines + 1 conditional) — *not* byte-identical; the oracle is the
+proof, not JSX-identity.
+
+## Characterization phase (first, before the fold)
+
+Append to `AudioRecorder.test.tsx` (the W3 948-LOC oracle; the existing 45
+tests untouched), green on the **unchanged W3 baseline**, committed first:
+
+1. **Live playbackRate while playing** — playback active (`state==='playing'`),
+   click a speed button → the live `<audio>` element's `playbackRate` equals
+   the chosen speed (assert the element/mock `playbackRate`, not button
+   render).
+2. **No live poke when not playing** — in `stopped` state, click a speed
+   button → state speed updates but the element's `playbackRate` is *not*
+   imperatively set (snapshots the `state==='playing'` guard).
+3. **Retry-guard reset re-enables play** — drive the existing-recording
+   load-failure path that sets `playbackRetryRef.current = true`, then click
+   the user play button → it resets the guard and re-attempts (the L112
+   behaviour), distinct from the internal retry path which does NOT reset.
+
+If any of these cannot be expressed against the unchanged W3 component, that is
+a test-setup problem or a discovered real behaviour to encode faithfully — do
+not modify the component in the characterization task; do not weaken to a
+tautology.
+
+## Testing
+
+Phase order: characterization green on W3 baseline (committed first, both
+production files untouched) → fold → the existing 45 + the 3 characterization
+tests stay green **unchanged** through the fold (oracle; enforced via
+`git diff --exit-code` since the characterization commit). Plus ≥2 hook unit
+tests via `renderHook`: `play()` resets `playbackRetryRef` then invokes
+playback; `applyPlaybackSpeed` always sets state but pokes the live element's
+`playbackRate` **only** when `stateRef.current === 'playing'`.
+
+## Definition of done
+
+- Characterization tests green on the W3 baseline **before** any production
+  change (committed as the first task).
+- `cd frontend && npm run type-check` (`tsc -b`, the real gate — never
+  `tsc --noEmit`) → exit 0.
+- `cd frontend && npm run build` → succeeds.
+- `cd frontend && npm run lint` → 0 errors; **no new `biome-ignore`** (W3's
+  relocated keyboard-effect suppression stays untouched); no `any`.
+- `cd frontend && npx vitest run` → full suite green; the existing 45 + the 3
+  characterization tests **byte-unchanged from the characterization commit
+  through the fold** + ≥2 new hook unit tests.
+- `useAudioRecorder.ts` `ui` no longer exposes `playbackRetryRef`/
+  `audioPlayerRef`; `AudioRecorder.tsx` no longer references them; `play` and
+  `setPlaybackSpeed` returned are the new wrappers; `playRecording` and the raw
+  state setter are unchanged and still used internally.
+- Consumers `Step1_Feedback.tsx`/`Step2_Questionnaire.tsx` untouched, still
+  type-checking; `AudioRecorderProps` unchanged.
+- **No observable behaviour change** — proof is the unchanged oracle, not
+  code-identity.
+- Stacked on `chore/code-quality-wave3-useaudiorecorder`; PR diff framed vs
+  that branch; merge order **#179 → this**.
+
+## Non-goals
+
+- Any observable behaviour, UX, or media-pipeline change.
+- Modifying the existing 45 `AudioRecorder.test.tsx` tests (oracle).
+- Touching `playRecording`, the raw `setPlaybackSpeed` state setter, or any
+  internal caller of either (only the *returned* bindings change).
+- Changing `AudioRecorderProps` or the consumers.
+- Re-relocating or otherwise altering W3's verbatim-moved lifecycle beyond the
+  two named wrappers + the interface reduction.
+- Removing/relocating W3's pre-existing keyboard-effect suppression.
+- Any other deferred backlog item (QSortEditor JSX decomposition; the
+  designer-draft-model refactor) or any other wave's files.

--- a/frontend/src/components/audio/AudioRecorder.test.tsx
+++ b/frontend/src/components/audio/AudioRecorder.test.tsx
@@ -25,6 +25,19 @@ vi.mock('sonner', () => ({
     toast: mockToast,
 }));
 
+// Characterization (W3-followup oracle) only: the existing-recording load-failure
+// retry path in useAudioRecorder dynamically imports this module inside
+// refreshPresignedUrl(), which only runs when `sessionToken` is set. None of the
+// existing 45 tests set a sessionToken, so this mock is inert for them; it exists
+// so the load-failure path in behaviour #3 below is deterministic (rejects rather
+// than performing a real network call in jsdom).
+const mockGetAudioUrl = vi.hoisted(() =>
+    vi.fn().mockRejectedValue(new Error('refresh failed (characterization)'))
+);
+vi.mock('@/api/generated', () => ({
+    getAudioUrlApiAudioRecordingIdUrlGet: mockGetAudioUrl,
+}));
+
 describe('AudioRecorder', () => {
     // Captured MediaRecorder instance — set by mock constructor, used to trigger handlers
     let capturedMediaRecorder: {
@@ -944,5 +957,148 @@ describe('AudioRecorder', () => {
         unmount();
 
         expect(mockStream.getTracks()[0].stop).toHaveBeenCalled();
+    });
+
+    // ── CHARACTERIZATION — UI COUPLING (W3-FOLLOWUP ORACLE) ──────────
+    //
+    // These three tests pin the EXACT observable behaviour of the two
+    // imperative JSX→ref couplings in AudioRecorder.tsx on the UNCHANGED
+    // W3 baseline, so a later fold into useAudioRecorder wrappers is
+    // provably behaviour-preserving. They assert REAL observable state
+    // (the live `new Audio()` element's `.playbackRate`; a re-attempt =
+    // a fresh Audio construction), never a mock tautology.
+    describe('Characterization — ui coupling (W3-followup oracle)', () => {
+        /** The most recently constructed `new Audio()` instance (the live element). */
+        function lastAudioElement(): { playbackRate: number } | undefined {
+            return (
+                global.Audio as unknown as {
+                    mock: { results: { value: { playbackRate: number } }[] };
+                }
+            ).mock.results.at(-1)?.value;
+        }
+
+        /** How many `new Audio()` elements the hook has constructed so far. */
+        function audioConstructionCount(): number {
+            return (global.Audio as unknown as { mock: { results: unknown[] } }).mock.results
+                .length;
+        }
+
+        it('applies playbackRate to the live audio element when a speed button is clicked WHILE playing', async () => {
+            render(
+                <AudioRecorder {...defaultProps} existingRecording={existingRecordingFixture} />
+            );
+
+            // Start playback (reuse 'plays audio when play button is clicked').
+            fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+            });
+
+            const liveAudio = lastAudioElement();
+            expect(liveAudio).toBeDefined();
+            // Constructed default speed is 1.0 (hook sets audio.playbackRate =
+            // playbackSpeed at construction; default playbackSpeed is 1.0).
+            expect(liveAudio?.playbackRate).toBe(1.0);
+
+            // Click the 1.5x speed button WHILE playing → the JSX coupling
+            // (audioPlayerRef.current && state === 'playing') pokes the live
+            // element's playbackRate. Assert against the ELEMENT, not the button.
+            await act(async () => {
+                fireEvent.click(screen.getByText('1.5x'));
+            });
+            expect(lastAudioElement()?.playbackRate).toBe(1.5);
+
+            // A second speed change while still playing pokes again (2.0x).
+            await act(async () => {
+                fireEvent.click(screen.getByText('2x'));
+            });
+            expect(lastAudioElement()?.playbackRate).toBe(2.0);
+            // Still the SAME constructed element — no replay was triggered.
+            expect(audioConstructionCount()).toBe(1);
+        });
+
+        it('does NOT imperatively set playbackRate when a speed button is clicked while NOT playing', async () => {
+            render(
+                <AudioRecorder {...defaultProps} existingRecording={existingRecordingFixture} />
+            );
+
+            // Stopped state: the play bar is shown but playback was never started,
+            // so the hook never ran `new Audio()` — there is no live element to poke.
+            expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+            expect(audioConstructionCount()).toBe(0);
+
+            // Click 1.5x while NOT playing.
+            await act(async () => {
+                fireEvent.click(screen.getByText('1.5x'));
+            });
+
+            // State speed updated: the 1.5x button now carries the selected
+            // styling class the component applies when `playbackSpeed === speed`.
+            const selectedBtn = screen.getByText('1.5x').closest('button');
+            expect(selectedBtn?.className).toContain('bg-slate-100');
+            expect(selectedBtn?.className).toContain('text-slate-800');
+
+            // But the `state === 'playing'` guard short-circuits the element
+            // poke: no Audio element was ever constructed by the click, so the
+            // rate is only carried as state until a fresh playRecording applies
+            // it. (Snapshot of the current guard: no-poke when not playing.)
+            expect(audioConstructionCount()).toBe(0);
+        });
+
+        it('user play button resets the retry guard so a load-failed existing recording can be re-played', async () => {
+            // sessionToken makes the existing-recording retry branch in
+            // audio.onerror reachable (existingRecording && sessionToken &&
+            // !playbackRetryRef.current) — that branch sets
+            // playbackRetryRef.current = true.
+            render(
+                <AudioRecorder
+                    {...defaultProps}
+                    existingRecording={existingRecordingFixture}
+                    sessionToken="sess-characterization"
+                />
+            );
+
+            // First user play → constructs Audio #1.
+            fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+            });
+            expect(audioConstructionCount()).toBe(1);
+
+            // Drive the playback load-failure path: trigger the live element's
+            // error handler (the hook assigns audio.onerror). With a sessionToken
+            // and the guard still false, this sets playbackRetryRef.current = true
+            // and then awaits refreshPresignedUrl(), which the mocked
+            // @/api/generated rejects → catch → resetPlaybackAfterFailure()
+            // (state → 'stopped'). The internal playRecording() retry is NOT
+            // reached (it sits after the awaited, rejected refresh), so the
+            // guard stays true and no new Audio is constructed by the failure.
+            const failed = lastAudioElement() as unknown as {
+                onerror: (() => Promise<void>) | null;
+            };
+            expect(failed.onerror).toBeTypeOf('function');
+            await act(async () => {
+                await failed.onerror?.();
+            });
+
+            // Back to stopped, still exactly one Audio (no internal re-attempt).
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+            });
+            expect(mockToast.error).toHaveBeenCalled();
+            expect(audioConstructionCount()).toBe(1);
+
+            // Now the USER clicks the play button. The JSX coupling runs
+            // `playbackRetryRef.current = false; playRecording()`. Because the
+            // guard was reset, playback re-attempts → a NEW Audio is
+            // constructed (#2). This is the user-play path, distinct from the
+            // internal onerror retry path; it is the observable the fold must
+            // preserve.
+            fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+            });
+            expect(audioConstructionCount()).toBe(2);
+        });
     });
 });

--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -26,14 +26,7 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = (props) => {
         upload: { retry: retryUpload, delete: deleteRecording },
         waveform: { audioLevels },
         dom: { containerRef },
-        ui: {
-            formatTime,
-            maxDurationSeconds,
-            disabled,
-            existingRecording,
-            playbackRetryRef,
-            audioPlayerRef,
-        },
+        ui: { formatTime, maxDurationSeconds, disabled, existingRecording },
     } = useAudioRecorder(props);
 
     return (
@@ -105,14 +98,7 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = (props) => {
                     <div className="flex flex-wrap items-center gap-2 px-3 py-2.5 rounded-xl border border-slate-200 bg-white shadow-sm">
                         <button
                             type="button"
-                            onClick={
-                                state === 'playing'
-                                    ? pausePlayback
-                                    : () => {
-                                          playbackRetryRef.current = false;
-                                          playRecording();
-                                      }
-                            }
+                            onClick={state === 'playing' ? pausePlayback : playRecording}
                             aria-label={
                                 state === 'playing'
                                     ? t('audio.pause', 'Pause')
@@ -169,12 +155,7 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = (props) => {
                                 <button
                                     type="button"
                                     key={speed}
-                                    onClick={() => {
-                                        setPlaybackSpeed(speed);
-                                        if (audioPlayerRef.current && state === 'playing') {
-                                            audioPlayerRef.current.playbackRate = speed;
-                                        }
-                                    }}
+                                    onClick={() => setPlaybackSpeed(speed)}
                                     className={`px-2 py-1 text-xs font-medium transition-colors ${
                                         playbackSpeed === speed
                                             ? 'bg-slate-100 text-slate-800'

--- a/frontend/src/hooks/participant/useAudioRecorder.test.ts
+++ b/frontend/src/hooks/participant/useAudioRecorder.test.ts
@@ -93,6 +93,22 @@ function setupWebApiMocks() {
 
     global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
     global.URL.revokeObjectURL = vi.fn();
+
+    // Audio constructor for playback — must use function (not arrow) to be
+    // constructable with `new`. Mirrors oracle's global.Audio factory pattern.
+    // biome-ignore lint/complexity/useArrowFunction: must be constructable for `new Audio()`
+    global.Audio = vi.fn(function () {
+        return {
+            play: vi.fn().mockResolvedValue(undefined),
+            pause: vi.fn(),
+            onended: null,
+            onerror: null,
+            ontimeupdate: null,
+            playbackRate: 1.0,
+            currentTime: 0,
+            src: '',
+        };
+    }) as unknown as typeof Audio;
 }
 
 function makeProps(over: Record<string, unknown> = {}) {
@@ -234,5 +250,128 @@ describe('useAudioRecorder — max-duration auto-stop', () => {
         expect(capturedMediaRecorder?.stop).toHaveBeenCalled();
         // Duration has advanced to at least 1s — confirms the timer was running
         expect(result.current.recording.duration).toBeGreaterThanOrEqual(1);
+    });
+});
+
+// Helper: an existing-recording fixture whose URL is not expired, so
+// refreshUrlBeforePlayback returns true without hitting the network.
+const existingRecordingFixture = {
+    id: 1,
+    presigned_url: 'https://example.com/audio.webm',
+    duration_seconds: 45,
+    file_size_bytes: 1024,
+    created_at: new Date().toISOString(),
+    url_expires_at: new Date(Date.now() + 2 * 3600 * 1000).toISOString(), // 2 h from now
+};
+
+// Helper: read the Nth (0-based) Audio instance constructed by global.Audio mock.
+function capturedAudio(index: number): { playbackRate: number; play: ReturnType<typeof vi.fn> } {
+    const mock = global.Audio as unknown as {
+        mock: {
+            results: Array<{ value: { playbackRate: number; play: ReturnType<typeof vi.fn> } }>;
+        };
+    };
+    const result = mock.mock.results[index];
+    if (!result) throw new Error(`No Audio instance at index ${index}`);
+    return result.value;
+}
+
+describe('useAudioRecorder — play() wrapper', () => {
+    beforeEach(setupWebApiMocks);
+
+    it('resets playbackRetryRef and invokes playback (new Audio constructed each call)', async () => {
+        // Arrange: hook with an existing recording so audioUrl is initialised
+        // (without a URL, playRecording returns early before constructing Audio).
+        const { result } = renderHook(() =>
+            useAudioRecorder(makeProps({ existingRecording: existingRecordingFixture }))
+        );
+
+        // Wait for the initialise-existing-recording effect to settle
+        // (sets audioUrl + state = 'stopped')
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(result.current.status.state).toBe('stopped');
+        expect(
+            (global.Audio as unknown as { mock: { results: unknown[] } }).mock.results
+        ).toHaveLength(0);
+
+        // Act 1: first play() — resets guard (was false), invokes playRecording.
+        await act(async () => {
+            await result.current.playback.play();
+        });
+
+        // Observable 1: a new Audio element was constructed (playback attempted).
+        expect(
+            (global.Audio as unknown as { mock: { results: unknown[] } }).mock.results
+        ).toHaveLength(1);
+        expect(result.current.status.state).toBe('playing');
+
+        // Act 2: second play() from the playing state — play() resets the guard
+        // (which the internal onerror path may have set to true) and calls
+        // playRecording again regardless, constructing a second Audio element.
+        // This directly asserts the contract: play() always re-attempts.
+        await act(async () => {
+            await result.current.playback.play();
+        });
+
+        // Observable 2: a second Audio element was constructed — the guard was
+        // reset so playRecording was not short-circuited.
+        expect(
+            (global.Audio as unknown as { mock: { results: unknown[] } }).mock.results
+        ).toHaveLength(2);
+    });
+});
+
+describe('useAudioRecorder — setPlaybackSpeed wrapper', () => {
+    beforeEach(setupWebApiMocks);
+
+    it('always updates state speed but pokes the live element ONLY while playing', async () => {
+        // Arrange: hook with an existing recording
+        const { result } = renderHook(() =>
+            useAudioRecorder(makeProps({ existingRecording: existingRecordingFixture }))
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(result.current.status.state).toBe('stopped');
+
+        // --- Not playing: speed state updates but NO audio element to poke ---
+
+        act(() => {
+            result.current.playback.setPlaybackSpeed(1.5);
+        });
+
+        // Observable: hook exposes updated speed
+        expect(result.current.playback.playbackSpeed).toBe(1.5);
+        // No Audio element has been constructed yet — no playbackRate mutation possible
+        expect(
+            (global.Audio as unknown as { mock: { results: unknown[] } }).mock.results
+        ).toHaveLength(0);
+
+        // --- Transition to playing ---
+
+        await act(async () => {
+            await result.current.playback.play();
+        });
+
+        expect(result.current.status.state).toBe('playing');
+        // playRecording applied the current playbackSpeed (1.5) to the element on construction
+        expect(capturedAudio(0).playbackRate).toBe(1.5);
+
+        // --- While playing: speed state updates AND element is poked immediately ---
+
+        act(() => {
+            result.current.playback.setPlaybackSpeed(2.0);
+        });
+
+        // Observable 1: state speed updated
+        expect(result.current.playback.playbackSpeed).toBe(2.0);
+        // Observable 2: live element's playbackRate was imperatively set to 2.0
+        // (applyPlaybackSpeed branches on stateRef.current === 'playing', which is true)
+        expect(capturedAudio(0).playbackRate).toBe(2.0);
     });
 });

--- a/frontend/src/hooks/participant/useAudioRecorder.test.ts
+++ b/frontend/src/hooks/participant/useAudioRecorder.test.ts
@@ -308,10 +308,12 @@ describe('useAudioRecorder — play() wrapper', () => {
         ).toHaveLength(1);
         expect(result.current.status.state).toBe('playing');
 
-        // Act 2: second play() from the playing state — play() resets the guard
-        // (which the internal onerror path may have set to true) and calls
-        // playRecording again regardless, constructing a second Audio element.
-        // This directly asserts the contract: play() always re-attempts.
+        // Act 2: second play() from the playing state. play() unconditionally
+        // clears playbackRetryRef then calls playRecording, constructing a
+        // second Audio element. (The internal onerror path is not driven at
+        // unit level — sessionToken is unset — so the guard is never actually
+        // true here; the second Audio construction is the real proof that
+        // play() always re-attempts regardless of guard state.)
         await act(async () => {
             await result.current.playback.play();
         });

--- a/frontend/src/hooks/participant/useAudioRecorder.ts
+++ b/frontend/src/hooks/participant/useAudioRecorder.ts
@@ -128,8 +128,6 @@ export interface UseAudioRecorderResult {
         maxDurationSeconds: number;
         disabled: boolean;
         existingRecording: AudioRecorderProps['existingRecording'];
-        playbackRetryRef: MutableRef<boolean>;
-        audioPlayerRef: RefObject<HTMLAudioElement | null>;
     };
 }
 
@@ -805,6 +803,24 @@ export function useAudioRecorder(props: AudioRecorderProps): UseAudioRecorderRes
         return `${mins}:${secs.toString().padStart(2, '0')}`;
     };
 
+    // Public play entry: resets the existing-recording retry guard, then plays.
+    // Internal callers keep using `playRecording` directly (they must NOT reset
+    // the guard — that is the guard's purpose).
+    const play = () => {
+        playbackRetryRef.current = false;
+        return playRecording();
+    };
+
+    // Public speed setter: sets state, and — only while actually playing —
+    // applies the rate to the live audio element (closure-safe via stateRef,
+    // the hook's existing mirror of `state`).
+    const applyPlaybackSpeed = (s: number) => {
+        setPlaybackSpeed(s);
+        if (audioPlayerRef.current && stateRef.current === 'playing') {
+            audioPlayerRef.current.playbackRate = s;
+        }
+    };
+
     // `_questionKey` is destructured to preserve the exact identifier the
     // moved component body declared (it was already unused there, hence the
     // underscore prefix); referenced via `void` to keep the verbatim move
@@ -818,9 +834,9 @@ export function useAudioRecorder(props: AudioRecorderProps): UseAudioRecorderRes
             audioUrl,
             urlExpiresAt,
             playbackSpeed,
-            setPlaybackSpeed,
+            setPlaybackSpeed: applyPlaybackSpeed,
             playbackPosition,
-            play: playRecording,
+            play: play,
             pause: pausePlayback,
         },
         upload: { retry: retryUpload, delete: deleteRecording },
@@ -831,8 +847,6 @@ export function useAudioRecorder(props: AudioRecorderProps): UseAudioRecorderRes
             maxDurationSeconds,
             disabled,
             existingRecording,
-            playbackRetryRef,
-            audioPlayerRef,
         },
     };
 }


### PR DESCRIPTION
> **Stacked PR.** Base = `chore/code-quality-wave3-useaudiorecorder` (PR #179), **not main** — so this diff shows only the 6 follow-up files. Merge order: **#179 → this**. Retarget to `main` after #179 merges.

## Summary

The deferred Wave-3 follow-up (the W3 verbatim relocation could not fold the JSX→imperative coupling — that is behaviour-touching, forbidden in a verbatim wave; the W3 reviews flagged it as a legitimate separate cycle). **The program's first behaviour-touching refactor.**

- Folds the two imperative JSX→ref mutations into intent-named hook wrappers: `play()` resets the existing-recording retry guard then plays; `applyPlaybackSpeed(s)` sets state and — only while playing — applies the rate to the live `<audio>` element (closure-safe via the hook's existing `stateRef` mirror).
- **`useAudioRecorder`'s public `ui` group drops `playbackRetryRef`/`audioPlayerRef`** — their only two consumers vanished. The boundary smell the W3 reviews flagged is fully resolved; the public surface shrinks.
- `playRecording`, the raw `setPlaybackSpeed` state setter, and the internal existing-recording retry path (which must NOT reset the guard) are **byte-unchanged**; only the *returned* bindings changed.

**Characterization-first (W4 model).** Task 1 added 3 tests to `AudioRecorder.test.tsx` (the 948-LOC W3 oracle) pinning the exact observable micro-behaviours (live `playbackRate` while playing; no poke when not playing; retry-guard reset re-enables play) on the **unchanged W3 baseline** → 48 tests. That file is **byte-frozen at the characterization commit and stays green through the fold** — the sole behaviour-preservation proof (no code-identity fallback for a behaviour-touching change). The one real risk (substituting `stateRef.current` for the JSX's render-time `state`) was independently verified sound: `stateRef.current = state` is assigned unconditionally every render. Final review: **READY TO MERGE, zero issues** — "an exemplary template for the program's first behaviour-touching refactor."

4 code/test files + 2 docs. Spec/plan: `docs/superpowers/{specs,plans}/2026-05-16-w3-followup-uicoupling*`.

## Test Plan

- [x] `cd frontend && npm run type-check` (`tsc -b`) — exit 0
- [x] `cd frontend && npm run build` — succeeds
- [x] `cd frontend && npm run lint` — 0 errors; no new `biome-ignore` in production (W3's keyboard-effect suppression untouched); no `any`
- [x] `cd frontend && npx vitest run` — 1426 passed | 6 skipped (W3 baseline 1421 + 3 characterization + 2 hook unit tests)
- [x] `AudioRecorder.test.tsx` byte-frozen since the characterization commit; 48 green through the fold (behaviour-preservation proof)
- [x] `UseAudioRecorderResult.ui` no longer declares `playbackRetryRef`/`audioPlayerRef`; component references neither; consumers `Step1_Feedback.tsx`/`Step2_Questionnaire.tsx` unmodified, type-check against unchanged `AudioRecorderProps`
- [ ] ⚠️ shares the pre-existing repo-wide stale-lockfile `make ci` red — fixed by #177; not in this diff

**Backlog after this:** ~~Wave 2-tail~~ (closed — honest drop); ~~W3 ui-coupling~~ (this PR). Remaining open: the 1110-LOC `QSortEditor` JSX per-tab decomposition (surfaced in W4) and the optional typed-designer-draft-model refactor (~13 sites, from the W2-tail triage) — both standalone, neither a wave on the original audit's exhausted true-monolith list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)