### PR TITLE
chore: reconcile CITATION date + root package version with v0.7.1 (P1)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ abstract: >-
   transparency of analytical choices and integration of post-sort
   participant voice.
 version: "0.7.1" # x-release-please-version
-date-released: "2026-05-15" # update manually when merging the release PR
+date-released: "2026-06-12" # matches the v0.7.1 tag date; update on each release
 doi: "10.5281/zenodo.19985835"
 identifiers:
   - type: doi
@@ -20,11 +20,12 @@ identifiers:
   - type: doi
     value: "10.5281/zenodo.20199750"
     description: "Zenodo archive of Qualis v0.6.7"
-  # TODO (0.7.0 SoftwareX submission): after archiving v0.7.0 on Zenodo, add the
-  # version DOI below and update date-released + the manuscript C3/S3 capsule link.
+  # TODO (0.7.1 SoftwareX submission): once the GitHub release triggers the Zenodo
+  # archive for v0.7.1, replace the placeholder DOI below with the real version DOI
+  # and point the manuscript C3/S3 capsule link at it.
   #   - type: doi
   #     value: "10.5281/zenodo.XXXXXXXX"
-  #     description: "Zenodo archive of Qualis v0.7.0"
+  #     description: "Zenodo archive of Qualis v0.7.1"
 url: "https://github.com/jvastenaekels/qualis"
 repository-code: "https://github.com/jvastenaekels/qualis"
 license: "AGPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qualis-root",
-  "version": "0.1.0",
+  "version": "0.7.1",
   "private": true,
   "scripts": {
     "build": "cd frontend && npm install --include=dev && npm run build",


### PR DESCRIPTION
Post-release metadata reconciliation for **P1** (version/Zenodo consistency), now that **v0.7.1** is cut from the hardened HEAD (includes #212 Lipset CI guard, #213 comparison table, #214 transparency fixes, #215 deployment note).

## Fixed now (no external input needed)
- `CITATION.cff` `date-released`: **2026-05-15 → 2026-06-12**. release-please bumps the `version` field via its marker but does not touch `date-released`; it was still the v0.6.7/v0.6.8 date.
- Root `package.json` `version`: **0.1.0 → 0.7.1** (a `private: true` workspace root that release-please does not manage; aligned for consistency).
- Refreshed the `CITATION.cff` identifiers TODO to target the **v0.7.1** Zenodo archive (was v0.7.0).

## Still pending — needs maintainer input (do NOT merge-block on these)
These are the last two P1 items and require facts I can't supply:
1. **Zenodo v0.7.1 archive DOI.** The GitHub release of v0.7.1 should trigger the Zenodo webhook; once the deposit exists, send me the version DOI and I'll uncomment + fill the `identifiers` entry and point the manuscript C3/S3 capsule link at it.
2. **Both authors' ORCIDs** (Vastenaekels, Dedinger) — still commented-out placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)