### PR TITLE
fix(deps): pin mando<0.8 to resolve radon conflict breaking Scalingo deploy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,13 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    # `mando` is a transitive dependency pulled in only by `radon`.
+    # radon 6.0.1 (latest) hard-caps it at `mando<0.8`, so a Dependabot
+    # bump to mando>=0.8 produces an unsolvable pip resolution and breaks
+    # the Scalingo deploy (PR #132 did exactly this). Its version is
+    # dictated by radon — never bump it independently.
+    ignore:
+      - dependency-name: "mando"
 
   - package-ecosystem: "npm"
     directory: "/frontend"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -128,7 +128,7 @@ limits==5.6.0
     # via slowapi
 mako==1.3.10
     # via alembic
-mando==0.8.2
+mando==0.7.1
     # via radon
 markdown-it-py==4.0.0
     # via rich


### PR DESCRIPTION
## Problem

Every Scalingo deploy of `libre-q-testing` since commit `2e2b944` has been a **build error**. The frontend build succeeds; the **Python buildpack** fails:

\`\`\`
ERROR: Cannot install mando==0.8.2 and radon==6.0.1 because these package versions have conflicting dependencies.
    The user requested mando==0.8.2
    radon 6.0.1 depends on mando<0.8 and >=0.6
ERROR: ResolutionImpossible
\`\`\`

## Root cause

Dependabot PR #132 (`2e2b9440`, "Bump mando from 0.7.1 to 0.8.2") hand-edited the **pinned line in `backend/requirements.txt`**. But `mando` is a *transitive* dependency pulled in only by `radon` (`# via radon`), and `radon==6.0.1` (latest) hard-caps `mando<0.8`. `uv.lock` correctly has `mando 0.7.1`.

Scalingo's plain `pip install -r requirements.txt` does strict resolution and correctly rejects the combo. `make ci` / `uv` use the existing venv, so CI never caught it. Every commit after #132 (incl. unrelated UI work) inherited the broken file.

## Fix (surgical, 2 files)

- `backend/requirements.txt`: `mando==0.8.2` → `mando==0.7.1` (the `uv.lock` value; satisfies `radon`). No other pin touched.
- `.github/dependabot.yml`: add `mando` to the pip `ignore` list — its version is dictated by `radon`, so Dependabot must not bump it independently.

## Verification

Clean `pip install --dry-run --ignore-installed -r backend/requirements.txt` (fresh resolver — exactly Scalingo's path): **exit 0, zero conflicts**. `mando-0.7.1` + `radon-6.0.1` coexist; all other Dependabot bumps (coverage 7.13.5, numpy 2.4.4, librt 0.9.0, pydantic 2.12.5 …) preserved — no churn, no second lurking conflict.

## Follow-up (not in this PR)

`backend/uv.lock` and `requirements.txt` are broadly desynced from multiple Dependabot hand-edits — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)