### PR TITLE
docs: note build-from-source deployment; no hosted instance needed (P7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ A reusable pool of candidate statements that lives at the project level, not the
 
 This is the recommended path for SoftwareX evaluation and first-time use. It starts PostgreSQL, the backend, and the built frontend with development demo credentials.
 
+> The first `make demo-up` **builds the backend and frontend images from source** (no pre-built image is pulled), so the initial run compiles the stack and may take a few minutes; subsequent runs reuse the cached layers. Qualis is self-hosted by design — there is no third-party-hosted instance, which is the point: participant data stays on infrastructure you control.
+
 Prerequisite:
 
 - Docker with the `docker compose` plugin


### PR DESCRIPTION
Scopes **P7** (anticipated SoftwareX reviewer position: "deployment heavier than alternatives, no hosted demo"). The decision was made on **evidence, not assumption** — a 3-agent sourced review of SoftwareX's actual practice.

## What SoftwareX actually requires (sourced)
- **Published container image: not expected.** The mandatory artifacts are a public **GitHub** repo + `README.md` + `License.txt` + the **Code metadata table C1–C8** (official template v6, March 2026). C6 is "Compilation requirements, operating environments and dependencies" — i.e. *documented build-from-source*, not a shipped binary. No row asks for an executable, image, or running instance.
- **Reviewers need not run it as a gate.** The official Reviewer Form Q11 ("able to build, deploy, install and run … following the documentation") accepts **Yes / Partial / No / Not available**, and screenshots/videos count as evidence it "runs as described".
- **Hosted demo: not expected** (the Code Ocean compute capsule is an *opt-in* review accelerator, not a precondition).
- **Modal practice for web apps:** a `Dockerfile` + `docker-compose` the reader builds and runs locally — **exactly what Qualis already ships**.

## Conclusion → docs-only
No GHCR image and no hosted demo are warranted. A public hosted demo would also *contradict* Qualis's pitch ("participant data stays on your server"). The proportionate action is to set reviewer expectations:

- Note that the first `make demo-up` **builds the images from source** (no pre-built image is pulled; first run compiles, later runs reuse cache).
- State that Qualis is **self-hosted by design** — the absence of a third-party-hosted instance is intentional.

## Notes for the maintainer
- The repo has `README.md` and `LICENSE` ✓. SoftwareX's template pedantically says "Licence.txt"; `LICENSE` is GitHub-recognised and used by many accepted SoftwareX repos, so I did **not** rename the canonical license file — flagging it in case you want to add a `LICENSE.txt` alias before submission.
- The real submission lever is the paper's **C1–C8 table** (esp. C6 = runtime + dependencies); the README/deploy docs already cover the dependency list and the clone→build→run path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
