### PR TITLE
refactor(designer): extract useQSortEditor — code-quality wave 4

### DIFF
--- a/docs/superpowers/plans/2026-05-16-useqsorteditor-wave4.md
+++ b/docs/superpowers/plans/2026-05-16-useqsorteditor-wave4.md
@@ -1,0 +1,467 @@
+# Wave 4 — useQSortEditor Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce `frontend/src/components/admin/designer/QSortEditor.tsx` (1488 LOC on the W2 branch) to a JSX shell (+ the discrete `SortableStatementItem`) by relocating its ~385 LOC of inline state/store/query/handler logic verbatim into `frontend/src/hooks/admin/useQSortEditor.ts`, after first hardening the behaviour net with characterization tests — no behaviour change.
+
+**Architecture:** Characterization-first, then Phase-5-G hook extraction (precedents: `useInteractiveDataView` W1, `useAudioRecorder` W3 — including the W3 pattern of the hook returning a JSX-bound value created by a hook call: here `sensors = useSensors(...)`). Stacked on the Wave-2 branch.
+
+**Tech Stack:** React 19, TypeScript (strict via `tsc -b`/Biome), Zustand (`useStudyDesigner`), @tanstack/react-query (generated hooks), @dnd-kit, Vitest + `@testing-library/react` (`renderWithStore`, `userEvent`, `renderHook`).
+
+**Branch:** `chore/code-quality-wave4-useqsorteditor`, **based on `chore/code-quality-wave2-studyconfig-typing`** (base commit `0646b64d`; already created; spec committed there). PR diff is framed against the W2 branch; merge order #178 → W4.
+
+**The real typecheck gate is `cd frontend && npm run type-check` (= `tsc -b`).** Never `npx tsc --noEmit` (false-green, root tsconfig references-only).
+
+---
+
+### Task 0: Baseline
+
+**Files:** none modified.
+
+- [ ] **Step 1: Record the green baseline**
+
+Run: `cd frontend && npm run type-check && npx vitest run 2>&1 | grep -E "Test Files|Tests " | tail -2 && wc -l < src/components/admin/designer/QSortEditor.tsx`
+Expected: `tsc -b` exit 0; full suite green — **record the exact `Tests N passed | M skipped` line** (behaviour-preservation target for Tasks 1, 3, 4); `QSortEditor.tsx` = 1488.
+
+- [ ] **Step 2: Record the existing QSortEditor test count (oracle seed)**
+
+Run: `cd frontend && npx vitest run src/components/admin/designer/QSortEditor.test.tsx 2>&1 | tail -3`
+Expected: all pass (17 tests). Note the count. After Task 1 this file gains characterization tests; from Task 2 onward the **whole file must remain byte-unchanged and green** (the behaviour-preservation oracle). If at any later step it requires modification to pass, behaviour changed → STOP and escalate.
+
+- [ ] **Step 3: Confirm the sole consumer**
+
+Run: `grep -rln "designer/QSortEditor" frontend/src --include="*.tsx" --include="*.ts" | grep -vE "QSortEditor\.(tsx|helpers|test)"`
+Expected: exactly `frontend/src/pages/admin/StudyDesignPage.tsx`. Anything else → STOP, report.
+
+No commit (read-only).
+
+---
+
+### Task 1: Characterization tests (harden the net BEFORE any component change)
+
+**Files:**
+- Modify: `frontend/src/components/admin/designer/QSortEditor.test.tsx` (append 4 `describe` blocks; do not alter existing tests)
+
+**These are characterization tests: they assert whatever the component does *today* on the W2 branch, even if a behaviour looks odd — the point is to lock current behaviour so the Task-3 extraction cannot drift it. Do not "fix" surprising behaviour; snapshot it.**
+
+- [ ] **Step 1: Append the four characterization `describe` blocks**
+
+Append to `QSortEditor.test.tsx`, reusing the file's existing harness (`renderWithStore`, `userEvent`, `TooltipProvider`, the `sonner` mock, and the existing render helper/store-seed pattern used by the current 17 tests — read the top of the file and the existing `describe('Statement Management')`/`describe('Bulk Statement Import')` blocks and mirror their setup exactly):
+
+```tsx
+describe('Characterization — dnd reorder (W4 oracle)', () => {
+    it('reordering statements via drag-end updates draft order', async () => {
+        // Render with a seeded draft of >=3 statements (mirror the seed the
+        // existing 'Statement Management' describe uses). The dnd-kit
+        // drag-end handler reorders draft.statements. Drive it the way the
+        // codebase's other dnd tests do (search the repo for an existing
+        // `DragEndEvent`/`fireEvent`/`@dnd-kit` test — e.g. dispatch the
+        // handler via the rendered DnD context, or simulate keyboard
+        // reorder through the sortable item's role/aria). Assert the
+        // resulting draft.statements ORDER (read via the store) matches the
+        // post-drag order. Snapshot whatever the current handler produces.
+    });
+});
+
+describe('Characterization — concourse sync + stale map (W4 oracle)', () => {
+    it('syncing a stale statement calls the sync mutation and clears its stale flag', async () => {
+        // Seed `original.statements` with one entry having
+        // source_concourse_item_id set; mock the generated
+        // useCheckStaleStatements query to return that id as stale and the
+        // useSyncStatementFromConcourse mutation. Mirror how other tests
+        // mock '@/api/generated'. Trigger the per-statement sync affordance
+        // (the button rendered when staleByStatementId has the id). Assert
+        // the sync mutation was called with the expected args and the UI
+        // reflects the post-sync state the component currently produces.
+    });
+});
+
+describe('Characterization — import-mode matrix (W4 oracle)', () => {
+    it.each(['replace', 'append', 'sync'] as const)(
+        'bulk import in %s mode produces the current draft.statements result',
+        async (mode) => {
+            // Open the import dialog, paste a known multi-line bulk text
+            // (cover both detected formats the parser supports — see
+            // QSortEditor.helpers / parseCsvTsv), select the import mode,
+            // confirm. Assert the resulting draft.statements EXACTLY as the
+            // current code yields for that mode (replace overwrites; append
+            // concatenates; sync reconciles). Snapshot current behaviour.
+        }
+    );
+});
+
+describe('Characterization — inline statement edit (W4 oracle)', () => {
+    it('enter→edit→commit updates the statement; cancel discards', async () => {
+        // Seed >=1 statement. Trigger inline edit (sets editingIndex/
+        // editingText/editingCode). Change text+code, commit — assert the
+        // statement updated in draft. Repeat: edit, change, cancel — assert
+        // the statement is UNCHANGED. Snapshot the exact commit/cancel
+        // semantics the current handlers implement.
+    });
+});
+```
+
+Fill the bodies by reading the component's current rendered output and the existing tests' patterns. Each assertion targets **observed current behaviour** (read draft state via the store, like the existing tests). No mock tautologies — assert the draft mutation / mutation-call, not that a mock returned its configured value.
+
+- [ ] **Step 2: Run — characterization tests green on the W2 baseline**
+
+Run: `cd frontend && npx vitest run src/components/admin/designer/QSortEditor.test.tsx`
+Expected: all pass — the original 17 **plus** the 4 new blocks (≥4 new test cases; the import-mode `it.each` is 3). If a characterization test cannot be made to pass against the *unchanged* W2 component, you have either a test-setup bug or discovered real behaviour you must encode — investigate; do NOT modify the component (it is untouched in Task 1).
+
+- [ ] **Step 3: Lint/format the test file**
+
+Run: `cd frontend && npx @biomejs/biome check --write src/components/admin/designer/QSortEditor.test.tsx && npx @biomejs/biome check src/components/admin/designer/QSortEditor.test.tsx`
+Expected: formatting normalized; second run 0 errors/0 warnings (no `any`, no unused import). Re-run Step 2's vitest to confirm formatting didn't break a test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/admin/designer/QSortEditor.test.tsx
+git commit -m "test(designer): characterization net for QSortEditor (W4 oracle)
+
+Locks current behaviour of dnd reorder, concourse sync + stale map,
+import-mode matrix, and inline edit on the W2 baseline BEFORE the
+useQSortEditor extraction. Existing 17 tests unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Create useQSortEditor + first failing test
+
+**Files:**
+- Create: `frontend/src/hooks/admin/useQSortEditor.ts`
+- Create: `frontend/src/hooks/admin/useQSortEditor.test.ts`
+- Read for the verbatim move: `QSortEditor.tsx` — `QSortEditorProps` (lines 302–305) and the main-component logic block (line 308 `const QSortEditor = (...) => {` through the line immediately before the JSX `return (` at 699).
+
+- [ ] **Step 1: Write the first failing hook test**
+
+Create `frontend/src/hooks/admin/useQSortEditor.test.ts`:
+
+```ts
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Qualis Team
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Unit tests for useQSortEditor — pure-logic paths only. Full behaviour
+ * through the component is covered by the unchanged QSortEditor.test.tsx
+ * (existing 17 + W4 characterization tests = the oracle).
+ */
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// Mirror the generated-API + store mocks the precedent hook tests use
+// (read frontend/src/hooks/admin/useRecruitmentPage.test.ts for the
+// canonical @/api/generated + @/store/useStudyDesigner mocking pattern and
+// replicate the shapes the moved body actually calls).
+
+import { useQSortEditor } from './useQSortEditor';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('useQSortEditor — initial shape', () => {
+    it('returns the role-grouped surface without throwing on mount', () => {
+        const { result } = renderHook(() => useQSortEditor({}));
+        expect(result.current.dnd.sensors).toBeDefined();
+        expect(typeof result.current.bulk.setBulkText).toBe('function');
+        expect(result.current.dialogs.importDialogOpen).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/hooks/admin/useQSortEditor.test.ts`
+Expected: FAIL — `Failed to resolve import "./useQSortEditor"`.
+
+- [ ] **Step 3: Create the hook by relocating the logic verbatim**
+
+Create `frontend/src/hooks/admin/useQSortEditor.ts`:
+
+```ts
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Qualis Team
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * useQSortEditor hook
+ *
+ * Owns the durable state-and-effect logic for the Q-sort statement/grid
+ * editor: useStudyDesigner store slice, stale-statements query +
+ * concourse-sync mutation, bulk-import + detected-format state, inline-edit
+ * state, grid-capacity handlers, dnd sensors + drag-end. QSortEditor renders
+ * JSX from this hook's return value (Phase-5-G; precedents
+ * useInteractiveDataView W1, useAudioRecorder W3).
+ *
+ * `sensors` (useSensors) is returned and bound by the component as
+ * <DndContext sensors={sensors}> — same pattern as W3's hook-returned
+ * containerRef.
+ */
+
+// ⟶ MOVE: carry over every import the moved body uses (react, @dnd-kit
+//   core/sortable, @/store/useStudyDesigner, @tanstack/react-query, the
+//   generated stale/sync hooks, @/components/admin/designer/
+//   QSortEditor.helpers, types). Let `tsc -b` drive which: add an import
+//   here the moment a moved line references a missing symbol. JSX-only
+//   imports stay in the component.
+
+// ⟶ MOVE verbatim: the `QSortEditorProps` interface (QSortEditor.tsx
+//   302–305) — export it (the component imports it back). Also any
+//   small local type aliases the moved body needs that currently live
+//   above the component (e.g. `Statement`/`Translation`/`GridColumn`/
+//   `StaleInfo` aliases at ~66–73) IF the moved body references them and
+//   they are not already exported from a shared module — move/export the
+//   minimum set, verbatim. Do NOT move `SortableStatementItem`.
+
+export interface UseQSortEditorResult {
+    // ⟶ Role-grouped, any-free. The shape below is the TARGET; during
+    //   implementation map every field 1:1 to a real identifier the JSX
+    //   (QSortEditor.tsx 699–1488) consumes. Expose ONLY what exists — no
+    //   fabricated handlers (W3 lesson). If the JSX consumes something not
+    //   listed, add it to the right group; if a listed item has no source
+    //   counterpart, remove it and note it. Final interface is whatever the
+    //   real consumed set is, grouped as: data / bulk / editing / dialogs /
+    //   actions / dnd.
+    data: Record<string, unknown>;     // replace with the real typed fields
+    bulk: { bulkText: string; setBulkText: (v: string) => void; [k: string]: unknown };
+    editing: Record<string, unknown>;
+    dialogs: { importDialogOpen: boolean; setImportDialogOpen: (v: boolean) => void;
+        [k: string]: unknown };
+    actions: Record<string, unknown>;
+    dnd: { sensors: unknown; [k: string]: unknown };
+}
+
+export function useQSortEditor(props: QSortEditorProps): UseQSortEditorResult {
+    // ⟶ MOVE verbatim: the entire component body from `const { t } =
+    //   useTranslation();` (QSortEditor.tsx:309) through the LAST line
+    //   before `return (` at 699 — every useState, the staleByStatementId
+    //   useMemo, both useEffects, useSensors, all handlers
+    //   (handleSyncStatement, handleStatementDragEnd, handleBulkSave,
+    //   handleClearAll, updateGridCapacity, addExtremeColumns,
+    //   removeExtremeColumns, autoShapeGrid, handleSaveStatement,
+    //   handleImported, …), and the derived values (hasLinkedStatements,
+    //   activeSubTab/setActiveSubTab proxy, grid).
+    //
+    //   Wiring changes ALLOWED (behaviour-identical only):
+    //   - destructure `props` instead of the component's param list:
+    //     the component is `({ readOnly, structureLocked }) =>` — use
+    //     `const { readOnly, structureLocked } = props;` preserving those
+    //     exact identifiers (and any unused-prefixed name verbatim).
+    //   NO other logic edits — behaviour identical. The moved code's
+    //   store calls, query/mutation, effects, and handlers must be byte-
+    //   identical (only the function wrapper + props destructure differ).
+
+    return {
+        // ⟶ Build the role-grouped object from the moved locals, mapping
+        //   keys 1:1 to the identifiers the JSX consumes. `dnd.sensors`
+        //   is the moved `sensors`. Do not rename a handler the JSX uses;
+        //   alias it under its group with its exact JSX-referenced name.
+    } as UseQSortEditorResult;
+}
+```
+
+Note: the placeholder interface uses index signatures so the scaffold
+type-checks before the body is filled. During implementation, **replace each
+`Record<string, unknown>` / `[k: string]: unknown` with the explicit typed
+fields** — the final interface must be fully typed and `any`-free, every
+member a real JSX-consumed identifier (read the JSX 699–1488, list every
+identifier it references from the moved body, and that list IS the interface).
+If you cannot complete the typed interface without `any`, narrow with a
+precise type; never `any`, never `biome-ignore`. If a JSX-needed identifier
+has no source counterpart or vice-versa, STOP and report (do not fabricate).
+
+- [ ] **Step 4: Run the first hook test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/hooks/admin/useQSortEditor.test.ts`
+Expected: PASS. If the moved body throws on mount in the test env (missing store/query mock), add the mocks per the precedent (`useRecruitmentPage.test.ts`) — that is test scaffolding, not a behaviour change.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd frontend && npm run type-check`
+Expected: exit 0. (`QSortEditor.tsx` still has its own copy — fine; removed in Task 3.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/hooks/admin/useQSortEditor.ts frontend/src/hooks/admin/useQSortEditor.test.ts
+git commit -m "feat(designer): extract useQSortEditor hook (logic verbatim)
+
+Phase-5-G W4. State/store/query/handlers relocated verbatim into the
+hook; role-grouped any-free return mapped to JSX-consumed identifiers;
+sensors returned for <DndContext> binding. QSortEditor.tsx still holds
+its own copy until Task 3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Rewire QSortEditor.tsx to consume the hook
+
+**Files:**
+- Modify: `frontend/src/components/admin/designer/QSortEditor.tsx`
+
+- [ ] **Step 1: Replace the logic block with the hook call**
+
+In `QSortEditor.tsx`:
+- Add `import { useQSortEditor, type UseQSortEditorResult } from '@/hooks/admin/useQSortEditor';` and import `QSortEditorProps` from the hook if it now owns it (otherwise keep the local interface and pass it to the hook generic — pick whichever keeps types single-sourced and cycle-free; the hook exporting `QSortEditorProps` and the component importing it back is the precedent, W3).
+- Replace the span from `const { t } = useTranslation();` (309) through the last line before `return (` (699) with a single destructured `useQSortEditor(props)` call. Change the component signature to `(props: QSortEditorProps)` and pass `props` straight through; destructure the hook's grouped return into the EXACT identifiers the JSX below already uses (do NOT edit the JSX — alias to it). Bind `sensors` from `dnd` onto the existing `<DndContext sensors={sensors}>`.
+- Delete the now-orphaned moved local types (if they were moved to the hook). Keep `SortableStatementItem` (95–300) exactly as-is.
+
+- [ ] **Step 2: Handle the pre-existing complexity suppression**
+
+The `biome-ignore lint/complexity/noExcessiveCognitiveComplexity` at line ~307 was justified by the inline logic now moved out. After the rewrite the component is mostly declarative JSX:
+- Run `cd frontend && npm run lint`. If lint passes **without** the suppression, delete it (precedent: W2/W3 dropped suppressions no longer needed). If `noExcessiveCognitiveComplexity` still fires on the JSX shell, keep the suppression **on the component shell** with an updated one-line rationale (tabbed JSX shell). **Never** move it into the hook; never add a new suppression of any rule.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd frontend && npm run type-check`
+Expected: exit 0. Fix unused/missing imports until clean (let `tsc -b`/Biome drive; the component should lose the react-query/dnd-sensors/store imports it no longer uses). No `any` introduced.
+
+- [ ] **Step 4: Lint**
+
+Run: `cd frontend && npm run lint`
+Expected: 0 errors. No new `biome-ignore`. (The complexity suppression is either gone or unchanged-on-shell per Step 2.)
+
+- [ ] **Step 5: The cardinal gate — QSortEditor.test.tsx unchanged + green**
+
+Run: `cd frontend && git diff --exit-code src/components/admin/designer/QSortEditor.test.tsx && npx vitest run src/components/admin/designer/QSortEditor.test.tsx 2>&1 | tail -3`
+Expected: `git diff --exit-code` exits 0 (the oracle — existing 17 + Task-1 characterization tests — is byte-UNMODIFIED) AND every test passes (same count as end of Task 1). If the test file had to change to pass, behaviour changed → STOP and escalate; do NOT edit the test.
+
+- [ ] **Step 6: Full suite + consumer**
+
+Run: `cd frontend && npx vitest run 2>&1 | grep -E "Tests " | tail -1`
+Expected: full suite green at the **Task-0 baseline count + Task-1 characterization adds + the 1 Task-2 hook test**. `StudyDesignPage.tsx` unmodified; `tsc -b` (Step 3) already proved its `<QSortEditor … />` call site type-checks against the unchanged `QSortEditorProps`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/admin/designer/QSortEditor.tsx
+git commit -m "refactor(designer): QSortEditor consumes useQSortEditor
+
+Component reduced to JSX shell + SortableStatementItem. Oracle
+(QSortEditor.test.tsx) byte-unchanged and green. Props unchanged;
+StudyDesignPage untouched. No behaviour change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Add the pure-logic hook unit tests
+
+**Files:**
+- Modify: `frontend/src/hooks/admin/useQSortEditor.test.ts`
+
+- [ ] **Step 1: Add ≥4 more pure-logic tests (≥5 total)**
+
+Append `describe` blocks via `renderHook` (mock store/generated per the
+precedent; reuse the Task-2 setup) covering genuine hook-derived behaviour
+(not mock tautologies):
+
+1. **import-format detection** — set `bulk.setBulkText` to a CSV sample then a
+   TSV sample; assert `detectedFormat` updates as the current code derives it.
+2. **reorder index math** — drive `dnd.onDragEnd` with a known
+   active/over id pair; assert the resulting statement order (the same
+   reorder the characterization test asserts at the component level, here at
+   the hook level).
+3. **stale-map derivation** — with the stale query mocked to return ids,
+   assert `data`'s `staleByStatementId` maps exactly those ids.
+4. **edit-state machine** — `editing.begin(index)` then `commit` mutates;
+   `begin` then `cancel` leaves state unchanged.
+5. **import-mode selection** — `bulk.setImportMode('append')` then `runImport`
+   appends (vs `replace` overwrites) on a seeded draft.
+
+Assert real behaviour; if a path can only be expressed as a mock tautology,
+substitute a different genuine pure-logic path and say so.
+
+- [ ] **Step 2: Run the hook test file**
+
+Run: `cd frontend && npx vitest run src/hooks/admin/useQSortEditor.test.ts`
+Expected: ≥5 tests pass.
+
+- [ ] **Step 3: Lint/format**
+
+Run: `cd frontend && npx @biomejs/biome check --write src/hooks/admin/useQSortEditor.test.ts && npx @biomejs/biome check src/hooks/admin/useQSortEditor.test.ts`
+Expected: formatting normalized; 0 errors/0 warnings. Re-run Step 2's vitest to confirm.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/hooks/admin/useQSortEditor.test.ts
+git commit -m "test(designer): cover useQSortEditor pure-logic paths (>=5)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Final verification against the Definition of Done
+
+**Files:** none (verification only; fix inline if a gate fails).
+
+- [ ] **Step 1: Type + build + lint**
+
+Run: `cd frontend && npm run type-check && npm run build && npm run lint 2>&1 | tail -1`
+Expected: `tsc -b` exit 0; `vite build` succeeds; lint 0 errors, no new `biome-ignore`.
+
+- [ ] **Step 2: Oracle byte-unchanged-since-Task-1 + full suite**
+
+Run: `cd frontend && git diff --exit-code $(git rev-parse HEAD~3) -- src/components/admin/designer/QSortEditor.test.tsx; echo "diff-vs-task1-exit:$?" && npx vitest run 2>&1 | grep -E "Test Files|Tests " | tail -2`
+Expected: the test file is identical to its Task-1 committed state (no change in Tasks 2–4 — adjust the rev to the Task-1 commit if `HEAD~3` is not it; the intent: `QSortEditor.test.tsx` unchanged since Task 1). Full suite green at Task-0 baseline + Task-1 characterization adds + ≥5 Task-2/4 hook tests, no regression.
+
+- [ ] **Step 3: Shell shrank; scope discipline**
+
+Run: `wc -l < frontend/src/components/admin/designer/QSortEditor.tsx && git diff chore/code-quality-wave2-studyconfig-typing...HEAD --name-only`
+Expected: `QSortEditor.tsx` decreased ≥300 lines from 1488. Changed files vs the W2 branch = the spec/plan docs + `useQSortEditor.ts` + `useQSortEditor.test.ts` + `QSortEditor.tsx` + `QSortEditor.test.tsx` ONLY. `StudyDesignPage.tsx` NOT in the diff. `QSortEditor.helpers.ts`/`.helpers.test.ts` NOT in the diff. No other wave's files.
+
+- [ ] **Step 4: No `any`, no new suppressions**
+
+Run: `cd frontend && grep -nE ': any|as any|<any>' src/hooks/admin/useQSortEditor.ts src/components/admin/designer/QSortEditor.tsx || echo "no any"` and `git diff chore/code-quality-wave2-studyconfig-typing...HEAD -- src/hooks/admin/useQSortEditor.ts src/components/admin/designer/QSortEditor.tsx | grep '^+' | grep -c "biome-ignore"`
+Expected: "no any"; added-`biome-ignore` count 0 (the pre-existing shell suppression is either deleted or unchanged-in-place — a relocated/kept pre-existing line is not a `+` add unless its rationale text changed; if it changed, confirm it is still on the component shell, never in the hook).
+
+- [ ] **Step 5: Final commit if inline fixes were made**
+
+```bash
+git add -A
+git commit -m "chore(designer): wave-4 DoD fixups
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(Skip if Steps 1–4 were green with no edits.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Characterization-first, committed before any component change → Task 1 (component untouched; Task 2+ are the only component edits). ✓
+- 4 under-covered areas (dnd reorder / concourse sync + stale map / import-mode matrix / inline edit) → Task 1 Step 1 (one `describe` each). ✓
+- Phase-5-G state-hook extraction; `sensors` hook-returned, JSX-bound → Task 2 Step 3 + Task 3 Step 1. ✓
+- `SortableStatementItem` stays; `.helpers.ts` untouched → Task 2 "Do NOT move SortableStatementItem", Task 5 Step 3 asserts helpers not in diff. ✓
+- Illustrative API fixed to real consumed identifiers, no fabrication (W3 lesson) → Task 2 Step 3 explicit interface-build instruction + STOP-on-discrepancy. ✓
+- Oracle (existing 17 + characterization) byte-unchanged through extraction → Task 3 Step 5 `git diff --exit-code`, Task 5 Step 2. ✓
+- ≥5 hook unit tests → Task 4. ✓
+- DoD (type-check/build/lint/suite/≥300-drop/consumer/no-any/no-new-biome-ignore) → Task 5. ✓
+- Pre-existing complexity suppression: keep-on-shell-or-drop, never in hook → Task 3 Step 2. ✓
+- Stacked on W2 branch; diff framed vs W2 → header + Task 5 Step 3. ✓
+
+**Placeholder scan:** The `// ⟶ MOVE` markers are explicit verbatim-relocation directives with exact line anchors (re-transcribing ~385 LOC risks transcription error and violates no-behaviour-change — the W1/W3 reviewers accepted this approach). The interface scaffold's index signatures are a deliberate compile-before-fill device with an explicit "replace each with the real typed fields" instruction — not a TBD. The characterization test bodies are intentionally specified by *behaviour to lock + harness to reuse* rather than literal selectors: characterization tests must be written against the live component's actual DOM, which the engineer reads at implementation time; the exact behaviours to assert (drag-end order, sync mutation call + stale clear, the replace/append/sync results, commit-vs-cancel semantics) are concrete. Genuinely new standalone code (hook test scaffold, hook docstring/signature) is shown in full.
+
+**Type consistency:** `UseQSortEditorResult` group names (`data/bulk/editing/dialogs/actions/dnd`) are identical in Task 2 (definition), Task 2 first test (`dnd.sensors`, `bulk.setBulkText`, `dialogs.importDialogOpen`), Task 3 (destructure), and Task 4 (`bulk.setImportMode`, `dnd.onDragEnd`, `editing.begin`, `data` stale map). `QSortEditorProps` exported from the hook, imported back by the component (W3 precedent, stated in Task 3 Step 1).
+
+**Open note for the reviewer:** the judgement risks are (a) the verbatim move of ~385 LOC of store/query/dnd glue — defended structurally by the byte-unchanged oracle (existing 17 + Task-1 characterization) enforced via `git diff --exit-code`, and (b) the characterization tests genuinely capturing the under-covered behaviours rather than passing trivially. The spec-reviewer should independently confirm the four characterization tests assert real draft/mutation state (not mock tautologies) and that the Task-2 interface ended up fully typed (no residual `Record<string, unknown>`/index-signature escape hatch, no `any`).

--- a/docs/superpowers/plans/2026-05-16-useqsorteditor-wave4.md
+++ b/docs/superpowers/plans/2026-05-16-useqsorteditor-wave4.md
@@ -318,7 +318,17 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 
 In `QSortEditor.tsx`:
 - Add `import { useQSortEditor, type UseQSortEditorResult } from '@/hooks/admin/useQSortEditor';` and import `QSortEditorProps` from the hook if it now owns it (otherwise keep the local interface and pass it to the hook generic — pick whichever keeps types single-sourced and cycle-free; the hook exporting `QSortEditorProps` and the component importing it back is the precedent, W3).
-- Replace the span from `const { t } = useTranslation();` (309) through the last line before `return (` (699) with a single destructured `useQSortEditor(props)` call. Change the component signature to `(props: QSortEditorProps)` and pass `props` straight through; destructure the hook's grouped return into the EXACT identifiers the JSX below already uses (do NOT edit the JSX — alias to it). Bind `sensors` from `dnd` onto the existing `<DndContext sensors={sensors}>`.
+- Replace the span from `const { t } = useTranslation();` (309) through the last line before `return (` (699) with the hook call **plus the re-applied null-guard** (the hook returns `UseQSortEditorResult | null` because the verbatim `if (!draft) return null;` moved into it — directly destructuring a `… | null` fails `tsc -b`). Change the component signature to `(props: QSortEditorProps)` and pass `props` straight through. The replacement is **exactly**:
+  ```tsx
+  const editor = useQSortEditor(props);
+  if (!editor) return null;
+  const { data, bulk, editing, dialogs, actions, dnd } = editor;
+  // then alias the group members to the EXACT identifiers the JSX below
+  // already uses (do NOT edit the JSX — alias to it), e.g.
+  // const { t, draft, grid, statements, … } = data; const { bulkText,
+  // setBulkText, … } = bulk; … etc. — map 1:1 to the hook's typed groups.
+  ```
+  The `if (!editor) return null;` MUST sit here — logically **before** the JSX `return (` — exactly mirroring the parent's `if (!draft) return null;` (was line ~443, before JSX at 699): same condition, same point, behaviour-identical. Do NOT relocate the guard elsewhere or change when null is produced. Bind `sensors` from `dnd` onto the existing `<DndContext sensors={sensors}>` unchanged; bind `handleStatementDragEnd` from `dnd` and keep `SortableContext` items keyed by `s.code` and row textContent stable (T1-oracle dnd test depends on real `arrayMove` + `.code` keying — a behaviour-preserving rewire keeps these; do not alter them).
 - Delete the now-orphaned moved local types (if they were moved to the hook). Keep `SortableStatementItem` (95–300) exactly as-is.
 
 - [ ] **Step 2: Handle the pre-existing complexity suppression**

--- a/docs/superpowers/specs/2026-05-16-useqsorteditor-wave4-design.md
+++ b/docs/superpowers/specs/2026-05-16-useqsorteditor-wave4-design.md
@@ -1,0 +1,158 @@
+# Wave 4 — useQSortEditor extraction — design
+
+**Date:** 2026-05-16
+**Status:** Approved (design)
+**Scope:** Code-quality program, Wave 4 of the audit-waves track.
+
+## Background
+
+The Wave-2 backlog review identified `QSortEditor.tsx` as the deferred
+Wave-3 alternative and the next true monolith after AudioRecorder: 1494 LOC,
+the highest-churn frontend file (55 commits/12mo), `.helpers.ts` (245 LOC pure)
+already extracted but **no state hook**, ~390 LOC of inline logic before the
+JSX `return` (line 699 on the W2 branch).
+
+W4 **stacks on the Wave-2 branch** (`chore/code-quality-wave2-studyconfig-typing`,
+base `0646b64d`): W2 (#178) already modified `QSortEditor.tsx` (StudyConfig
+typing adoption, +19/−25). Extracting the hook from the already-typed file
+avoids a guaranteed merge conflict and is cleaner (moving typed logic, not
+`any`-laden logic). W4's PR slots after #178 in the merge order
+(#177 → #176 → #178 → #179 → W4).
+
+Structure on the W2 branch (1488 LOC):
+- `SortableStatementItem` sub-component (lines 95–300) — already a discrete
+  in-file dnd-kit sortable row (`useSortable`, JSX at 125).
+- `QSortEditor` main component 308 → JSX `return (` at **699**: ~390 LOC of
+  inline logic — `useStudyDesigner()` store, `useQueryClient`, the generated
+  stale-statements query + sync-from-concourse mutation, ~7 `useState`,
+  `staleByStatementId` `useMemo`, 2 `useEffect`s, `useSensors`, and all
+  handlers (bulk import/parse, statement add/edit/delete, translation, grid
+  config, dnd drag-end, concourse-sync).
+- Siblings: `QSortEditor.helpers.ts` (+ `.helpers.test.ts`) — pure logic,
+  already extracted; **untouched** by W4. `QSortEditor.test.tsx` (314 LOC,
+  17 tests, 7 describe blocks).
+- Sole real consumer: `StudyDesignPage.tsx` (`parseCsvTsv.ts:9` is a comment,
+  not an import).
+
+Decisions taken at brainstorm:
+- **Safety net: characterization-first.** Harden the net before extracting.
+- Boundary: state hook only; `SortableStatementItem` stays; helpers untouched.
+
+This is Wave 4; its own spec → plan → impl cycle.
+
+## Goal
+
+Reduce `QSortEditor.tsx` to a JSX shell (+ the discrete `SortableStatementItem`)
+by extracting the ~390 LOC of inline state/store/query/handler logic into
+`frontend/src/hooks/admin/useQSortEditor.ts`, with no behaviour change.
+
+## Architecture & boundary
+
+Phase-5-G hook-extraction (precedents: `useInteractiveDataView` W1,
+`useAudioRecorder` W3 — including the W3 pattern of a hook returning a
+JSX-bound value created by a hook call).
+
+**Moves into `frontend/src/hooks/admin/useQSortEditor.ts`** (main body
+~308–698): `useStudyDesigner()` store subscription, `useQueryClient`, the
+generated stale-statements query and sync-from-concourse mutation, the ~7
+`useState`, the `staleByStatementId` `useMemo`, the 2 `useEffect`s,
+`useSensors(useSensor(PointerSensor…), useSensor(KeyboardSensor…))`, and every
+handler (bulk import/parse, statement add/edit/delete, translation update,
+grid config, dnd drag-end, concourse-sync). `sensors` is **returned** by the
+hook (it is a hook call) and bound by the component as
+`<DndContext sensors={sensors}>` — identical to W3's hook-returned
+`containerRef`; an established precedent, not a novel exception.
+
+**Stays in `QSortEditor.tsx`:** the JSX (699–1488) and the
+`SortableStatementItem` sub-component (95–300, already discrete) — **not
+split** (no cycle forces it; program precedent is not to gratuitously move
+sub-components). `QSortEditor.helpers.ts` is **untouched**.
+
+**Sole consumer** `StudyDesignPage.tsx` — `QSortEditorProps` unchanged, must
+still type-check.
+
+## Hook API
+
+`useQSortEditor(props)` returns a role-grouped, `any`-free object. The shape
+below is **illustrative**; the exact surface is fixed during
+planning/implementation against the identifiers the JSX actually consumes —
+**exposing only what exists, no fabricated handlers** (the W3 lesson: a
+brainstorm-time aspirational API had to be synced to source; W4 bakes that in
+to avoid repeating the defect cycle).
+
+```ts
+{
+  data:    { statements, translations, staleByStatementId, … },
+  bulk:    { bulkText, setBulkText, detectedFormat, importMode,
+             setImportMode, runImport },
+  editing: { editingIndex, editingText, editingCode, begin, commit, cancel },
+  dialogs: { importDialogOpen, setImportDialogOpen, … },
+  actions: { addStatement, deleteStatement, updateTranslation,
+             syncFromConcourse, … },
+  dnd:     { sensors, onDragEnd },   // sensors: hook-created, bound by JSX
+}
+```
+
+Controls are stable `useCallback`s; `dnd.sensors` is the hook-returned
+binding. Every returned identifier maps 1:1 to a real one the JSX consumes.
+
+## Testing
+
+**Phase order is mandatory:**
+
+1. **Characterization first (on the W2-branch baseline, before any component
+   change).** `QSortEditor.test.tsx` (17 tests) covers sub-tab nav, bulk
+   import, statement/translation management, grid, validation — but
+   under-covers the riskiest extraction surfaces. Add characterization tests
+   for: **dnd reorder** (drag-end handler reorders statements); **concourse
+   sync** (the sync mutation flow + `staleByStatementId` stale-query memo);
+   **import-mode matrix** (`detectedFormat` auto-detect × `replace`/`append`/
+   `sync`); **inline edit** (`editingIndex/editingText/editingCode`
+   enter→edit→commit/cancel). These run green against the W2-branch
+   `QSortEditor` first, committed as the first task — locking current
+   behaviour.
+2. **Extraction.**
+3. The existing 17 tests **and** the new characterization tests stay green
+   **unchanged** through the extraction — together they are the
+   behaviour-preservation oracle.
+
+Plus ≥5 pure-logic `useQSortEditor` unit tests (`renderHook`) for the
+testable paths: import-format detection, reorder index math, stale-map
+derivation, edit-state machine, import-mode selection.
+
+## Definition of done
+
+- Characterization tests green on the W2 baseline **before** any
+  `QSortEditor.tsx` change (committed as the first task).
+- `cd frontend && npm run type-check` (`tsc -b`, the real gate — never
+  `tsc --noEmit`) → exit 0.
+- `cd frontend && npm run build` → succeeds.
+- `cd frontend && npm run lint` → 0 errors; **no new `biome-ignore`** (a
+  pre-existing shell-complexity suppression, if present, may remain on the
+  component shell — never inside the hook); no `any`.
+- `cd frontend && npx vitest run` → full suite green; the existing
+  `QSortEditor.test.tsx` **and** the new characterization tests unchanged and
+  green + ≥5 new `useQSortEditor` unit tests.
+- `QSortEditor.tsx` reduced to a JSX shell + `SortableStatementItem` (~390
+  logic LOC moved; expect a ≥300-line decrease).
+- `StudyDesignPage.tsx` untouched and still type-checking; `QSortEditorProps`
+  unchanged.
+- No behaviour change.
+- Branch: W4 stacks on `chore/code-quality-wave2-studyconfig-typing`; its PR
+  diff is framed against that branch (contains W2 commits until #178 merges);
+  PR documents the stack + merge order #178 → W4.
+
+## Non-goals
+
+- Splitting/moving `SortableStatementItem` to a sibling file (no cycle forces
+  it; out of scope).
+- Touching `QSortEditor.helpers.ts` / `.helpers.test.ts` (pure logic, already
+  extracted in a prior phase).
+- Modifying the existing `QSortEditor.test.tsx` (it is part of the
+  behaviour-preservation oracle — if it must change to pass, behaviour
+  changed → stop).
+- Changing `QSortEditorProps` or touching `StudyDesignPage.tsx`.
+- Refactoring the moved logic (verbatim relocation; only the ref/closure
+  wiring needed to live in a hook may change, behaviour-identically).
+- Removing/relocating any pre-existing complexity suppression off the shell.
+- Touching any other wave's files; reworking the dnd UX or the import parser.

--- a/frontend/src/components/admin/designer/QSortEditor.test.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.test.tsx
@@ -1,8 +1,10 @@
-import { screen, within } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { renderWithStore } from '@/test-utils/renderWithStore';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { useStudyDesigner } from '@/store/useStudyDesigner';
+import type { StaleStatementRead, StudyRead } from '@/api/model';
 import QSortEditor from './QSortEditor';
 
 vi.mock('sonner', () => ({
@@ -13,7 +15,42 @@ vi.mock('sonner', () => ({
     },
 }));
 
-// Mock removed
+// --- Concourse-sync harness (W4 oracle) -----------------------------------
+// `vi.mock` is file-hoisted, so it also wraps the existing 17 tests. We spread
+// the real module and override ONLY the three concourse symbols the component
+// imports, driven by mutable holders. The defaults below are behaviourally
+// identical to the real hooks for the existing tests (which never seed
+// `original`, so the stale query is disabled and the mutation never fires):
+// stale query → no data, sync mutation → idle no-op.
+const staleHolder: { data: StaleStatementRead[] | undefined } = { data: undefined };
+const syncMutate = vi.fn();
+const syncMutationHolder: {
+    mutate: typeof syncMutate;
+    isPending: boolean;
+    variables: { slug: string; statementId: number } | undefined;
+} = { mutate: syncMutate, isPending: false, variables: undefined };
+const invalidateQueries = vi.fn();
+
+vi.mock('@/api/generated', async () => {
+    const actual = await vi.importActual<typeof import('@/api/generated')>('@/api/generated');
+    return {
+        ...actual,
+        useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet: () => ({
+            data: staleHolder.data,
+        }),
+        useSyncStatementFromConcourseApiAdminStudiesSlugSyncStatementStatementIdPost: () =>
+            syncMutationHolder,
+    };
+});
+
+vi.mock('@tanstack/react-query', async () => {
+    const actual =
+        await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+    return {
+        ...actual,
+        useQueryClient: () => ({ invalidateQueries }),
+    };
+});
 
 describe('QSortEditor', () => {
     // biome-ignore lint/suspicious/noExplicitAny: convenient partial mock
@@ -311,4 +348,319 @@ describe('QSortEditor', () => {
             expect(screen.getByTestId('grid-column-4-slots').children).toHaveLength(1);
         });
     });
+});
+
+// ===========================================================================
+// W4 characterization oracle — locks current behaviour of the four
+// under-covered areas on the W2 baseline BEFORE the useQSortEditor extraction.
+// These assert whatever the UNCHANGED component does today (even if odd); the
+// point is to detect any drift introduced by the later hook relocation.
+// ===========================================================================
+
+// Shared seed mirroring the existing describe blocks' `mockDraft`.
+// biome-ignore lint/suspicious/noExplicitAny: convenient partial mock (mirrors existing tests)
+const seedDraft: any = {
+    slug: 'test-study',
+    state: 'draft',
+    statements: [
+        { code: 's1', translations: [{ language_code: 'en', text: 'Existing Statement' }] },
+    ],
+    grid_config: [
+        { score: -2, capacity: 2 },
+        { score: -1, capacity: 3 },
+        { score: 0, capacity: 4 },
+        { score: 1, capacity: 3 },
+        { score: 2, capacity: 2 },
+    ],
+    translations: [{ language_code: 'en' }, { language_code: 'fr' }],
+};
+
+const readCodes = () => (useStudyDesigner.getState().draft?.statements ?? []).map((s) => s.code);
+const readTexts = () =>
+    (useStudyDesigner.getState().draft?.statements ?? []).map(
+        (s) => s.translations?.find((tr) => tr.language_code === 'en')?.text ?? ''
+    );
+
+beforeEach(() => {
+    staleHolder.data = undefined;
+    syncMutationHolder.isPending = false;
+    syncMutationHolder.variables = undefined;
+    syncMutate.mockReset();
+    invalidateQueries.mockReset();
+});
+
+describe('Characterization — dnd reorder (W4 oracle)', () => {
+    const origRect = Element.prototype.getBoundingClientRect;
+
+    afterEach(() => {
+        Element.prototype.getBoundingClientRect = origRect;
+    });
+
+    it('reordering statements via drag-end updates draft order', async () => {
+        // dnd-kit's KeyboardSensor needs real layout rects; jsdom returns
+        // all-zero, which silently no-ops the reorder. Stub stable per-row
+        // rects keyed off the row text so the keyboard sensor can resolve a
+        // valid `over` and the REAL handleStatementDragEnd (arrayMove +
+        // updateDraft) fires. Nothing in the component is mocked.
+        Element.prototype.getBoundingClientRect = function (this: Element) {
+            const txt = (this as HTMLElement).textContent ?? '';
+            let row = 0;
+            if (txt.includes('Beta') && !txt.includes('Alpha')) row = 1;
+            if (txt.includes('Gamma') && !txt.includes('Alpha')) row = 2;
+            const top = row * 100;
+            return {
+                x: 0,
+                y: top,
+                top,
+                left: 0,
+                bottom: top + 40,
+                right: 100,
+                width: 100,
+                height: 40,
+                toJSON() {},
+            } as DOMRect;
+        };
+
+        const user = userEvent.setup();
+        renderWithStore(
+            <TooltipProvider>
+                <QSortEditor />
+            </TooltipProvider>,
+            {
+                initialState: {
+                    draft: {
+                        ...seedDraft,
+                        statements: [
+                            {
+                                code: 's1',
+                                translations: [{ language_code: 'en', text: 'Alpha' }],
+                            },
+                            {
+                                code: 's2',
+                                translations: [{ language_code: 'en', text: 'Beta' }],
+                            },
+                            {
+                                code: 's3',
+                                translations: [{ language_code: 'en', text: 'Gamma' }],
+                            },
+                        ],
+                    },
+                    activeLocale: 'en',
+                    activeSubStep: 'statements',
+                },
+            }
+        );
+
+        expect(readCodes()).toEqual(['s1', 's2', 's3']);
+
+        const handles = document.querySelectorAll('[aria-roledescription="sortable"]');
+        expect(handles).toHaveLength(3);
+        (handles[0] as HTMLElement).focus();
+
+        // Pick up s1 (Space), move down two rows, drop (Space). Current
+        // handler does arrayMove(statements, 0, 2) → s1 lands last.
+        await user.keyboard('{ }{ArrowDown}{ArrowDown}{ }');
+
+        await waitFor(() => {
+            expect(readCodes()).toEqual(['s2', 's3', 's1']);
+        });
+        // Texts travel with their statement object (order, not identity, moved).
+        expect(readTexts()).toEqual(['Beta', 'Gamma', 'Alpha']);
+    }, 15000);
+});
+
+describe('Characterization — concourse sync + stale map (W4 oracle)', () => {
+    it('syncing a stale statement calls the sync mutation and clears its stale flag', async () => {
+        const user = userEvent.setup();
+
+        // Seed `original.statements` with a concourse-linked entry so the
+        // component's hasLinkedStatements gate is true; the (mocked) stale
+        // query reports statement id 42 as stale → staleByStatementId has it
+        // → the per-row "Update" sync button renders.
+        staleHolder.data = [
+            {
+                statement_id: 42,
+                statement_code: 's1',
+                source_concourse_item_id: 7,
+                source_deleted: false,
+                current_translations: [{ language_code: 'en', text: 'Existing Statement' }],
+                concourse_translations: [{ language_code: 'en', text: 'Fresher concourse text' }],
+            },
+        ];
+        // Drive the real onSuccess path: invalidateQueries + toast.success.
+        syncMutate.mockImplementation(
+            (_vars: { slug: string; statementId: number }, opts?: { onSuccess?: () => void }) => {
+                opts?.onSuccess?.();
+            }
+        );
+
+        renderWithStore(
+            <TooltipProvider>
+                <QSortEditor />
+            </TooltipProvider>,
+            {
+                initialState: {
+                    draft: {
+                        ...seedDraft,
+                        statements: [
+                            {
+                                id: 42,
+                                code: 's1',
+                                source_concourse_item_id: 7,
+                                translations: [{ language_code: 'en', text: 'Existing Statement' }],
+                            },
+                        ],
+                    },
+                    original: {
+                        slug: 'test-study',
+                        statements: [{ id: 42, source_concourse_item_id: 7 }],
+                    } as unknown as StudyRead,
+                    activeLocale: 'en',
+                    activeSubStep: 'statements',
+                },
+            }
+        );
+
+        // Stale banner appears (staleByStatementId.size > 0).
+        expect(
+            screen.getByText(/statement\(s\) have updates available from the concourse/i)
+        ).toBeInTheDocument();
+
+        const syncButton = screen.getByRole('button', { name: 'Update' });
+        await user.click(syncButton);
+
+        // The mutation is invoked with the exact {slug, statementId} the
+        // current handler passes — not a mock tautology: we assert the args
+        // the component computed from original.slug + statement.id.
+        expect(syncMutate).toHaveBeenCalledTimes(1);
+        expect(syncMutate.mock.calls[0][0]).toEqual({ slug: 'test-study', statementId: 42 });
+
+        // onSuccess wiring the current code runs: query invalidation fires.
+        await waitFor(() => {
+            expect(invalidateQueries).toHaveBeenCalledTimes(1);
+        });
+    });
+});
+
+describe('Characterization — import-mode matrix (W4 oracle)', () => {
+    it.each([
+        'replace',
+        'append',
+        'sync',
+    ] as const)('bulk import in %s mode produces the current draft.statements result', async (mode) => {
+        const user = userEvent.setup();
+        renderWithStore(
+            <TooltipProvider>
+                <QSortEditor />
+            </TooltipProvider>,
+            {
+                initialState: {
+                    draft: { ...seedDraft },
+                    activeLocale: 'en',
+                    activeSubStep: 'statements',
+                },
+            }
+        );
+
+        // Select the import mode (default radio is 'replace').
+        if (mode === 'append') {
+            await user.click(screen.getByLabelText('Append to list'));
+        } else if (mode === 'sync') {
+            await user.click(screen.getByLabelText('Sync/Merge by code'));
+        }
+
+        // "list" format: `code: text` per line (detectedFormat → list).
+        // Line 1 reuses the existing code s1; line 2 is a new code s5.
+        const textarea = screen.getByPlaceholderText(/Simple:/i);
+        await user.type(textarea, 's1: Synced One\ns5: Fresh One');
+
+        const processButton = screen.getByRole('button', {
+            name:
+                mode === 'replace'
+                    ? 'Process & replace statements'
+                    : mode === 'append'
+                      ? 'Process & append statements'
+                      : 'Process & sync translations',
+        });
+        await user.click(processButton);
+
+        await waitFor(() => {
+            if (mode === 'replace') {
+                // Replace wipes the list, then both lines become new
+                // statements keyed by their parsed code.
+                expect(readCodes()).toEqual(['s1', 's5']);
+                expect(readTexts()).toEqual(['Synced One', 'Fresh One']);
+            } else if (mode === 'append') {
+                // Append keeps the original s1 ("Existing Statement"),
+                // then pushes BOTH parsed items as new entries — even the
+                // one whose code (s1) duplicates an existing code. The
+                // current merge only de-dupes by code in sync mode, so
+                // append yields a duplicate s1. Snapshot that.
+                expect(readCodes()).toEqual(['s1', 's1', 's5']);
+                expect(readTexts()).toEqual(['Existing Statement', 'Synced One', 'Fresh One']);
+            } else {
+                // Sync matches the existing s1 by code and overwrites its
+                // active-locale text in place; s5 has no match → appended.
+                expect(readCodes()).toEqual(['s1', 's5']);
+                expect(readTexts()).toEqual(['Synced One', 'Fresh One']);
+            }
+        });
+    }, 15000);
+});
+
+describe('Characterization — inline statement edit (W4 oracle)', () => {
+    it('enter→edit→commit updates the statement; cancel discards', async () => {
+        const user = userEvent.setup();
+        renderWithStore(
+            <TooltipProvider>
+                <QSortEditor />
+            </TooltipProvider>,
+            {
+                initialState: {
+                    draft: { ...seedDraft },
+                    activeLocale: 'en',
+                    activeSubStep: 'statements',
+                },
+            }
+        );
+
+        // --- commit path ---
+        await user.click(screen.getByText('Existing Statement'));
+
+        const textInput = screen.getByDisplayValue('Existing Statement');
+        const codeInput = screen.getByDisplayValue('s1');
+        await user.clear(textInput);
+        await user.type(textInput, 'Edited Text');
+        await user.clear(codeInput);
+        await user.type(codeInput, 's99');
+
+        // Enter inside the text input commits (handleSaveStatement).
+        await user.type(textInput, '{Enter}');
+
+        await waitFor(() => {
+            expect(readCodes()).toEqual(['s99']);
+            expect(readTexts()).toEqual(['Edited Text']);
+        });
+        expect(screen.getByText('Edited Text')).toBeInTheDocument();
+
+        // --- cancel path ---
+        await user.click(screen.getByText('Edited Text'));
+        const textInput2 = screen.getByDisplayValue('Edited Text');
+        const codeInput2 = screen.getByDisplayValue('s99');
+        await user.clear(textInput2);
+        await user.type(textInput2, 'Should Not Persist');
+        await user.clear(codeInput2);
+        await user.type(codeInput2, 'sX');
+
+        // Escape inside the text input cancels (setEditingIndex(null)),
+        // discarding the edits — draft is untouched.
+        await user.type(textInput2, '{Escape}');
+
+        await waitFor(() => {
+            expect(screen.getByText('Edited Text')).toBeInTheDocument();
+        });
+        expect(readCodes()).toEqual(['s99']);
+        expect(readTexts()).toEqual(['Edited Text']);
+        expect(screen.queryByText('Should Not Persist')).not.toBeInTheDocument();
+    }, 15000);
 });

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -1,9 +1,5 @@
-import { useState, useEffect, useMemo } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import { useStudyDesigner } from '@/store/useStudyDesigner';
 import type { StudyTranslationCreate } from '@/api/model';
 import { toast } from 'sonner';
-import { parseCsvTsv } from '@/utils/parseCsvTsv';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -32,49 +28,21 @@ import { Switch } from '@/components/ui/switch';
 import { useTranslation } from 'react-i18next';
 import { MultiLangFieldIcon } from './MultiLangFieldIcon';
 import { ImportFromConcourseDialog } from './ImportFromConcourseDialog';
-import {
-    applyCapacityDelta,
-    computeAutoShapedCapacities,
-    mergeParsedItemIntoStatements,
-} from './QSortEditor.helpers';
-import {
-    getGetStudyApiAdminStudiesSlugGetQueryKey,
-    useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet,
-    useSyncStatementFromConcourseApiAdminStudiesSlugSyncStatementStatementIdPost,
-} from '@/api/generated';
-import {
-    DndContext,
-    closestCenter,
-    KeyboardSensor,
-    PointerSensor,
-    useSensor,
-    useSensors,
-    type DragEndEvent,
-} from '@dnd-kit/core';
-import {
-    arrayMove,
-    SortableContext,
-    sortableKeyboardCoordinates,
-    verticalListSortingStrategy,
-    useSortable,
-} from '@dnd-kit/sortable';
+import { DndContext, closestCenter } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-import type { StatementRead, StatementTranslationRead, GridColumn, StudyUpdate } from '@/api/model';
-
-// Define basic types for clarity
-type Statement = StatementRead;
-type Translation = StatementTranslationRead;
-
-interface StaleInfo {
-    concourse_translations: { language_code: string; text: string }[];
-    source_deleted: boolean;
-}
+import type { StatementRead, StudyUpdate } from '@/api/model';
+import {
+    useQSortEditor,
+    type QSortEditorProps,
+    type StaleInfo,
+} from '@/hooks/admin/useQSortEditor';
 
 interface SortableStatementItemProps {
     item: { code: string; text: string };
     idx: number;
-    statement: Statement;
+    statement: StatementRead;
     isEditing: boolean;
     editingCode: string;
     editingText: string;
@@ -299,402 +267,56 @@ function SortableStatementItem({
 
 // CSV/TSV parsing moved to @/utils/parseCsvTsv (shared with ConcourseDetailPage).
 
-interface QSortEditorProps {
-    readOnly?: boolean;
-    structureLocked?: boolean;
-}
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5/W4 — logic extracted to useQSortEditor; what remains is the large declarative tabbed JSX shell (statements + grid tabs, nested conditional rendering). The conditional JSX IS the surface; no extractable algorithmic logic remains.
+const QSortEditor = (props: QSortEditorProps) => {
+    const editor = useQSortEditor(props);
+    if (!editor) return null;
+    const { data, bulk, editing, dialogs, actions, dnd } = editor;
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — page-level orchestrator (6 useEffects, multiple inline handlers, tabbed JSX shell). Pure-logic extractions done by W3b T1-T3 (autoShape / mergeParsedItem / applyCapacityDelta); what remains is glue.
-const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
-    const { t } = useTranslation();
-    const { draft, original, activeLocale, updateDraft, activeSubStep, setActiveSubStep } =
-        useStudyDesigner();
-    const [importDialogOpen, setImportDialogOpen] = useState(false);
-    const queryClient = useQueryClient();
-
-    // Concourse traceability: check for stale statements
-    const hasLinkedStatements = original?.statements?.some(
-        (s) => s.source_concourse_item_id != null
-    );
-    const { data: staleData } = useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet(
-        original?.slug ?? '',
-        {
-            query: {
-                enabled: !!original?.slug && !!hasLinkedStatements,
-                refetchInterval: 30_000,
-            },
-        }
-    );
-    const staleByStatementId = useMemo(
-        () =>
-            new Map<number, StaleInfo>(
-                staleData?.map((s) => [
-                    s.statement_id,
-                    {
-                        concourse_translations: s.concourse_translations,
-                        source_deleted: s.source_deleted,
-                    },
-                ]) ?? []
-            ),
-        [staleData]
-    );
-
-    const syncMutation =
-        useSyncStatementFromConcourseApiAdminStudiesSlugSyncStatementStatementIdPost();
-
-    const handleSyncStatement = (statementId: number) => {
-        if (!original?.slug) return;
-        syncMutation.mutate(
-            { slug: original.slug, statementId },
-            {
-                onSuccess: () => {
-                    queryClient.invalidateQueries({
-                        queryKey: getGetStudyApiAdminStudiesSlugGetQueryKey(original.slug),
-                    });
-                    toast.success(
-                        t('admin.concourse_sync.synced', 'Statement updated from concourse')
-                    );
-                },
-                onError: () => {
-                    toast.error(
-                        t(
-                            'admin.concourse_sync.error',
-                            'Could not sync from the concourse. Try again.'
-                        )
-                    );
-                },
-            }
-        );
-    };
-
-    const [bulkText, setBulkText] = useState('');
-    const [detectedFormat, setDetectedFormat] = useState<{
-        type: 'excel' | 'list' | 'simple' | null;
-        langs: string[];
-        hasCode: boolean;
-    }>({ type: null, langs: [], hasCode: false });
-
-    // Alias to keep existing logic working
-    const activeSubTab = (activeSubStep as 'statements' | 'grid') || 'statements';
-
-    // Helper to update store
-    const setActiveSubTab = (v: 'statements' | 'grid') => setActiveSubStep(v);
-
-    // Auto-detect format on change
-    useEffect(() => {
-        if (!bulkText.trim()) {
-            setDetectedFormat({ type: null, langs: [], hasCode: false });
-            return;
-        }
-
-        const lines = bulkText.split('\n').filter((l) => l.trim() !== '');
-        const firstLine = lines[0];
-        if (!firstLine) {
-            setDetectedFormat({ type: null, langs: [], hasCode: false });
-            return;
-        }
-
-        if (firstLine.includes('\t')) {
-            const cells = firstLine.split('\t').map((c) => c.trim().toLowerCase());
-            const langs = cells.filter((c) =>
-                draft?.translations?.some((tr) => tr.language_code === c)
-            );
-            setDetectedFormat({
-                type: 'excel',
-                langs,
-                hasCode: cells.includes('code'),
-            });
-        } else if (lines.some((l) => /^([a-zA-Z0-9_-]{1,15})\s*[:,-]\s+/.test(l))) {
-            setDetectedFormat({ type: 'list', langs: [], hasCode: true });
-        } else {
-            setDetectedFormat({ type: 'simple', langs: [], hasCode: false });
-        }
-    }, [bulkText, draft?.translations]);
-
-    // Auto-initialize grid if empty (-4 to +4) with bell curve (total 34)
-    useEffect(() => {
-        if (draft && (!draft.grid_config || draft.grid_config.length === 0)) {
-            updateDraft((d) => {
-                d.grid_config = [
-                    { score: -4, capacity: 2 },
-                    { score: -3, capacity: 3 },
-                    { score: -2, capacity: 4 },
-                    { score: -1, capacity: 5 },
-                    { score: 0, capacity: 6 },
-                    { score: 1, capacity: 5 },
-                    { score: 2, capacity: 4 },
-                    { score: 3, capacity: 3 },
-                    { score: 4, capacity: 2 },
-                ];
-            });
-        }
-    }, [draft, updateDraft]);
-
-    const [importMode, setImportMode] = useState<'replace' | 'append' | 'sync'>('replace');
-    const [editingIndex, setEditingIndex] = useState<number | null>(null);
-    const [editingText, setEditingText] = useState('');
-    const [editingCode, setEditingCode] = useState('');
-
-    const sensors = useSensors(
-        useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-    );
-
-    if (!draft) return null;
-
-    // --- Statements Logic ---
-    const statements: Statement[] = (draft.statements || []) as Statement[];
-    const localizedStatements = statements.map((s: Statement) => {
-        const t = (s.translations as Translation[])?.find(
-            (st: Translation) => st.language_code === activeLocale
-        );
-        return { code: s.code, text: t?.text || '' };
-    });
-
-    const handleStatementDragEnd = (event: DragEndEvent) => {
-        const { active, over } = event;
-        if (over && active.id !== over.id) {
-            const oldIndex = localizedStatements.findIndex((s) => s.code === active.id);
-            const newIndex = localizedStatements.findIndex((s) => s.code === over.id);
-            updateDraft((d) => {
-                if (d.statements) {
-                    d.statements = arrayMove(d.statements, oldIndex, newIndex);
-                }
-            });
-        }
-    };
-
-    const handleBulkSave = () => {
-        if (!bulkText.trim()) return;
-
-        type ParsedItem = {
-            code?: string | null;
-            text?: string;
-            translations?: { language_code: string; text: string }[];
-        };
-        let parsedItems: ParsedItem[] = [];
-
-        if (detectedFormat.type === 'excel') {
-            const rows = parseCsvTsv(bulkText, '\t');
-            const headerRow = rows[0];
-            if (!headerRow) return;
-
-            const headers = headerRow.map((h) => h.toLowerCase());
-            const hasCodeHeader = headers.includes('code');
-            const langHeaders = headers.filter((h) =>
-                draft.translations?.some((t) => t.language_code === h)
-            );
-
-            if (hasCodeHeader || langHeaders.length > 0) {
-                // EXCEL HEADER MODE
-                parsedItems = rows.slice(1).map((cells) => {
-                    const item: ParsedItem = { translations: [] };
-                    if (hasCodeHeader) {
-                        item.code = cells[headers.indexOf('code')]?.trim();
-                    }
-                    langHeaders.forEach((lang) => {
-                        const cellIdx = headers.indexOf(lang);
-                        if (cellIdx !== -1 && cells[cellIdx] !== undefined && item.translations) {
-                            item.translations.push({ language_code: lang, text: cells[cellIdx] });
-                        }
-                    });
-                    return item;
-                });
-            } else {
-                // EXCEL SIMPLE MODE (No headers but has tabs)
-                parsedItems = rows.map((cells) => {
-                    return {
-                        code: cells[0]?.trim(),
-                        text: cells.slice(1).join(' ').trim(),
-                    };
-                });
-            }
-        } else {
-            // CLASSIC MODE (One per line)
-            const lines = bulkText
-                .split('\n')
-                .map((l) => l.trim())
-                .filter((l) => l !== '');
-            parsedItems = lines.map((line) => {
-                // Check for CSV-like with quotes: "Code","Text"
-                const csvMatch = line.match(/^"([^"]+)"\s*,\s*"(.+)"$/);
-                if (csvMatch) {
-                    return { code: csvMatch[1], text: csvMatch[2] };
-                }
-
-                // Regex for common separators: "Code: Text" or "Code, Text" or "Code - Text"
-                const match = line.match(/^([a-zA-Z0-9_-]{1,15})\s*[:,-]\s+(.+)$/);
-                if (match?.[1] && match[2]) {
-                    return { code: match[1], text: match[2].trim() };
-                }
-
-                // Fallback: remove leading numbering "1. ", "1) "
-                return { code: null, text: line.replace(/^\d+[.)\-\s]+/, '').trim() };
-            });
-        }
-
-        updateDraft((d) => {
-            if (importMode === 'replace') {
-                d.statements = [];
-            }
-            const currentStatements = d.statements || [];
-            const draftLangs = (d.translations || []) as { language_code: string }[];
-            for (const item of parsedItems) {
-                mergeParsedItemIntoStatements(
-                    item,
-                    currentStatements,
-                    draftLangs,
-                    importMode,
-                    activeLocale
-                );
-            }
-            d.statements = currentStatements;
-        });
-
-        setBulkText('');
-        toast.success(t('admin.design.qsort.set.imported', { count: parsedItems.length }));
-    };
-
-    const handleClearAll = () => {
-        if (confirm(t('admin.design.qsort.set.confirm_clear'))) {
-            updateDraft((d) => {
-                d.statements = [];
-            });
-            toast.info(t('admin.design.qsort.set.cleared'));
-        }
-    };
-
-    const grid = (draft.grid_config || []) as GridColumn[];
-    const totalSlots = grid.reduce((acc: number, col: GridColumn) => acc + (col.capacity || 0), 0);
-    const totalStatements = statements.length;
-    const isValid = totalSlots === totalStatements;
-
-    const isSymmetric =
-        grid.length > 0 &&
-        grid.every((col, idx) => {
-            const opposite = grid[grid.length - 1 - idx];
-            return col.capacity === opposite?.capacity;
-        });
-
-    const isBellShaped =
-        isSymmetric &&
-        grid.length >= 5 &&
-        (() => {
-            const centerIdx = Math.floor(grid.length / 2);
-            for (let i = 0; i < centerIdx; i++) {
-                if ((grid[i]?.capacity || 0) > (grid[i + 1]?.capacity || 0)) return false;
-            }
-            return true;
-        })();
-
-    const updateGridCapacity = (idx: number, delta: number) => {
-        updateDraft((d) => {
-            if (!d.grid_config) return;
-            applyCapacityDelta(d.grid_config, idx, delta, d.symmetry_lock ?? true);
-        });
-    };
-
-    const addExtremeColumns = () => {
-        updateDraft((d) => {
-            if (!d.grid_config || d.grid_config.length === 0) {
-                // Default -4 to +4 if empty
-                d.grid_config = [
-                    { score: -4, capacity: 2 },
-                    { score: -3, capacity: 3 },
-                    { score: -2, capacity: 4 },
-                    { score: -1, capacity: 5 },
-                    { score: 0, capacity: 6 },
-                    { score: 1, capacity: 5 },
-                    { score: 2, capacity: 4 },
-                    { score: 3, capacity: 3 },
-                    { score: 4, capacity: 2 },
-                ];
-                return;
-            }
-            const scores = d.grid_config.map((c: GridColumn) => c.score);
-            const minScore = Math.min(...scores);
-            const maxScore = Math.max(...scores);
-
-            if (minScore <= -6 || maxScore >= 6) {
-                toast.error(t('admin.design.qsort.grid.max_reached', 'Maximum range reached (±6)'));
-                return;
-            }
-
-            d.grid_config.unshift({ score: minScore - 1, capacity: 1 });
-            d.grid_config.push({ score: maxScore + 1, capacity: 1 });
-        });
-    };
-
-    const removeExtremeColumns = () => {
-        updateDraft((d) => {
-            if (!d.grid_config || d.grid_config.length <= 5) {
-                toast.error(t('admin.design.qsort.grid.min_reached', 'Minimum range reached (±2)'));
-                return;
-            }
-            d.grid_config.shift();
-            d.grid_config.pop();
-        });
-    };
-
-    const autoShapeGrid = () => {
-        if (totalStatements === 0) {
-            toast.error(
-                t(
-                    'admin.design.qsort.grid.no_statements',
-                    'Add statements first to auto-shape the grid'
-                )
-            );
-            return;
-        }
-
-        updateDraft((d) => {
-            if (!d.grid_config || d.grid_config.length === 0) return;
-
-            const newCapacities = computeAutoShapedCapacities(
-                totalStatements,
-                d.grid_config.length
-            );
-
-            for (let i = 0; i < newCapacities.length; i++) {
-                const col = d.grid_config[i];
-                const cap = newCapacities[i];
-                if (col && cap !== undefined) {
-                    col.capacity = cap;
-                }
-            }
-        });
-        toast.success(
-            t('admin.design.qsort.grid.balanced', 'Grid balanced to standard distribution')
-        );
-    };
-
-    const handleSaveStatement = () => {
-        updateDraft((d) => {
-            const statement = d.statements?.[editingIndex as number];
-            if (statement) {
-                // Update code
-                statement.code = editingCode;
-
-                const translation = statement.translations?.find(
-                    (t) => t.language_code === activeLocale
-                );
-                if (translation) {
-                    translation.text = editingText;
-                }
-            }
-        });
-        setEditingIndex(null);
-        toast.success(t('admin.design.qsort.set.updated'));
-    };
-
-    const handleImported = () => {
-        // Invalidate study query so the design page re-fetches with new statements
-        if (original?.slug) {
-            queryClient.invalidateQueries({
-                queryKey: getGetStudyApiAdminStudiesSlugGetQueryKey(original.slug),
-            });
-        }
-    };
+    // Alias the role-grouped surface to the exact identifiers the JSX uses.
+    const {
+        t,
+        readOnly,
+        structureLocked,
+        draft,
+        original,
+        activeLocale,
+        activeSubTab,
+        statements,
+        localizedStatements,
+        staleByStatementId,
+        grid,
+        totalSlots,
+        totalStatements,
+        isValid,
+        isSymmetric,
+        isBellShaped,
+    } = data;
+    const { bulkText, setBulkText, importMode, setImportMode, detectedFormat, handleBulkSave } =
+        bulk;
+    const {
+        editingIndex,
+        editingText,
+        editingCode,
+        setEditingIndex,
+        setEditingText,
+        setEditingCode,
+        handleSaveStatement,
+    } = editing;
+    const { importDialogOpen, setImportDialogOpen } = dialogs;
+    const {
+        setActiveSubTab,
+        updateDraft,
+        handleClearAll,
+        handleSyncStatement,
+        syncMutation,
+        updateGridCapacity,
+        addExtremeColumns,
+        removeExtremeColumns,
+        autoShapeGrid,
+        handleImported,
+    } = actions;
+    const { sensors, handleStatementDragEnd } = dnd;
 
     return (
         <>

--- a/frontend/src/hooks/admin/useQSortEditor.test.ts
+++ b/frontend/src/hooks/admin/useQSortEditor.test.ts
@@ -137,8 +137,8 @@ describe('useQSortEditor — import-format detection', () => {
             expect(result.current?.bulk.detectedFormat.type).toBe('excel');
         });
         expect(result.current.bulk.detectedFormat.hasCode).toBe(true);
-        // 'en' matches draft.translations language_code → found in langs
-        expect(result.current.bulk.detectedFormat.langs).toContain('en');
+        // seedDraft has only 'en' in translations → langs is exactly ['en']
+        expect(result.current.bulk.detectedFormat.langs).toEqual(['en']);
     });
 
     it('clears detectedFormat when bulkText is emptied', async () => {
@@ -296,14 +296,15 @@ describe('useQSortEditor — edit-state machine', () => {
 });
 
 // ── 5. Import-mode selection — append ────────────────────────────────────────
-// Faithfully reflects the W4-oracle-locked quirk: in 'append' mode the hook
-// calls `mergeParsedItemIntoStatements` with importMode='append', which always
-// pushes a new entry (de-dup is sync-only). If the draft already has code 's1'
-// and we append a new statement without an explicit code, a new entry is pushed
-// (code auto-assigned as `s${n+1}`). We assert the count increased and the
-// original entry is still present — NOT ideal de-dup.
+// Reproduces the W4-oracle-locked duplicate-code quirk at hook level (mirrors
+// QSortEditor.test.tsx characterization case). In 'append' mode the hook calls
+// `mergeParsedItemIntoStatements` with importMode='append', which always pushes
+// a new entry (de-dup is sync-only). Feeding an explicitly-coded input whose
+// code ('s1') matches the existing statement yields a duplicate 's1' entry.
+// The oracle (QSortEditor.test.tsx) snapshots ['s1','s1','s5'] for this input;
+// we assert the same result at hook level.
 describe('useQSortEditor — import-mode selection (append)', () => {
-    it('append mode pushes new statements without replacing existing ones', async () => {
+    it('append mode with explicit existing code produces duplicate code (oracle-locked quirk)', async () => {
         const { result } = renderHook(() => useQSortEditor({}));
         if (!result.current) throw new Error('hook returned null with a seeded draft');
 
@@ -315,26 +316,25 @@ describe('useQSortEditor — import-mode selection (append)', () => {
         });
         expect(result.current.bulk.importMode).toBe('append');
 
-        // Set simple-list bulk text (2 new statements)
+        // List-format input with explicit codes: 's1' duplicates the existing entry,
+        // 's5' is new. This mirrors the exact oracle input in QSortEditor.test.tsx.
         act(() => {
-            result.current?.bulk.setBulkText('New statement one\nNew statement two');
+            result.current?.bulk.setBulkText('s1: Synced One\ns5: Fresh One');
         });
 
-        // Wait for format detection to settle (simple)
-        await waitFor(() => expect(result.current?.bulk.detectedFormat.type).toBe('simple'));
+        // Wait for format detection to settle (list)
+        await waitFor(() => expect(result.current?.bulk.detectedFormat.type).toBe('list'));
 
         // Run bulk save
         act(() => {
             result.current?.bulk.handleBulkSave();
         });
 
-        // After append: original 1 + 2 new = 3 statements
+        // Oracle-locked quirk: append pushes both parsed items regardless of code
+        // collision — de-dup is sync-only. Result: original s1 + appended s1 + s5.
         const afterStatements = useStudyDesigner.getState().draft?.statements;
-        expect(afterStatements).toHaveLength(3);
-
-        // Original 's1' entry still present (append did not replace)
         const codes = afterStatements?.map((s) => (s as { code: string }).code);
-        expect(codes).toContain('s1');
+        expect(codes).toEqual(['s1', 's1', 's5']);
 
         // bulkText cleared after save
         expect(result.current.bulk.bulkText).toBe('');

--- a/frontend/src/hooks/admin/useQSortEditor.test.ts
+++ b/frontend/src/hooks/admin/useQSortEditor.test.ts
@@ -10,10 +10,12 @@
  * (existing 17 + W4 characterization tests = the oracle).
  */
 
-import { renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { StudyUpdate } from '@/api/model';
+import type { StudyRead, StudyUpdate } from '@/api/model';
 import { useStudyDesigner } from '@/store/useStudyDesigner';
+import { arrayMove } from '@dnd-kit/sortable';
+import type { DragEndEvent } from '@dnd-kit/core';
 
 vi.mock('react-i18next', () => ({
     useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
@@ -65,6 +67,21 @@ const seedDraft: StudyUpdate = {
     translations: [{ language_code: 'en' }],
 } as unknown as StudyUpdate;
 
+/** Three-statement draft used in reorder + import tests */
+const multiDraft: StudyUpdate = {
+    statements: [
+        { code: 'a', translations: [{ language_code: 'en', text: 'Alpha' }] },
+        { code: 'b', translations: [{ language_code: 'en', text: 'Beta' }] },
+        { code: 'c', translations: [{ language_code: 'en', text: 'Gamma' }] },
+    ],
+    grid_config: [
+        { score: -1, capacity: 1 },
+        { score: 0, capacity: 1 },
+        { score: 1, capacity: 1 },
+    ],
+    translations: [{ language_code: 'en' }],
+} as unknown as StudyUpdate;
+
 beforeEach(() => {
     vi.clearAllMocks();
     mockStaleQuery.mockReturnValue({ data: undefined });
@@ -88,5 +105,238 @@ describe('useQSortEditor — initial shape', () => {
         expect(result.current.dnd.sensors).toBeDefined();
         expect(typeof result.current.bulk.setBulkText).toBe('function');
         expect(result.current.dialogs.importDialogOpen).toBe(false);
+    });
+});
+
+// ── 1. Import-format detection ────────────────────────────────────────────────
+// Drives `setBulkText` with a CSV-like "list" line and then a TSV header line;
+// asserts that `detectedFormat` updates as the useEffect derives it from the
+// text content (pure derived state — no mock tautology).
+describe('useQSortEditor — import-format detection', () => {
+    it('detects "list" format from code:text pattern, then "excel" from TSV header', async () => {
+        const { result } = renderHook(() => useQSortEditor({}));
+        if (!result.current) throw new Error('hook returned null with a seeded draft');
+
+        // Initially format is null
+        expect(result.current.bulk.detectedFormat.type).toBeNull();
+
+        // Set a "list" sample — matches /^([a-zA-Z0-9_-]{1,15})\s*[:,-]\s+/
+        act(() => {
+            result.current?.bulk.setBulkText('s1: This is a statement\ns2: Another statement');
+        });
+        await waitFor(() => {
+            expect(result.current?.bulk.detectedFormat.type).toBe('list');
+        });
+        expect(result.current.bulk.detectedFormat.hasCode).toBe(true);
+
+        // Now set a TSV header sample — first line contains tab + 'code' + 'en'
+        act(() => {
+            result.current?.bulk.setBulkText('code\ten\ns1\tFirst statement');
+        });
+        await waitFor(() => {
+            expect(result.current?.bulk.detectedFormat.type).toBe('excel');
+        });
+        expect(result.current.bulk.detectedFormat.hasCode).toBe(true);
+        // 'en' matches draft.translations language_code → found in langs
+        expect(result.current.bulk.detectedFormat.langs).toContain('en');
+    });
+
+    it('clears detectedFormat when bulkText is emptied', async () => {
+        const { result } = renderHook(() => useQSortEditor({}));
+        if (!result.current) throw new Error('hook returned null with a seeded draft');
+
+        act(() => {
+            result.current?.bulk.setBulkText('s1: A statement');
+        });
+        await waitFor(() => expect(result.current?.bulk.detectedFormat.type).toBe('list'));
+
+        act(() => {
+            result.current?.bulk.setBulkText('');
+        });
+        await waitFor(() => {
+            expect(result.current?.bulk.detectedFormat.type).toBeNull();
+        });
+    });
+});
+
+// ── 2. Reorder index math ─────────────────────────────────────────────────────
+// Drives `handleStatementDragEnd` with known active/over codes; asserts that
+// the resulting draft.statements order equals the real `arrayMove` output.
+// (The hook uses `localizedStatements.findIndex(s => s.code === ...)` to map
+// codes to indices — pure index math, asserted against the same arrayMove.)
+describe('useQSortEditor — reorder index math', () => {
+    it('moves the dragged statement to the correct position via arrayMove', () => {
+        useStudyDesigner.setState({ draft: multiDraft });
+        const { result } = renderHook(() => useQSortEditor({}));
+        if (!result.current) throw new Error('hook returned null with a seeded draft');
+
+        // Drag 'a' (index 0) over 'c' (index 2) → expected order: b, c, a
+        const expected = arrayMove(['a', 'b', 'c'], 0, 2);
+
+        const fakeEvent = {
+            active: { id: 'a' },
+            over: { id: 'c' },
+        } as unknown as DragEndEvent;
+
+        act(() => {
+            result.current?.dnd.handleStatementDragEnd(fakeEvent);
+        });
+
+        const newCodes = useStudyDesigner
+            .getState()
+            .draft?.statements?.map((s) => (s as { code: string }).code);
+        expect(newCodes).toEqual(expected);
+    });
+});
+
+// ── 3. Stale-map derivation ───────────────────────────────────────────────────
+// Mocks the stale query to return a known entry; asserts that `staleByStatementId`
+// maps exactly that statement_id to the correct StaleInfo object.
+describe('useQSortEditor — stale-map derivation', () => {
+    it('maps stale query data into staleByStatementId keyed by statement_id', () => {
+        // Seed original with a slug + a statement that has source_concourse_item_id
+        // so the hook enables the stale query.
+        const mockOriginal = {
+            id: 1,
+            slug: 'test-study',
+            statements: [{ id: 42, code: 's1', source_concourse_item_id: 7 }],
+        } as unknown as StudyRead;
+        useStudyDesigner.setState({ original: mockOriginal });
+
+        // Mock the stale query to return one stale entry
+        mockStaleQuery.mockReturnValue({
+            data: [
+                {
+                    statement_id: 42,
+                    statement_code: 's1',
+                    source_concourse_item_id: 7,
+                    source_deleted: false,
+                    concourse_translations: [{ language_code: 'en', text: 'Concourse text' }],
+                    current_translations: [{ language_code: 'en', text: 'Local text' }],
+                },
+            ],
+        });
+
+        const { result } = renderHook(() => useQSortEditor({}));
+        if (!result.current) throw new Error('hook returned null with a seeded draft');
+
+        const staleMap = result.current.data.staleByStatementId;
+        expect(staleMap.has(42)).toBe(true);
+        const entry = staleMap.get(42);
+        expect(entry?.source_deleted).toBe(false);
+        expect(entry?.concourse_translations[0]?.text).toBe('Concourse text');
+        // Only the one entry — no phantom ids
+        expect(staleMap.size).toBe(1);
+    });
+});
+
+// ── 4. Edit-state machine ─────────────────────────────────────────────────────
+// (a) begin edit → commit → draft mutated;
+// (b) begin edit → cancel (setEditingIndex(null)) → draft unchanged.
+describe('useQSortEditor — edit-state machine', () => {
+    it('commit path: setEditingIndex+Text+Code then handleSaveStatement updates draft', () => {
+        const { result } = renderHook(() => useQSortEditor({}));
+        if (!result.current) throw new Error('hook returned null with a seeded draft');
+
+        // Begin editing statement at index 0
+        act(() => {
+            result.current?.editing.setEditingIndex(0);
+            result.current?.editing.setEditingText('Updated text');
+            result.current?.editing.setEditingCode('s1-updated');
+        });
+
+        expect(result.current.editing.editingIndex).toBe(0);
+        expect(result.current.editing.editingText).toBe('Updated text');
+        expect(result.current.editing.editingCode).toBe('s1-updated');
+
+        // Commit
+        act(() => {
+            result.current?.editing.handleSaveStatement();
+        });
+
+        // editingIndex reset to null after save
+        expect(result.current.editing.editingIndex).toBeNull();
+
+        // Draft statement mutated
+        const saved = useStudyDesigner.getState().draft?.statements?.[0] as {
+            code: string;
+            translations: { language_code: string; text: string }[];
+        };
+        expect(saved.code).toBe('s1-updated');
+        expect(saved.translations[0]?.text).toBe('Updated text');
+    });
+
+    it('cancel path: setEditingIndex then setEditingIndex(null) leaves draft unchanged', () => {
+        const { result } = renderHook(() => useQSortEditor({}));
+        if (!result.current) throw new Error('hook returned null with a seeded draft');
+
+        const originalCode = useStudyDesigner.getState().draft?.statements?.[0] as {
+            code: string;
+        };
+
+        act(() => {
+            result.current?.editing.setEditingIndex(0);
+            result.current?.editing.setEditingText('Abandoned edit');
+            result.current?.editing.setEditingCode('abandoned');
+        });
+
+        // Cancel by resetting index without calling handleSaveStatement
+        act(() => {
+            result.current?.editing.setEditingIndex(null);
+        });
+
+        expect(result.current.editing.editingIndex).toBeNull();
+
+        // Draft is unchanged — code is still the original
+        const afterCancel = useStudyDesigner.getState().draft?.statements?.[0] as {
+            code: string;
+        };
+        expect(afterCancel.code).toBe(originalCode.code);
+    });
+});
+
+// ── 5. Import-mode selection — append ────────────────────────────────────────
+// Faithfully reflects the W4-oracle-locked quirk: in 'append' mode the hook
+// calls `mergeParsedItemIntoStatements` with importMode='append', which always
+// pushes a new entry (de-dup is sync-only). If the draft already has code 's1'
+// and we append a new statement without an explicit code, a new entry is pushed
+// (code auto-assigned as `s${n+1}`). We assert the count increased and the
+// original entry is still present — NOT ideal de-dup.
+describe('useQSortEditor — import-mode selection (append)', () => {
+    it('append mode pushes new statements without replacing existing ones', async () => {
+        const { result } = renderHook(() => useQSortEditor({}));
+        if (!result.current) throw new Error('hook returned null with a seeded draft');
+
+        // Confirm baseline: 1 statement with code 's1'
+        expect(result.current.data.statements).toHaveLength(1);
+
+        act(() => {
+            result.current?.bulk.setImportMode('append');
+        });
+        expect(result.current.bulk.importMode).toBe('append');
+
+        // Set simple-list bulk text (2 new statements)
+        act(() => {
+            result.current?.bulk.setBulkText('New statement one\nNew statement two');
+        });
+
+        // Wait for format detection to settle (simple)
+        await waitFor(() => expect(result.current?.bulk.detectedFormat.type).toBe('simple'));
+
+        // Run bulk save
+        act(() => {
+            result.current?.bulk.handleBulkSave();
+        });
+
+        // After append: original 1 + 2 new = 3 statements
+        const afterStatements = useStudyDesigner.getState().draft?.statements;
+        expect(afterStatements).toHaveLength(3);
+
+        // Original 's1' entry still present (append did not replace)
+        const codes = afterStatements?.map((s) => (s as { code: string }).code);
+        expect(codes).toContain('s1');
+
+        // bulkText cleared after save
+        expect(result.current.bulk.bulkText).toBe('');
     });
 });

--- a/frontend/src/hooks/admin/useQSortEditor.test.ts
+++ b/frontend/src/hooks/admin/useQSortEditor.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Qualis Team
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Unit tests for useQSortEditor — pure-logic paths only. Full behaviour
+ * through the component is covered by the unchanged QSortEditor.test.tsx
+ * (existing 17 + W4 characterization tests = the oracle).
+ */
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StudyUpdate } from '@/api/model';
+import { useStudyDesigner } from '@/store/useStudyDesigner';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+const { mockStaleQuery, mockSyncMutation, mockInvalidateQueries } = vi.hoisted(() => ({
+    mockStaleQuery: vi.fn(),
+    mockSyncMutation: vi.fn(),
+    mockInvalidateQueries: vi.fn(),
+}));
+
+// Mirror the generated-API + store mocking pattern used by the precedent
+// hook tests (useRecruitmentPage.test.ts): spread the real module, override
+// only the symbols the moved body calls.
+vi.mock('@/api/generated', async () => {
+    const actual = await vi.importActual<typeof import('@/api/generated')>('@/api/generated');
+    return {
+        ...actual,
+        useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet: () => mockStaleQuery(),
+        useSyncStatementFromConcourseApiAdminStudiesSlugSyncStatementStatementIdPost: () =>
+            mockSyncMutation(),
+    };
+});
+
+vi.mock('@tanstack/react-query', async () => {
+    const actual =
+        await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+    return {
+        ...actual,
+        useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+    };
+});
+
+import { useQSortEditor } from './useQSortEditor';
+
+const seedDraft: StudyUpdate = {
+    statements: [
+        {
+            code: 's1',
+            translations: [{ language_code: 'en', text: 'Existing Statement' }],
+        },
+    ],
+    grid_config: [
+        { score: -1, capacity: 1 },
+        { score: 0, capacity: 1 },
+        { score: 1, capacity: 1 },
+    ],
+    translations: [{ language_code: 'en' }],
+} as unknown as StudyUpdate;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockStaleQuery.mockReturnValue({ data: undefined });
+    mockSyncMutation.mockReturnValue({ mutate: vi.fn(), isPending: false, variables: undefined });
+    // The moved body keeps its verbatim `if (!draft) return null;` guard, so
+    // a non-null draft must be seeded for the hook to return its surface.
+    // Store seeding is test scaffolding, not a behaviour change.
+    useStudyDesigner.setState({
+        draft: seedDraft,
+        original: null,
+        activeLocale: 'en',
+        activeSubStep: 'statements',
+    });
+});
+
+describe('useQSortEditor — initial shape', () => {
+    it('returns the role-grouped surface without throwing on mount', () => {
+        const { result } = renderHook(() => useQSortEditor({}));
+        expect(result.current).not.toBeNull();
+        if (!result.current) throw new Error('hook returned null with a seeded draft');
+        expect(result.current.dnd.sensors).toBeDefined();
+        expect(typeof result.current.bulk.setBulkText).toBe('function');
+        expect(result.current.dialogs.importDialogOpen).toBe(false);
+    });
+});

--- a/frontend/src/hooks/admin/useQSortEditor.ts
+++ b/frontend/src/hooks/admin/useQSortEditor.ts
@@ -1,0 +1,593 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Qualis Team
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * useQSortEditor hook
+ *
+ * Owns the durable state-and-effect logic for the Q-sort statement/grid
+ * editor: useStudyDesigner store slice, stale-statements query +
+ * concourse-sync mutation, bulk-import + detected-format state, inline-edit
+ * state, grid-capacity handlers, dnd sensors + drag-end. QSortEditor renders
+ * JSX from this hook's return value (Phase-5-G; precedents
+ * useInteractiveDataView W1, useAudioRecorder W3).
+ *
+ * `sensors` (useSensors) is returned and bound by the component as
+ * <DndContext sensors={sensors}> — same pattern as W3's hook-returned
+ * containerRef.
+ *
+ * The moved body keeps its verbatim `if (!draft) return null;` guard, so the
+ * hook returns `UseQSortEditorResult | null`; the component re-applies the
+ * null-guard before rendering JSX (behaviour-identical to the original
+ * component-level early return).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import {
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+} from '@dnd-kit/core';
+import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { useStudyDesigner } from '@/store/useStudyDesigner';
+import { parseCsvTsv } from '@/utils/parseCsvTsv';
+import {
+    getGetStudyApiAdminStudiesSlugGetQueryKey,
+    useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet,
+    useSyncStatementFromConcourseApiAdminStudiesSlugSyncStatementStatementIdPost,
+} from '@/api/generated';
+import type {
+    GridColumn,
+    StatementRead,
+    StatementTranslationRead,
+    StudyRead,
+    StudyUpdate,
+} from '@/api/model';
+import {
+    applyCapacityDelta,
+    computeAutoShapedCapacities,
+    mergeParsedItemIntoStatements,
+} from '@/components/admin/designer/QSortEditor.helpers';
+
+// Define basic types for clarity (moved verbatim from QSortEditor.tsx ~66-72,
+// the moved body references these — exported so the component can import back).
+type Statement = StatementRead;
+type Translation = StatementTranslationRead;
+
+export interface StaleInfo {
+    concourse_translations: { language_code: string; text: string }[];
+    source_deleted: boolean;
+}
+
+export interface QSortEditorProps {
+    readOnly?: boolean;
+    structureLocked?: boolean;
+}
+
+type TFunc = ReturnType<typeof useTranslation>['t'];
+type SyncMutation = ReturnType<
+    typeof useSyncStatementFromConcourseApiAdminStudiesSlugSyncStatementStatementIdPost
+>;
+type DndSensors = ReturnType<typeof useSensors>;
+type LocalizedStatement = { code: string; text: string };
+type DetectedFormat = {
+    type: 'excel' | 'list' | 'simple' | null;
+    langs: string[];
+    hasCode: boolean;
+};
+
+export interface UseQSortEditorResult {
+    data: {
+        t: TFunc;
+        readOnly?: boolean;
+        structureLocked?: boolean;
+        draft: StudyUpdate;
+        original: StudyRead | null;
+        activeLocale: string;
+        activeSubTab: 'statements' | 'grid';
+        statements: Statement[];
+        localizedStatements: LocalizedStatement[];
+        staleByStatementId: Map<number, StaleInfo>;
+        grid: GridColumn[];
+        totalSlots: number;
+        totalStatements: number;
+        isValid: boolean;
+        isSymmetric: boolean;
+        isBellShaped: boolean;
+    };
+    bulk: {
+        bulkText: string;
+        setBulkText: (v: string) => void;
+        importMode: 'replace' | 'append' | 'sync';
+        setImportMode: (v: 'replace' | 'append' | 'sync') => void;
+        detectedFormat: DetectedFormat;
+        handleBulkSave: () => void;
+    };
+    editing: {
+        editingIndex: number | null;
+        editingText: string;
+        editingCode: string;
+        setEditingIndex: (idx: number | null) => void;
+        setEditingText: (text: string) => void;
+        setEditingCode: (code: string) => void;
+        handleSaveStatement: () => void;
+    };
+    dialogs: {
+        importDialogOpen: boolean;
+        setImportDialogOpen: (v: boolean) => void;
+    };
+    actions: {
+        setActiveSubTab: (v: 'statements' | 'grid') => void;
+        updateDraft: (fn: (d: StudyUpdate) => void) => void;
+        handleClearAll: () => void;
+        handleSyncStatement: (statementId: number) => void;
+        syncMutation: SyncMutation;
+        updateGridCapacity: (idx: number, delta: number) => void;
+        addExtremeColumns: () => void;
+        removeExtremeColumns: () => void;
+        autoShapeGrid: () => void;
+        handleImported: () => void;
+    };
+    dnd: {
+        sensors: DndSensors;
+        handleStatementDragEnd: (event: DragEndEvent) => void;
+    };
+}
+
+export function useQSortEditor(props: QSortEditorProps): UseQSortEditorResult | null {
+    const { readOnly, structureLocked } = props;
+    const { t } = useTranslation();
+    const { draft, original, activeLocale, updateDraft, activeSubStep, setActiveSubStep } =
+        useStudyDesigner();
+    const [importDialogOpen, setImportDialogOpen] = useState(false);
+    const queryClient = useQueryClient();
+
+    // Concourse traceability: check for stale statements
+    const hasLinkedStatements = original?.statements?.some(
+        (s) => s.source_concourse_item_id != null
+    );
+    const { data: staleData } = useCheckStaleStatementsApiAdminStudiesSlugStaleStatementsGet(
+        original?.slug ?? '',
+        {
+            query: {
+                enabled: !!original?.slug && !!hasLinkedStatements,
+                refetchInterval: 30_000,
+            },
+        }
+    );
+    const staleByStatementId = useMemo(
+        () =>
+            new Map<number, StaleInfo>(
+                staleData?.map((s) => [
+                    s.statement_id,
+                    {
+                        concourse_translations: s.concourse_translations,
+                        source_deleted: s.source_deleted,
+                    },
+                ]) ?? []
+            ),
+        [staleData]
+    );
+
+    const syncMutation =
+        useSyncStatementFromConcourseApiAdminStudiesSlugSyncStatementStatementIdPost();
+
+    const handleSyncStatement = (statementId: number) => {
+        if (!original?.slug) return;
+        syncMutation.mutate(
+            { slug: original.slug, statementId },
+            {
+                onSuccess: () => {
+                    queryClient.invalidateQueries({
+                        queryKey: getGetStudyApiAdminStudiesSlugGetQueryKey(original.slug),
+                    });
+                    toast.success(
+                        t('admin.concourse_sync.synced', 'Statement updated from concourse')
+                    );
+                },
+                onError: () => {
+                    toast.error(
+                        t(
+                            'admin.concourse_sync.error',
+                            'Could not sync from the concourse. Try again.'
+                        )
+                    );
+                },
+            }
+        );
+    };
+
+    const [bulkText, setBulkText] = useState('');
+    const [detectedFormat, setDetectedFormat] = useState<{
+        type: 'excel' | 'list' | 'simple' | null;
+        langs: string[];
+        hasCode: boolean;
+    }>({ type: null, langs: [], hasCode: false });
+
+    // Alias to keep existing logic working
+    const activeSubTab = (activeSubStep as 'statements' | 'grid') || 'statements';
+
+    // Helper to update store
+    const setActiveSubTab = (v: 'statements' | 'grid') => setActiveSubStep(v);
+
+    // Auto-detect format on change
+    useEffect(() => {
+        if (!bulkText.trim()) {
+            setDetectedFormat({ type: null, langs: [], hasCode: false });
+            return;
+        }
+
+        const lines = bulkText.split('\n').filter((l) => l.trim() !== '');
+        const firstLine = lines[0];
+        if (!firstLine) {
+            setDetectedFormat({ type: null, langs: [], hasCode: false });
+            return;
+        }
+
+        if (firstLine.includes('\t')) {
+            const cells = firstLine.split('\t').map((c) => c.trim().toLowerCase());
+            const langs = cells.filter((c) =>
+                draft?.translations?.some((tr) => tr.language_code === c)
+            );
+            setDetectedFormat({
+                type: 'excel',
+                langs,
+                hasCode: cells.includes('code'),
+            });
+        } else if (lines.some((l) => /^([a-zA-Z0-9_-]{1,15})\s*[:,-]\s+/.test(l))) {
+            setDetectedFormat({ type: 'list', langs: [], hasCode: true });
+        } else {
+            setDetectedFormat({ type: 'simple', langs: [], hasCode: false });
+        }
+    }, [bulkText, draft?.translations]);
+
+    // Auto-initialize grid if empty (-4 to +4) with bell curve (total 34)
+    useEffect(() => {
+        if (draft && (!draft.grid_config || draft.grid_config.length === 0)) {
+            updateDraft((d) => {
+                d.grid_config = [
+                    { score: -4, capacity: 2 },
+                    { score: -3, capacity: 3 },
+                    { score: -2, capacity: 4 },
+                    { score: -1, capacity: 5 },
+                    { score: 0, capacity: 6 },
+                    { score: 1, capacity: 5 },
+                    { score: 2, capacity: 4 },
+                    { score: 3, capacity: 3 },
+                    { score: 4, capacity: 2 },
+                ];
+            });
+        }
+    }, [draft, updateDraft]);
+
+    const [importMode, setImportMode] = useState<'replace' | 'append' | 'sync'>('replace');
+    const [editingIndex, setEditingIndex] = useState<number | null>(null);
+    const [editingText, setEditingText] = useState('');
+    const [editingCode, setEditingCode] = useState('');
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+    );
+
+    if (!draft) return null;
+
+    // --- Statements Logic ---
+    const statements: Statement[] = (draft.statements || []) as Statement[];
+    const localizedStatements = statements.map((s: Statement) => {
+        const t = (s.translations as Translation[])?.find(
+            (st: Translation) => st.language_code === activeLocale
+        );
+        return { code: s.code, text: t?.text || '' };
+    });
+
+    const handleStatementDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+        if (over && active.id !== over.id) {
+            const oldIndex = localizedStatements.findIndex((s) => s.code === active.id);
+            const newIndex = localizedStatements.findIndex((s) => s.code === over.id);
+            updateDraft((d) => {
+                if (d.statements) {
+                    d.statements = arrayMove(d.statements, oldIndex, newIndex);
+                }
+            });
+        }
+    };
+
+    const handleBulkSave = () => {
+        if (!bulkText.trim()) return;
+
+        type ParsedItem = {
+            code?: string | null;
+            text?: string;
+            translations?: { language_code: string; text: string }[];
+        };
+        let parsedItems: ParsedItem[] = [];
+
+        if (detectedFormat.type === 'excel') {
+            const rows = parseCsvTsv(bulkText, '\t');
+            const headerRow = rows[0];
+            if (!headerRow) return;
+
+            const headers = headerRow.map((h) => h.toLowerCase());
+            const hasCodeHeader = headers.includes('code');
+            const langHeaders = headers.filter((h) =>
+                draft.translations?.some((t) => t.language_code === h)
+            );
+
+            if (hasCodeHeader || langHeaders.length > 0) {
+                // EXCEL HEADER MODE
+                parsedItems = rows.slice(1).map((cells) => {
+                    const item: ParsedItem = { translations: [] };
+                    if (hasCodeHeader) {
+                        item.code = cells[headers.indexOf('code')]?.trim();
+                    }
+                    langHeaders.forEach((lang) => {
+                        const cellIdx = headers.indexOf(lang);
+                        if (cellIdx !== -1 && cells[cellIdx] !== undefined && item.translations) {
+                            item.translations.push({ language_code: lang, text: cells[cellIdx] });
+                        }
+                    });
+                    return item;
+                });
+            } else {
+                // EXCEL SIMPLE MODE (No headers but has tabs)
+                parsedItems = rows.map((cells) => {
+                    return {
+                        code: cells[0]?.trim(),
+                        text: cells.slice(1).join(' ').trim(),
+                    };
+                });
+            }
+        } else {
+            // CLASSIC MODE (One per line)
+            const lines = bulkText
+                .split('\n')
+                .map((l) => l.trim())
+                .filter((l) => l !== '');
+            parsedItems = lines.map((line) => {
+                // Check for CSV-like with quotes: "Code","Text"
+                const csvMatch = line.match(/^"([^"]+)"\s*,\s*"(.+)"$/);
+                if (csvMatch) {
+                    return { code: csvMatch[1], text: csvMatch[2] };
+                }
+
+                // Regex for common separators: "Code: Text" or "Code, Text" or "Code - Text"
+                const match = line.match(/^([a-zA-Z0-9_-]{1,15})\s*[:,-]\s+(.+)$/);
+                if (match?.[1] && match[2]) {
+                    return { code: match[1], text: match[2].trim() };
+                }
+
+                // Fallback: remove leading numbering "1. ", "1) "
+                return { code: null, text: line.replace(/^\d+[.)\-\s]+/, '').trim() };
+            });
+        }
+
+        updateDraft((d) => {
+            if (importMode === 'replace') {
+                d.statements = [];
+            }
+            const currentStatements = d.statements || [];
+            const draftLangs = (d.translations || []) as { language_code: string }[];
+            for (const item of parsedItems) {
+                mergeParsedItemIntoStatements(
+                    item,
+                    currentStatements,
+                    draftLangs,
+                    importMode,
+                    activeLocale
+                );
+            }
+            d.statements = currentStatements;
+        });
+
+        setBulkText('');
+        toast.success(t('admin.design.qsort.set.imported', { count: parsedItems.length }));
+    };
+
+    const handleClearAll = () => {
+        if (confirm(t('admin.design.qsort.set.confirm_clear'))) {
+            updateDraft((d) => {
+                d.statements = [];
+            });
+            toast.info(t('admin.design.qsort.set.cleared'));
+        }
+    };
+
+    const grid = (draft.grid_config || []) as GridColumn[];
+    const totalSlots = grid.reduce((acc: number, col: GridColumn) => acc + (col.capacity || 0), 0);
+    const totalStatements = statements.length;
+    const isValid = totalSlots === totalStatements;
+
+    const isSymmetric =
+        grid.length > 0 &&
+        grid.every((col, idx) => {
+            const opposite = grid[grid.length - 1 - idx];
+            return col.capacity === opposite?.capacity;
+        });
+
+    const isBellShaped =
+        isSymmetric &&
+        grid.length >= 5 &&
+        (() => {
+            const centerIdx = Math.floor(grid.length / 2);
+            for (let i = 0; i < centerIdx; i++) {
+                if ((grid[i]?.capacity || 0) > (grid[i + 1]?.capacity || 0)) return false;
+            }
+            return true;
+        })();
+
+    const updateGridCapacity = (idx: number, delta: number) => {
+        updateDraft((d) => {
+            if (!d.grid_config) return;
+            applyCapacityDelta(d.grid_config, idx, delta, d.symmetry_lock ?? true);
+        });
+    };
+
+    const addExtremeColumns = () => {
+        updateDraft((d) => {
+            if (!d.grid_config || d.grid_config.length === 0) {
+                // Default -4 to +4 if empty
+                d.grid_config = [
+                    { score: -4, capacity: 2 },
+                    { score: -3, capacity: 3 },
+                    { score: -2, capacity: 4 },
+                    { score: -1, capacity: 5 },
+                    { score: 0, capacity: 6 },
+                    { score: 1, capacity: 5 },
+                    { score: 2, capacity: 4 },
+                    { score: 3, capacity: 3 },
+                    { score: 4, capacity: 2 },
+                ];
+                return;
+            }
+            const scores = d.grid_config.map((c: GridColumn) => c.score);
+            const minScore = Math.min(...scores);
+            const maxScore = Math.max(...scores);
+
+            if (minScore <= -6 || maxScore >= 6) {
+                toast.error(t('admin.design.qsort.grid.max_reached', 'Maximum range reached (±6)'));
+                return;
+            }
+
+            d.grid_config.unshift({ score: minScore - 1, capacity: 1 });
+            d.grid_config.push({ score: maxScore + 1, capacity: 1 });
+        });
+    };
+
+    const removeExtremeColumns = () => {
+        updateDraft((d) => {
+            if (!d.grid_config || d.grid_config.length <= 5) {
+                toast.error(t('admin.design.qsort.grid.min_reached', 'Minimum range reached (±2)'));
+                return;
+            }
+            d.grid_config.shift();
+            d.grid_config.pop();
+        });
+    };
+
+    const autoShapeGrid = () => {
+        if (totalStatements === 0) {
+            toast.error(
+                t(
+                    'admin.design.qsort.grid.no_statements',
+                    'Add statements first to auto-shape the grid'
+                )
+            );
+            return;
+        }
+
+        updateDraft((d) => {
+            if (!d.grid_config || d.grid_config.length === 0) return;
+
+            const newCapacities = computeAutoShapedCapacities(
+                totalStatements,
+                d.grid_config.length
+            );
+
+            for (let i = 0; i < newCapacities.length; i++) {
+                const col = d.grid_config[i];
+                const cap = newCapacities[i];
+                if (col && cap !== undefined) {
+                    col.capacity = cap;
+                }
+            }
+        });
+        toast.success(
+            t('admin.design.qsort.grid.balanced', 'Grid balanced to standard distribution')
+        );
+    };
+
+    const handleSaveStatement = () => {
+        updateDraft((d) => {
+            const statement = d.statements?.[editingIndex as number];
+            if (statement) {
+                // Update code
+                statement.code = editingCode;
+
+                const translation = statement.translations?.find(
+                    (t) => t.language_code === activeLocale
+                );
+                if (translation) {
+                    translation.text = editingText;
+                }
+            }
+        });
+        setEditingIndex(null);
+        toast.success(t('admin.design.qsort.set.updated'));
+    };
+
+    const handleImported = () => {
+        // Invalidate study query so the design page re-fetches with new statements
+        if (original?.slug) {
+            queryClient.invalidateQueries({
+                queryKey: getGetStudyApiAdminStudiesSlugGetQueryKey(original.slug),
+            });
+        }
+    };
+
+    return {
+        data: {
+            t,
+            readOnly,
+            structureLocked,
+            draft,
+            original,
+            activeLocale,
+            activeSubTab,
+            statements,
+            localizedStatements,
+            staleByStatementId,
+            grid,
+            totalSlots,
+            totalStatements,
+            isValid,
+            isSymmetric,
+            isBellShaped,
+        },
+        bulk: {
+            bulkText,
+            setBulkText,
+            importMode,
+            setImportMode,
+            detectedFormat,
+            handleBulkSave,
+        },
+        editing: {
+            editingIndex,
+            editingText,
+            editingCode,
+            setEditingIndex,
+            setEditingText,
+            setEditingCode,
+            handleSaveStatement,
+        },
+        dialogs: {
+            importDialogOpen,
+            setImportDialogOpen,
+        },
+        actions: {
+            setActiveSubTab,
+            updateDraft,
+            handleClearAll,
+            handleSyncStatement,
+            syncMutation,
+            updateGridCapacity,
+            addExtremeColumns,
+            removeExtremeColumns,
+            autoShapeGrid,
+            handleImported,
+        },
+        dnd: {
+            sensors,
+            handleStatementDragEnd,
+        },
+    };
+}


### PR DESCRIPTION
Supersedes #180 (auto-closed by GitHub when its stacked base branch `chore/code-quality-wave2-studyconfig-typing` was deleted on #178's squash-merge). Branch rebased `--onto main` (W2's content is already in main via #178; only W4's own commits replay) — clean, no conflicts.

## Summary

Code-quality program, **Wave 4**. `QSortEditor.tsx` 1488→1110 LOC; ~389 LOC of store/query/dnd/handler logic relocated verbatim into `hooks/admin/useQSortEditor.ts`. Characterization-first: 6 tests pinned dnd-reorder / concourse-sync / import-mode-matrix (incl. the faithfully-snapshotted append duplicate-code quirk) / inline-edit on the W2 baseline; that oracle stayed byte-unchanged through the extraction. `sensors`/`SortableContext` `.code`-keying preserved; consumer `StudyDesignPage.tsx` untouched.

Full per-task spec/plan/review history is on closed #180. Final review there: READY TO MERGE, zero issues.

## Test Plan
- [x] `npm run type-check` (`tsc -b`) exit 0; `npm run build` ok; `npm run lint` 0 errors; full suite green (1435|6 on the wave; rebased branch verified clean vs main)
- [x] oracle `QSortEditor.test.tsx` byte-unchanged since characterization commit; `StudyDesignPage.tsx` unmodified, type-checks
- [x] rebased `--onto main`: contains only W4's own commits; W2's changes already in main via #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)