### PR TITLE
fix(demo): backend healthcheck start_period so make demo-up survives cold starts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,13 @@ services:
       interval: 5s
       timeout: 3s
       retries: 12
+      # On a cold first start the backend runs `uv sync` (dependency download)
+      # and Alembic migrations before serving /health — this can exceed the
+      # retry window (12 x 5s) on a fresh build. During start_period, failing
+      # probes do NOT mark the container unhealthy, so `make demo-up` no longer
+      # aborts the frontend on slow first boots. A probe that succeeds earlier
+      # flips the container healthy immediately.
+      start_period: 180s
 
   frontend:
     build: ./frontend


### PR DESCRIPTION
## Problem

On a fresh `docker compose up` (e.g. `make demo-up` on first build), the backend container runs `uv sync` (dependency download) and Alembic migrations **before** it serves `/health`. On a cold build this can exceed the healthcheck retry window (`interval 5s` × `retries 12` ≈ 60s), so Compose marks the backend **unhealthy** and skips the `frontend` service (which `depends_on backend: service_healthy`), aborting with *"dependency failed to start"*. A second `up -d` then works, which is confusing.

## Fix

Add `start_period: 180s` to the backend healthcheck. During the start period, failing probes do **not** count toward `retries` and do **not** flip the container unhealthy; the first successful probe marks it healthy immediately. This is the canonical Docker mechanism for slow-starting services and changes nothing in steady state.

## Verification

- `docker compose config` valid; `start_period` resolves to `3m0s` on the backend only.
- A cold `docker compose up -d` whose backend took **~147s** to become healthy now brings the frontend up in a **single command** (sequence: backend `Waiting → Healthy` → frontend `Started`). Previously this aborted at ~60s.

No application code changed — docker-compose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)