### PR TITLE
chore: sync frontend package-lock.json version to 0.7.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "qualis",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "qualis",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",


### PR DESCRIPTION
## Why

release-please bumped `frontend/package.json` to **0.7.1** but left `frontend/package-lock.json` at **0.7.0** (both the root `version` and `packages[""].version`). `npm ci` requires the two to be in sync, so:

- the **Frontend Lint & Quality** CI job failed at its first step (`npm ci`) on *every* PR, and
- `make ci`'s `check_installation_docs.py` gate was red locally.

This is the pre-existing drift noted in #226 / #227.

## What

Bumps the two lockfile `version` fields to `0.7.1`. **No dependency changes** (diff is exactly 2 lines).

## Verification

- `npm ci` → exit 0 ✅ (previously failed immediately on the sync mismatch)
- `python3 scripts/check_installation_docs.py` → "Installation docs are coherent." ✅

Unblocks green CI for #227 and future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)