### PR TITLE
fix: audit Wave A — security & data-integrity quick wins (4 findings)

### DIFF
--- a/backend/app/models/participant.py
+++ b/backend/app/models/participant.py
@@ -124,6 +124,19 @@ class Participant(Base):
             return self.presort_answers.get("_recruitment_token")
         return None
 
+    @property
+    def code(self) -> str:
+        """Short, non-sensitive display code for the admin UI.
+
+        The full ``session_token`` is the participant's bearer credential
+        (resume, draft read, submission, GDPR self-erasure) and must never be
+        serialised to clients — exposing it lets even a viewer impersonate any
+        participant. This truncated, non-reversible 8-char prefix is exactly
+        what the admin UI already rendered, and matches the dump/export
+        ``str(session_token)[:8].upper()`` convention.
+        """
+        return str(self.session_token)[:8].upper()
+
 
 class QSortEntry(Base):
     """SQLAlchemy model for individual Q-sort card placements."""

--- a/backend/app/routers/audio.py
+++ b/backend/app/routers/audio.py
@@ -346,12 +346,27 @@ async def delete_audio_recording(
     if participant.submitted_at:
         raise HTTPException(status_code=400, detail="Cannot delete after submission")
 
-    # Delete from S3
-    await storage_service.delete_audio(recording.s3_key)
+    # Commit the DB delete FIRST, then remove the S3 object. If we deleted from
+    # S3 first and the commit then failed, the object would be permanently gone
+    # while the AudioRecording row survived (a 404 on get_audio_url/export) —
+    # the same atomicity bug already fixed on the re-upload path (commit 9d349f2a).
+    s3_key = recording.s3_key
 
-    # Delete from database
     await db.delete(recording)
     await db.commit()
+
+    # Best-effort S3 cleanup: the row is already durably deleted, so a storage
+    # failure must not 500 the request. Worst case is a harmless orphan object
+    # that storage lifecycle/cleanup can reap.
+    try:
+        await storage_service.delete_audio(s3_key)
+    except Exception:
+        logger.warning(
+            "Failed to delete S3 object %s after deleting AudioRecording %s",
+            s3_key,
+            recording_id,
+            exc_info=True,
+        )
 
     return {"message": "Audio deleted successfully"}
 

--- a/backend/app/schemas/participants.py
+++ b/backend/app/schemas/participants.py
@@ -114,11 +114,19 @@ class SubmissionInput(BaseModel):
 
 
 class ParticipantRead(BaseModel):
-    """Schema for reading a participant."""
+    """Schema for reading a participant.
+
+    Security: the raw ``session_token`` is the participant's bearer credential
+    and is deliberately NOT exposed here — this schema is reachable by the
+    lowest (viewer) role via the study participant list. Only the truncated,
+    non-reversible ``code`` (session_token[:8]) is surfaced for display.
+    ``recruitment_token`` and ``user_agent`` are research metadata, not
+    credentials, and remain available.
+    """
 
     id: int
     study_id: int
-    session_token: UUID
+    code: str
     language_used: str
     status: ParticipantStatus
     created_at: datetime

--- a/backend/tests/security/wave_3/test_participant_token_not_exposed.py
+++ b/backend/tests/security/wave_3/test_participant_token_not_exposed.py
@@ -1,0 +1,77 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Audit Wave A (A1) regression — ``ParticipantRead`` must not leak the raw
+``session_token``.
+
+The study participant list (``GET /api/admin/studies/{slug}/participants``)
+is reachable by the **lowest** role, ``viewer``. Before the fix,
+``ParticipantRead`` serialised the full ``session_token`` — the participant's
+sole bearer credential (resume, draft read, submission, GDPR self-erasure).
+A viewer could therefore harvest every participant's credential and
+impersonate them or erase their data.
+
+The schema now exposes only a truncated, non-reversible ``code``
+(``session_token[:8]`` uppercased — exactly what the admin UI already
+rendered). ``recruitment_token`` and ``user_agent`` are research metadata,
+not credentials, and remain available.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from .conftest import TenancyFixtures
+
+
+@pytest.mark.asyncio
+async def test_viewer_participant_list_exposes_code_not_session_token(
+    tenancy: TenancyFixtures,
+    client: AsyncClient,
+) -> None:
+    """A project viewer listing participants gets the display code, never the token."""
+    response = await client.get(
+        f"/api/admin/studies/{tenancy.study_in_a.slug}/participants",
+        headers={"Authorization": f"Bearer {tenancy.token_a_viewer}"},
+    )
+    assert response.status_code == 200, response.text
+
+    items = response.json()["items"]
+    record = next((it for it in items if it["id"] == tenancy.participant_in_a.id), None)
+    assert record is not None, "seeded participant_in_a should be in the list"
+
+    # The bearer credential must never be serialised to any client...
+    assert "session_token" not in record, (
+        "session_token leaked in ParticipantRead — a viewer could impersonate "
+        "or erase any participant"
+    )
+    assert "resume_code" not in record
+    assert "confirmation_code" not in record
+
+    # ...only the truncated, non-reversible display code is exposed.
+    expected_code = str(tenancy.participant_in_a.session_token)[:8].upper()
+    assert record["code"] == expected_code
+    assert len(record["code"]) == 8
+
+    # Research metadata (not credentials) stays available to the viewer.
+    assert "recruitment_token" in record
+    assert "user_agent" in record
+
+
+@pytest.mark.asyncio
+async def test_participant_detail_exposes_code_not_session_token(
+    tenancy: TenancyFixtures,
+    client: AsyncClient,
+) -> None:
+    """The member/owner detail view is also free of the raw session_token."""
+    response = await client.get(
+        f"/api/admin/studies/participants/{tenancy.participant_in_a.id}",
+        headers={"Authorization": f"Bearer {tenancy.token_a_member}"},
+    )
+    assert response.status_code == 200, response.text
+
+    record = response.json()
+    assert "session_token" not in record
+    assert record["code"] == str(tenancy.participant_in_a.session_token)[:8].upper()

--- a/frontend/e2e/admin/responsive-overflow.spec.ts
+++ b/frontend/e2e/admin/responsive-overflow.spec.ts
@@ -75,7 +75,10 @@ const participants = {
         {
             id: 1,
             study_id: 1,
-            session_token: 'responsive-session-token',
+            // ParticipantRead now exposes the non-sensitive `code` (session_token[:8]
+            // uppercased), not the raw session_token (audit A1). RecentActivityCard
+            // reads participant.code, so the fixture must provide it.
+            code: 'RESPONSI',
             language_used: 'en',
             status: 'completed',
             created_at: '2026-05-11T00:00:00Z',

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -9800,10 +9800,9 @@
             "type": "integer",
             "title": "Study Id"
           },
-          "session_token": {
+          "code": {
             "type": "string",
-            "format": "uuid",
-            "title": "Session Token"
+            "title": "Code"
           },
           "language_used": {
             "type": "string",
@@ -9919,7 +9918,7 @@
         "required": [
           "id",
           "study_id",
-          "session_token",
+          "code",
           "language_used",
           "status",
           "created_at",
@@ -10035,10 +10034,9 @@
             "type": "integer",
             "title": "Study Id"
           },
-          "session_token": {
+          "code": {
             "type": "string",
-            "format": "uuid",
-            "title": "Session Token"
+            "title": "Code"
           },
           "language_used": {
             "type": "string",
@@ -10129,7 +10127,7 @@
         "required": [
           "id",
           "study_id",
-          "session_token",
+          "code",
           "language_used",
           "status",
           "created_at",
@@ -10139,7 +10137,7 @@
           "user_agent"
         ],
         "title": "ParticipantRead",
-        "description": "Schema for reading a participant."
+        "description": "Schema for reading a participant.\n\nSecurity: the raw ``session_token`` is the participant's bearer credential\nand is deliberately NOT exposed here \u2014 this schema is reachable by the\nlowest (viewer) role via the study participant list. Only the truncated,\nnon-reversible ``code`` (session_token[:8]) is surfaced for display.\n``recruitment_token`` and ``user_agent`` are research metadata, not\ncredentials, and remain available."
       },
       "ParticipantStatus": {
         "type": "string",

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -17766,7 +17766,7 @@ export const getListStudyParticipantsApiAdminStudiesSlugParticipantsGetResponseM
         () => ({
             id: faker.number.int({ min: undefined, max: undefined }),
             study_id: faker.number.int({ min: undefined, max: undefined }),
-            session_token: faker.string.uuid(),
+            code: faker.string.alpha({ length: { min: 10, max: 20 } }),
             language_used: faker.string.alpha({ length: { min: 10, max: 20 } }),
             status: faker.helpers.arrayElement(Object.values(ParticipantStatus)),
             created_at: `${faker.date.past().toISOString().split('.')[0]}Z`,
@@ -17817,7 +17817,7 @@ export const getGetParticipantApiAdminStudiesParticipantsParticipantIdGetRespons
 ): ParticipantDetailRead => ({
     id: faker.number.int({ min: undefined, max: undefined }),
     study_id: faker.number.int({ min: undefined, max: undefined }),
-    session_token: faker.string.uuid(),
+    code: faker.string.alpha({ length: { min: 10, max: 20 } }),
     language_used: faker.string.alpha({ length: { min: 10, max: 20 } }),
     status: faker.helpers.arrayElement(Object.values(ParticipantStatus)),
     created_at: `${faker.date.past().toISOString().split('.')[0]}Z`,
@@ -17902,7 +17902,7 @@ export const getDiscardParticipantApiAdminStudiesParticipantsParticipantIdDiscar
     (overrideResponse: Partial<ParticipantRead> = {}): ParticipantRead => ({
         id: faker.number.int({ min: undefined, max: undefined }),
         study_id: faker.number.int({ min: undefined, max: undefined }),
-        session_token: faker.string.uuid(),
+        code: faker.string.alpha({ length: { min: 10, max: 20 } }),
         language_used: faker.string.alpha({ length: { min: 10, max: 20 } }),
         status: faker.helpers.arrayElement(Object.values(ParticipantStatus)),
         created_at: `${faker.date.past().toISOString().split('.')[0]}Z`,

--- a/frontend/src/api/model/participantDetailRead.ts
+++ b/frontend/src/api/model/participantDetailRead.ts
@@ -22,7 +22,7 @@ import type { AudioRecordingRead } from './audioRecordingRead';
 export interface ParticipantDetailRead {
     id: number;
     study_id: number;
-    session_token: string;
+    code: string;
     language_used: string;
     status: ParticipantStatus;
     created_at: string;

--- a/frontend/src/api/model/participantRead.ts
+++ b/frontend/src/api/model/participantRead.ts
@@ -14,11 +14,18 @@ import type { ParticipantReadRecruitmentToken } from './participantReadRecruitme
 
 /**
  * Schema for reading a participant.
+
+Security: the raw ``session_token`` is the participant's bearer credential
+and is deliberately NOT exposed here — this schema is reachable by the
+lowest (viewer) role via the study participant list. Only the truncated,
+non-reversible ``code`` (session_token[:8]) is surfaced for display.
+``recruitment_token`` and ``user_agent`` are research metadata, not
+credentials, and remain available.
  */
 export interface ParticipantRead {
     id: number;
     study_id: number;
-    session_token: string;
+    code: string;
     language_used: string;
     status: ParticipantStatus;
     created_at: string;

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -77,7 +77,7 @@ function ParticipantRow({
     onView,
 }: ParticipantRowProps) {
     const { t } = useTranslation();
-    const colors = getParticipantColor(participant.session_token);
+    const colors = getParticipantColor(participant.code);
     const isCompleted = participant.status === 'completed';
     const activityTime = getActivityTime(participant);
     const ua = parseUA(participant.user_agent as string | undefined);
@@ -104,14 +104,14 @@ function ParticipantRow({
                     color: colors.text,
                 }}
             >
-                {participant.session_token.substring(0, 2).toUpperCase()}
+                {participant.code.substring(0, 2)}
             </div>
 
             <div className="flex-1 min-w-0 space-y-0.5">
                 {/* Line 1: token + recruitment badge */}
                 <div className="flex items-center gap-1.5 min-w-0">
                     <span className="text-xs font-mono font-bold text-slate-800 shrink-0">
-                        {participant.session_token.substring(0, 8)}
+                        {participant.code}
                     </span>
                     {participant.recruitment_token && (
                         <Badge

--- a/frontend/src/hooks/admin/useRecruitmentPage.test.ts
+++ b/frontend/src/hooks/admin/useRecruitmentPage.test.ts
@@ -211,7 +211,7 @@ describe('useRecruitmentPage', () => {
         });
     });
 
-    it('handleCreate omits capacity for non-individual link types and name when blank', () => {
+    it('handleCreate maps the input to capacity (not count) for a limited link', () => {
         const mutate = vi.fn();
         mockCreateMutationHook.mockReturnValue({ mutate, isPending: false });
 
@@ -228,11 +228,45 @@ describe('useRecruitmentPage', () => {
             result.current.handleCreate();
         });
 
+        // A "limited" link capped at 20 must be ONE link with capacity 20 —
+        // not 20 uncapped links (the regression this guards against).
         expect(mutate).toHaveBeenCalledWith({
             slug: 'demo-study',
-            params: { count: 20 },
+            params: { count: 1 },
             data: {
                 type: 'limited',
+                name: undefined,
+                capacity: 20,
+            },
+        });
+    });
+
+    it('handleCreate forces count:1 / uncapped for a public link, ignoring a stale count', () => {
+        const mutate = vi.fn();
+        mockCreateMutationHook.mockReturnValue({ mutate, isPending: false });
+
+        const { result } = renderHook(() => useRecruitmentPage(), {
+            wrapper: AllTheProviders,
+        });
+
+        // Simulate a stale newLinkCount left over from a previous type selection.
+        act(() => {
+            result.current.setNewLinkType('individual');
+            result.current.setNewLinkCount(7);
+        });
+        act(() => {
+            result.current.setNewLinkType('public');
+        });
+
+        act(() => {
+            result.current.handleCreate();
+        });
+
+        expect(mutate).toHaveBeenCalledWith({
+            slug: 'demo-study',
+            params: { count: 1 },
+            data: {
+                type: 'public',
                 name: undefined,
                 capacity: undefined,
             },

--- a/frontend/src/hooks/admin/useRecruitmentPage.ts
+++ b/frontend/src/hooks/admin/useRecruitmentPage.ts
@@ -265,13 +265,23 @@ export function useRecruitmentPage(): RecruitmentPageApi {
     // ── Handlers ─────────────────────────────────────────────────
     const handleCreate = useCallback(() => {
         if (!slug) return;
+        // The single numeric input (newLinkCount) means different things per type:
+        //  - individual: how many one-shot links to generate (count=N, capacity=1)
+        //  - limited:    submission cap for ONE link        (count=1, capacity=N)
+        //  - public:     one uncapped link                  (count=1, capacity=∞)
+        // Mapping it explicitly per type avoids the bug where a "limited" link
+        // capped at N produced N *unlimited* links, and guards against a stale
+        // newLinkCount leaking into the public/limited count.
+        const count = newLinkType === 'individual' ? newLinkCount : 1;
+        const capacity =
+            newLinkType === 'individual' ? 1 : newLinkType === 'limited' ? newLinkCount : undefined; // public → uncapped
         createMutation.mutate({
             slug,
-            params: { count: newLinkCount },
+            params: { count },
             data: {
                 type: newLinkType,
                 name: newLinkName || undefined,
-                capacity: newLinkType === 'individual' ? 1 : undefined,
+                capacity,
             },
         });
     }, [slug, newLinkCount, newLinkType, newLinkName, createMutation]);

--- a/frontend/src/layouts/AdminLayout.helpers.test.ts
+++ b/frontend/src/layouts/AdminLayout.helpers.test.ts
@@ -56,12 +56,12 @@ describe('resolveBreadcrumbLabel', () => {
         );
     });
 
-    it('handles /participants/:id detail route with session_token code', () => {
+    it('handles /participants/:id detail route with the participant code', () => {
         expect(
             resolveBreadcrumbLabel(
                 '/app/proj1/studies/study/participants/7',
                 null,
-                { session_token: 'abcdef0123456789' },
+                { code: 'ABCDEF01' },
                 t
             )
         ).toBe('Participant ABCDEF01');

--- a/frontend/src/layouts/AdminLayout.helpers.ts
+++ b/frontend/src/layouts/AdminLayout.helpers.ts
@@ -1,7 +1,7 @@
 import type { TFunction } from 'i18next';
 
 interface BreadcrumbParticipant {
-    session_token?: string;
+    code?: string;
 }
 
 const SEGMENT_LABEL_KEYS: Record<string, [string, string?]> = {
@@ -27,8 +27,8 @@ const SEGMENT_LABEL_KEYS: Record<string, [string, string?]> = {
  * Detail routes:
  *  - `/concourses/:id` (digit-only id) → "Concourse"
  *  - `/participants/:id` (digit-only id) → "Participant <CODE>" where CODE is
- *    the first 8 chars of session_token uppercased; falls back to the URL id
- *    while the fetch is in flight.
+ *    the participant's short display code (session_token[:8], computed
+ *    server-side); falls back to the URL id while the fetch is in flight.
  */
 export function resolveBreadcrumbLabel(
     pathname: string,
@@ -49,7 +49,7 @@ export function resolveBreadcrumbLabel(
         return t('admin.breadcrumbs.concourse', 'Concourse');
     }
     if (prev === 'participants' && /^\d+$/.test(last)) {
-        const code = breadcrumbParticipant?.session_token?.substring(0, 8).toUpperCase() ?? last;
+        const code = breadcrumbParticipant?.code ?? last;
         return t('admin.breadcrumbs.participant_n', 'Participant {{code}}', { code });
     }
 

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -28,7 +28,7 @@ export default function AdminLayout() {
     const { project: adminProject, study: adminStudy } = useAdminContext();
     const { t } = useTranslation();
 
-    // Resolve the participant code (session_token[:8]) for the breadcrumb
+    // Resolve the participant's short display `code` for the breadcrumb
     // when on /participants/:participantId. The fetch is gated to that route
     // and shares the React Query cache with ParticipantDetailsPage, so the
     // page render and the breadcrumb dedupe to a single network call.

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -9,8 +9,13 @@ export const queryClient = new QueryClient({
             refetchOnWindowFocus: false,
         },
         mutations: {
-            retry: 3,
-            retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000),
+            // Mutations must NOT auto-retry: a POST/PUT/DELETE that times out
+            // may have already committed server-side, so a blind replay can
+            // duplicate non-idempotent writes (recruitment links, project
+            // creates, force-password-reset side effects). retry:0 is
+            // react-query's intended default; hooks that genuinely need a retry
+            // can opt in explicitly.
+            retry: 0,
             networkMode: 'online', // Ensures mutations are queued when offline
         },
     },

--- a/frontend/src/pages/admin/ParticipantDetailsPage.tsx
+++ b/frontend/src/pages/admin/ParticipantDetailsPage.tsx
@@ -151,7 +151,7 @@ export default function ParticipantDetailsPage() {
             // biome-ignore lint/suspicious/noExplicitAny: audio recordings dynamic structure
             audio_recordings?: Record<string, any>;
         } = {
-            id: participant.session_token,
+            id: participant.code,
             db_id: participant.id,
             duration_seconds:
                 participant.submitted_at && participant.created_at
@@ -255,7 +255,7 @@ export default function ParticipantDetailsPage() {
                 <div className="flex items-center justify-between gap-4">
                     <StudyPageHeader
                         title={t('admin.data.detail.participant_n', 'Participant {{code}}', {
-                            code: participant.session_token.substring(0, 8).toUpperCase(),
+                            code: participant.code,
                         })}
                         icon={User}
                     />

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -757,7 +757,11 @@ const RecruitmentPage = () => {
                                                         id="count"
                                                         type="number"
                                                         min="1"
-                                                        max="500"
+                                                        // individual maps to backend `count` (capped at 100);
+                                                        // limited maps to per-link `capacity` (no backend cap).
+                                                        max={
+                                                            newLinkType === 'individual' ? 100 : 500
+                                                        }
                                                         value={newLinkCount}
                                                         onChange={(e) =>
                                                             setNewLinkCount(

--- a/openapi.json
+++ b/openapi.json
@@ -9800,10 +9800,9 @@
             "type": "integer",
             "title": "Study Id"
           },
-          "session_token": {
+          "code": {
             "type": "string",
-            "format": "uuid",
-            "title": "Session Token"
+            "title": "Code"
           },
           "language_used": {
             "type": "string",
@@ -9919,7 +9918,7 @@
         "required": [
           "id",
           "study_id",
-          "session_token",
+          "code",
           "language_used",
           "status",
           "created_at",
@@ -10035,10 +10034,9 @@
             "type": "integer",
             "title": "Study Id"
           },
-          "session_token": {
+          "code": {
             "type": "string",
-            "format": "uuid",
-            "title": "Session Token"
+            "title": "Code"
           },
           "language_used": {
             "type": "string",
@@ -10129,7 +10127,7 @@
         "required": [
           "id",
           "study_id",
-          "session_token",
+          "code",
           "language_used",
           "status",
           "created_at",
@@ -10139,7 +10137,7 @@
           "user_agent"
         ],
         "title": "ParticipantRead",
-        "description": "Schema for reading a participant."
+        "description": "Schema for reading a participant.\n\nSecurity: the raw ``session_token`` is the participant's bearer credential\nand is deliberately NOT exposed here \u2014 this schema is reachable by the\nlowest (viewer) role via the study participant list. Only the truncated,\nnon-reversible ``code`` (session_token[:8]) is surfaced for display.\n``recruitment_token`` and ``user_agent`` are research metadata, not\ncredentials, and remain available."
       },
       "ParticipantStatus": {
         "type": "string",


### PR DESCRIPTION
## Audit Wave A — security & data-integrity quick wins

First wave of an adversarially-verified maintainability / quality / stability / performance audit. Four independent, high-ROI fixes with minimal blast radius, each independently shippable.

### Findings fixed
- **A1 · `session_token` exposure (security / high)** — `ParticipantRead` (reachable by the lowest *viewer* role via the participant list) serialized the full `session_token`, a participant bearer credential (resume, draft read, submission, GDPR self-erasure). A viewer could impersonate or erase any participant. Now only a truncated, non-reversible `code` (`session_token[:8]`, uppercased — exactly what the UI already displayed) is exposed. `recruitment_token` / `user_agent` are research metadata and remain. The `/dump` endpoint already truncated the token, so there is no twin leak.
- **A2 · mutation retry (stability / high)** — react-query mutations defaulted to `retry: 3`; a timed-out-but-committed write was replayed up to 3× (duplicate recruitment links, project creates, repeated side effects). Flipped to `retry: 0`.
- **A3 · "limited" recruitment links (data-integrity / high)** — the capacity input was sent as `count`, creating *N uncapped* links instead of one capped link (the opposite of intent). Now mapped correctly per type; `public` is forced to `count: 1`.
- **A4 · audio delete atomicity (stability / medium)** — `delete_audio_recording` deleted the S3 object *before* the DB commit; reordered to commit first then best-effort S3 cleanup (mirrors the upload-path fix in 9d349f2a).

### Deviation from the raw finding
A1 originally proposed dropping `recruitment_token` / `user_agent` too. Impact analysis showed they are load-bearing for the viewer UI (the "Ref" column, device/OS parsing) and are not credentials, so they were kept. Only the actual credential (`session_token`) was removed.

### Tests
- New backend regression tests: viewer list + member detail expose `code`, never `session_token` / `resume_code` / `confirmation_code`.
- Hook tests for all three recruitment link types (limited→capacity, public→count:1).

### Verification
- `make ci` green (lint, mypy, vulture, check-api, security suite, i18n, dead-code, build).
- A1 tests + neighbouring IDOR harness: 97 passed.
- API client regenerated and committed.

### Follow-up (out of scope)
`export_service.py:162` writes the full `session_token` into the CSV export (editor/owner-gated file download) — to be decided separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)