### PR TITLE
feat(demo): bundle local MinIO for working audio in docker-compose

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -74,6 +74,15 @@ class Settings(BaseSettings):
     S3_ENDPOINT_URL: str | None = (
         None  # e.g., https://cellar-c2.services.clever-cloud.com
     )
+    # Browser-reachable object-storage host used *only* to mint presigned
+    # URLs, when it differs from the internal upload endpoint. The classic
+    # case is MinIO in docker-compose: the backend uploads via the internal
+    # service hostname (http://minio:9000) but the participant's browser
+    # must fetch playback URLs from a host-published address
+    # (http://localhost:9000). Presigning is an offline SigV4 operation, so
+    # a client pointed at this endpoint mints valid URLs without connecting.
+    # Leave unset for normal deployments where one endpoint serves both.
+    S3_PUBLIC_ENDPOINT_URL: str | None = None
     S3_REGION: str = "us-east-1"
     S3_BUCKET_NAME: str | None = None
     S3_ACCESS_KEY_ID: str | None = None

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -117,6 +117,29 @@ class StorageService:
                 response_checksum_validation="when_required",
             ),
         )
+        # Presigned-URL client. When S3_PUBLIC_ENDPOINT_URL is set and differs
+        # from the internal endpoint, presigned URLs must point at the
+        # browser-reachable host, not the internal one (e.g. MinIO in
+        # docker-compose: backend uploads via http://minio:9000, the
+        # participant's browser plays back from http://localhost:9000).
+        # Presigning is an offline SigV4 operation, so this client never has
+        # to reach the public host. Otherwise reuse the single client.
+        public_endpoint = settings.S3_PUBLIC_ENDPOINT_URL
+        if public_endpoint and public_endpoint != settings.S3_ENDPOINT_URL:
+            self.presign_client = boto3.client(
+                "s3",
+                endpoint_url=public_endpoint,
+                region_name=settings.S3_REGION,
+                aws_access_key_id=settings.S3_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.S3_SECRET_ACCESS_KEY,
+                config=BotoConfig(
+                    request_checksum_calculation="when_required",
+                    response_checksum_validation="when_required",
+                ),
+            )
+        else:
+            self.presign_client = self.s3_client
+
         # settings.S3_BUCKET_NAME is str | None; the all() guard above guarantees
         # it is non-None at this point. Use an explicit raise (not assert) so the
         # narrow holds even if Python is run with -O.
@@ -232,7 +255,7 @@ class StorageService:
             ServiceError: If URL generation fails
         """
         try:
-            url = self.s3_client.generate_presigned_url(
+            url = self.presign_client.generate_presigned_url(
                 "get_object",
                 Params={"Bucket": self.bucket_name, "Key": s3_key},
                 ExpiresIn=expiration,

--- a/backend/tests/unit/test_storage_service.py
+++ b/backend/tests/unit/test_storage_service.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError
 
+from app.core.config import settings
 from app.exceptions import NotFoundError, ServiceError
 from app.services.storage_service import StorageService
 
@@ -31,6 +32,8 @@ def _make_service() -> tuple[StorageService, MagicMock]:
     svc = StorageService(skip_init=True)
     mock_client = MagicMock()
     svc.s3_client = mock_client
+    # Default: one client serves both upload and presigning (no split endpoint).
+    svc.presign_client = mock_client
     svc.bucket_name = "test-bucket"
     return svc, mock_client
 
@@ -251,6 +254,60 @@ def test_generate_presigned_url_client_error_raises_service_error():
 
     with pytest.raises(ServiceError, match="Failed to generate audio URL"):
         svc.generate_presigned_url("audio/study/x.webm")
+
+
+# ---------------------------------------------------------------------------
+# split internal / public endpoint (S3_PUBLIC_ENDPOINT_URL)
+# ---------------------------------------------------------------------------
+
+
+def test_presign_client_uses_public_endpoint_when_set():
+    """When S3_PUBLIC_ENDPOINT_URL differs from the internal endpoint, a
+    *separate* boto3 client is built for presigning, pointed at the public
+    (browser-reachable) host. The MinIO docker-compose case.
+    """
+    internal_client = MagicMock(name="internal")
+    presign_client = MagicMock(name="presign")
+    built: list[str | None] = []
+
+    def _fake_client(_service: str, **kwargs: object):
+        built.append(kwargs.get("endpoint_url"))  # type: ignore[arg-type]
+        return internal_client if len(built) == 1 else presign_client
+
+    with (
+        patch("app.services.storage_service.boto3.client", side_effect=_fake_client),
+        patch.object(settings, "S3_ENDPOINT_URL", "http://minio:9000"),
+        patch.object(settings, "S3_PUBLIC_ENDPOINT_URL", "http://localhost:9000"),
+        patch.object(settings, "S3_BUCKET_NAME", "qualis-audio"),
+        patch.object(settings, "S3_ACCESS_KEY_ID", "key"),
+        patch.object(settings, "S3_SECRET_ACCESS_KEY", "secret"),
+    ):
+        svc = StorageService()
+
+    assert built == ["http://minio:9000", "http://localhost:9000"]
+    assert svc.s3_client is internal_client
+    assert svc.presign_client is presign_client
+
+
+def test_presign_client_aliases_main_client_when_public_endpoint_unset():
+    """With no S3_PUBLIC_ENDPOINT_URL, presigning reuses the single client —
+    no redundant second client is constructed (normal deployments)."""
+    only_client = MagicMock(name="only")
+
+    with (
+        patch(
+            "app.services.storage_service.boto3.client", return_value=only_client
+        ) as mk,
+        patch.object(settings, "S3_ENDPOINT_URL", "https://cellar.example.com"),
+        patch.object(settings, "S3_PUBLIC_ENDPOINT_URL", None),
+        patch.object(settings, "S3_BUCKET_NAME", "qualis-audio"),
+        patch.object(settings, "S3_ACCESS_KEY_ID", "key"),
+        patch.object(settings, "S3_SECRET_ACCESS_KEY", "secret"),
+    ):
+        svc = StorageService()
+
+    assert mk.call_count == 1
+    assert svc.presign_client is svc.s3_client is only_client
 
 
 # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,13 @@
+# Internal S3 credentials/endpoint shared by the backend (server-side
+# uploads) and the one-shot bucket bootstrap. The browser never uses these;
+# presigned playback URLs are minted against S3_PUBLIC_ENDPOINT_URL below.
+x-s3-internal-env: &s3-internal-env
+  S3_ENDPOINT_URL: http://minio:9000
+  S3_BUCKET_NAME: qualis-audio
+  S3_ACCESS_KEY_ID: qualis
+  S3_SECRET_ACCESS_KEY: qualis-minio-dev
+  S3_REGION: us-east-1
+
 services:
   db:
     image: postgres:16-alpine
@@ -13,9 +23,45 @@ services:
       timeout: 3s
       retries: 5
 
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: qualis
+      MINIO_ROOT_PASSWORD: qualis-minio-dev
+    ports:
+      - "9000:9000"  # S3 API — must be host-reachable for audio playback
+      - "9001:9001"  # web console (http://localhost:9001), optional
+    volumes:
+      - miniodata:/data
+
+  # One-shot: waits for MinIO to accept connections, then creates and
+  # configures the audio bucket (ACL, CORS, lifecycle) via the existing
+  # scripts/create_bucket.py. Reuses the backend image (boto3 + the script
+  # are already present). Exits 0; the backend gates on its success.
+  bucket-init:
+    build: ./backend
+    environment:
+      <<: *s3-internal-env
+    depends_on:
+      minio:
+        condition: service_started
+    restart: "no"
+    command:
+      - sh
+      - -c
+      - >
+        until uv run python -c "import boto3,os;
+        boto3.client('s3', endpoint_url=os.environ['S3_ENDPOINT_URL'],
+        aws_access_key_id=os.environ['S3_ACCESS_KEY_ID'],
+        aws_secret_access_key=os.environ['S3_SECRET_ACCESS_KEY']).list_buckets()"
+        2>/dev/null; do echo "waiting for minio..."; sleep 2; done
+        && uv run python scripts/create_bucket.py
+
   backend:
     build: ./backend
     environment:
+      <<: *s3-internal-env
       DATABASE_URL: postgresql+asyncpg://qualis:qualis@db:5432/qualis
       SECRET_KEY: docker-dev-secret-change-in-production
       IP_HASH_SALT: docker-dev-salt-change-in-production
@@ -23,9 +69,16 @@ services:
       ENVIRONMENT: development
       ADMIN_EMAIL: admin@example.com
       ADMIN_PASSWORD: admin123
+      # Browser-reachable MinIO host for presigned playback URLs. The
+      # backend still uploads via the internal http://minio:9000.
+      S3_PUBLIC_ENDPOINT_URL: http://localhost:9000
     depends_on:
       db:
         condition: service_healthy
+      bucket-init:
+        condition: service_completed_successfully
+      minio:
+        condition: service_started
     healthcheck:
       test:
         [
@@ -46,3 +99,4 @@ services:
 
 volumes:
   pgdata:
+  miniodata:

--- a/docs/guides/s3-setup.md
+++ b/docs/guides/s3-setup.md
@@ -116,6 +116,28 @@ Qualis uses the standard AWS S3 SDK (boto3). Any S3-compatible provider should w
 
 For non-AWS providers, you may need to set an additional `S3_ENDPOINT_URL` environment variable pointing to the provider's S3-compatible endpoint.
 
+### Split internal / public endpoint (`S3_PUBLIC_ENDPOINT_URL`)
+
+When the object-storage host the **backend** reaches differs from the
+host the **participant's browser** must reach for playback, set the
+optional `S3_PUBLIC_ENDPOINT_URL`. Presigned playback URLs are then
+minted against it while server-side uploads keep using
+`S3_ENDPOINT_URL`. Presigning is an offline SigV4 operation, so the
+backend never has to reach the public host itself.
+
+The canonical case is the bundled `docker-compose.yml`, which runs a
+local MinIO so the demo has working audio out of the box:
+
+| Variable | Value | Used by |
+|----------|-------|---------|
+| `S3_ENDPOINT_URL` | `http://minio:9000` | backend upload (internal Docker network) |
+| `S3_PUBLIC_ENDPOINT_URL` | `http://localhost:9000` | browser playback (host-published port) |
+
+Leave `S3_PUBLIC_ENDPOINT_URL` unset for normal single-endpoint
+deployments (AWS, Cellar, R2) — presigning then reuses the one client.
+The bucket itself is created and configured automatically by the
+`bucket-init` service via `scripts/create_bucket.py`.
+
 ---
 
 ## Upload Reliability


### PR DESCRIPTION
## Why

The demo `docker-compose.yml` had no object storage, so Qualis ran in **storage-optional mode**: the audio subsystem was unavailable and audio-enabled studies silently degraded to text-only. The audio capture/playback flow — a core feature — was invisible in the demo.

## What

- **`minio` service** + one-shot **`bucket-init`** (reuses the backend image to run the existing `scripts/create_bucket.py`) so audio works out of the box on `docker compose up`. MinIO API published on host `:9000`, console on `:9001`.
- **`S3_PUBLIC_ENDPOINT_URL`** (optional, `config.py` + `storage_service.py`): the backend uploads via the internal `http://minio:9000`, but presigned **playback** URLs must point at the host-reachable `http://localhost:9000`. Presigning is an offline SigV4 op, so a separate boto3 client minted against the public endpoint never connects. When unset, the single client is reused (no behaviour change for AWS/Cellar/R2). Useful beyond the demo wherever the public object-storage host differs from the internal one.
- Docs: `s3-setup.md` documents the setting + the MinIO split-endpoint table.

## Tests

- TDD; `storage_service` is under `mypy --strict`. +2 unit tests (split builds 2 clients with correct endpoints; unset → single client, no redundant construction). `test_storage_service.py` 15/15.
- `make ci` green locally (backend 293, frontend 1478, build OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)