### PR TITLE
feat(admin): move superuser platform settings into account menu

### DIFF
--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -254,6 +254,7 @@
             "beta": "Research beta",
             "logout": "Log out",
             "account": "Account settings",
+            "platform_settings": "Platform settings",
             "admin_user": "Admin user"
         },
         "account": {
@@ -341,9 +342,7 @@
             "select_project": "Select project",
             "concourses": "Concourses",
             "concourse": "Concourse",
-            "members": "Team members",
-            "platform": "Platform",
-            "users": "Users"
+            "members": "Team members"
         },
         "concourse": {
             "title": "Concourse",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -166,6 +166,7 @@
             "beta": "Bêta",
             "logout": "Déconnexion",
             "account": "Paramètres du compte",
+            "platform_settings": "Paramètres de la plateforme",
             "admin_user": "Administrateur"
         },
         "account": {
@@ -253,9 +254,7 @@
             "study_tools": "Outils d'étude",
             "concourses": "Concours",
             "concourse": "Concours",
-            "members": "Membres de l'équipe",
-            "platform": "Plateforme",
-            "users": "Utilisateurs"
+            "members": "Membres de l'équipe"
         },
         "concourse": {
             "title": "Concours",

--- a/frontend/src/components/admin/AppSidebar.tsx
+++ b/frontend/src/components/admin/AppSidebar.tsx
@@ -93,8 +93,16 @@ function NavLanguage() {
     );
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: mock user
-function NavUser({ user, projectSlug }: { user: any; projectSlug?: string }) {
+function NavUser({
+    user,
+    projectSlug,
+    isSuperuser,
+}: {
+    // biome-ignore lint/suspicious/noExplicitAny: mock user
+    user: any;
+    projectSlug?: string;
+    isSuperuser: boolean;
+}) {
     const logout = useAuthStore((state) => state.logout);
     const navigate = useNavigate();
     const { t } = useTranslation();
@@ -150,6 +158,12 @@ function NavUser({ user, projectSlug }: { user: any; projectSlug?: string }) {
                                 <BadgeCheck className="mr-2 h-4 w-4" />
                                 {t('admin.layout.account', 'Account settings')}
                             </DropdownMenuItem>
+                            {isSuperuser && (
+                                <DropdownMenuItem onSelect={() => navigate('/app/users')}>
+                                    <ShieldCheck className="mr-2 h-4 w-4" />
+                                    {t('admin.layout.platform_settings', 'Platform settings')}
+                                </DropdownMenuItem>
+                            )}
                         </DropdownMenuGroup>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem onSelect={handleLogout}>
@@ -380,30 +394,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                         </SidebarMenu>
                     </SidebarGroup>
                 )}
-                {isSuperuser && (
-                    <SidebarGroup>
-                        <SidebarGroupLabel className="px-2 text-xs font-semibold text-slate-600">
-                            {t('admin.sidebar.platform', 'Platform')}
-                        </SidebarGroupLabel>
-                        <SidebarMenu>
-                            <SidebarMenuItem>
-                                <SidebarMenuButton
-                                    asChild
-                                    isActive={location.pathname === '/app/users'}
-                                >
-                                    <Link to="/app/users">
-                                        <Users />
-                                        <span>{t('admin.sidebar.users', 'Users')}</span>
-                                    </Link>
-                                </SidebarMenuButton>
-                            </SidebarMenuItem>
-                        </SidebarMenu>
-                    </SidebarGroup>
-                )}
             </SidebarContent>
             <SidebarFooter className="gap-2">
                 <NavLanguage />
-                <NavUser user={user} projectSlug={projectSlug} />
+                <NavUser user={user} projectSlug={projectSlug} isSuperuser={isSuperuser} />
             </SidebarFooter>
         </Sidebar>
     );


### PR DESCRIPTION
## What

Replaces the left-sidebar superuser **Platform → Users** group with a **Platform settings** entry in the user dropdown menu, directly below **Account settings**.

## Why

The superuser user-management link cluttered the left navigation. It is now grouped with the other account/settings actions, shown only to superusers.

## Details

- `AppSidebar.tsx`: removed the `isSuperuser` sidebar group; added a conditional `DropdownMenuItem` (`ShieldCheck` icon) in `NavUser` below "Account settings", navigating to `/app/users`. `isSuperuser` threaded in as a prop.
- The `/app/users` page itself is unchanged and still guarded by `RequireSuperuser`.
- i18n: added `admin.layout.platform_settings` (EN "Platform settings" / FR "Paramètres de la plateforme"); removed the now-unused `admin.sidebar.platform` and `admin.sidebar.users` keys (EN/FR parity preserved).

## Verification

`make ci-fast` green — lint + types + 282 backend tests + 1459 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)