### PR TITLE
fix: audit Wave B — API error hygiene & info-leak hardening (4 findings)

### DIFF
--- a/backend/app/routers/admin/invitations.py
+++ b/backend/app/routers/admin/invitations.py
@@ -1,3 +1,4 @@
+import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -20,30 +21,42 @@ async def verify_invitation(
     token: str, db: AsyncSession = Depends(get_db)
 ) -> dict[str, object]:
     """Verify an invitation token and return details including project name."""
+    # Only the decode is inside the try: a token problem is a 400, but a DB
+    # failure below must surface as a 500 (a real fault to investigate), not be
+    # masked as a misleading "invalid token". Never leak str(e) to the client.
     try:
         payload = decode_invitation_token(token)
-        project_id = payload.get("project_id") or payload.get("workspace_id")
-
-        project_name = "Unknown Project"
-        if project_id:
-            from app.models import Project
-
-            result = await db.execute(select(Project).where(Project.id == project_id))
-            project = result.scalar_one_or_none()
-            if project:
-                project_name = project.title
-
-        return {
-            "email": payload["sub"],
-            "project_id": project_id,
-            "project_name": project_name,
-            "role": payload["role"],
-        }
-    except Exception as e:
+    except jwt.PyJWTError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid or expired invitation token: {str(e)}",
+            detail="Invalid or expired invitation token",
         )
+
+    email = payload.get("sub")
+    role = payload.get("role")
+    if not email or not role:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid invitation token payload",
+        )
+
+    project_id = payload.get("project_id") or payload.get("workspace_id")
+
+    project_name = "Unknown Project"
+    if project_id:
+        from app.models import Project
+
+        result = await db.execute(select(Project).where(Project.id == project_id))
+        project = result.scalar_one_or_none()
+        if project:
+            project_name = project.title
+
+    return {
+        "email": email,
+        "project_id": project_id,
+        "project_name": project_name,
+        "role": role,
+    }
 
 
 class InvitationAccept(BaseModel):
@@ -64,10 +77,10 @@ async def accept_invitation(
     """
     try:
         payload = decode_invitation_token(data.token)
-    except Exception as e:
+    except jwt.PyJWTError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid token: {str(e)}",
+            detail="Invalid or expired invitation token",
         )
 
     # Verify email match

--- a/backend/app/routers/admin/studies_import_export.py
+++ b/backend/app/routers/admin/studies_import_export.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -385,20 +386,22 @@ def _build_validation_summary(
         return None, [f"Error building summary: {str(e)}"]
 
 
-@router.post("/validate-import", response_model=ValidationResult)
-@limiter.limit("30/minute")
-async def validate_study_import(
-    request: Request,
+def _run_import_checks(
     config: dict[str, Any],
-    current_user: User = Depends(get_current_user),
-    project_ctx: tuple[Project, ProjectMember] = Depends(get_current_project),
-    db: AsyncSession = Depends(get_db),
-) -> "ValidationResult":
-    """Validate an imported study payload without creating the study.
+) -> tuple[
+    list[str],
+    list[str],
+    dict[str, Any],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    Any,
+]:
+    """Run every structural ``_check_*`` validator on an import payload.
 
-    Each section is checked by a dedicated `_check_*` helper that returns
-    its own error / warning lists; this orchestrator aggregates them and
-    builds the summary.
+    Shared by ``/validate-import`` (advisory) and ``/import`` (enforcing) so
+    the two can never drift: ``/import`` is reachable directly, so it must run
+    the same structural checks the advisory endpoint does. Returns
+    ``(errors, warnings, study_data, translations, statements, grid_config)``.
     """
     errors: list[str] = []
     warnings: list[str] = []
@@ -440,6 +443,28 @@ async def validate_study_import(
     warnings.extend(_check_import_branding(study_data.get("branding") or {}))
     errors.extend(_check_import_recruitment_links(study_data))
 
+    return errors, warnings, study_data, translations, statements, grid_config
+
+
+@router.post("/validate-import", response_model=ValidationResult)
+@limiter.limit("30/minute")
+async def validate_study_import(
+    request: Request,
+    config: dict[str, Any],
+    current_user: User = Depends(get_current_user),
+    project_ctx: tuple[Project, ProjectMember] = Depends(get_current_project),
+    db: AsyncSession = Depends(get_db),
+) -> "ValidationResult":
+    """Validate an imported study payload without creating the study.
+
+    Each section is checked by a dedicated `_check_*` helper that returns
+    its own error / warning lists; this orchestrator aggregates them and
+    builds the summary.
+    """
+    errors, warnings, study_data, translations, statements, grid_config = (
+        _run_import_checks(config)
+    )
+
     summary: ValidationSummary | None = None
     if not errors:
         summary, extra_errors = _build_validation_summary(
@@ -455,6 +480,30 @@ async def validate_study_import(
 # ------------------------------------------------------------------
 # Import
 # ------------------------------------------------------------------
+
+
+# Canonical StudyTranslation fields accepted on import — mirrors the exporter's
+# translation key set in export_study_config. Spreading raw import JSON as
+# **kwargs would let an unknown/cross-version key raise TypeError (caught as a
+# leaky 500) and would allow id/study_id override attempts.
+_STUDY_TRANSLATION_IMPORT_FIELDS = frozenset(
+    {
+        "language_code",
+        "title",
+        "subtitle",
+        "description",
+        "objective",
+        "instructions",
+        "condition_of_instruction",
+        "pre_instruction",
+        "consent_title",
+        "consent_description",
+        "ui_labels",
+        "process_steps",
+        "methodology_tips",
+        "step_help",
+    }
+)
 
 
 class StudyImportRequest(BaseModel):
@@ -510,6 +559,20 @@ async def import_study_config(
             detail=f"Study with slug '{import_data.new_slug}' already exists",
         )
 
+    # Structurally validate the payload BEFORE touching the DB. /import is
+    # reachable directly (the /validate-import endpoint is advisory and
+    # skippable), so without this a malformed payload would 500 with leaked
+    # driver/exception text instead of a clean, actionable 400.
+    validation_errors, _, _, _, _, _ = _run_import_checks(config)
+    if validation_errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "message": "Invalid study configuration",
+                "errors": validation_errors,
+            },
+        )
+
     study_data = config.get("study", {}).copy()
 
     # Create Study in DRAFT
@@ -539,12 +602,17 @@ async def import_study_config(
         db.add(db_study)
         await db.flush()
 
-        # Translations
+        # Translations — build from a whitelisted field set; never spread raw
+        # import JSON as **kwargs (an unknown/cross-version key would 500, and
+        # id/study_id could be overridden). See _STUDY_TRANSLATION_IMPORT_FIELDS.
         for t_data in study_data.get("translations", []):
-            # Ensure required non-nullable fields have defaults
-            if "description" not in t_data or t_data["description"] is None:
-                t_data["description"] = ""
-            db.add(StudyTranslation(study_id=db_study.id, **t_data))
+            t_fields = {
+                k: v for k, v in t_data.items() if k in _STUDY_TRANSLATION_IMPORT_FIELDS
+            }
+            # description is non-nullable; ensure a default.
+            if t_fields.get("description") is None:
+                t_fields["description"] = ""
+            db.add(StudyTranslation(study_id=db_study.id, **t_fields))
 
         # Statements
         for idx, s_data in enumerate(study_data.get("statements", [])):
@@ -580,12 +648,22 @@ async def import_study_config(
             )
 
         await db.commit()
-    except Exception as e:
+    except (IntegrityError, ValueError) as e:
+        # Structurally-plausible payload that slipped past pre-validation
+        # (e.g. a malformed date string → ValueError, or a DB constraint hit →
+        # IntegrityError). Surface a clean 400; never leak str(e) to the client.
         await db.rollback()
-        logger.error(f"Error during study import: {e}", exc_info=True)
+        logger.warning("Study import rejected (bad payload): %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The study configuration could not be imported. Check the file and try again.",
+        )
+    except Exception:
+        await db.rollback()
+        logger.error("Unexpected error during study import", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to import study: {str(e)}",
+            detail="An unexpected error occurred while importing the study.",
         )
 
     return StudyImportResponse(

--- a/backend/app/routers/submissions.py
+++ b/backend/app/routers/submissions.py
@@ -64,9 +64,13 @@ async def submit_study(
             f"Unexpected error during submission (study={data.study_slug}): {e}",
             exc_info=True,
         )
+        # Do NOT leak str(e) to the client: /submit is an unauthenticated,
+        # participant-facing endpoint and the exception text can disclose
+        # internal variable/key names or truncated SQL. The full detail is
+        # already captured server-side via logger.error(exc_info=True) above.
         raise HTTPException(
             status_code=500,
-            detail=f"Unexpected error during submission: {str(e)}",
+            detail="An unexpected error occurred while processing your submission.",
         )
 
 

--- a/backend/tests/integration/test_api_error_hygiene.py
+++ b/backend/tests/integration/test_api_error_hygiene.py
@@ -1,0 +1,144 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Audit Wave B — API error hygiene & info-leak hardening (B1–B4).
+
+These endpoints previously echoed ``str(e)`` to clients and/or caught bare
+``Exception`` (masking server faults as client errors). Each test pins down
+the hardened behaviour:
+
+- B1: ``/submit`` (unauthenticated) returns a generic 500, never the
+  exception text.
+- B2: ``/import`` structurally validates before touching the DB → clean 400
+  for malformed payloads instead of a 500 / a silently-broken empty study.
+- B3: unknown / forbidden translation keys are dropped instead of being
+  spread into the ORM constructor (which raised a leaky 500 or overrode the PK).
+- B4: a malformed invitation token yields a generic 400 with no PyJWT internals.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from app.models import User
+from app.services.study_service import StudyService
+
+
+def _minimal_valid_config() -> dict:
+    """Smallest study config that passes _run_import_checks."""
+    return {
+        "version": "1.0",
+        "study": {
+            "default_language": "en",
+            "translations": [
+                {
+                    "language_code": "en",
+                    "title": "T",
+                    "description": "D",
+                    "consent_title": "C",
+                    "consent_description": "CD",
+                }
+            ],
+            "statements": [
+                {"code": "S1", "translations": [{"language_code": "en", "text": "s1"}]}
+            ],
+            "grid_config": [{"score": 0, "capacity": 1}],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_submit_500_does_not_leak_exception_text(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """B1: an unexpected error in /submit returns a generic 500, never str(e)."""
+    secret = "SECRET_INTERNAL_COLUMN_x9q"
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(StudyService, "process_submission", _boom)
+
+    resp = await client.post(
+        "/api/submit",
+        json={
+            "study_slug": "whatever",
+            "session_token": str(uuid4()),
+            "language_used": "en",
+            "qsort": [],
+        },
+    )
+    assert resp.status_code == 500
+    assert secret not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_import_invalid_payload_returns_400_not_500(
+    client: AsyncClient, test_user: User, project_factory, auth_token_factory
+) -> None:
+    """B2: a structurally invalid import payload is a clean 400, not a broken study."""
+    ws = await project_factory(owner=test_user)
+    headers = {**auth_token_factory(test_user), "X-Project-ID": str(ws.id)}
+
+    resp = await client.post(
+        "/api/admin/studies/import",
+        json={"config": {"version": "1.0", "study": {}}, "new_slug": "broken-study"},
+        headers=headers,
+    )
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_import_drops_unknown_translation_keys(
+    client: AsyncClient, test_user: User, project_factory, auth_token_factory, db
+) -> None:
+    """B3: unknown/forbidden translation keys are dropped, not spread into the ORM."""
+    ws = await project_factory(owner=test_user)
+    headers = {**auth_token_factory(test_user), "X-Project-ID": str(ws.id)}
+
+    config = _minimal_valid_config()
+    # Previously these would raise TypeError (-> leaky 500) or override the PK.
+    config["study"]["translations"][0]["id"] = 999999
+    config["study"]["translations"][0]["unknown_field"] = "x"
+
+    resp = await client.post(
+        "/api/admin/studies/import",
+        json={"config": config, "new_slug": "clean-import"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    from app.models import Study
+
+    study = (
+        await db.execute(
+            select(Study)
+            .where(Study.slug == "clean-import")
+            .options(selectinload(Study.translations))
+        )
+    ).scalar_one()
+    trans = study.translations[0]
+    assert trans.id != 999999  # forbidden PK override was not honoured
+    assert trans.title == "T"
+
+
+@pytest.mark.asyncio
+async def test_verify_invitation_bad_token_400_no_leak(client: AsyncClient) -> None:
+    """B4: a malformed invitation token yields a generic 400 with no PyJWT internals."""
+    resp = await client.get(
+        "/api/admin/invitations/verify", params={"token": "not-a-real-jwt"}
+    )
+    assert resp.status_code == 400
+    # The app wraps HTTPException(detail=<str>) into {code, message, ...}.
+    body = resp.json()
+    message = body.get("message") or body.get("detail")
+    assert message == "Invalid or expired invitation token"
+    for leak in ("Segment", "segment", "DecodeError", "padding", "Traceback"):
+        assert leak not in resp.text

--- a/backend/tests/integration/test_import_validation.py
+++ b/backend/tests/integration/test_import_validation.py
@@ -134,9 +134,15 @@ class TestImportPartial:
         test_user: User,
         test_project,
         auth_token_factory,
+        db,
     ):
-        """
-        Test that we can actually create the study with missing description (defaults to empty string).
+        """A translation with a missing description imports fine; it defaults to "".
+
+        The study must otherwise be valid: /import now enforces the same
+        structural checks as /validate-import (audit Wave B / B2), so an
+        empty-statements payload — which used to create a silently-broken
+        study — is rejected. This test therefore uses a valid minimal study
+        and asserts the description actually defaulted.
         """
         auth_headers = auth_token_factory(test_user)
         auth_headers["X-Project-ID"] = str(test_project.id)
@@ -151,11 +157,18 @@ class TestImportPartial:
                         {
                             "language_code": "en",
                             "title": "Title Only",
-                            # Description missing
+                            # Description missing -> should default to ""
                         }
                     ],
-                    "statements": [],
-                    "grid_config": [],
+                    "statements": [
+                        {
+                            "code": "S1",
+                            "translations": [
+                                {"language_code": "en", "text": "Statement 1"}
+                            ],
+                        }
+                    ],
+                    "grid_config": [{"score": 0, "capacity": 1}],
                 },
             },
             "new_slug": "partial-import-create-123",
@@ -166,3 +179,17 @@ class TestImportPartial:
         )
 
         assert response.status_code == 200, response.text
+
+        from sqlalchemy import select
+        from sqlalchemy.orm import selectinload
+
+        from app.models import Study
+
+        study = (
+            await db.execute(
+                select(Study)
+                .where(Study.slug == "partial-import-create-123")
+                .options(selectinload(Study.translations))
+            )
+        ).scalar_one()
+        assert study.translations[0].description == ""


### PR DESCRIPTION
## Audit Wave B — API error hygiene & info-leak hardening

Second wave of the adversarially-verified audit. A consistent cross-cutting weakness: several handlers echoed `str(e)` to clients or caught bare `Exception` (masking server faults as misleading client errors). All fixes follow the established log-`exc_info`/return-generic-detail pattern.

### Findings fixed
- **B1 · `/submit` leaks exception text (security / medium)** — the unauthenticated participant submission endpoint returned `Unexpected error during submission: {str(e)}` in its 500. `str(e)` can disclose internal variable/key names or truncated SQL. Now a fixed generic message; the full detail is already logged server-side via `exc_info=True`.
- **B2 · `/import` runs no structural validation (stability / medium)** — clients can POST straight to `/import` (the `/validate-import` endpoint is advisory and skippable). A malformed payload either 500'd with leaked driver text or silently created a broken study. `/import` now runs the same checks as `/validate-import` via a shared `_run_import_checks` helper (→ clean 400), and the post-DML catch is narrowed (`IntegrityError`/`ValueError` → 400, everything else → generic 500, never `str(e)`).
- **B3 · `StudyTranslation(**t_data)` spreads untrusted JSON (stability / low)** — an unknown/extra/cross-version key raised `TypeError` (→ leaky 500) and `id`/`study_id` could be overridden. The translation row is now built from a whitelisted field set mirroring the exporter's canonical keys.
- **B4 · invitation verify catches bare `Exception` (stability / low)** — any server fault (DB outage, payload-shape change) became a misleading `400 "invalid token"` with leaked `str(e)`. `verify`/`accept` now catch `jwt.PyJWTError` only and return a generic 400; the DB lookup in `verify` moved out of the `try` so a real fault surfaces as a 500.

### Behaviour change
Importing a structurally-incomplete study (e.g. zero statements) is now rejected with a clean 400 — it used to silently create a broken study. This aligns `/import` with `/validate-import`. The affected existing test was updated to use a valid minimal study (and now also asserts the description-defaulting it was meant to cover).

### Deviation from the raw finding
B4's verifier said `accept_invitation` was already fine, but it carried the same `str(e)` leak; both endpoints were hardened for consistency with the wave's theme.

### Tests
- New `test_api_error_hygiene.py`: B1 (monkeypatched 500 doesn't leak), B2 (invalid payload → 400 not 500), B3 (unknown/forbidden translation keys dropped, no PK override), B4 (bad token → generic 400, no PyJWT internals).
- `make ci` green (lint, mypy, vulture, check-api, full test suite incl. security, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)