### PR TITLE
fix(admin): /app/users showed no users + harden flaky backend tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,9 +14,13 @@ from dotenv import load_dotenv
 # Load .env from project root so TEST_DATABASE_URL is available
 load_dotenv(Path(__file__).resolve().parents[2] / ".env")
 
+import asyncio
+
+import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select, text
+from sqlalchemy.engine import make_url
 
 # Set testing environment variable BEFORE app modules are imported
 os.environ["TESTING"] = "true"
@@ -46,10 +50,82 @@ TEST_PASSWORD = "testpassword"
 
 # Use PostgreSQL for testing.
 # Set TEST_DATABASE_URL in your .env file (project root) or environment.
-TEST_DATABASE_URL = os.getenv(
+_BASE_TEST_DATABASE_URL = os.getenv(
     "TEST_DATABASE_URL",
     "postgresql+asyncpg://postgres:postgres@localhost:5432/qualis_test",
 )
+
+
+def _derive_isolated_db() -> tuple[str, str, str | None]:
+    """Give every pytest *process* its own database.
+
+    Test isolation here is per-test ``DROP SCHEMA public CASCADE`` on a
+    single shared database. That is correct *within* one process but
+    catastrophic *across* concurrent processes: two overlapping
+    ``pytest`` runs (overlapping ``make ci-fast`` invocations, a CI job
+    racing a local run, two git worktrees — see the worktree test-env
+    notes) drop each other's schema mid-test, producing nondeterministic
+    SQLAlchemy failures that pass on every retry-in-isolation.
+
+    Fix: namespace the database name with ``{xdist-worker}_{pid}`` so
+    concurrent processes never share storage. CREATE/DROP DATABASE runs
+    over the *base* URL itself — the one the suite already connects to
+    successfully — so this assumes no extra privileges (e.g. access to
+    the ``postgres`` maintenance database) beyond what the suite needs
+    today, and leaves the base database pristine (only the per-process
+    copies are ever schema-dropped). Opt out (e.g. a CI role without
+    CREATEDB) with ``QUALIS_TEST_DB_ISOLATION=0`` — that restores the
+    legacy shared-DB behaviour and its concurrency hazard.
+
+    Returns ``(test_url, maintenance_url, isolated_db_name)``.
+    ``isolated_db_name`` is ``None`` when isolation is disabled.
+    """
+    url = make_url(_BASE_TEST_DATABASE_URL)
+    if os.getenv("QUALIS_TEST_DB_ISOLATION", "1") == "0":
+        return _BASE_TEST_DATABASE_URL, _BASE_TEST_DATABASE_URL, None
+    worker = os.getenv("PYTEST_XDIST_WORKER", "main")
+    db_name = f"{url.database or 'qualis_test'}_{worker}_{os.getpid()}"
+    # render_as_string(hide_password=False): str(URL) masks the password
+    # as "***", which would break authentication for every DB connection.
+    per_process_url = url.set(database=db_name).render_as_string(hide_password=False)
+    return per_process_url, _BASE_TEST_DATABASE_URL, db_name
+
+
+TEST_DATABASE_URL, _MAINTENANCE_DATABASE_URL, _ISOLATED_DB_NAME = _derive_isolated_db()
+# Propagate so subprocess-driven tests (Alembic integration) and any
+# importer of TEST_DATABASE_URL target this process's isolated database.
+os.environ["TEST_DATABASE_URL"] = TEST_DATABASE_URL
+
+
+async def _maintenance_exec(sql: str) -> None:
+    """Run one autocommit statement against the base database.
+
+    CREATE/DROP DATABASE cannot run inside a transaction, hence the
+    AUTOCOMMIT isolation level and a dedicated short-lived engine.
+    """
+    engine = create_async_engine(_MAINTENANCE_DATABASE_URL, isolation_level="AUTOCOMMIT")
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text(sql))
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolated_test_database():
+    """Create this process's database before tests, drop it after.
+
+    Sync fixture driving ``asyncio.run`` so it does not depend on
+    pytest-asyncio's per-test event-loop scope. ``WITH (FORCE)`` evicts
+    any straggler connection (PostgreSQL 13+) so the drop cannot hang.
+    """
+    if _ISOLATED_DB_NAME is None:
+        yield
+        return
+    asyncio.run(_maintenance_exec(f'DROP DATABASE IF EXISTS "{_ISOLATED_DB_NAME}" WITH (FORCE)'))
+    asyncio.run(_maintenance_exec(f'CREATE DATABASE "{_ISOLATED_DB_NAME}"'))
+    yield
+    asyncio.run(_maintenance_exec(f'DROP DATABASE IF EXISTS "{_ISOLATED_DB_NAME}" WITH (FORCE)'))
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/security/wave_2/test_email_enumeration.py
+++ b/backend/tests/security/wave_2/test_email_enumeration.py
@@ -116,24 +116,43 @@ async def _time_post(
     return r.status_code, body, dt
 
 
-async def _collect_arm(
-    fire: Callable[[], Awaitable[tuple[int, Any, float]]],
-) -> tuple[list[int], list[Any], float]:
-    """Fire ``fire()`` ``N_WARMUP + N_SAMPLES`` times. Drop warmup,
-    return (statuses, bodies, median_ms).
+async def _collect_interleaved(
+    known: Callable[[], Awaitable[tuple[int, Any, float]]],
+    unknown: Callable[[], Awaitable[tuple[int, Any, float]]],
+) -> tuple[float, float]:
+    """Sample both arms *alternately* in one loop; return
+    ``(median_known_ms, median_unknown_ms)`` over ``N_SAMPLES`` after
+    dropping ``N_WARMUP``.
 
-    Median (not mean) is used so sporadic CI scheduler/GC spikes in a
-    few samples don't shift the arm's reported latency — only a
-    systematic, exploitable shift in central tendency does.
+    Why interleaved, not arm-after-arm: the original collector ran all
+    ``known`` samples, then all ``unknown`` samples. Slow system-load
+    drift across the ~15 s phase boundary (a CI I/O burst, CPU
+    contention ramping — e.g. a concurrent backup during ``make ci``)
+    shifts one arm's median relative to the other with no actual
+    code-path leak, and a 200 ms bound can't survive that. Median +
+    warmup (the earlier hardening) defeats *sporadic spikes* but not
+    *phase-correlated drift*. Interleaving samples both arms under the
+    same instantaneous load, so drift hits both equally and cancels in
+    the delta. The order is alternated each iteration so neither arm
+    systematically pays the other's cache/scheduler warm-up cost.
+
+    Median (not mean) still guards against the residual sporadic spike.
     """
-    samples: list[tuple[int, Any, float]] = []
-    for _ in range(N_WARMUP + N_SAMPLES):
-        samples.append(await fire())
-    samples = samples[N_WARMUP:]
-    statuses = [s[0] for s in samples]
-    bodies = [s[1] for s in samples]
-    median_ms = statistics.median(s[2] for s in samples)
-    return statuses, bodies, median_ms
+    k_ms: list[float] = []
+    u_ms: list[float] = []
+    for i in range(N_WARMUP + N_SAMPLES):
+        if i % 2 == 0:
+            ks = await known()
+            us = await unknown()
+        else:
+            us = await unknown()
+            ks = await known()
+        k_ms.append(ks[2])
+        u_ms.append(us[2])
+    return (
+        statistics.median(k_ms[N_WARMUP:]),
+        statistics.median(u_ms[N_WARMUP:]),
+    )
 
 
 @pytest_asyncio.fixture
@@ -227,8 +246,7 @@ class TestTokenEnumeration:
                 data={"username": "no-such@example.com", "password": "wrong"},
             )
 
-        _, _, median_known = await _collect_arm(known)
-        _, _, median_unknown = await _collect_arm(unknown)
+        median_known, median_unknown = await _collect_interleaved(known, unknown)
 
         delta = abs(median_known - median_unknown)
         assert delta < TIMING_THRESHOLD_MS, (
@@ -291,8 +309,7 @@ class TestPasswordResetRequestEnumeration:
                 json_payload={"email": "no-such@example.com"},
             )
 
-        _, _, median_known = await _collect_arm(known)
-        _, _, median_unknown = await _collect_arm(unknown)
+        median_known, median_unknown = await _collect_interleaved(known, unknown)
 
         delta = abs(median_known - median_unknown)
         assert delta < self._RESET_TIMING_THRESHOLD_MS, (
@@ -339,8 +356,7 @@ class TestVerifyResendEnumeration:
                 json_payload={"email": "no-such@example.com"},
             )
 
-        _, _, median_known = await _collect_arm(known)
-        _, _, median_unknown = await _collect_arm(unknown)
+        median_known, median_unknown = await _collect_interleaved(known, unknown)
 
         delta = abs(median_known - median_unknown)
         assert delta < TIMING_THRESHOLD_MS, (
@@ -385,8 +401,7 @@ class TestTwofaDisableRequestEnumeration:
                 json_payload={"email": "no-such@example.com"},
             )
 
-        _, _, median_known = await _collect_arm(known)
-        _, _, median_unknown = await _collect_arm(unknown)
+        median_known, median_unknown = await _collect_interleaved(known, unknown)
 
         delta = abs(median_known - median_unknown)
         assert delta < TIMING_THRESHOLD_MS, (

--- a/backend/tests/unit/test_db_isolation.py
+++ b/backend/tests/unit/test_db_isolation.py
@@ -1,0 +1,52 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Regression guard for per-process test-database isolation.
+
+Root cause of the recurring "passes in isolation, fails under the full
+suite" flake: every test isolates via ``DROP SCHEMA public CASCADE`` on a
+single shared database, so two concurrent ``pytest`` processes drop each
+other's schema mid-test. ``conftest._derive_isolated_db`` namespaces the
+database per process to make concurrent runs collision-proof. These tests
+fail if that namespacing is reverted or broken.
+"""
+
+import os
+
+from sqlalchemy.engine import make_url
+
+from tests.conftest import (
+    TEST_DATABASE_URL,
+    _BASE_TEST_DATABASE_URL,
+    _derive_isolated_db,
+)
+
+
+def test_active_url_is_namespaced_per_process() -> None:
+    """The live URL must carry this process's pid, not the bare base name."""
+    base_db = make_url(_BASE_TEST_DATABASE_URL).database or "qualis_test"
+    active_db = make_url(TEST_DATABASE_URL).database
+    assert active_db is not None
+    assert active_db != base_db, "shared DB name — concurrent runs would collide"
+    assert active_db.endswith(f"_{os.getpid()}")
+    # And the process-wide env mirrors it (subprocess Alembic inherits this).
+    assert os.environ["TEST_DATABASE_URL"] == TEST_DATABASE_URL
+
+
+def test_derive_uses_base_db_for_maintenance() -> None:
+    """CREATE/DROP runs over the base URL (no extra-privilege assumptions)."""
+    _, maintenance_url, db_name = _derive_isolated_db()
+    base_db = make_url(_BASE_TEST_DATABASE_URL).database
+    assert make_url(maintenance_url).database == base_db
+    # The per-process DB must differ from the base it is created from.
+    assert db_name is not None and db_name != base_db
+
+
+def test_opt_out_restores_shared_db(monkeypatch) -> None:
+    """QUALIS_TEST_DB_ISOLATION=0 must fall back to the unnamespaced base."""
+    monkeypatch.setenv("QUALIS_TEST_DB_ISOLATION", "0")
+    test_url, maintenance_url, db_name = _derive_isolated_db()
+    assert test_url == _BASE_TEST_DATABASE_URL
+    assert maintenance_url == _BASE_TEST_DATABASE_URL
+    assert db_name is None

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -2192,6 +2192,8 @@
             "subtitle": "Manage platform accounts and audit hygiene.",
             "error_title": "Action failed",
             "generic_error": "Something went wrong. Please try again.",
+            "load_error_title": "Could not load users",
+            "load_error_body": "The user list could not be retrieved. Please refresh the page or try again later.",
             "search_placeholder": "Search by email or name",
             "empty": "No users match.",
             "inactive": "Inactive",

--- a/frontend/src/hooks/admin/useAdminUsersPage.test.ts
+++ b/frontend/src/hooks/admin/useAdminUsersPage.test.ts
@@ -133,6 +133,24 @@ describe('deriveRiskBadges — dormant', () => {
     });
 });
 
+// Regression: the list query must respect the backend pagination contract.
+// `PaginationParams` caps `limit` at MAX_PAGE_SIZE=100; requesting 200 makes
+// the endpoint return 422, the page renders empty, and the error is swallowed
+// because AdminUsersPage never surfaces the query error. (#171 shipped at 200.)
+describe('useAdminUsersPage — list query contract', () => {
+    it('requests the user list with a limit within the API maximum (<=100)', () => {
+        renderHook(() => useAdminUsersPage(), { wrapper: AllTheProviders });
+
+        expect(mockListUsersHook).toHaveBeenCalled();
+        const params = mockListUsersHook.mock.calls[0]?.[0] as
+            | { limit?: number; offset?: number }
+            | undefined;
+        expect(params?.limit).toBeDefined();
+        expect(params?.limit).toBeLessThanOrEqual(100);
+        expect(params?.limit).toBeGreaterThanOrEqual(1);
+    });
+});
+
 // Fix C — renderHook integration tests for filter/search/sort inside useAdminUsersPage
 describe('useAdminUsersPage — filtered list integration', () => {
     const userA: AdminUser = {

--- a/frontend/src/hooks/admin/useAdminUsersPage.ts
+++ b/frontend/src/hooks/admin/useAdminUsersPage.ts
@@ -105,7 +105,9 @@ export function useAdminUsersPage() {
         user: AdminUser;
     } | null>(null);
 
-    const listParams = { limit: 200, offset: 0 };
+    // limit is capped at the backend MAX_PAGE_SIZE (100); requesting more
+    // makes GET /api/admin/users return 422 and the page renders empty.
+    const listParams = { limit: 100, offset: 0 };
 
     const { data, isLoading, error } = useListUsersApiAdminUsersGet(listParams);
 

--- a/frontend/src/pages/admin/AdminUsersPage.test.tsx
+++ b/frontend/src/pages/admin/AdminUsersPage.test.tsx
@@ -235,4 +235,15 @@ describe('AdminUsersPage', () => {
         expect(screen.getByText(/no users match/i)).toBeInTheDocument();
         expect(screen.queryAllByTestId('admin-users-row')).toHaveLength(0);
     });
+
+    // Regression: a failed list query must surface an error, NOT masquerade
+    // as an empty "No users match." list (the bug that hid the limit=200 422).
+    it('surfaces a load error instead of the empty state when the query fails', () => {
+        useAdminUsersPageMock.mockReturnValue(
+            hookValue({ users: [], error: new Error('Request failed with status code 422') })
+        );
+        renderWithProviders(<AdminUsersPage />);
+        expect(screen.getByText(/could not load users/i)).toBeInTheDocument();
+        expect(screen.queryByText(/no users match/i)).not.toBeInTheDocument();
+    });
 });

--- a/frontend/src/pages/admin/AdminUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminUsersPage.tsx
@@ -126,6 +126,7 @@ export default function AdminUsersPage() {
     const {
         users,
         isLoading,
+        error,
         search,
         setSearch,
         filter,
@@ -211,6 +212,21 @@ export default function AdminUsersPage() {
                             {Array.from({ length: 4 }).map((_, i) => (
                                 <Skeleton key={i} className="h-16 w-full rounded-xl" />
                             ))}
+                        </div>
+                    ) : error != null ? (
+                        <div className="p-12">
+                            <Alert variant="destructive">
+                                <AlertCircle className="size-4" />
+                                <AlertTitle>
+                                    {t('admin.users.load_error_title', 'Could not load users')}
+                                </AlertTitle>
+                                <AlertDescription>
+                                    {t(
+                                        'admin.users.load_error_body',
+                                        'The user list could not be retrieved. Please refresh the page or try again later.'
+                                    )}
+                                </AlertDescription>
+                            </Alert>
                         </div>
                     ) : users.length === 0 ? (
                         <div className="p-12 text-center text-sm font-medium text-slate-500">


### PR DESCRIPTION
## Summary

Three independent fixes, surfaced while debugging an empty `/app/users` page:

1. **`fix(admin)` — `/app/users` showed no users.** `useAdminUsersPage` requested `limit=200`, but the backend caps pagination at `MAX_PAGE_SIZE=100`. Every `GET /api/admin/users` returned HTTP 422 before reaching the data; the page read `isLoading` but never the query error, so it rendered a silent *"No users match."* Broken for any user count since the feature shipped (#171); the fully-mocked hook test couldn't see the contract violation. Fix: `limit 200 → 100`, surface the query error in an Alert, + regression tests (hook asserts `limit ≤ 100` — fails at 200; page asserts a failed query shows the error).

2. **`test(backend)` — per-process test-database isolation.** Test isolation was per-test `DROP SCHEMA public CASCADE` on a single hardcoded DB. Two concurrent pytest processes (overlapping `make ci-fast`, CI racing a local run, two worktrees) dropped each other's schema mid-test — the recurring "passes in isolation, fails under full suite" flake, reproduced deterministically. Fix: namespace the DB per process (`{base}_{worker}_{pid}`), created/dropped by a session-scoped fixture over the base URL. Opt-out `QUALIS_TEST_DB_ISOLATION=0`. Regression guard added.

3. **`test(security)` — interleave timing-parity arms.** The 4 `test_timing_parity` tests collected each arm sequentially, so slow system-load drift across the phase boundary (a concurrent backup during `make ci`) masqueraded as a timing leak — failed `make ci` under load while passing in isolation. Fix: sample both arms alternately so drift cancels in the median delta.

## Verification

- Frontend: hook 17/17, page 9/9; `make ci-fast` green.
- DB isolation: controlled two-concurrent-run experiment now 18/18 each (was A:4 failed/3 errors, B:3 failed/6 errors); full `make ci` ran the Alembic integration tests + `test_db_isolation.py` — 930 passed.
- Timing fix: 4/4 ×3 normal **and once under induced CPU+IO contention** reproducing the `make ci` failure condition; full file 8/8; ruff clean.

Note: the only `make ci` failure pre-fix was the timing flake (#3), now fixed; a full green-on-record `make ci` is best run on an idle machine (each run is ~20min under current load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)