### PR TITLE
ci: exclude all localhost URLs from the Lychee doc-link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -11,7 +11,10 @@ exclude = [
     "doi\\.org/10\\.5281/zenodo\\.XXXXXXX",
     "doi\\.org/10\\.4135/9781446251911",
     "zenodo\\.org/account/settings/github/",
-    "localhost:3000",
+    # Local dev-stack URLs (Vite :5173, API :8000, MinIO console :9001, …) are
+    # never reachable from CI and are never legitimate published links, so
+    # exclude every localhost reference rather than enumerating ports.
+    "localhost",
     # Commercial Q-software vendor site cited in the README comparison table;
     # resolves in browsers/curl but bot-protection can block automated checkers.
     "qmethodsoftware\\.com",


### PR DESCRIPTION
Fixes the long-standing red **Documentation Links** CI job (failing on `main`, e.g. on #234, #236, #237).

**Cause:** Lychee tried to reach `http://localhost:9001` — the MinIO console URL documented in `README.md` for the local Docker dev stack — and got `Connection refused` in CI. The `lychee.toml` exclude list enumerated some dev ports (`localhost:3000`) but not `:9001`.

**Fix:** replace the per-port entry with a blanket `localhost` exclusion. No `localhost` URL is reachable from CI, nor is it ever a legitimate published link, so excluding all of them is correct and future-proofs against new dev-stack ports appearing in docs.

The Lychee run log confirmed `localhost:9001` was the only failing link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)