### PR TITLE
fix(deps): bump starlette to >=1.3.1 for CVE-2026-54282/54283

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "gunicorn>=23.0.0",
     "pyjwt>=2.13.0",
     "httpx>=0.27.0",
-    "starlette>=1.0.1",
+    "starlette>=1.3.1",  # >=1.3.1 excludes CVE-2026-54282 / CVE-2026-54283
     "pyotp>=2.9.0",
     "alembic>=1.18.1",
     "python-multipart>=0.0.27",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1665,7 +1665,7 @@ wheels = [
 
 [[package]]
 name = "qualis-backend"
-version = "0.7.0"
+version = "0.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1738,7 +1738,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.45" },
-    { name = "starlette", specifier = ">=1.0.1" },
+    { name = "starlette", specifier = ">=1.3.1" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
@@ -2012,14 +2012,14 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "1.2.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Two advisories were published for **starlette 1.2.1** — **CVE-2026-54282** and **CVE-2026-54283** — fixed in 1.3.x. As of today `pip-audit` fails on **every** PR, in two places:

- the standalone **pip-audit (Python SCA)** job, and
- the **Security SCA (Pip Audit)** step inside **Backend Lint & Quality** (Ruff / Mypy / Bandit all pass).

This surfaced while fixing the frontend lockfile drift (#229) and is unrelated to it.

## What

- `starlette>=1.0.1` → `starlette>=1.3.1` in `backend/pyproject.toml` (raises the floor to exclude the vulnerable range), then `uv lock`.
- FastAPI 0.136.3 only requires `starlette>=0.46.0`, so **no fastapi change** is needed.
- Lockfile diff: starlette `1.2.1 → 1.3.1`, plus an incidental sync of the `qualis-backend` version `0.7.0 → 0.7.1` (matches `pyproject.toml` — the backend analog of the #229 frontend lockfile drift).

## Verification

- `pip-audit` (CI ignore-list) → **No known vulnerabilities found**
- Full backend suite green under starlette 1.3.1: **unit 301 · integration 376 · security 276 = 953 passed, 4 skipped** (run in chunks to avoid OOM)
- `ruff` · `mypy` (no type-stub regressions) · `deptry` all clean

Unblocks pip-audit / Backend Lint for #227, #229, and future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)