### PR TITLE
fix: surface centroid non-convergence + document reliability/bootstrap assumptions (F-06-010, F-06-004)

### DIFF
--- a/backend/app/models/analysis.py
+++ b/backend/app/models/analysis.py
@@ -24,7 +24,7 @@ class AnalysisRun(Base):
     """Persisted record of a Q-method factor analysis execution.
 
     Captures both the analytical choices the researcher made (extraction,
-    rotation, n_factors, flagging mode/threshold) and the full result, so
+    rotation, n_factors, flagging mode) and the full result, so
     that analytical decisions are auditable across sessions and visible to
     co-authors and reviewers. This supports the critical Q-methodology
     requirement that analytical choices be transparent (Stainton Rogers

--- a/backend/app/routers/admin/analysis.py
+++ b/backend/app/routers/admin/analysis.py
@@ -366,6 +366,7 @@ async def run_factor_analysis(
         ],
         manual_rotations=list(body.manual_rotations) if body.manual_rotations else [],
         bootstrap=bootstrap_payload,
+        warnings=result["warnings"],
     )
 
     # Persist the run as part of the audit trail. We persist on the success

--- a/backend/app/schemas/analysis.py
+++ b/backend/app/schemas/analysis.py
@@ -252,6 +252,12 @@ class AnalysisResult(BaseModel):
         description="Bootstrap stability output (Zabala & Pascual 2016). Set "
         "only when the request opted in via `bootstrap_iterations`.",
     )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Non-fatal warnings raised while computing this result, e.g. "
+        "centroid extraction that did not fully converge (F-06-010). Empty when "
+        "the analysis ran cleanly. Surfaced to the researcher above the results.",
+    )
 
 
 class EigenvalueResult(BaseModel):

--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -28,6 +28,13 @@ from app.types.wire import (
 
 logger = logging.getLogger(__name__)
 
+# Average reliability coefficient used in the Spearman-Brown composite
+# reliability and the standard error of factor scores. Fixed at 0.8 following
+# the qmethod-R default (Brown 1980, Political Subjectivity, p. 293); Qualis
+# does not currently expose this as a per-study parameter, so it is a named
+# constant rather than a configurable input (F-06-004).
+DEFAULT_AV_REL_COEF = 0.8
+
 
 # ---------------------------------------------------------------------------
 # Cluster 1 — Analysis wire types (private to this module)
@@ -136,6 +143,7 @@ class AnalysisRunResult(TypedDict):
     distinguishing: list[StatementClassEntry]
     consensus: list[StatementClassEntry]
     manual_rotations: list[dict[str, object]]
+    warnings: list[str]
 
 
 def build_sort_matrix(
@@ -256,7 +264,7 @@ def extract_pca(cor_mat: NDArray[np.float64], n_factors: int) -> NDArray[np.floa
 
 def extract_centroid(
     cor_mat: NDArray[np.float64], n_factors: int, spc: float = 1e-5
-) -> NDArray[np.float64]:
+) -> tuple[NDArray[np.float64], list[str]]:
     """Extract factors using Brown's centroid method.
 
     Based on Brown (1980), Political Subjectivity, pp. 208-224.
@@ -269,7 +277,14 @@ def extract_centroid(
         spc: Convergence threshold
 
     Returns:
-        Loadings matrix of shape (n_participants, n_factors)
+        Tuple of (loadings, warnings) where ``loadings`` has shape
+        (n_participants, n_factors) and ``warnings`` is a list of
+        human-readable strings describing any non-convergence or
+        degeneracy encountered during extraction (empty when the
+        iteration converged cleanly for every factor). The same messages
+        are also emitted via ``logger.warning`` for server-side logs;
+        the returned list is what gets surfaced to the researcher (see
+        F-06-010).
 
     Translated to Python in 2026 by Julien Vastenaekels from the R `qmethod`
     package (centroid.R, Frans Hermans, 2021), used under GPL-2+.
@@ -278,6 +293,7 @@ def extract_centroid(
     n = cor_mat.shape[0]
     tmat = cor_mat.copy()
     loadings = np.zeros((n, n_factors))
+    warnings: list[str] = []
 
     for f in range(n_factors):
         np.fill_diagonal(tmat, 0.0)
@@ -302,6 +318,11 @@ def extract_centroid(
                 f + 1,
                 max_reflections,
             )
+            warnings.append(
+                f"Centroid factor {f + 1}: sign-reflection step did not stabilise "
+                f"after {max_reflections} iterations; loadings for this factor may "
+                "be less reliable."
+            )
 
         # Step 2: Initial factor estimate
         col_sums = tmat.sum(axis=0)
@@ -312,6 +333,11 @@ def extract_centroid(
             logger.warning(
                 "Centroid factor %d: degenerate initial estimate (sum <= 0)",
                 f + 1,
+            )
+            warnings.append(
+                f"Centroid factor {f + 1}: degenerate initial estimate; extraction "
+                f"stopped early, so fewer than the {n_factors} requested factors "
+                "were fully extracted."
             )
             break
         f1 = t1 / np.sqrt(sum_t1)
@@ -325,6 +351,10 @@ def extract_centroid(
             if sum_t2 <= 0:
                 logger.warning(
                     "Centroid factor %d: degenerate matrix (sum <= 0)", f + 1
+                )
+                warnings.append(
+                    f"Centroid factor {f + 1}: residual matrix became degenerate "
+                    "during iteration; this factor may be unreliable."
                 )
                 break
             t2 = tmat.sum(axis=0) + rmean_new
@@ -341,6 +371,11 @@ def extract_centroid(
                 "Centroid factor %d: did not converge after %d iterations",
                 f + 1,
                 max_iter,
+            )
+            warnings.append(
+                f"Centroid factor {f + 1}: did not converge after {max_iter} "
+                f"iterations (tolerance {spc:g}); loadings for this factor may be "
+                "less reliable."
             )
 
         # Step 4: Reverse reflections on the factor
@@ -361,7 +396,7 @@ def extract_centroid(
 
         tmat = residual
 
-    return loadings
+    return loadings, warnings
 
 
 def rotate_varimax(
@@ -679,7 +714,7 @@ def compute_factor_characteristics(
     loadings: NDArray[np.float64],
     flagged: NDArray[np.bool_],
     z_scores: NDArray[np.float64],
-    av_rel_coef: float = 0.8,
+    av_rel_coef: float = DEFAULT_AV_REL_COEF,
 ) -> tuple[list[FactorCharacteristicDict], NDArray[np.float64], NDArray[np.float64]]:
     """Compute factor characteristics, correlation, and SED matrix.
 
@@ -687,7 +722,9 @@ def compute_factor_characteristics(
         loadings: (Rotated) loadings matrix (n_participants x n_factors)
         flagged: Flagging matrix (n_participants x n_factors)
         z_scores: Z-scores matrix (n_statements x n_factors)
-        av_rel_coef: Average reliability coefficient (default 0.8)
+        av_rel_coef: Average reliability coefficient. Fixed at the qmethod-R /
+            Brown (1980) default of 0.8 (``DEFAULT_AV_REL_COEF``); not exposed
+            as a per-study parameter (F-06-004).
 
     Returns:
         Tuple of (characteristics, factor_correlation, sed_matrix)
@@ -1056,10 +1093,11 @@ def run_analysis(
     all_eigenvalues, _ = compute_eigenvalues(cor_mat)
 
     # Step 3: Factor extraction
+    warnings: list[str] = []
     if extraction == "pca":
         unrotated = extract_pca(cor_mat, n_factors)
     elif extraction == "centroid":
-        unrotated = extract_centroid(cor_mat, n_factors)
+        unrotated, warnings = extract_centroid(cor_mat, n_factors)
     else:
         raise ValueError(f"Unknown extraction method: {extraction}")
 
@@ -1082,7 +1120,17 @@ def run_analysis(
     rotated = standardize_factor_signs(rotated)
 
     # Step 5: Flagging
-    if flagging == "manual" and manual_flags_matrix is not None:
+    if flagging == "manual":
+        if manual_flags_matrix is None:
+            # Fail loudly rather than silently falling back to auto flagging
+            # (F-06-004). The router already rejects this combination with a
+            # 400, but a service-level guard stops any future caller from
+            # silently producing an auto-flagged solution it asked to be
+            # manual. Bootstrap/preview deliberately pass flagging="auto".
+            raise ValueError(
+                "flagging='manual' requires a manual_flags_matrix; refusing to "
+                "silently fall back to automatic flagging"
+            )
         flags = manual_flags_matrix
     else:
         flags = flag_sorts(rotated, n_statements)
@@ -1122,6 +1170,7 @@ def run_analysis(
         distinguishing=dist_list,
         consensus=cons_list,
         manual_rotations=list(manual_rotations) if manual_rotations else [],
+        warnings=warnings,
     )
 
 

--- a/backend/tests/unit/test_analysis_service.py
+++ b/backend/tests/unit/test_analysis_service.py
@@ -165,17 +165,18 @@ class TestExtractPCA:
 class TestExtractCentroid:
     def test_shape(self, dataset):
         cor = correlation_matrix(dataset)
-        loadings = extract_centroid(cor, 2)
+        loadings, warnings = extract_centroid(cor, 2)
         assert loadings.shape == (8, 2)
+        assert warnings == []
 
     def test_loadings_not_all_zero(self, dataset):
         cor = correlation_matrix(dataset)
-        loadings = extract_centroid(cor, 2)
+        loadings, _ = extract_centroid(cor, 2)
         assert np.any(np.abs(loadings) > 0.1)
 
     def test_single_factor(self, dataset):
         cor = correlation_matrix(dataset)
-        loadings = extract_centroid(cor, 1)
+        loadings, _ = extract_centroid(cor, 1)
         assert loadings.shape == (8, 1)
 
 
@@ -508,14 +509,14 @@ class TestCentroidEdgeCases:
     def test_centroid_single_factor(self, dataset):
         """Single factor centroid extraction should produce valid loadings."""
         cor = correlation_matrix(dataset)
-        loadings = extract_centroid(cor, 1)
+        loadings, _ = extract_centroid(cor, 1)
         assert loadings.shape == (8, 1)
         assert not np.all(loadings == 0)
 
     def test_centroid_many_factors(self, dataset):
         """Extracting many factors (up to n_participants) should not crash."""
         cor = correlation_matrix(dataset)
-        loadings = extract_centroid(cor, 7)
+        loadings, _ = extract_centroid(cor, 7)
         assert loadings.shape == (8, 7)
 
     def test_centroid_near_singular(self):
@@ -532,9 +533,57 @@ class TestCentroidEdgeCases:
             dtype=np.float64,
         )
         cor = correlation_matrix(data)
-        loadings = extract_centroid(cor, 2)
+        loadings, _ = extract_centroid(cor, 2)
         assert loadings.shape == (4, 2)
         assert np.all(np.isfinite(loadings))
+
+
+class TestCentroidWarnings:
+    """F-06-010: centroid non-convergence / degeneracy is surfaced, not silent."""
+
+    def test_clean_run_has_no_warnings(self, dataset):
+        cor = correlation_matrix(dataset)
+        _loadings, warnings = extract_centroid(cor, 2)
+        assert warnings == []
+
+    def test_degenerate_matrix_emits_warning(self):
+        # Perfectly collinear participants -> all-ones correlation; the residual
+        # collapses after factor 1, so factor 2 hits the degenerate-estimate path.
+        cor = np.ones((4, 4))
+        _loadings, warnings = extract_centroid(cor, 3)
+        assert warnings, "expected a non-convergence/degeneracy warning"
+        assert any("Centroid factor" in w for w in warnings)
+        assert any("degenerate" in w.lower() for w in warnings)
+
+    def test_run_analysis_propagates_centroid_warnings(self):
+        # 6 statements x 4 identical participants -> all-ones correlation matrix.
+        col = np.linspace(2.0, -2.0, 6).reshape(-1, 1)
+        data = np.tile(col, (1, 4))
+        result = run_analysis(
+            data, n_factors=2, extraction="centroid", rotation="varimax"
+        )
+        assert result["warnings"], "centroid warnings should reach run_analysis"
+
+    def test_run_analysis_pca_has_empty_warnings(self, dataset):
+        result = run_analysis(
+            dataset, n_factors=2, extraction="pca", rotation="varimax"
+        )
+        assert result["warnings"] == []
+
+
+class TestManualFlaggingGuard:
+    """F-06-004: manual flagging never silently falls back to auto."""
+
+    def test_manual_without_matrix_raises(self, dataset):
+        with pytest.raises(ValueError, match="manual_flags_matrix"):
+            run_analysis(
+                dataset,
+                n_factors=2,
+                extraction="pca",
+                rotation="varimax",
+                flagging="manual",
+                manual_flags_matrix=None,
+            )
 
 
 class TestVarimaxEdgeCases:

--- a/docs/explanation/q-methodology.md
+++ b/docs/explanation/q-methodology.md
@@ -143,7 +143,7 @@ Qualis provides affordances for **both** strands. Extraction, rotation, and expo
 
 | Reflexive / transparency need | How Qualis supports it |
 |-------------------------------|--------------------------|
-| Transparency of analytical choices | Every analysis run is persisted with its parameters (extraction method, rotation, flagging threshold, `av_rel_coef`). Researchers can audit what was changed when, and explain those changes in their methods section. |
+| Transparency of analytical choices | Every analysis run is persisted with the choices that produced it — extraction method, number of factors, rotation, flagging mode, and any judgmental rotations. Researchers can audit what was changed when, and explain those choices in their methods section. The reliability coefficient behind composite reliability and the standard errors is held at the qmethod-R / Brown (1980) default (`av_rel_coef` = 0.8) rather than being a per-study setting. |
 | Researcher control over flagging | Auto-flagging is a starting point. Flagging is exposed and editable per study, and researcher decisions are part of the audit trail. |
 | Integration of participant voice | Post-sort recordings (audio + free-text) are stored alongside the Q-sort and are linkable to factor membership in the analysis interface. This supports the reflexive practice of grounding factor interpretation in the words of the people who define each factor (Sneegas 2020; Robbins & Krueger 2000). |
 | Reflexivity about the P-set | The recruitment funnel records who was invited, who started, who completed, and from which channel. The constructed nature of the P-set is visible rather than implicit. |

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7199,6 +7199,14 @@
               }
             ],
             "description": "Bootstrap stability output (Zabala & Pascual 2016). Set only when the request opted in via `bootstrap_iterations`."
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings",
+            "description": "Non-fatal warnings raised while computing this result, e.g. centroid extraction that did not fully converge (F-06-010). Empty when the analysis ran cleanly. Surfaced to the researcher above the results."
           }
         },
         "type": "object",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -503,6 +503,8 @@
             "reanalyzing": "Re-analyzing...",
             "success": "Analysis complete. {{n}} factors extracted.",
             "error": "Analysis failed: {{message}}",
+            "warnings_title": "This analysis raised warnings",
+            "ci_tooltip": "95% percentile CI (2.5th–97.5th percentile of bootstrapped z-scores) [{{lo}}, {{hi}}]",
             "scree_hint": "Each bar shows how much variance a factor explains (its eigenvalue). The dashed line marks eigenvalue = 1 (Kaiser criterion). Click a bar to select the number of factors to extract.",
             "kaiser_suggestion": "{{n}} factor(s) have eigenvalues above 1 (Kaiser criterion)",
             "factor": "Factor",
@@ -672,10 +674,10 @@
             "bootstrap": {
                 "toggle_label": "Run bootstrap stability",
                 "iterations_label": "Iterations (B)",
-                "helper": "Optional. Resamples Q-sorts B times to estimate confidence intervals on factor scores.",
+                "helper": "Optional. Resamples Q-sorts B times to estimate percentile confidence intervals on factor scores.",
                 "running": "Running bootstrap…",
                 "se_column": "Mean SE (z)",
-                "tooltip": "Non-parametric bootstrap of Q-sorts (resampled with replacement); analysis is repeated B times to estimate 95% CIs on z-scores."
+                "tooltip": "Non-parametric bootstrap of Q-sorts (resampled with replacement); analysis is repeated B times to estimate 95% percentile CIs (2.5th–97.5th percentile) on z-scores. Resampling does not preserve participant identity, so each resample is auto-flagged even when the committed run used manual flagging."
             },
             "explore": {
                 "diagnostics_title": "Diagnostics",

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -18277,6 +18277,12 @@ export const getRunFactorAnalysisApiAdminStudiesSlugAnalysisRunPostResponseMock 
         ]),
         undefined,
     ]),
+    warnings: faker.helpers.arrayElement([
+        Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() =>
+            faker.string.alpha({ length: { min: 10, max: 20 } })
+        ),
+        undefined,
+    ]),
     ...overrideResponse,
 });
 

--- a/frontend/src/api/model/analysisResult.ts
+++ b/frontend/src/api/model/analysisResult.ts
@@ -39,4 +39,6 @@ export interface AnalysisResult {
     manual_rotations?: ManualRotation[];
     /** Bootstrap stability output (Zabala & Pascual 2016). Set only when the request opted in via `bootstrap_iterations`. */
     bootstrap?: AnalysisResultBootstrap;
+    /** Non-fatal warnings raised while computing this result, e.g. centroid extraction that did not fully converge (F-06-010). Empty when the analysis ran cleanly. Surfaced to the researcher above the results. */
+    warnings?: string[];
 }

--- a/frontend/src/components/admin/analysis/StatementsTable.tsx
+++ b/frontend/src/components/admin/analysis/StatementsTable.tsx
@@ -237,7 +237,14 @@ export function StatementsTable({ result }: StatementsTableProps) {
                                                 )}
                                                 title={
                                                     stab
-                                                        ? `95% CI [${stab.ci_lower.toFixed(2)}, ${stab.ci_upper.toFixed(2)}]`
+                                                        ? t(
+                                                              'admin.analysis.ci_tooltip',
+                                                              '95% percentile CI (2.5th–97.5th percentile of bootstrapped z-scores) [{{lo}}, {{hi}}]',
+                                                              {
+                                                                  lo: stab.ci_lower.toFixed(2),
+                                                                  hi: stab.ci_upper.toFixed(2),
+                                                              }
+                                                          )
                                                         : undefined
                                                 }
                                             >

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -570,6 +570,64 @@ describe('AnalysisPage', () => {
         expect(await screen.findByText(/Reading Factor Loadings/i)).toBeInTheDocument();
     });
 
+    it('surfaces non-fatal analysis warnings above the results (F-06-010)', async () => {
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+        const warning = 'Centroid factor 2: did not converge after 1000 iterations';
+        mockGetRunHook.mockReturnValue({
+            data: {
+                ...mockRun,
+                result: {
+                    ...mockResult,
+                    warnings: [warning],
+                } as unknown as AnalysisRunRead['result'],
+            },
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+        });
+
+        renderWithProviders(<AnalysisPage />, {
+            initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+        });
+
+        const banner = await screen.findByTestId('analysis-warnings');
+        expect(banner).toHaveTextContent(warning);
+    });
+
+    it('renders no warnings banner when the run is clean', async () => {
+        mockEigenvaluesHook.mockReturnValue({
+            data: mockEigenvalues,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+        mockGetRunHook.mockReturnValue({
+            data: mockRun,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+            error: null,
+        });
+
+        renderWithProviders(<AnalysisPage />, {
+            initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+        });
+
+        // Wait for the interpret phase to mount, then assert no warnings banner.
+        await screen.findAllByTestId('interpret-phase');
+        expect(screen.queryByTestId('analysis-warnings')).not.toBeInTheDocument();
+    });
+
     // ── Phase-routing tests (Task 11) ──────────────────────────────
 
     it('renders Explore phase by default when no run is loaded', async () => {

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -1131,6 +1131,30 @@ function InterpretShell({
                 </div>
             </div>
 
+            {/* Non-fatal analysis warnings (e.g. centroid non-convergence, F-06-010).
+                Persistent rather than dismissible: a data-quality caveat should
+                stay visible while the analyst interprets and writes up the run. */}
+            {analysisResult.warnings && analysisResult.warnings.length > 0 ? (
+                <div
+                    className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-900"
+                    role="status"
+                    aria-live="polite"
+                    data-testid="analysis-warnings"
+                >
+                    <AlertTriangle className="size-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
+                    <div className="flex-1">
+                        <p className="font-semibold">
+                            {t('admin.analysis.warnings_title', 'This analysis raised warnings')}
+                        </p>
+                        <ul className="mt-1 list-disc pl-5 space-y-0.5">
+                            {analysisResult.warnings.map((w, i) => (
+                                <li key={`${i}-${w}`}>{w}</li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            ) : null}
+
             {/* Results */}
             {mode === 'focus' ? (
                 <FactorCanvas

--- a/openapi.json
+++ b/openapi.json
@@ -7199,6 +7199,14 @@
               }
             ],
             "description": "Bootstrap stability output (Zabala & Pascual 2016). Set only when the request opted in via `bootstrap_iterations`."
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings",
+            "description": "Non-fatal warnings raised while computing this result, e.g. centroid extraction that did not fully converge (F-06-010). Empty when the analysis ran cleanly. Surfaced to the researcher above the results."
           }
         },
         "type": "object",


### PR DESCRIPTION
Closes two own-audit items a SoftwareX reviewer could turn against the authors (anticipated reviewer positions P4 + P9). Adversarially reviewed across four dimensions (q-methodology correctness, type/contract integrity, frontend/i18n/a11y, regression/scope) — all clean before commit.

## F-06-010 — centroid non-convergence is now surfaced
`extract_centroid()` could fail to converge or hit a degenerate residual and only `logger.warning`-ed it server-side; the researcher received silently degraded loadings with no signal.

- `extract_centroid()` → returns `(loadings, warnings: list[str])`, accumulating a human-readable message at each of the four non-convergence/degeneracy sites. **Numerics are byte-identical** — only `warnings.append(...)` lines were inserted beside the existing logs.
- `run_analysis()` threads the list into `AnalysisRunResult`; `AnalysisResult` gains `warnings: list[str]` (`default_factory=list`, backward-compatible with persisted runs); the router passes it through.
- The Analysis page renders a **persistent** (not dismissible) amber banner above the results when `warnings` is non-empty — a data-quality caveat should stay visible while the analyst writes up the run.

## F-06-004 — analysis transparency bundle
- `av_rel_coef = 0.8` promoted to a named `DEFAULT_AV_REL_COEF` constant (qmethod-R / Brown 1980); behaviour-preserving.
- `run_analysis()` now **raises** `ValueError` on `flagging='manual'` without a flag matrix instead of silently falling back to auto. Bootstrap and preview still pass `flagging='auto'` explicitly; the router already 400s the user-facing case, so this is defence-in-depth for future callers.
- Bootstrap CIs documented as **percentile** CIs (2.5th–97.5th) in the statements CI tooltip and the bootstrap helper/tooltip, which now also disclose that resampling auto-flags each replicate (participant identity is not preserved).
- `q-methodology.md` and the `AnalysisRun` docstring no longer present `av_rel_coef` or a non-existent "flagging threshold" as recorded researcher choices.

## Tests
- `TestCentroidWarnings`: deterministic degenerate-matrix trigger, PCA empty-warnings, and `run_analysis` propagation.
- `TestManualFlaggingGuard`: the new `ValueError` path.
- Two `AnalysisPage` cases: banner shown when warnings present / absent when clean.
- Regenerated frontend client (`warnings` field). `make ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
