### PR TITLE
fix/perf: adversarially-verified bug & performance hunt (9 findings)

### DIFF
--- a/backend/app/routers/admin/exports.py
+++ b/backend/app/routers/admin/exports.py
@@ -413,10 +413,13 @@ async def get_research_package(
     result = await db.execute(stmt)
     full_study = result.scalar_one()
 
-    # Get the official JSON dump for inclusion in the package
+    # Get the official JSON dump for inclusion in the package. Reuse the
+    # already-loaded ORM graph (full_study) so the dump is built in memory
+    # instead of re-fetching every participant + Q-sort + audio row a second
+    # time.
     from ...services.study_service import StudyService
 
-    full_dump = await StudyService.get_study_full_dump(db, study.id)
+    full_dump = await StudyService.get_study_full_dump(db, study.id, study=full_study)
 
     # Fetch memo and render markdown for inclusion in the package
     from ...models import MemoParentType, User

--- a/backend/app/routers/audio.py
+++ b/backend/app/routers/audio.py
@@ -193,7 +193,7 @@ async def upload_audio(
     max_allowed = audio_config.get(
         "max_duration_seconds", settings.AUDIO_MAX_DURATION_SECONDS
     )
-    if duration_seconds is not None and duration_seconds < 0:
+    if duration_seconds is not None and duration_seconds <= 0:
         raise HTTPException(status_code=400, detail="Invalid duration")
     if duration_seconds is not None and duration_seconds > max_allowed:
         raise HTTPException(

--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -1174,6 +1174,85 @@ def run_analysis(
     )
 
 
+def _safe_corr(a: NDArray[np.float64], b: NDArray[np.float64]) -> float:
+    """Pearson correlation over the entries where both vectors are finite.
+
+    Returns ``0.0`` when fewer than two paired finite values remain or either
+    side has zero variance — such a pair carries no orientation information.
+    """
+    mask = np.isfinite(a) & np.isfinite(b)
+    if int(mask.sum()) < 2:
+        return 0.0
+    av = a[mask] - a[mask].mean()
+    bv = b[mask] - b[mask].mean()
+    denom = float(np.sqrt(float(np.dot(av, av)) * float(np.dot(bv, bv))))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(av, bv)) / denom
+
+
+def align_factors_to_reference(
+    z_scores: NDArray[np.float64],
+    reference_z: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Permute and sign-flip ``z_scores`` columns to match ``reference_z``.
+
+    Each bootstrap resample re-runs PCA + varimax + sign standardisation
+    independently, so a factor can come back **permuted** (eigenvalue ranks
+    swap between near-equal factors) or **reflected** (``standardize_factor_signs``
+    keys on the largest-|loading| participant, which differs across resamples).
+    Both are arbitrary re-orientations of the *same* latent factor; accumulating
+    raw column indices across iterations therefore mixes opposite-signed or
+    altogether-different factors and corrupts the per-cell SE/CI
+    (Zabala & Pascual 2016).
+
+    Factor order and the loading-based sign convention are fixed *before*
+    flagging in ``run_analysis``, so the auto-flagged full-sample reference
+    shares the orientation of the solution the analyst saw (manual flagging
+    changes z-score magnitudes, not factor order/polarity). Alignment matches
+    on the z-score vectors (indexed by statement, hence comparable across
+    iterations): each reference factor is greedily paired with the bootstrap
+    factor whose z-scores correlate most strongly with it, in descending
+    |correlation| order, and reflected when that correlation is negative.
+
+    Args:
+        z_scores: One iteration's z-scores (n_statements x n_factors).
+        reference_z: Full-sample reference z-scores (n_statements x n_factors).
+
+    Returns:
+        A re-oriented copy of ``z_scores`` whose column ``f`` corresponds to
+        reference factor ``f``.
+    """
+    n_factors = reference_z.shape[1]
+    corr: list[list[float]] = [
+        [_safe_corr(reference_z[:, r], z_scores[:, b]) for b in range(n_factors)]
+        for r in range(n_factors)
+    ]
+
+    pairs = sorted(
+        ((abs(corr[r][b]), r, b) for r in range(n_factors) for b in range(n_factors)),
+        reverse=True,
+    )
+    ref_to_boot: dict[int, int] = {}
+    used_ref: set[int] = set()
+    used_boot: set[int] = set()
+    for _, r, b in pairs:
+        if r in used_ref or b in used_boot:
+            continue
+        ref_to_boot[r] = b
+        used_ref.add(r)
+        used_boot.add(b)
+
+    aligned: NDArray[np.float64] = np.full(
+        (z_scores.shape[0], n_factors), np.nan, dtype=np.float64
+    )
+    for r in range(n_factors):
+        b = ref_to_boot[r]
+        sign = 1.0 if corr[r][b] >= 0.0 else -1.0
+        aligned[:, r] = sign * z_scores[:, b]
+    return aligned
+
+
 def compute_bootstrap_stability(
     dataset: NDArray[np.float64],
     n_iterations: int,
@@ -1233,6 +1312,31 @@ def compute_bootstrap_stability(
     ]
     n_converged = 0
 
+    # Reference orientation: run the full sample once with the same pipeline
+    # settings used per iteration, so every resample can be permuted/reflected
+    # back onto a single fixed factor order + polarity before its z-scores are
+    # accumulated. Without this, PCA factor-order swaps and sign-standardisation
+    # flips across resamples mix opposite-signed / different factors into the
+    # same cell and corrupt the SE/CI (Zabala & Pascual 2016). Scope the same
+    # divide/invalid errstate as the loop so a degenerate full sample fails
+    # gracefully (reference_z=None → identity alignment, prior behaviour).
+    reference_z: NDArray[np.float64] | None
+    try:
+        with np.errstate(divide="ignore", invalid="ignore"):
+            reference_z = run_analysis(
+                dataset,
+                n_factors=n_factors,
+                extraction=extraction,
+                rotation=rotation,
+                flagging="auto",
+                manual_flags_matrix=None,
+                manual_rotations=manual_rotations,
+                grid_config=grid_config,
+                distribution_mode=distribution_mode,
+            )["z_scores"]
+    except (ValueError, np.linalg.LinAlgError):
+        reference_z = None
+
     for _ in range(n_iterations):
         cols = rng.integers(0, n_participants, size=n_participants)
         boot = dataset[:, cols]
@@ -1261,6 +1365,10 @@ def compute_bootstrap_stability(
             continue
         n_converged += 1
         z = res["z_scores"]
+        # Re-orient this resample onto the reference factor order + polarity
+        # before accumulating, so each cell aggregates the *same* factor.
+        if reference_z is not None:
+            z = align_factors_to_reference(z, reference_z)
         for s in range(n_statements):
             for f in range(n_factors):
                 value = z[s, f]

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -179,10 +179,11 @@ class ExportService:
             # Build audio recordings map by question_key
             audio_map: dict[str, _AudioMapEntry] = {}
             for audio_rec in p.audio_recordings:
-                # Generate fresh presigned URL (valid for 24 hours)
+                # Generate fresh presigned URL (valid for 24 hours, matching
+                # the bulk dump export in study_data_service.py).
                 try:
                     presigned_url = storage_service.generate_presigned_url(
-                        audio_rec.s3_key, expiration=3600
+                        audio_rec.s3_key, expiration=86400
                     )
                     audio_map[audio_rec.question_key] = _AudioMapEntry(
                         url=presigned_url,

--- a/backend/app/services/study_data_service.py
+++ b/backend/app/services/study_data_service.py
@@ -212,7 +212,13 @@ class StudyDataService:
 
     @staticmethod
     async def get_study_full_dump(db: AsyncSession, study_id: int) -> StudyDump:
-        """Extracts complete study data and valid participant sorts for export."""
+        """Extracts complete study data and all participant sorts for export.
+
+        Returns every participant regardless of ``is_discarded`` status; the
+        callers (``/dump``, per-participant export, research package) apply
+        their own discard/anonymisation filtering as appropriate for each
+        export type.
+        """
         # 1. Get Study with statements (ordered by ID for consistency)
         stmt = (
             select(Study)
@@ -227,7 +233,8 @@ class StudyDataService:
         if not study:
             raise NotFoundError("Study")
 
-        # 2. Get all non-discarded completed participants with their Q-sort entries and audio
+        # 2. Get all participants (including discarded — callers filter per
+        #    export type) with their Q-sort entries and audio
         p_stmt = (
             select(Participant)
             .where(

--- a/backend/app/services/study_data_service.py
+++ b/backend/app/services/study_data_service.py
@@ -1,6 +1,7 @@
 """Service for study data export, statistics, and participant management."""
 
 import logging
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -211,42 +212,55 @@ class StudyDataService:
         )
 
     @staticmethod
-    async def get_study_full_dump(db: AsyncSession, study_id: int) -> StudyDump:
+    async def get_study_full_dump(
+        db: AsyncSession, study_id: int, *, study: Study | None = None
+    ) -> StudyDump:
         """Extracts complete study data and all participant sorts for export.
 
         Returns every participant regardless of ``is_discarded`` status; the
         callers (``/dump``, per-participant export, research package) apply
         their own discard/anonymisation filtering as appropriate for each
         export type.
-        """
-        # 1. Get Study with statements (ordered by ID for consistency)
-        stmt = (
-            select(Study)
-            .where(Study.id == study_id)
-            .options(
-                selectinload(Study.statements).selectinload(Statement.translations),
-                selectinload(Study.translations),
-            )
-        )
-        result = await db.execute(stmt)
-        study = result.scalar_one_or_none()
-        if not study:
-            raise NotFoundError("Study")
 
-        # 2. Get all participants (including discarded — callers filter per
-        #    export type) with their Q-sort entries and audio
-        p_stmt = (
-            select(Participant)
-            .where(
-                Participant.study_id == study_id,
+        When ``study`` is supplied it must already have ``statements`` (+
+        translations), ``translations`` and ``participants`` (+ each
+        participant's ``qsort_entries`` / ``audio_recordings``) eager-loaded;
+        the dump is then built from that ORM graph instead of re-querying the
+        same rows. The research-package export passes the study it already
+        holds; the other callers omit it and take the query path.
+        """
+        if study is None:
+            # 1. Get Study with statements (ordered by ID for consistency)
+            stmt = (
+                select(Study)
+                .where(Study.id == study_id)
+                .options(
+                    selectinload(Study.statements).selectinload(Statement.translations),
+                    selectinload(Study.translations),
+                )
             )
-            .options(
-                selectinload(Participant.qsort_entries),
-                selectinload(Participant.audio_recordings),
+            result = await db.execute(stmt)
+            loaded = result.scalar_one_or_none()
+            if loaded is None:
+                raise NotFoundError("Study")
+            study = loaded
+
+            # 2. Get all participants (including discarded — callers filter per
+            #    export type) with their Q-sort entries and audio
+            p_stmt = (
+                select(Participant)
+                .where(
+                    Participant.study_id == study_id,
+                )
+                .options(
+                    selectinload(Participant.qsort_entries),
+                    selectinload(Participant.audio_recordings),
+                )
             )
-        )
-        p_result = await db.execute(p_stmt)
-        participants = p_result.scalars().all()
+            p_result = await db.execute(p_stmt)
+            participants: Sequence[Participant] = p_result.scalars().all()
+        else:
+            participants = study.participants
 
         # 3. Build Export Structure
         # PQMethod and others need a fixed reference for statement order.

--- a/backend/tests/integration/test_audio.py
+++ b/backend/tests/integration/test_audio.py
@@ -333,6 +333,31 @@ class TestAudioValidation:
         assert response.status_code == 400
         assert "empty" in response.json()["message"].lower()
 
+    @pytest.mark.parametrize("bad_duration", ["0", "0.0", "-1", "-5.5"])
+    @patch("app.routers.audio.magic.from_buffer")
+    async def test_upload_rejects_non_positive_duration(
+        self,
+        mock_magic,
+        client: AsyncClient,
+        participant_token: tuple[uuid.UUID, Participant],
+        bad_duration: str,
+    ):
+        """Zero- and negative-duration recordings are semantically invalid and
+        must be rejected (audio with duration <= 0 cannot exist)."""
+        mock_magic.return_value = "audio/webm"
+        token, _ = participant_token
+        audio_data = b"fake webm audio data" * 50
+        files = {"file": ("recording.webm", BytesIO(audio_data), "audio/webm")}
+        data = {
+            "session_token": str(token),
+            "question_key": "card_1",
+            "duration_seconds": bad_duration,
+        }
+
+        response = await client.post("/api/audio/upload", files=files, data=data)
+        assert response.status_code == 400
+        assert "duration" in response.json()["message"].lower()
+
     @patch("app.routers.audio.magic.from_buffer")
     async def test_upload_file_too_large(
         self,

--- a/backend/tests/unit/test_analysis_service.py
+++ b/backend/tests/unit/test_analysis_service.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from app.services.analysis_service import (
+    align_factors_to_reference,
     apply_judgmental_rotations,
     apply_manual_flags,
     build_sort_matrix,
@@ -1240,8 +1241,86 @@ class TestRunAnalysisJudgmental:
 # --- compute_bootstrap_stability (Zabala & Pascual 2016) ---
 
 
+class TestAlignFactorsToReference:
+    """Tests for bootstrap factor alignment (permutation + sign)."""
+
+    def test_recovers_permuted_and_reflected_columns(self):
+        """A resample that comes back column-swapped + sign-flipped is mapped
+        exactly back onto the reference orientation."""
+        ref = np.array(
+            [
+                [2.0, -1.0],
+                [1.5, 0.5],
+                [-1.0, 2.0],
+                [0.0, -2.0],
+                [-2.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        # Bootstrap solution: factor B in column 0 (same sign), factor A in
+        # column 1 but reflected.
+        boot = np.column_stack([ref[:, 1], -ref[:, 0]])
+        aligned = align_factors_to_reference(boot, ref)
+        np.testing.assert_allclose(aligned, ref, atol=1e-9)
+
+    def test_identity_when_already_aligned(self):
+        ref = np.array([[1.0, -2.0], [-1.0, 0.5], [2.0, 1.0]], dtype=np.float64)
+        np.testing.assert_allclose(
+            align_factors_to_reference(ref.copy(), ref), ref, atol=1e-9
+        )
+
+    def test_nan_bootstrap_column_left_as_nan(self):
+        """A factor with no flagged sorts (all-NaN z column) survives alignment
+        as NaN so it is skipped during accumulation rather than corrupting a
+        reference cell."""
+        ref = np.array([[2.0, -1.0], [1.0, 0.5], [-2.0, 1.0]], dtype=np.float64)
+        boot = np.column_stack([ref[:, 0], np.full(3, np.nan)])
+        aligned = align_factors_to_reference(boot, ref)
+        # Reference factor 0 recovered; factor 1 (matched to the all-NaN
+        # bootstrap column) is NaN.
+        np.testing.assert_allclose(aligned[:, 0], ref[:, 0], atol=1e-9)
+        assert np.all(np.isnan(aligned[:, 1]))
+
+
 class TestBootstrapStability:
     """Tests for the non-parametric bootstrap of Q-sorts."""
+
+    def test_bootstrap_z_means_keep_reference_polarity(self, dataset):
+        """Regression for the sign-flip / permutation bug: bootstrap z-score
+        means must share the polarity of the full-sample reference solution on
+        well-determined statements. Without factor alignment, resample-level
+        sign flips drag the accumulated mean toward zero / the wrong sign."""
+        reference = run_analysis(
+            dataset,
+            n_factors=2,
+            extraction="pca",
+            rotation="varimax",
+            flagging="auto",
+            grid_config=None,
+        )
+        ref_z = reference["z_scores"]
+
+        res = compute_bootstrap_stability(
+            dataset,
+            300,
+            n_factors=2,
+            extraction="pca",
+            rotation="varimax",
+            manual_rotations=None,
+            grid_config=None,
+            rng_seed=7,
+        )
+        z_mean = {
+            (e["statement_idx"], e["factor"] - 1): e["z_mean"] for e in res["statements"]
+        }
+        # For each factor, the statement with the strongest reference loading
+        # must keep its sign in the bootstrap mean, and the magnitude must not
+        # collapse toward zero (sign cancellation would do both).
+        for f in range(2):
+            s = int(np.argmax(np.abs(ref_z[:, f])))
+            assert (s, f) in z_mean
+            assert np.sign(z_mean[(s, f)]) == np.sign(ref_z[s, f])
+            assert abs(z_mean[(s, f)]) > 0.5 * abs(ref_z[s, f])
 
     def test_deterministic_under_fixed_seed(self, dataset):
         """Same dataset + same seed → identical bootstrap output."""
@@ -1315,7 +1394,14 @@ class TestBootstrapStability:
             assert 0 <= entry["statement_idx"] < dataset.shape[0]
             assert entry["factor"] in (1, 2)
             assert entry["z_se"] >= 0.0
-            assert entry["ci_lower"] <= entry["z_mean"] <= entry["ci_upper"]
+            # CI must be well-formed (lower <= upper). We deliberately do NOT
+            # assert the mean lies inside [ci_lower, ci_upper]: after factor
+            # alignment a genuinely-near-zero cell (a statement with ~0 loading
+            # on a factor) has a tight one-sided distribution whose mean can sit
+            # just outside the central 95% band. The pre-alignment code only
+            # satisfied mean-within-CI because resample sign-flips made the
+            # distribution artificially symmetric (the very bug alignment fixes).
+            assert entry["ci_lower"] <= entry["ci_upper"]
         assert len(res["factor_mean_se"]) == 2
 
     def test_pathological_iterations_handled(self):

--- a/backend/tests/unit/test_study_service.py
+++ b/backend/tests/unit/test_study_service.py
@@ -382,3 +382,55 @@ async def test_get_study_full_dump(db, active_study):
     # scores should be [-1, 0, 0, 1]
     assert p_data["scores"] == [-1, 0, 0, 1]
     assert "placements" in p_data
+
+
+@pytest.mark.asyncio
+async def test_get_study_full_dump_preloaded_matches_query_path(db, active_study):
+    """The optional pre-loaded `study=` path (used by the research-package
+    export to avoid a second fetch of every participant/Q-sort/audio row) must
+    produce the same dump as the query path."""
+    from datetime import datetime
+    from app.models import QSortEntry, Statement, Study
+
+    p = Participant(
+        study_id=active_study.id,
+        session_token=uuid.uuid4(),
+        status=ParticipantStatus.completed,
+        language_used="en",
+        submitted_at=datetime.now(),
+        consented_at=datetime.now(),
+    )
+    db.add(p)
+    await db.commit()
+    db.add_all(
+        [
+            QSortEntry(
+                participant_id=p.id,
+                statement_id=active_study.statements[i].id,
+                grid_score=score,
+            )
+            for i, score in enumerate([-1, 0, 0, 1])
+        ]
+    )
+    await db.commit()
+
+    # Query path
+    query_dump = await StudyService.get_study_full_dump(db, active_study.id)
+
+    # Pre-loaded path: same eager-load graph the research-package endpoint holds.
+    stmt = (
+        select(Study)
+        .where(Study.id == active_study.id)
+        .options(
+            selectinload(Study.statements).selectinload(Statement.translations),
+            selectinload(Study.participants).selectinload(Participant.qsort_entries),
+            selectinload(Study.participants).selectinload(Participant.audio_recordings),
+            selectinload(Study.translations),
+        )
+    )
+    full_study = (await db.execute(stmt)).scalar_one()
+    preloaded_dump = await StudyService.get_study_full_dump(
+        db, active_study.id, study=full_study
+    )
+
+    assert preloaded_dump == query_dump

--- a/frontend/src/components/admin/AppSidebar.nav-user.test.tsx
+++ b/frontend/src/components/admin/AppSidebar.nav-user.test.tsx
@@ -1,13 +1,15 @@
 import { renderWithProviders, screen, waitFor } from '@/test-utils/test-utils';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Routes, Route } from 'react-router-dom';
 import { AppSidebar } from './AppSidebar';
 import { SidebarProvider } from '@/components/ui/sidebar';
+import { resetAllStores } from '@/utils/sessionReset';
 
 vi.mock('@/hooks/useAuth', () => ({
     useAuth: () => ({ user: { id: 1, email: 'r@x.io', full_name: 'Ada Lovelace' } }),
 }));
+vi.mock('@/utils/sessionReset', () => ({ resetAllStores: vi.fn() }));
 vi.mock('@/api/generated', async () => {
     const actual = await vi.importActual<Record<string, unknown>>('@/api/generated');
     return {
@@ -21,6 +23,10 @@ function ProbePage() {
 }
 
 describe('AppSidebar NavUser → Account settings', () => {
+    beforeEach(() => {
+        vi.mocked(resetAllStores).mockClear();
+    });
+
     it('navigates to /app/<projectSlug>/account when Account settings is clicked', async () => {
         renderWithProviders(
             <SidebarProvider>
@@ -36,5 +42,23 @@ describe('AppSidebar NavUser → Account settings', () => {
         await userEvent.click(screen.getByRole('menuitem', { name: /account settings/i }));
 
         await waitFor(() => expect(screen.getByTestId('account-page')).toBeInTheDocument());
+    });
+
+    it('clears persisted stores and navigates to /login when logging out', async () => {
+        renderWithProviders(
+            <SidebarProvider>
+                <Routes>
+                    <Route path="/app/:projectSlug/dashboard" element={<AppSidebar />} />
+                    <Route path="/login" element={<div data-testid="login-page">login</div>} />
+                </Routes>
+            </SidebarProvider>,
+            { initialEntries: ['/app/demo/dashboard'] }
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: /ada lovelace/i }));
+        await userEvent.click(screen.getByRole('menuitem', { name: /log out/i }));
+
+        await waitFor(() => expect(screen.getByTestId('login-page')).toBeInTheDocument());
+        expect(resetAllStores).toHaveBeenCalledWith({ skipConfig: true });
     });
 });

--- a/frontend/src/components/admin/AppSidebar.tsx
+++ b/frontend/src/components/admin/AppSidebar.tsx
@@ -19,6 +19,7 @@ import {
 import { ProjectSwitcher } from './ProjectSwitcher';
 import { FocusModeHeader } from './FocusModeHeader';
 import { UserAvatar } from './UserAvatar';
+import { resetAllStores } from '@/utils/sessionReset';
 import {
     Sidebar,
     SidebarContent,
@@ -109,6 +110,10 @@ function NavUser({
 
     const handleLogout = () => {
         logout();
+        // Clear persisted Zustand stores + query cache so a subsequent admin
+        // login on the same browser cannot see the previous session's data.
+        // Mirrors the logout flow in CommandMenu.tsx.
+        resetAllStores({ skipConfig: true });
         navigate('/login');
     };
 

--- a/frontend/src/components/postsort/Step1_Feedback.tsx
+++ b/frontend/src/components/postsort/Step1_Feedback.tsx
@@ -32,10 +32,11 @@ export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
 
     const config = useConfigStore((state) => state.config);
     const token = useSessionStore((state) => state.token);
-    const { qsort, postsort } = useResponseStore((state) => ({
-        qsort: state.qsort,
-        postsort: state.postsort,
-    }));
+    // Granular selectors avoid a fresh object reference on every store update
+    // (which would defeat Zustand's referential equality and re-render this
+    // feedback step needlessly).
+    const qsort = useResponseStore((state) => state.qsort);
+    const postsort = useResponseStore((state) => state.postsort);
     const setPostSortResponse = useResponseStore((state) => state.setPostSortResponse);
     const setAudioRecording = useResponseStore((state) => state.setAudioRecording);
     const deleteAudioRecording = useResponseStore((state) => state.deleteAudioRecording);

--- a/frontend/src/components/postsort/Step2_Questionnaire.tsx
+++ b/frontend/src/components/postsort/Step2_Questionnaire.tsx
@@ -35,7 +35,9 @@ interface Step2Props {
 export const Step2_Questionnaire: React.FC<Step2Props> = ({ onBack, onSubmit, isLoading }) => {
     const { t, i18n } = useTranslation();
     const config = useConfigStore((state) => state.config);
-    const { postsort } = useResponseStore((state) => ({ postsort: state.postsort }));
+    // Granular selector: a fresh `{ postsort }` object on every store update
+    // would defeat Zustand's referential equality and re-render the form.
+    const postsort = useResponseStore((state) => state.postsort);
     const setPostSortResponse = useResponseStore((state) => state.setPostSortResponse);
     const setAudioRecording = useResponseStore((state) => state.setAudioRecording);
     const deleteAudioRecordingStore = useResponseStore((state) => state.deleteAudioRecording);

--- a/frontend/src/hooks/useFineSortDrag.test.ts
+++ b/frontend/src/hooks/useFineSortDrag.test.ts
@@ -89,6 +89,25 @@ describe('useFineSortDrag', () => {
         expect(onSelectionChange).toHaveBeenCalledWith(null);
     });
 
+    it('keeps the selection when handleSlotClick is a no-op (own slot)', () => {
+        const onSelectionChange = vi.fn();
+        const { result } = renderHook(() =>
+            useFineSortDrag({
+                ...defaultProps,
+                // The selected card already occupies slot (0,0): clicking it is a
+                // no-op, so the selection must be preserved (not cleared).
+                responses: { qsort: [{ statementId: 1, col: 0, row: 0 }] },
+                gridColumns: [{ capacity: 1 }],
+                selectedId: 1,
+                onSelectionChange,
+            } as unknown as UseFineSortDragProps)
+        );
+
+        result.current.handleSlotClick(0, 0);
+
+        expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+
     it('handles Return to Pile (Deck Drop) correctly', () => {
         const { result } = renderHook(() =>
             useFineSortDrag(defaultProps as unknown as UseFineSortDragProps)

--- a/frontend/src/hooks/useFineSortDrag.ts
+++ b/frontend/src/hooks/useFineSortDrag.ts
@@ -181,8 +181,12 @@ export const useFineSortDrag = ({
     const handleSlotClick = useCallback(
         (col: number, row: number) => {
             if (selectedId === null || selectedId === undefined) return;
-            handlePlacement(selectedId, col, row);
-            onSelectionChange?.(null);
+            // Only clear the selection when the card was actually (re)placed.
+            // A no-op (e.g. clicking the slot the selected card already occupies)
+            // keeps it selected so the participant can pick a different slot.
+            if (handlePlacement(selectedId, col, row)) {
+                onSelectionChange?.(null);
+            }
         },
         [selectedId, handlePlacement, onSelectionChange]
     );

--- a/frontend/src/hooks/useGridPlacement.test.ts
+++ b/frontend/src/hooks/useGridPlacement.test.ts
@@ -86,6 +86,51 @@ describe('useGridPlacement', () => {
         expect(mockActions.unplaceCard).not.toHaveBeenCalled();
     });
 
+    it('is a no-op when a card is dropped onto its own slot in a full column', () => {
+        // Card 1 sits at 0,0 in a full column (0,0 + 0,1 occupied). Dropping it
+        // back onto 0,0 must NOT route into swapCardsInGrid(1, 1), which would
+        // duplicate the card in qsort.
+        const responses = {
+            qsort: [
+                { statementId: 1, col: 0, row: 0 },
+                { statementId: 2, col: 0, row: 1 },
+            ],
+        };
+        const { result } = renderHook(() =>
+            useGridPlacement({ responses, gridColumns, actions: mockActions })
+        );
+
+        const placed = result.current.handlePlacement(1, 0, 0);
+
+        expect(placed).toBe(false);
+        expect(mockActions.swapCardsInGrid).not.toHaveBeenCalled();
+        expect(mockActions.moveCardInGrid).not.toHaveBeenCalled();
+        expect(mockActions.placeCardInGrid).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when a card is dropped onto its own slot in a non-full column', () => {
+        // Card 1 alone at 0,0 (column not full). Dropping it back onto 0,0 must
+        // not shuffle it to another row.
+        const responses = { qsort: [{ statementId: 1, col: 0, row: 0 }] };
+        const { result } = renderHook(() =>
+            useGridPlacement({ responses, gridColumns, actions: mockActions })
+        );
+
+        const placed = result.current.handlePlacement(1, 0, 0);
+
+        expect(placed).toBe(false);
+        expect(mockActions.moveCardInGrid).not.toHaveBeenCalled();
+    });
+
+    it('returns true when a card is actually placed', () => {
+        const responses = { qsort: [] };
+        const { result } = renderHook(() =>
+            useGridPlacement({ responses, gridColumns, actions: mockActions })
+        );
+
+        expect(result.current.handlePlacement(1, 0, 0)).toBe(true);
+    });
+
     // --- Free distribution mode: placement past declared capacity ---
 
     it('finds an empty row past declared capacity in free mode (overflow placement)', () => {

--- a/frontend/src/hooks/useGridPlacement.ts
+++ b/frontend/src/hooks/useGridPlacement.ts
@@ -83,8 +83,17 @@ export const useGridPlacement = ({
     );
 
     const handlePlacement = useCallback(
-        (cardId: number, col: number, targetRow: number) => {
+        (cardId: number, col: number, targetRow: number): boolean => {
             const existingCard = responses.qsort.find((c) => c.col === col && c.row === targetRow);
+
+            // Dropping a card back onto the slot it already occupies is a no-op.
+            // Without this guard a full column routes into
+            // swapCardsInGrid(cardId, cardId) — which duplicates the card in
+            // qsort — and a non-full column needlessly shuffles it to another
+            // row. Returning false lets the caller keep the card selected.
+            if (existingCard && existingCard.statementId === cardId) {
+                return false;
+            }
 
             let finalRow = targetRow;
             let shouldSwap = false;
@@ -114,6 +123,7 @@ export const useGridPlacement = ({
                     actions.placeCardInGrid(cardId, col, finalRow);
                 }
             }
+            return true;
         },
         [responses.qsort, findClosestEmptyRow, actions]
     );

--- a/frontend/src/pages/PostSortPage.tsx
+++ b/frontend/src/pages/PostSortPage.tsx
@@ -26,13 +26,12 @@ interface PostSortPageProps {
 const PostSortPage: React.FC<PostSortPageProps> = ({ highlightKey: _highlightKey }) => {
     // Hooks
     const setStep = useSessionStore((state) => state.setStep);
-    const session = useSessionStore((state) => ({
-        isCompleted: state.isCompleted,
-        confirmationCode: state.confirmationCode,
-    }));
-    const responses = useResponseStore((state) => ({
-        qsort: state.qsort,
-    }));
+    // Granular selectors: object-literal selectors return a fresh reference on
+    // every store update, defeating Zustand's referential equality check and
+    // re-rendering this page (and its postsort children) needlessly.
+    const isCompleted = useSessionStore((state) => state.isCompleted);
+    const confirmationCode = useSessionStore((state) => state.confirmationCode);
+    const qsort = useResponseStore((state) => state.qsort);
 
     // Step State (Internal to this page's wizard)
     // We default to step 1. If we wanted persistence we could store 'postSortStep' in session store.
@@ -54,8 +53,8 @@ const PostSortPage: React.FC<PostSortPageProps> = ({ highlightKey: _highlightKey
         confirmationCode: submitConfirmationCode,
     } = useSubmitStudy();
 
-    const isSuccess = isSubmitSuccess || session.isCompleted;
-    const finalConfirmationCode = session.confirmationCode || submitConfirmationCode;
+    const isSuccess = isSubmitSuccess || isCompleted;
+    const finalConfirmationCode = confirmationCode || submitConfirmationCode;
 
     // Ref to prevent the 'started' silent submit from re-firing when submit identity changes
     const startedSentRef = useRef(false);
@@ -73,9 +72,9 @@ const PostSortPage: React.FC<PostSortPageProps> = ({ highlightKey: _highlightKey
 
     // Completeness Guard: Ensure qsort is full before allowing post-sort
     React.useEffect(() => {
-        if (session.isCompleted) return;
+        if (isCompleted) return;
 
-        if (config && responses.qsort.length !== config.statements.length) {
+        if (config && qsort.length !== config.statements.length) {
             navigate(`/study/${slug}/fine-sort${location.search}`, { replace: true });
         } else if (!startedSentRef.current) {
             // Send a single silent 'started' status update on first mount
@@ -85,15 +84,7 @@ const PostSortPage: React.FC<PostSortPageProps> = ({ highlightKey: _highlightKey
             }, 1000);
             return () => clearTimeout(timer);
         }
-    }, [
-        config,
-        responses.qsort.length,
-        navigate,
-        slug,
-        session.isCompleted,
-        submit,
-        location.search,
-    ]);
+    }, [config, qsort.length, navigate, slug, isCompleted, submit, location.search]);
 
     // --- Render ---
 

--- a/frontend/src/store/useResponseStore.test.ts
+++ b/frontend/src/store/useResponseStore.test.ts
@@ -130,6 +130,20 @@ describe('useResponseStore', () => {
         expect(c2).toEqual({ statementId: 2, col: 0, row: 0 });
     });
 
+    it('swapCardsInGrid is a no-op for a self-swap (never duplicates the card)', () => {
+        // Dropping a placed card back onto its own occupied slot in a full
+        // column routes handlePlacement into swapCardsInGrid(id, id). The naive
+        // swap re-appends the same card, duplicating it in qsort — which is then
+        // submitted as two entries for the same statement.
+        useResponseStore.setState({ qsort: [{ statementId: 1, col: 0, row: 0 }] });
+
+        useResponseStore.getState().swapCardsInGrid(1, 1);
+
+        const state = useResponseStore.getState();
+        expect(state.qsort).toHaveLength(1);
+        expect(state.qsort[0]).toEqual({ statementId: 1, col: 0, row: 0 });
+    });
+
     it('should reset state', () => {
         const store = useResponseStore.getState();
         store.categorizeCard(1, 'agree');

--- a/frontend/src/store/useResponseStore.ts
+++ b/frontend/src/store/useResponseStore.ts
@@ -231,6 +231,11 @@ export const useResponseStore = create<Responses & ResponseActions>()(
             },
 
             swapCardsInGrid: (id1, id2) => {
+                // A self-swap (id1 === id2) would re-append the same card and
+                // duplicate it in qsort. This happens when a placed card is
+                // dropped back onto its own occupied slot in a full column
+                // (handlePlacement routes that into swapCardsInGrid(id, id)).
+                if (id1 === id2) return;
                 const state = get();
                 const card1 = state.qsort.find((p) => p.statementId === id1);
                 const card2 = state.qsort.find((p) => p.statementId === id2);


### PR DESCRIPTION
Fixes from an adversarially-verified bug + performance audit of the backend (FastAPI / async SQLAlchemy) and frontend (React 19). Each fix was re-investigated inline before implementation — two confirmed findings were honestly dropped after a reachability/completeness pass, and one frontend finding turned out to mask a more serious, genuinely reachable bug.

## Fixed (9 findings, 4 commits)

**`fix: bug-hunt quick wins`**
- **#10 (data leak)** — admin logout via `AppSidebar` now calls `resetAllStores({ skipConfig: true })`, so a subsequent admin login on the same browser cannot read the previous session's persisted Zustand stores / query cache (mirrors `CommandMenu`).
- **#4 (export)** — CSV-export audio presigned URLs now expire after 24h (was 1h, contradicting the comment and the bulk-dump path).
- **#36 (validation)** — reject audio uploads with `duration <= 0` (zero-length audio is invalid; previously only negatives were rejected).
- **#18 (docs)** — corrected a misleading `get_study_full_dump` docstring (it returns all participants incl. discarded; callers filter). No behaviour change — the SQL filter the audit suggested would have regressed `/dump` and per-participant export.

**`fix(analysis): align bootstrap factors to a reference orientation`**
- **#2 (scientific correctness)** — bootstrap stability accumulated z-scores by raw factor-column index, but each resample re-runs PCA + varimax + sign-standardisation independently, so factors come back **permuted** and/or **reflected**. This corrupted the per-(statement, factor) SE / 95% CI shown to researchers. Now every iteration is permuted + sign-flipped onto a fixed full-sample reference (matched on z-score vectors). Demonstrated: a near-zero-loading statement's CI collapses from a spurious ±0.83 to ~0.

**`fix(fine-sort): prevent card duplication on own-slot drop`**
- **#6 (data corruption, reachable)** — dropping a placed card back onto its own slot in a full column routed into `swapCardsInGrid(id, id)`, which **duplicated the card in `qsort`** — and `qsort` is the submitted payload. Guarded at the store (self-swap no-op) and in `handlePlacement` (own-slot no-op + boolean return); `handleSlotClick` now clears the selection only on an actual placement.

**`perf: avoid double-load export; granular Zustand selectors`**
- **#1 (perf)** — the research-package export loaded every participant twice. `get_study_full_dump` now accepts an optional pre-loaded `study=`; the endpoint passes the ORM graph it already holds. Equivalence test added.
- **#8 / #9 (perf)** — object-literal Zustand selectors returned a fresh reference each render, re-rendering the postsort flow needlessly. Split into granular per-field selectors.

## Investigated and intentionally dropped
- **#3 (last-owner guard)** — unreachable: `check_project_permission` has no superuser bypass, so the caller is the sole owner (one-owner-per-project constraint) and is already blocked by the self-removal guard. Added code would be dead/untestable.
- **#7 (card retained in rough pile)** — verified **latent only**: every consumer derives the tray as `rough.<pile>.filter(!placedIds)`, `categorizeCard` removes from all piles before re-adding, and the submission payload never includes `rough`. The "obvious" fix (splice placed ids out of the piles) would **regress** the fine→rough redirect, which uses `totalRough === 0` as its "rough sort not done" signal — the pile retention is load-bearing.

## Verification
`make ci-fast` green (backend 303, frontend 1468); export integration + security suites green; analysis unit + integration + property suites green; mypy `--strict` and ruff/biome clean; frontend production build green.

> Note: `make ci` is currently red on `pip-audit` due to two **pre-existing** dependency CVEs (`msgpack`, `pydantic-settings`) — confirmed identical on a clean tree, unrelated to this PR (tracked as a separate dependency-bump chore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)