### PR TITLE
perf(demo): start backend from baked venv (cold start ~147s → ~6s)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,7 +26,12 @@ RUN groupadd --system app \
     && chown -R app:app /app
 USER app
 
-# Run migrations and seed, then start the server
-CMD ["sh", "-c", "uv run python init_db.py && uv run uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+# Run migrations and seed, then start the server.
+# Call the baked virtualenv directly instead of `uv run`: a bare `uv run`
+# re-syncs the FULL dev environment (ruff/mypy/deptry/…) on first container
+# start, because the image was built with --no-dev. That cold-start download
+# took ~2-3 minutes. The venv from `uv sync --frozen --no-dev` already has every
+# runtime dependency, so `.venv/bin/...` starts in seconds.
+CMD ["sh", "-c", ".venv/bin/python init_db.py && .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000"]
 
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,10 +72,12 @@ services:
       minio-init:
         condition: service_completed_successfully
     healthcheck:
+      # Use the baked venv directly; a bare `uv run` here would also trigger a
+      # dev re-sync on the first probe (see backend/Dockerfile CMD).
       test:
         [
           "CMD-SHELL",
-          "uv run python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2).read()\"",
+          ".venv/bin/python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2).read()\"",
         ]
       interval: 5s
       timeout: 3s


### PR DESCRIPTION
## Problem

The backend container's cold start was dominated by a **runtime re-sync of dev dependencies**. The image is built with `uv sync --frozen --no-dev`, but the CMD and healthcheck used a bare `uv run`, which re-syncs the *full* dev environment (ruff, mypy, deptry, grimp, pytest…) on first start — a ~2-3 minute download. This also caused the original `make demo-up` papercut (backend unhealthy within the 60s window → frontend skipped), since patched defensively in #233 with `start_period`.

## Fix

Call the baked virtualenv directly instead of `uv run`:

- `backend/Dockerfile` CMD → `.venv/bin/python init_db.py && .venv/bin/uvicorn app.main:app …`
- `docker-compose.yml` backend healthcheck → `.venv/bin/python -c "…"`

The `--no-dev` venv already contains every runtime dependency, and `init_db.py` runs Alembic migrations **in-process** (Python API), so nothing needs `uv run` at runtime.

## Verification

- `docker compose build backend` (deps layer cached) + force-recreate → **backend healthy in ~6s** (was ~147s).
- Runtime venv no longer contains dev tools (`ruff/mypy/deptry/pytest` absent) — leaner runtime surface and proof the dev re-sync is gone.
- App serves (`/api/study/bioeconomy-futures` OK), seeded data persists, `docker compose config` valid.

`start_period` from #233 remains as a safety net for genuinely slow first builds. No application code changed — Dockerfile + compose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)