### PR TITLE
fix(designer): admin-E2E regression — presortFields {enabled} wrapper leak

### DIFF
--- a/frontend/src/store/useStudyDesigner.test.ts
+++ b/frontend/src/store/useStudyDesigner.test.ts
@@ -116,3 +116,40 @@ describe('useStudyDesigner - importConfig', () => {
         expect(useStudyDesigner.getState().syncStatus).toBe('modified');
     });
 });
+
+describe('useStudyDesigner - setStudy normalize regression (admin-E2E crash)', () => {
+    // Regression: a study with presort enabled but ZERO presort fields has
+    // `presort_config: { enabled: true }` (no `fields` key). The design page
+    // loads it via setStudy → normalizeStudyData. The W2 `presortFields`
+    // accessor's legacy fallback used to return the wrapper object itself, so
+    // normalizeQuestionMap iterated the boolean `enabled` and called
+    // normalizeQuestion(true) → "TypeError: Cannot create property 'label' on
+    // boolean 'true'" → StudyDesignPage error boundary → admin E2E failures
+    // (study-status missing; export menu unreachable). setStudy must not throw
+    // and must produce a usable draft.
+    it('setStudy does not throw for presort_config:{enabled:true} (no fields)', () => {
+        const study = {
+            ...MOCK_STUDY,
+            presort_config: { enabled: true },
+        } as unknown as StudyRead;
+        expect(() => useStudyDesigner.getState().setStudy(study)).not.toThrow();
+        expect(useStudyDesigner.getState().draft).not.toBeNull();
+        expect(useStudyDesigner.getState().draft?.statements?.length).toBe(1);
+    });
+
+    it('setStudy still normalizes real presort fields under the new wrapper', () => {
+        const study = {
+            ...MOCK_STUDY,
+            presort_config: {
+                enabled: true,
+                fields: { age: { type: 'number', label: 'Age' } },
+            },
+        } as unknown as StudyRead;
+        expect(() => useStudyDesigner.getState().setStudy(study)).not.toThrow();
+        const pc = useStudyDesigner.getState().draft?.presort_config as {
+            fields?: Record<string, { label?: unknown }>;
+        };
+        // The field survived normalization (label localized to an object map).
+        expect(pc.fields?.age).toBeDefined();
+    });
+});

--- a/frontend/src/utils/studyConfig.test.ts
+++ b/frontend/src/utils/studyConfig.test.ts
@@ -25,6 +25,18 @@ describe('presortFields — legacy/new union collapse', () => {
         expect(presortFields({ presort_config: null })).toEqual({});
         expect(presortFields(null)).toEqual({});
     });
+
+    // Regression (admin-E2E crash): new-shape config with `enabled` but NO
+    // `fields` key (presort enabled, zero fields — very common). MUST NOT
+    // fall through to the legacy branch and return the wrapper object (whose
+    // boolean `enabled` would then be iterated as a "field" by
+    // normalizeQuestionMap → normalizeQuestion(true) → "Cannot create
+    // property 'label' on boolean 'true'"). Pre-W2 code read `.fields` here
+    // (undefined → safe no-op); the accessor must reproduce that.
+    it('returns {} for an enabled wrapper that has no fields key', () => {
+        expect(presortFields({ presort_config: { enabled: true } })).toEqual({});
+        expect(presortFields({ presort_config: { enabled: false } })).toEqual({});
+    });
 });
 
 describe('postsortConfig', () => {

--- a/frontend/src/utils/studyConfig.ts
+++ b/frontend/src/utils/studyConfig.ts
@@ -48,11 +48,22 @@ type ConfigLike =
     | null
     | undefined;
 
-/** Field map regardless of legacy (flat record) vs new ({enabled, fields}). */
+/**
+ * Field map regardless of legacy (flat record) vs new ({enabled, fields}).
+ *
+ * The new wrapper shape is identified by the presence of EITHER `enabled` OR
+ * `fields` — in that case only the explicit `fields` map are fields (a config
+ * with `enabled` but no `fields` has zero presort fields → `{}`). Only a
+ * config carrying NEITHER key is a genuine legacy flat field-map. This matches
+ * the pre-accessor behaviour (`presort_config.fields`, undefined → no fields);
+ * returning the wrapper object itself would leak the boolean `enabled` into
+ * the field map (regression: normalizeQuestion(true) → "Cannot create
+ * property 'label' on boolean 'true'").
+ */
 export function presortFields(config: ConfigLike): Record<string, PreSortField> {
     const pc = config?.presort_config;
     if (!pc || typeof pc !== 'object') return {};
-    if ('fields' in pc) {
+    if ('fields' in pc || 'enabled' in pc) {
         return (pc as { fields?: Record<string, PreSortField> }).fields ?? {};
     }
     return pc as Record<string, PreSortField>;


### PR DESCRIPTION
## Root cause

The code-quality program's merge turned `main`'s Qualis CI red on **E2E Tests (Admin)** (pre-program `main` was green — direct causal evidence). Two failures, **one root cause**:

- `admin-flow.spec.ts › Zero to Hero` — `study-status` test-id element not found
- `import-export.spec.ts › export & re-import via paste-JSON` — config-export download event times out

Both are the **same StudyDesignPage render crash**, captured in the CI Playwright artifact: `TypeError: Cannot create property 'label' on boolean 'true'` → global error boundary → status element absent **and** export menu unreachable.

A study with presort enabled but zero presort fields has `presort_config: { enabled: true }` (no `fields`). W2's `presortFields` accessor's legacy fallback returned that wrapper object whole; `normalizeQuestionMap` iterated the boolean `enabled` → `normalizeQuestion(true)` → `true.label = …` → crash. **Pre-W2 code read `(presort_config as any).fields` (`undefined` → safe no-op)** — the W2 accessor silently changed this behaviour (the "accessor ≠ `as any`" cardinal risk W2's spec flagged; reviews verified only clean-field-map call sites, never `{enabled:true}`-without-`fields`). The `role:'researcher'` 422 in CI logs is an unrelated *passing* negative test.

## Fix

`presortFields`: a config with `enabled` **or** `fields` is the new wrapper → return `.fields ?? {}`; only a config with **neither** key is a genuine legacy flat field-map. Exactly restores pre-W2 behaviour at the source (benefits all callers).

## Test Plan
- [x] TDD: accessor regression test + `setStudy`→`normalizeStudyData` store regression test (the exact E2E crash path) — **both fail without the fix with the exact production error**, pass with it
- [x] full frontend suite 1455 passed | 6 skipped (no regressions; +1 vs pre-fix = new accessor test)
- [x] `tsc -b` 0, biome clean
- [ ] **CI Qualis / E2E Tests (Admin) green on this PR** — the definitive verification gate (will confirm before declaring resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)