### PR TITLE
fix: correctness lot — audio atomicity, analysis NaN, races, validation (6 findings)

### DIFF
--- a/backend/app/routers/audio.py
+++ b/backend/app/routers/audio.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func
 from uuid import UUID
 from datetime import datetime, timedelta, UTC
+import logging
 import re
 import magic
 
@@ -18,6 +19,8 @@ from app.schemas import AudioUploadResponse, AudioRecordingRead
 from app.services.storage_service import storage_service
 from app.core.config import settings
 from app.limiter import limiter
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/audio", tags=["audio"])
 
@@ -224,11 +227,21 @@ async def upload_audio(
     )
     existing_recording = existing.scalar_one_or_none()
 
-    # Delete old recording if exists (replace functionality)
+    # Re-upload atomicity (#5): when replacing an existing recording we must
+    # NOT delete the old S3 object before the new one is durably committed —
+    # otherwise a failed new upload (or a failed commit) would roll back the
+    # DB row while the old object is already permanently gone, destroying the
+    # participant's audio with no replacement.
+    #
+    # We still remove the old DB row inside the successful transaction (the
+    # uq_participant_question_audio unique constraint forbids two rows for the
+    # same participant+question), but we defer the old *object's* S3 deletion
+    # until after the new recording has been committed.
+    old_s3_object: str | None = None
     if existing_recording:
-        await storage_service.delete_audio(existing_recording.s3_key)
+        old_s3_object = existing_recording.s3_key
         await db.delete(existing_recording)
-        await db.flush()  # Flush deletion before creating new record
+        await db.flush()  # Free the unique slot before inserting the new row
 
     # Upload to S3
     s3_metadata = await storage_service.upload_audio(
@@ -257,6 +270,25 @@ async def upload_audio(
         await storage_service.delete_audio(s3_metadata["s3_key"])
         raise
     await db.refresh(audio_recording)
+
+    # The new recording is now durably committed; only now is it safe to
+    # delete the OLD object from S3 (replace functionality). This is
+    # best-effort: a failure to delete the now-orphaned old object must not
+    # fail the request — the new audio is already saved and a 500 here would
+    # wrongly tell the participant their replacement was lost. Worst case is a
+    # harmless orphan object that storage lifecycle/cleanup can reap.
+    if old_s3_object is not None and old_s3_object != audio_recording.s3_key:
+        try:
+            await storage_service.delete_audio(old_s3_object)
+        except Exception:
+            logger.warning(
+                "Failed to delete orphaned old audio object %s after successful "
+                "re-upload for participant %s question %s",
+                old_s3_object,
+                participant.id,
+                question_key,
+                exc_info=True,
+            )
 
     # Generate presigned URL for immediate playback
     presigned_url = storage_service.generate_presigned_url(audio_recording.s3_key)

--- a/backend/app/schemas/recruitment.py
+++ b/backend/app/schemas/recruitment.py
@@ -35,9 +35,7 @@ class RecruitmentLinkBase(BaseModel):
         of believing they capped sign-ups when the link is actually unlimited.
         """
         if self.type == RecruitmentLinkType.public and self.capacity is not None:
-            raise ValueError(
-                "capacity cannot be set for public (unlimited) links"
-            )
+            raise ValueError("capacity cannot be set for public (unlimited) links")
         return self
 
 

--- a/backend/app/schemas/recruitment.py
+++ b/backend/app/schemas/recruitment.py
@@ -2,7 +2,13 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 from app.models import RecruitmentLinkType, ProjectRole
 
@@ -20,6 +26,19 @@ class RecruitmentLinkBase(BaseModel):
     @classmethod
     def validate_name(cls, v: str | None) -> str | None:
         return validate_non_empty_string(v)
+
+    @model_validator(mode="after")
+    def reject_capacity_on_public(self) -> "RecruitmentLinkBase":
+        """Public links are unlimited; a capacity here would be silently dropped.
+
+        Reject it at the API boundary so the operator gets a clear 422 instead
+        of believing they capped sign-ups when the link is actually unlimited.
+        """
+        if self.type == RecruitmentLinkType.public and self.capacity is not None:
+            raise ValueError(
+                "capacity cannot be set for public (unlimited) links"
+            )
+        return self
 
 
 class RecruitmentLinkCreate(RecruitmentLinkBase):

--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -751,14 +751,25 @@ def compute_factor_characteristics(
         else:
             reliability = 0.0
 
-        # Standard error of factor scores
-        if not np.all(np.isnan(z_scores[:, f])):
+        # Standard error of factor scores.
+        # ddof=1 needs >= 2 non-NaN z-scores; with fewer, np.std returns NaN and
+        # emits a "Degrees of freedom <= 0" RuntimeWarning. Such a column means
+        # the factor has too few defining sorts to estimate a standard error, so
+        # we set ``se`` to NaN explicitly (skipping the warning-y path). The NaN
+        # then flows into the SED matrix, and classify_statements excludes the
+        # undecidable pair rather than silently treating it as consensus.
+        n_zscores = int(np.sum(~np.isnan(z_scores[:, f])))
+        if n_zscores >= 2:
             clamped_rel = min(reliability, 1.0)
             se = float(
                 np.std(z_scores[:, f], ddof=1) * np.sqrt(max(1 - clamped_rel, 0.0))
             )
-        else:
+        elif n_zscores == 0:
+            # No data at all for this factor — preserve the historical 0.0 so an
+            # entirely-empty factor column behaves as before (consensus path).
             se = 0.0
+        else:
+            se = float("nan")
         se_scores[f] = se
 
         characteristics.append(
@@ -844,6 +855,8 @@ def classify_statements(
     for s in range(n_statements):
         sig_pairs: dict[str, str] = {}
         any_significant = False
+        any_decidable = False
+        any_nonfinite_sed = False
 
         for i, j in pairs:
             if np.isnan(z_scores[s, i]) or np.isnan(z_scores[s, j]):
@@ -852,8 +865,20 @@ def classify_statements(
             diff = abs(z_scores[s, i] - z_scores[s, j])
             sed_val = sed[i, j]
 
-            if sed_val <= 0:
+            # A non-finite SED (NaN/inf) means we cannot test this pair: it
+            # arises when a factor has fewer than 2 defining sorts, so its
+            # standard error is undefined (np.std(ddof=1) over <2 values is
+            # NaN). Treat it exactly like sed_val <= 0 — skip it. NaN must be
+            # caught explicitly because ``NaN <= 0`` is False, which would
+            # otherwise let ``diff > NaN`` (always False) silently mark the
+            # statement as a confident non-distinguishing (consensus) result.
+            if not np.isfinite(sed_val) or sed_val <= 0:
+                if not np.isfinite(sed_val):
+                    any_nonfinite_sed = True
                 continue
+
+            # A real significance test ran for this pair (finite, positive SED).
+            any_decidable = True
 
             pair_key = f"{i + 1}-{j + 1}"
 
@@ -875,6 +900,12 @@ def classify_statements(
 
         if any_significant:
             distinguishing.append(entry)
+        elif any_nonfinite_sed and not any_decidable:
+            # Every pair that could have decided this statement had a non-finite
+            # SED (insufficient defining sorts). The data cannot support either
+            # verdict, so exclude the statement from both lists rather than
+            # defaulting it to consensus.
+            continue
         else:
             consensus.append(entry)
 

--- a/backend/tests/integration/test_audio.py
+++ b/backend/tests/integration/test_audio.py
@@ -249,6 +249,123 @@ class TestAudioUpload:
         assert all_recordings[0].s3_key == "audio/test-study/test-token/123_card_1.webm"
 
     @patch("app.routers.audio.magic.from_buffer")
+    async def test_successful_reupload_deletes_old_object_after_commit(
+        self,
+        mock_magic,
+        client: AsyncClient,
+        db: AsyncSession,
+        participant_token: tuple[uuid.UUID, Participant],
+        mock_storage_service,
+    ):
+        """Happy-path complement to the atomicity fix: a SUCCESSFUL re-upload
+        must still delete the old S3 object (now deferred to after the commit),
+        so deferring the delete does not leak orphans. The new recording must
+        be present and point at the new key."""
+        mock_magic.return_value = "audio/webm"
+
+        token, participant = participant_token
+
+        existing = AudioRecording(
+            participant_id=participant.id,
+            question_key="card_123",
+            s3_bucket="old-bucket",
+            s3_key="old-key",
+            file_size_bytes=500,
+            mime_type="audio/webm",
+        )
+        db.add(existing)
+        await db.commit()
+
+        audio_data = b"new audio data"
+        files = {"file": ("new.webm", BytesIO(audio_data), "audio/webm")}
+        data = {"session_token": str(token), "question_key": "card_123"}
+
+        response = await client.post("/api/audio/upload", files=files, data=data)
+        assert response.status_code == 200
+
+        # Old object deleted exactly once, with the OLD key (not the new one).
+        mock_storage_service.delete_audio.assert_called_once_with("old-key")
+
+        # Exactly one recording survives, pointing at the new key.
+        stmt = select(AudioRecording).where(
+            AudioRecording.participant_id == participant.id,
+            AudioRecording.question_key == "card_123",
+        )
+        recordings = await db.execute(stmt)
+        all_recordings = recordings.scalars().all()
+        assert len(all_recordings) == 1
+        assert all_recordings[0].s3_key == "audio/test-study/test-token/123_card_1.webm"
+
+    @patch("app.routers.audio.magic.from_buffer")
+    async def test_failed_reupload_preserves_existing_recording(
+        self,
+        mock_magic,
+        client: AsyncClient,
+        db: AsyncSession,
+        participant_token: tuple[uuid.UUID, Participant],
+        mock_storage_service,
+    ):
+        """Re-upload atomicity: if the NEW upload fails, the participant must
+        keep their PREVIOUS audio. The old S3 object must NOT be deleted and
+        the old DB row must survive (the request fails, but no data is lost).
+
+        Regression guard for the non-atomic re-upload bug (#5): the handler
+        used to delete the old S3 object *before* uploading the new one, so a
+        failed new upload left the DB row pointing at a now-missing object."""
+        mock_magic.return_value = "audio/webm"
+
+        token, participant = participant_token
+
+        # Existing recording for this question
+        existing = AudioRecording(
+            participant_id=participant.id,
+            question_key="card_123",
+            s3_bucket="old-bucket",
+            s3_key="old-key",
+            file_size_bytes=500,
+            mime_type="audio/webm",
+        )
+        db.add(existing)
+        await db.commit()
+        await db.refresh(existing)
+        existing_id = existing.id
+
+        # The NEW upload fails (e.g. S3 transient error)
+        mock_storage_service.upload_audio = AsyncMock(
+            side_effect=RuntimeError("S3 upload failed")
+        )
+
+        audio_data = b"new audio data"
+        files = {"file": ("new.webm", BytesIO(audio_data), "audio/webm")}
+        data = {"session_token": str(token), "question_key": "card_123"}
+
+        # The new upload raises, so the request fails (the ASGI transport
+        # re-raises unhandled exceptions). That is the expected outcome — what
+        # matters is that the participant's previous audio is left intact.
+        with pytest.raises(RuntimeError, match="S3 upload failed"):
+            await client.post("/api/audio/upload", files=files, data=data)
+
+        # INVARIANT 1: the old S3 object was NOT deleted. This is the core of
+        # the fix — pre-fix the handler deleted "old-key" *before* the (now
+        # failing) new upload, so the object was already permanently gone.
+        mock_storage_service.delete_audio.assert_not_called()
+
+        # INVARIANT 2: the old DB row still exists and is unchanged.
+        #
+        # In production each request owns its own session and `get_db`'s
+        # `async with SessionLocal()` rolls back automatically when the handler
+        # raises, restoring the (flushed-but-uncommitted) delete of the old
+        # row. The integration test shares one session with the handler, so we
+        # model that transaction boundary explicitly with rollback() before
+        # asserting the post-rollback state.
+        await db.rollback()
+        stmt = select(AudioRecording).where(AudioRecording.id == existing_id)
+        result = await db.execute(stmt)
+        survivor = result.scalar_one_or_none()
+        assert survivor is not None
+        assert survivor.s3_key == "old-key"
+
+    @patch("app.routers.audio.magic.from_buffer")
     async def test_upload_after_submission_fails(
         self,
         mock_magic,

--- a/backend/tests/integration/test_recruitment.py
+++ b/backend/tests/integration/test_recruitment.py
@@ -79,6 +79,86 @@ class TestRecruitment:
         )
         assert response.status_code == 422
 
+    async def test_public_link_with_capacity_is_rejected(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        test_user: User,
+        auth_token_factory,
+        study_factory,
+        project_factory,
+        project_member_factory,
+    ):
+        """A public (unlimited) link must reject an operator-supplied capacity.
+
+        Previously the service silently dropped the capacity, so an operator
+        could believe they had capped sign-ups when the link was unlimited.
+        The capacity must now be rejected at the API boundary (422).
+        """
+        ws = await project_factory(owner=test_user)
+        study = await study_factory(project=ws, owner=test_user)
+        headers = auth_token_factory(test_user)
+
+        response = await client.post(
+            f"/api/admin/recruitment/{study.slug}/links?count=1",
+            json={"type": "public", "capacity": 10},
+            headers=headers,
+        )
+        assert response.status_code == 422
+        body = response.text.lower()
+        assert "capacity" in body
+        assert "public" in body
+
+    async def test_public_link_without_capacity_succeeds(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        test_user: User,
+        auth_token_factory,
+        study_factory,
+        project_factory,
+        project_member_factory,
+    ):
+        """Control: a public link without capacity must still succeed (unlimited)."""
+        ws = await project_factory(owner=test_user)
+        study = await study_factory(project=ws, owner=test_user)
+        headers = auth_token_factory(test_user)
+
+        response = await client.post(
+            f"/api/admin/recruitment/{study.slug}/links?count=1",
+            json={"type": "public", "name": "Social Media"},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        links = response.json()
+        assert len(links) == 1
+        assert links[0]["capacity"] is None
+
+    async def test_limited_link_with_capacity_succeeds(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        test_user: User,
+        auth_token_factory,
+        study_factory,
+        project_factory,
+        project_member_factory,
+    ):
+        """Control: a non-public (limited) link must still accept capacity."""
+        ws = await project_factory(owner=test_user)
+        study = await study_factory(project=ws, owner=test_user)
+        headers = auth_token_factory(test_user)
+
+        response = await client.post(
+            f"/api/admin/recruitment/{study.slug}/links?count=1",
+            json={"type": "limited", "capacity": 20},
+            headers=headers,
+        )
+        assert response.status_code == 200
+        links = response.json()
+        assert len(links) == 1
+        assert links[0]["capacity"] == 20
+
     async def test_create_excludes_server_controlled_fields(
         self,
         client: AsyncClient,

--- a/backend/tests/unit/test_analysis_service.py
+++ b/backend/tests/unit/test_analysis_service.py
@@ -818,6 +818,90 @@ class TestClassifyWithNaN:
         assert len(cons) == 4
 
 
+class TestClassifyWithNonFiniteSED:
+    """Bug #17: a factor with <2 defining sorts yields NaN std-error → NaN SED.
+
+    ``np.std(..., ddof=1)`` returns NaN with fewer than 2 values, so a factor
+    flagged on a single sort produces a NaN ``se`` and NaN SED entries. A pair
+    with NaN SED is insufficient data to decide significance, so the statement
+    must be EXCLUDED from the significance test for that pair — never silently
+    counted as a confident non-distinguishing (consensus) result.
+    """
+
+    def test_nan_sed_pair_is_skipped_not_consensus(self):
+        """A clearly-distinguishing z-diff with NaN SED must not be classified.
+
+        The real z-score difference is huge (6.0), so on a finite SED this would
+        be strongly distinguishing. With a NaN SED the pair is undecidable: the
+        statement must NOT land in ``distinguishing`` (no finite test passed)
+        AND must NOT be counted as a confident consensus result.
+        """
+        # One statement, two factors, a large genuine difference.
+        z_scores = np.array([[3.0, -3.0]])
+        # SED is NaN (factor 2 flagged on a single sort → ddof=1 std == NaN).
+        sed = np.array([[0.0, np.nan], [np.nan, 0.0]])
+        dist, cons = classify_statements(z_scores, sed, n_factors=2)
+        # Not distinguishing: no finite significance test could pass.
+        assert dist == []
+        # And NOT a confident consensus: the only pair was undecidable, so the
+        # statement is excluded from the significance decision entirely.
+        assert cons == []
+
+    def test_finite_factor_still_classifies_when_other_sed_is_nan(self):
+        """A well-determined pair must classify EXACTLY as before, even when an
+        unrelated pair in the same SED matrix is NaN."""
+        # Three factors. Pair (1,2) is finite; pairs touching factor 3 are NaN
+        # (factor 3 has a single defining sort → NaN se).
+        z_scores = np.array(
+            [
+                [3.0, -3.0, 0.0],  # huge finite 1-2 diff → distinguishing on 1-2
+                [0.0, 0.0, 0.0],  # no difference anywhere → consensus
+            ]
+        )
+        sed = np.array(
+            [
+                [0.0, 0.3, np.nan],
+                [0.3, 0.0, np.nan],
+                [np.nan, np.nan, 0.0],
+            ]
+        )
+        dist, cons = classify_statements(z_scores, sed, n_factors=3)
+        # Statement 0 distinguishes on the finite 1-2 pair.
+        assert len(dist) == 1
+        assert dist[0]["statement_idx"] == 0
+        assert dist[0]["significance"]["1-2"] == "p<0.000001"
+        # NaN pairs (1-3, 2-3) must not appear in the significance dict.
+        assert "1-3" not in dist[0]["significance"]
+        assert "2-3" not in dist[0]["significance"]
+        # Statement 1 has no finite distinguishing pair → consensus (only the
+        # finite 1-2 pair was testable, and it showed no difference).
+        assert len(cons) == 1
+        assert cons[0]["statement_idx"] == 1
+
+    def test_fewer_than_two_zscores_yields_nonfinite_se_end_to_end(self):
+        """End-to-end through ``compute_factor_characteristics``: a factor whose
+        z-score column has fewer than 2 non-NaN values makes ``np.std(ddof=1)``
+        return NaN, so its SE and the cross-factor SED are non-finite, and
+        ``classify_statements`` must exclude the undecidable pair rather than
+        silently classifying the statement as consensus."""
+        loadings = np.array([[0.9, 0.2], [0.85, 0.1]])
+        flagged = np.array([[True, True], [True, True]])
+        # A single-statement factor column → ddof=1 std over 1 value == NaN se.
+        # A large genuine z-difference (2.5 vs -2.5) would distinguish on a
+        # finite SED; here the SED is NaN, so the pair is undecidable.
+        z_scores = np.array([[2.5, -2.5]])
+        chars, _, sed = compute_factor_characteristics(loadings, flagged, z_scores)
+        # Both factors' SE are non-finite (NaN) because ddof=1 needs >= 2 values.
+        assert not np.isfinite(chars[0]["se_factor_scores"])
+        assert not np.isfinite(chars[1]["se_factor_scores"])
+        # The cross-factor SED is therefore non-finite too.
+        assert not np.isfinite(sed[0, 1])
+        dist, cons = classify_statements(z_scores, sed, n_factors=2)
+        # The undecidable pair means the statement is excluded from both lists.
+        assert dist == []
+        assert cons == []
+
+
 class TestNFactorsZero:
     """Test n_factors=0 raises ValueError."""
 

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -68,19 +68,23 @@ def test_recruitment_link_validation():
     rl = RecruitmentLinkBase(name="  Valid Name  ")
     assert rl.name == "Valid Name"
 
-    # Capacity must be > 0
+    # Capacity must be > 0 (use a non-public type so capacity is allowed)
     with pytest.raises(ValidationError):
-        RecruitmentLinkBase(capacity=0)
+        RecruitmentLinkBase(type="limited", capacity=0)
 
     with pytest.raises(ValidationError):
-        RecruitmentLinkBase(capacity=-1)
+        RecruitmentLinkBase(type="limited", capacity=-1)
 
-    rl = RecruitmentLinkBase(capacity=1)
+    rl = RecruitmentLinkBase(type="limited", capacity=1)
     assert rl.capacity == 1
 
     # Capacity is optional (None is valid)
     rl = RecruitmentLinkBase(capacity=None)
     assert rl.capacity is None
+
+    # Public links are unlimited: a capacity here is rejected, not silently dropped
+    with pytest.raises(ValidationError):
+        RecruitmentLinkBase(type="public", capacity=10)
 
 
 def test_recruitment_link_create_excludes_server_fields():

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1671,7 +1671,7 @@ wheels = [
 
 [[package]]
 name = "qualis-backend"
-version = "0.7.1"
+version = "0.7.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/backend/vulture_whitelist.py
+++ b/backend/vulture_whitelist.py
@@ -408,3 +408,7 @@ email_delivery
 # Pydantic field read only at the JSON wire boundary; vulture can't see it.
 audio_storage
 require_audio_storage
+
+# --- app/schemas/recruitment.py (#24: public-link capacity validator) ---
+# Pydantic @model_validator invoked by the framework, not called directly.
+reject_capacity_on_public

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "qualis",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "qualis",
-            "version": "0.7.1",
+            "version": "0.7.2",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",

--- a/frontend/public/locales/de/participant.json
+++ b/frontend/public/locales/de/participant.json
@@ -241,6 +241,7 @@
             "label": "Rastersteuerung"
         },
         "grid": {
+            "cards_moved_to_neutral": "Einige Karten konnten nicht auf dem Raster bleiben und wurden zurück in den unsortierten Stapel verschoben. Bitte platzieren Sie sie erneut.",
             "label": "Q-Sortierungs-Raster",
             "column": "Spalte",
             "slot": "Position",

--- a/frontend/public/locales/en/participant.json
+++ b/frontend/public/locales/en/participant.json
@@ -241,6 +241,7 @@
             "label": "Grid controls"
         },
         "grid": {
+            "cards_moved_to_neutral": "Some cards could not be kept on the grid and were moved back to the unsorted pile. Please re-place them.",
             "label": "Q-Sort grid",
             "column": "Column",
             "slot": "Slot",

--- a/frontend/public/locales/es/participant.json
+++ b/frontend/public/locales/es/participant.json
@@ -229,6 +229,7 @@
             "label": "Controles de la cuadrícula"
         },
         "grid": {
+            "cards_moved_to_neutral": "Algunas tarjetas no pudieron mantenerse en la cuadrícula y se devolvieron a la pila sin ordenar. Vuelva a colocarlas.",
             "label": "Cuadrícula de clasificación Q",
             "column": "Columna",
             "slot": "Posición",

--- a/frontend/public/locales/fi/participant.json
+++ b/frontend/public/locales/fi/participant.json
@@ -241,6 +241,7 @@
             "label": "Ruudukon hallinta"
         },
         "grid": {
+            "cards_moved_to_neutral": "Joitakin kortteja ei voitu säilyttää ruudukossa, ja ne siirrettiin takaisin lajittelemattomaan pinoon. Aseta ne uudelleen.",
             "label": "Q-lajitteluruudukko",
             "column": "Sarake",
             "slot": "Paikka",

--- a/frontend/public/locales/fr/participant.json
+++ b/frontend/public/locales/fr/participant.json
@@ -241,6 +241,7 @@
             "label": "Contrôles de la grille"
         },
         "grid": {
+            "cards_moved_to_neutral": "Certaines cartes n'ont pas pu être conservées sur la grille et ont été replacées dans la pile non triée. Veuillez les replacer.",
             "label": "Grille Q-Sort",
             "column": "Colonne",
             "slot": "Emplacement",

--- a/frontend/public/locales/it/participant.json
+++ b/frontend/public/locales/it/participant.json
@@ -229,6 +229,7 @@
             "label": "Controlli della griglia"
         },
         "grid": {
+            "cards_moved_to_neutral": "Alcune carte non sono potute rimanere sulla griglia e sono state riportate nel mazzo non ordinato. Riposizionale.",
             "label": "Griglia di classificazione Q",
             "column": "Colonna",
             "slot": "Posizione",

--- a/frontend/public/locales/nl/participant.json
+++ b/frontend/public/locales/nl/participant.json
@@ -241,6 +241,7 @@
             "label": "Rasterbesturing"
         },
         "grid": {
+            "cards_moved_to_neutral": "Sommige kaarten konden niet op het raster blijven en zijn teruggeplaatst in de ongesorteerde stapel. Plaats ze opnieuw.",
             "label": "Q-sortering raster",
             "column": "Kolom",
             "slot": "Positie",

--- a/frontend/public/locales/pl/participant.json
+++ b/frontend/public/locales/pl/participant.json
@@ -241,6 +241,7 @@
             "label": "Sterowanie siatką"
         },
         "grid": {
+            "cards_moved_to_neutral": "Niektórych kart nie udało się zachować na siatce i zostały przeniesione z powrotem do nieposortowanego stosu. Umieść je ponownie.",
             "label": "Siatka sortowania Q",
             "column": "Kolumna",
             "slot": "Miejsce",

--- a/frontend/public/locales/pt/participant.json
+++ b/frontend/public/locales/pt/participant.json
@@ -241,6 +241,7 @@
             "label": "Controlos da grelha"
         },
         "grid": {
+            "cards_moved_to_neutral": "Alguns cartões não puderam ser mantidos na grelha e foram movidos de volta para a pilha não ordenada. Por favor, volte a colocá-los.",
             "label": "Grelha de classificação Q",
             "column": "Coluna",
             "slot": "Posição",

--- a/frontend/src/hooks/participant/useResumeSession.test.ts
+++ b/frontend/src/hooks/participant/useResumeSession.test.ts
@@ -63,7 +63,10 @@ describe('validateDraftResponses', () => {
         const draft = {
             presort: { q1: 'yes' },
             rough: { agree: [1], disagree: [2], neutral: [3], history: ['drag-1'] },
-            qsort: [[1], [2]],
+            qsort: [
+                { statementId: 1, col: 0, row: 0 },
+                { statementId: 2, col: 1, row: 0 },
+            ],
             postsort: { feedback: 'good' },
         };
         const result = validateDraftResponses(draft);
@@ -74,16 +77,81 @@ describe('validateDraftResponses', () => {
         const draft = {
             presort: { q1: 'yes' }, // valid
             rough: { agree: 'not-an-array' }, // invalid
-            qsort: [[1]], // valid
+            qsort: [{ statementId: 1, col: 0, row: 0 }], // valid
             postsort: 'not-an-object', // invalid
         };
         const result = validateDraftResponses(draft);
         expect(result).toEqual({
             presort: { q1: 'yes' },
             rough: initialResponses.rough,
-            qsort: [[1]],
+            qsort: [{ statementId: 1, col: 0, row: 0 }],
             postsort: initialResponses.postsort,
         });
+    });
+
+    it('accepts an empty qsort (early-step resume before any placement)', () => {
+        const draft = {
+            presort: { q1: 'yes' },
+            rough: { agree: [], disagree: [], neutral: [], history: [] },
+            qsort: [],
+            postsort: {},
+        };
+        const result = validateDraftResponses(draft);
+        expect(result?.qsort).toEqual([]);
+        expect(result?.presort).toEqual({ q1: 'yes' });
+    });
+
+    it('rejects malformed qsort elements while preserving a valid sibling slice', () => {
+        const draft = {
+            presort: { q1: 'yes' }, // valid sibling — must be preserved
+            qsort: [
+                { statementId: 1, col: 0, row: 0 }, // valid
+                { col: 0, row: 0 }, // missing statementId
+                { statementId: 'x', col: 0, row: 0 }, // wrong statementId type
+                { statementId: 1, col: 'x', row: 0 }, // wrong col type
+            ],
+        };
+        const result = validateDraftResponses(draft);
+        // The whole qsort is malformed → fall back to the empty array.
+        expect(result?.qsort).toEqual([]);
+        // The valid sibling slice is untouched.
+        expect(result?.presort).toEqual({ q1: 'yes' });
+    });
+
+    it('rejects qsort elements with negative col or row', () => {
+        const negCol = validateDraftResponses({
+            qsort: [{ statementId: 1, col: -1, row: 0 }],
+        });
+        expect(negCol?.qsort).toEqual([]);
+
+        const negRow = validateDraftResponses({
+            qsort: [{ statementId: 1, col: 0, row: -1 }],
+        });
+        expect(negRow?.qsort).toEqual([]);
+    });
+
+    it('rejects qsort elements with a non-positive statementId', () => {
+        const zeroId = validateDraftResponses({
+            qsort: [{ statementId: 0, col: 0, row: 0 }],
+        });
+        expect(zeroId?.qsort).toEqual([]);
+
+        const negId = validateDraftResponses({
+            qsort: [{ statementId: -3, col: 0, row: 0 }],
+        });
+        expect(negId?.qsort).toEqual([]);
+    });
+
+    it('rejects qsort elements with non-finite numbers', () => {
+        const nan = validateDraftResponses({
+            qsort: [{ statementId: 1, col: Number.NaN, row: 0 }],
+        });
+        expect(nan?.qsort).toEqual([]);
+
+        const inf = validateDraftResponses({
+            qsort: [{ statementId: 1, col: 0, row: Number.POSITIVE_INFINITY }],
+        });
+        expect(inf?.qsort).toEqual([]);
     });
 
     it('falls back to initialResponses on every malformed slice', () => {

--- a/frontend/src/hooks/participant/useResumeSession.ts
+++ b/frontend/src/hooks/participant/useResumeSession.ts
@@ -58,6 +58,31 @@ interface ValidatedDraft {
 }
 
 /**
+ * Validates a single `qsort` placement element. A well-formed element is a
+ * non-null object whose `statementId`, `col` and `row` are all finite numbers
+ * with `statementId > 0`, `col >= 0` and `row >= 0`. The per-mode upper-bound
+ * (`row < capacity`) is intentionally NOT checked here: it depends on
+ * `gridColumns` (absent at this pure boundary) and `row` may legitimately
+ * exceed capacity in free/flexible distribution modes. Overflow is caught later
+ * by `useGridSanity`, which has the grid context.
+ */
+function isQsortElementShape(el: unknown): boolean {
+    if (!el || typeof el !== 'object' || Array.isArray(el)) return false;
+    const { statementId, col, row } = el as Record<string, unknown>;
+    return (
+        typeof statementId === 'number' &&
+        Number.isFinite(statementId) &&
+        statementId > 0 &&
+        typeof col === 'number' &&
+        Number.isFinite(col) &&
+        col >= 0 &&
+        typeof row === 'number' &&
+        Number.isFinite(row) &&
+        row >= 0
+    );
+}
+
+/**
  * Per-key shape validation of a `draft_responses` payload. Each key falls
  * back to `initialResponses.<key>` independently when its shape is wrong, so
  * a corrupted slice cannot poison neighbouring slices.
@@ -80,7 +105,7 @@ export function validateDraftResponses(draft: unknown): ValidatedDraft | null {
         Array.isArray(roughObj.neutral) &&
         Array.isArray(roughObj.history);
 
-    const isQsortShape = Array.isArray(d.qsort);
+    const isQsortShape = Array.isArray(d.qsort) && d.qsort.every(isQsortElementShape);
 
     const isPostsortShape =
         d.postsort && typeof d.postsort === 'object' && !Array.isArray(d.postsort);

--- a/frontend/src/hooks/useGridSanity.test.ts
+++ b/frontend/src/hooks/useGridSanity.test.ts
@@ -1,6 +1,15 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
 import { useGridSanity } from './useGridSanity';
+
+vi.mock('sonner', () => ({
+    toast: {
+        warning: vi.fn(),
+        success: vi.fn(),
+        error: vi.fn(),
+    },
+}));
 
 describe('useGridSanity', () => {
     const mockUnplaceCard = vi.fn();
@@ -168,5 +177,44 @@ describe('useGridSanity', () => {
 
         expect(unplaceCard).toHaveBeenCalledWith(2);
         expect(unplaceCard).not.toHaveBeenCalledWith(1);
+    });
+
+    it('shows a toast when cards are removed (no longer silent)', () => {
+        vi.mocked(toast.warning).mockClear();
+        const unplaceCard = vi.fn();
+        const categorizeCard = vi.fn();
+        const qsort = [
+            { statementId: 1, col: 0, row: 5 }, // out of bounds (capacity 2, forced)
+        ];
+
+        renderHook(() =>
+            useGridSanity({
+                qsort,
+                gridColumns,
+                unplaceCard,
+                categorizeCard,
+            })
+        );
+
+        expect(unplaceCard).toHaveBeenCalledWith(1);
+        expect(toast.warning).toHaveBeenCalled();
+    });
+
+    it('does not show a toast when the grid is valid', () => {
+        vi.mocked(toast.warning).mockClear();
+        const unplaceCard = vi.fn();
+        const categorizeCard = vi.fn();
+        const qsort = [{ statementId: 1, col: 0, row: 0 }];
+
+        renderHook(() =>
+            useGridSanity({
+                qsort,
+                gridColumns,
+                unplaceCard,
+                categorizeCard,
+            })
+        );
+
+        expect(toast.warning).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/hooks/useGridSanity.ts
+++ b/frontend/src/hooks/useGridSanity.ts
@@ -1,4 +1,6 @@
 import { useEffect } from 'react';
+import { toast } from 'sonner';
+import i18n from '../i18n';
 
 interface GridColumn {
     capacity: number;
@@ -67,6 +69,15 @@ export const useGridSanity = ({
                 unplaceCard(id);
                 categorizeCard(id, 'neutral');
             });
+            // Surface the removal so the participant is not silently surprised
+            // by vanished cards (bug #42). The cards are moved to the neutral
+            // pile and can be re-placed.
+            toast.warning(
+                i18n.t(
+                    'grid.cards_moved_to_neutral',
+                    'Some cards could not be kept on the grid and were moved back to the unsorted pile. Please re-place them.'
+                )
+            );
         }
     }, [qsort, gridColumns, unplaceCard, categorizeCard, distributionMode]);
 };

--- a/frontend/src/hooks/useStudyConfig.test.tsx
+++ b/frontend/src/hooks/useStudyConfig.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../i18n';
 import { useConfigStore } from '../store/useConfigStore';
 import { useSessionStore } from '../store/useSessionStore';
 import { applyStudyOverrides } from '../utils/i18nOverrides';
@@ -160,6 +161,87 @@ describe('useStudyConfig', () => {
     // populate the store with the wrong slug, the slug-guard would fire a
     // reset, the refetch would replay, and the loop would exhaust the heap.
     // See `useStudyConfig.ts:246-253` for the rationale comment.
+    // ── Issue #30: uncancelled async test-mode load races on unmount ─────────
+    // The test-mode loading effect runs an async loadFromStorage() chain that
+    // awaits i18n.changeLanguage (via syncConfigLanguage) before calling
+    // setConfig. If the component unmounts (or the slug changes) mid-load, the
+    // chain must be cancelled — it must NOT fire setConfig with the stale
+    // study's data after unmount. Without a cancellation flag the deferred
+    // resolution writes the config post-unmount (a stale-study flash +
+    // setState-after-unmount).
+    it('does NOT write the test config after unmount when the async load resolves late', async () => {
+        // Force test mode via URL.
+        vi.spyOn(URLSearchParams.prototype, 'get').mockImplementation((key) => {
+            if (key === 'mode') return 'test';
+            return null;
+        });
+
+        // Make i18n believe the current UI language differs from the draft so
+        // syncConfigLanguage takes the `await i18n.changeLanguage(...)` branch.
+        // @ts-expect-error mocked module
+        i18n.language = 'en';
+
+        // Deferred control over the awaited changeLanguage promise: the load
+        // chain will suspend here until we resolve it.
+        let resolveChangeLanguage: () => void = () => {};
+        const changeLanguageGate = new Promise<void>((resolve) => {
+            resolveChangeLanguage = resolve;
+        });
+        vi.mocked(i18n.changeLanguage).mockReturnValue(
+            // biome-ignore lint/suspicious/noExplicitAny: i18n.changeLanguage returns a TFunction promise we don't use
+            changeLanguageGate as any
+        );
+
+        // Seed a draft for the pinned slug whose language differs from 'en'.
+        localStorage.clear();
+        localStorage.setItem(
+            'qualis-test-draft-test-study',
+            JSON.stringify({
+                slug: 'test-study',
+                statements: [],
+                translations: [
+                    {
+                        language_code: 'fr',
+                        title: 'Stale Test Study',
+                        ui_labels: {},
+                        process_steps: [],
+                    },
+                ],
+            })
+        );
+
+        // The query hook is disabled in test mode; provide an inert stub.
+        vi.mocked(useGetStudyConfig).mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            error: null,
+            refetch: vi.fn(),
+            // biome-ignore lint/suspicious/noExplicitAny: mock hook
+        } as any);
+
+        const { unmount } = renderHook(() => useStudyConfig());
+
+        // Wait until the chain has reached (and is suspended on) changeLanguage.
+        await waitFor(() => {
+            expect(i18n.changeLanguage).toHaveBeenCalledWith('fr');
+        });
+
+        // Config must still be unwritten — the await has not resolved yet.
+        expect(useConfigStore.getState().config).toBeNull();
+
+        // Unmount BEFORE the deferred await resolves.
+        unmount();
+
+        // Now resolve the late await: the cancelled chain must NOT call setConfig.
+        resolveChangeLanguage();
+        await changeLanguageGate;
+        // Flush any pending microtasks the chain might schedule.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(useConfigStore.getState().config).toBeNull();
+    });
+
     it('does NOT write a config response whose slug mismatches the URL slug', async () => {
         // The router mock pins the URL slug to 'test-study'. Mock the API
         // hook to return a response with a different slug — this is exactly

--- a/frontend/src/hooks/useStudyConfig.ts
+++ b/frontend/src/hooks/useStudyConfig.ts
@@ -168,6 +168,34 @@ export const useStudyConfig = () => {
     useEffect(() => {
         if (!isTestMode || !slug) return;
 
+        // Per-load cancellation guard (issue #30). The async loadFromStorage
+        // chain awaits i18n.changeLanguage / refetch before calling setState;
+        // if the slug changes or the component unmounts mid-load, the in-flight
+        // chain must not fire setState with the previous study's data (a stale
+        // study flash + setState-after-unmount). Cleanup flips this flag, and
+        // every awaited continuation below checks it before touching state.
+        // The storage listener also re-enters loadFromStorage, so gating on this
+        // single effect-scoped flag covers both the initial load and any late
+        // storage-triggered reload: once cancelled, neither can write state.
+        let cancelled = false;
+
+        // Cancellation-aware `setLoading(false)` for the load chain's finally
+        // blocks: a no-op once the effect has been torn down.
+        const finishLoading = (): void => {
+            if (!cancelled) setConfigLoading(false);
+        };
+
+        // Cancellation-aware commit of a resolved config + its UI overrides.
+        // Called only on the happy path after every await guard has passed.
+        const commitConfig = (resolved: StudyConfig): void => {
+            if (cancelled) return;
+            if (resolved.ui_labels) {
+                applyStudyOverrides(resolved.language || 'en', resolved.ui_labels);
+            }
+            setConfig(resolved);
+            setConfigError(null);
+        };
+
         const loadFromLocalDraft = async (
             draftJson: string | null,
             legacyJson: string | null
@@ -178,32 +206,37 @@ export const useStudyConfig = () => {
                     : (JSON.parse(legacyJson as string) as StudyConfig);
 
                 await syncConfigLanguage(config.language, sessionLanguage, setLanguage);
-                if (config.ui_labels) {
-                    applyStudyOverrides(config.language || 'en', config.ui_labels);
-                }
-
-                setConfig(config);
-                setConfigError(null);
+                if (cancelled) return;
+                commitConfig(config);
             } catch (e) {
+                if (cancelled) return;
                 console.error('Failed to parse test config from localStorage', e);
                 setConfigError('common.errors.validation');
             } finally {
-                setConfigLoading(false);
+                finishLoading();
             }
+        };
+
+        // Sync i18n + session language to the server data's resolved language.
+        // Returns false when the load was cancelled mid-await (caller must abort).
+        const syncServerLang = async (serverData: StudyConfig): Promise<boolean> => {
+            const langChanged =
+                !sessionLanguage ||
+                (serverData.language && sessionLanguage !== serverData.language);
+            if (!langChanged) return true;
+            const newLang = serverData.language || 'en';
+            await i18n.changeLanguage(newLang);
+            if (cancelled) return false;
+            setLanguage(newLang);
+            return true;
         };
 
         const applyServerData = async (serverData: StudyConfig): Promise<void> => {
             if (serverData.ui_labels) {
                 applyStudyOverrides(serverData.language || 'en', serverData.ui_labels);
             }
-            const langChanged =
-                !sessionLanguage ||
-                (serverData.language && sessionLanguage !== serverData.language);
-            if (langChanged) {
-                const newLang = serverData.language || 'en';
-                await i18n.changeLanguage(newLang);
-                setLanguage(newLang);
-            }
+            if (!(await syncServerLang(serverData))) return;
+            if (cancelled) return;
             setConfig(serverData);
             setConfigError(null);
         };
@@ -217,14 +250,16 @@ export const useStudyConfig = () => {
                 if (!serverData) throw new Error('Server returned no data');
                 await applyServerData(serverData);
             } catch (err) {
+                if (cancelled) return;
                 console.error('[useStudyConfig] Server fallback failed', err);
                 setConfigError('common.errors.not_found');
             } finally {
-                setConfigLoading(false);
+                finishLoading();
             }
         };
 
         const loadFromStorage = async () => {
+            if (cancelled) return;
             resetConfig(); // Clear previous study config
             setConfigLoading(true);
 
@@ -250,13 +285,17 @@ export const useStudyConfig = () => {
 
         // Listen for changes from other tabs (Designer)
         const handleStorageChange = (e: StorageEvent) => {
+            if (cancelled) return;
             if (e.key === `qualis-test-draft-${slug}` || e.key === `qualis-pilot-reset-${slug}`) {
                 loadFromStorage();
             }
         };
 
         window.addEventListener('storage', handleStorageChange);
-        return () => window.removeEventListener('storage', handleStorageChange);
+        return () => {
+            cancelled = true;
+            window.removeEventListener('storage', handleStorageChange);
+        };
     }, [
         isTestMode,
         slug,

--- a/frontend/src/hooks/useStudyPersistence.test.ts
+++ b/frontend/src/hooks/useStudyPersistence.test.ts
@@ -166,6 +166,55 @@ describe('useStudyPersistence', () => {
         expect(mockSetSyncStatus).toHaveBeenCalledWith('modified');
     });
 
+    it('should serialise saves: a second save while one is in flight does not re-invoke the mutation', async () => {
+        // Characterization test for the syncStatus === 'saving' guard at the top of save().
+        // It is the ACTUAL protection against concurrent/out-of-order saves (the AbortController
+        // was dead code — its signal was never wired to the mutation). This test locks the
+        // serialization contract: while a save is in flight, a second save() short-circuits.
+        const draft = { slug: 'test-study', statements: [] };
+
+        // First render: syncStatus 'modified' → save() proceeds and starts an in-flight mutation
+        // whose resolution we control, so the save stays "in flight" across the second call.
+        let resolveMutation: (value: unknown) => void = () => {};
+        mockMutateAsync.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolveMutation = resolve;
+            })
+        );
+
+        mockStoreState({ draft, syncStatus: 'modified' });
+        const first = renderHook(() => useStudyPersistence());
+
+        let firstSave: Promise<void> = Promise.resolve();
+        act(() => {
+            firstSave = first.result.current.save();
+        });
+
+        // The in-flight save invoked the mutation exactly once.
+        expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+
+        // Re-render with syncStatus now 'saving' — this is the state the store would be in while
+        // the mutation is pending. A second save() under this state must short-circuit on the
+        // guard and return WITHOUT invoking the mutation again.
+        mockStoreState({ draft, syncStatus: 'saving' });
+        const second = renderHook(() => useStudyPersistence());
+
+        await act(async () => {
+            await second.result.current.save();
+        });
+
+        // Still exactly one invocation: the second call returned early on the guard.
+        expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+
+        // Let the first (in-flight) save finish cleanly.
+        await act(async () => {
+            resolveMutation({ slug: 'test-study' });
+            await firstSave;
+        });
+
+        expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    });
+
     it('should warn user before unload when changes are unsaved', () => {
         const draft = { slug: 'test-study', statements: ['statement1'] };
 

--- a/frontend/src/hooks/useStudyPersistence.ts
+++ b/frontend/src/hooks/useStudyPersistence.ts
@@ -29,7 +29,6 @@ export function useStudyPersistence() {
     } = useStudyDesigner();
 
     const updateMutation = useUpdateStudyApiAdminStudiesSlugPatch();
-    const abortControllerRef = useRef<AbortController | null>(null);
 
     // Track the last draft we successfully sent to avoid redundant saves
     const lastSavedDraftRef = useRef<string | null>(null);
@@ -148,8 +147,6 @@ export function useStudyPersistence() {
     // Handles errors from the save mutation.
     const handleSaveError = useCallback(
         (error: unknown) => {
-            if (error instanceof Error && error.name === 'AbortError') return;
-
             const apiError = error as ApiError & { details: { server_state: StudyRead } };
 
             if (apiError?.status === 409 && apiError.details?.server_state) {
@@ -173,11 +170,6 @@ export function useStudyPersistence() {
         if (!draft || !effectiveSlug || syncStatus === 'saving') return;
 
         const draftJson = JSON.stringify(draft);
-
-        if (abortControllerRef.current) {
-            abortControllerRef.current.abort();
-        }
-        abortControllerRef.current = new AbortController();
 
         setSyncStatus('saving');
 

--- a/frontend/src/pages/ResumePage.test.tsx
+++ b/frontend/src/pages/ResumePage.test.tsx
@@ -167,7 +167,10 @@ describe('ResumePage', () => {
             draft_responses: {
                 presort: { q1: 'yes' },
                 rough: { agree: [1], disagree: [2], neutral: [3], history: [] },
-                qsort: [[1], [2]],
+                qsort: [
+                    { statementId: 1, col: 0, row: 0 },
+                    { statementId: 2, col: 1, row: 0 },
+                ],
                 postsort: { feedback: 'good' },
             },
             resume_code: 'brave-tiger-42',
@@ -185,7 +188,10 @@ describe('ResumePage', () => {
             expect(mocks.setState).toHaveBeenCalledWith({
                 presort: { q1: 'yes' },
                 rough: { agree: [1], disagree: [2], neutral: [3], history: [] },
-                qsort: [[1], [2]],
+                qsort: [
+                    { statementId: 1, col: 0, row: 0 },
+                    { statementId: 2, col: 1, row: 0 },
+                ],
                 postsort: { feedback: 'good' },
             });
             expect(mocks.navigate).toHaveBeenCalledWith('/study/test-study/rough-sort', {


### PR DESCRIPTION
The **correctness** batch from the bug/perf audit, re-triaged for Q-methodology scale (small P-set by design → throughput is moot; correctness is what matters). Each finding was deep-investigated for reachability + complete root cause before implementing, and each fix is TDD (failing test first).

## Fixes (6 findings)

**`fix(audio)` #5 — non-atomic re-upload (data loss).** Re-uploading audio deleted the old S3 object *before* the new upload + DB commit; a transient failure rolled back the DB (restoring the old row) but the old object was already gone → participant lost their audio. Now the old object's S3 delete is deferred until after the new recording commits (best-effort, never 500s a successful replacement).

**`fix(analysis)` #17 — insufficient-data statements silently marked consensus.** A factor with <2 defining sorts (realistic at Q's small N) makes `np.std(ddof=1)` NaN → the SED is NaN → the `sed_val <= 0` skip guard misses it (`NaN <= 0` is False) and `diff > NaN` is always False, so the statement was silently appended to **consensus**. Now `classify_statements` skips non-finite SED and excludes undecidable statements from *both* lists; SE is set explicitly for <2 z-scores. Well-determined factors classify identically.

**`fix(recruitment)` #24 — public links silently discard capacity.** A public link is unlimited; the service forced `capacity=None`, silently dropping an operator-supplied value (they might think they capped sign-ups). A Pydantic `model_validator` now rejects non-None capacity on public links with a 422. limited/individual links unaffected.

**`fix(resume)` #42 — corrupt drafts pass validation, cards vanish silently.** `validateDraftResponses` only checked `Array.isArray(d.qsort)`; malformed elements passed into the store, then `useGridSanity` moved them to neutral with only a `console.warn`. Now each qsort element is shape-validated (finite `statementId>0`/`col>=0`/`row>=0`, else fall back to empty); the grid-sanity removal raises a participant-facing toast (`grid.cards_moved_to_neutral`, added to all 9 participant locales). Empty qsort and free/flexible `row>capacity` stay valid.

**`fix(study-config)` #30 — uncancelled async load races on slug change.** The test-mode load chain wrote the old study's config after a slug change/unmount (a wrong-study flash + setState-after-unmount; the slug-guard only corrected the *final* state). Added an effect-scoped `cancelled` flag checked after each await + set in cleanup (matching the existing `useResumeSession` pattern), including the storage-listener re-entry. Verified with a mutation check.

**`refactor(study-persistence)` #31 — dead AbortController.** `save()` created an AbortController whose signal was never passed to the mutation (the orval client can't take one), making the AbortError branch unreachable; saves are actually serialised by the `syncStatus` guard. Removed the misleading dead code (kept a characterization test locking the syncStatus serialization) rather than wiring a non-functional cancellation.

## Investigated and dropped
- **#16 (varimax convergence criterion)** — `marginal`: the angle-sum criterion is inefficient and misrepresents Kaiser, but produces **identical** final loadings (zero correctness impact), and at Q scale (k=2–3 common) the extra iterations are sub-second. Not worth the change under a correctness-first lens.

## Also (post-release lockfile hygiene)
- `chore`: synced `backend/uv.lock` + `frontend/package-lock.json` self-versions to 0.7.2 (release-please bumped the manifests but doesn't re-lock; `check_installation_docs.py` enforces the match) and whitelisted the #24 validator for vulture. No dependency changes.

## Verification
Each fix is TDD (RED → GREEN, with regression/characterization tests). Full `make ci` green: lint + check (mypy `--strict`, vulture, deptry, pip-audit, i18n parity, installation-docs) + backend & frontend tests + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)