### PR TITLE
fix: audit Wave C — participant-flow correctness (4 findings)

### DIFF
--- a/backend/app/services/submission_service.py
+++ b/backend/app/services/submission_service.py
@@ -126,8 +126,15 @@ class SubmissionService:
 
         # If we fell through (update existing)
         if participant and participant not in db.new:
-            participant.consented_at = datetime.now(timezone.utc)
-            participant.consent_hash = consent_hash
+            # First-consent-wins: never overwrite the original consent timestamp
+            # or hash on a re-POST (re-mount, retry, back-nav). consented_at is
+            # the duration metric's start anchor — resetting it yields
+            # artificially short or negative durations (negatives are silently
+            # dropped, skewing the median) — and it is the legal record of when
+            # consent was given. Gate the hash with it so the two can't desync.
+            if not participant.consented_at:
+                participant.consented_at = datetime.now(timezone.utc)
+                participant.consent_hash = consent_hash
             participant.language_used = language_code
             participant.ip_address = hashed_ip
             participant.user_agent = hashed_ua
@@ -521,6 +528,32 @@ class SubmissionService:
             )
             if not link:
                 raise ForbiddenError("Invalid, expired, or full recruitment link")
+
+        # C4: an already-completed participant re-POSTing must idempotently get
+        # its stored confirmation back — even if the grid was edited since, which
+        # would make the old Q-sort fail validate_distribution below. Short-
+        # circuit BEFORE qsort/distribution validation, using a read-only lookup
+        # (no lock, no creation, no link-usage increment — those stay in
+        # _find_or_create_participant). The study_id guard preserves the
+        # "token belongs to this study" invariant that _find_or_create enforces.
+        already_completed = (
+            await db.execute(
+                select(Participant).where(
+                    Participant.session_token == data.session_token
+                )
+            )
+        ).scalar_one_or_none()
+        if (
+            already_completed is not None
+            and already_completed.study_id == study.id
+            and already_completed.status == ParticipantStatus.completed
+        ):
+            return {
+                "confirmation_code": already_completed.confirmation_code
+                or str(already_completed.session_token)[:8].upper(),
+                "id": already_completed.id,
+                "already_submitted": True,
+            }
 
         # 3-4. Validate Q-sort payload (presence, statement ownership, distribution)
         SubmissionService._validate_qsort_payload(study, data)

--- a/backend/tests/integration/test_participant_flow_correctness.py
+++ b/backend/tests/integration/test_participant_flow_correctness.py
@@ -1,0 +1,125 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Audit Wave C — participant-flow correctness (backend: C1, C4)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Participant, Statement, Study
+
+
+async def _fresh_participant(db: AsyncSession, token: str) -> Participant:
+    # populate_existing overwrites the identity-map copy with fresh DB values
+    # (async-safe), without expire_all() — which would also expire `active_study`
+    # and trigger a lazy reload outside the greenlet on the next attribute access.
+    return (
+        await db.execute(
+            select(Participant)
+            .where(Participant.session_token == uuid.UUID(token))
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_reconsent_does_not_overwrite_consent_timestamp_or_hash(
+    client: AsyncClient, db: AsyncSession, active_study: Study
+) -> None:
+    """C1: re-POSTing consent must NOT reset consented_at / consent_hash.
+
+    consented_at is the duration metric's start anchor (and the legal record
+    of consent); overwriting it on a re-mount / retry / back-nav produces
+    artificially short or negative durations (negatives are silently dropped,
+    skewing the median).
+    """
+    token = str(uuid.uuid4())
+
+    async def consent(consent_hash: str):
+        return await client.post(
+            f"/api/study/{active_study.slug}/consent",
+            json={
+                "session_token": token,
+                "study_slug": active_study.slug,
+                "language_code": "en",
+                "consent_hash": consent_hash,
+            },
+        )
+
+    r1 = await consent("hash-A")
+    assert r1.status_code == 200, r1.text
+    p1 = await _fresh_participant(db, token)
+    original_ts = p1.consented_at
+    assert original_ts is not None
+    assert p1.consent_hash == "hash-A"
+
+    # Re-consent with a different hash — first-consent must win on both fields.
+    r2 = await consent("hash-B")
+    assert r2.status_code == 200, r2.text
+    p2 = await _fresh_participant(db, token)
+    assert p2.consented_at == original_ts, "consented_at must not change on re-consent"
+    assert p2.consent_hash == "hash-A", "consent_hash must not change on re-consent"
+
+
+@pytest.mark.asyncio
+async def test_resubmit_completed_after_study_edit_returns_confirmation_not_422(
+    client: AsyncClient, db: AsyncSession, active_study: Study
+) -> None:
+    """C4: a completed participant re-POSTing after the study was edited (so the
+    stored Q-sort no longer validates) must idempotently get its confirmation
+    back, not a 422 ValidationError."""
+    token = str(uuid.uuid4())
+
+    consent = await client.post(
+        f"/api/study/{active_study.slug}/consent",
+        json={
+            "session_token": token,
+            "study_slug": active_study.slug,
+            "language_code": "en",
+            "consent_hash": "test-hash",
+        },
+    )
+    assert consent.status_code == 200, consent.text
+
+    statements = active_study.statements
+    qsort = [
+        {"statement_id": statements[0].id, "grid_score": -1, "col": 0, "row": 0},
+        {"statement_id": statements[1].id, "grid_score": 0, "col": 1, "row": 0},
+        {"statement_id": statements[2].id, "grid_score": 0, "col": 1, "row": 1},
+        {"statement_id": statements[3].id, "grid_score": 1, "col": 2, "row": 0},
+    ]
+    payload = {
+        "session_token": token,
+        "study_slug": active_study.slug,
+        "language_used": "en",
+        "status": "completed",
+        "qsort": qsort,
+        "postsort_answers": {},
+    }
+
+    r1 = await client.post("/api/submit", json=payload)
+    assert r1.status_code == 200, r1.text
+    confirmation = r1.json()["confirmation_code"]
+
+    # Operator edits the study after completion: adding a statement makes the
+    # stored 4-card Q-sort fail validate_distribution (len(qsort) != stmt_count)
+    # in every distribution mode.
+    db.add(Statement(study_id=active_study.id, code="EXTRA-AFTER"))
+    await db.commit()
+
+    # Re-POST the original (now-invalid) completed payload.
+    r2 = await client.post("/api/submit", json=payload)
+    assert r2.status_code == 200, (
+        f"Completed re-submit after a study edit must short-circuit to the "
+        f"stored confirmation, not 422. Got {r2.status_code}: {r2.text}"
+    )
+    body2 = r2.json()
+    assert body2.get("already_submitted") is True
+    assert body2.get("confirmation_code") == confirmation

--- a/backend/tests/integration/test_submission_concurrency.py
+++ b/backend/tests/integration/test_submission_concurrency.py
@@ -331,10 +331,11 @@ async def test_record_consent_idempotent_for_existing_participant(
     ).scalars().all()
     assert len(rows) == 1
 
-    # language_used was updated
+    # language_used is still updated on re-consent
     assert rows[0].language_used == "fr"
-    # consent_hash was updated
-    assert rows[0].consent_hash == "hash-v2"
+    # consent_hash is first-consent-wins (gated with consented_at, audit C1):
+    # it must NOT change on re-consent so the hash and timestamp can't desync.
+    assert rows[0].consent_hash == "hash-v1"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_study_service_consent.py
+++ b/backend/tests/unit/test_study_service_consent.py
@@ -50,7 +50,9 @@ async def test_record_consent_new_participant(db, seed_study):
 
 @pytest.mark.asyncio
 async def test_record_consent_existing_participant(db, seed_study):
-    """Should update existing participant on re-consent."""
+    """Re-consent updates language/ip/ua, but consent_hash and consented_at are
+    first-consent-wins (audit C1): they must not change on a re-POST, so the
+    duration-metric anchor and legal consent record stay stable and coherent."""
     session_token = uuid.uuid4()
 
     # 1. First consent
@@ -72,6 +74,6 @@ async def test_record_consent_existing_participant(db, seed_study):
     res = await db.execute(stmt)
     p = res.scalar_one()
 
-    assert p.language_used == language
-    assert p.consent_hash == consent_hash
+    assert p.language_used == language  # mutable: still updated on re-consent
+    assert p.consent_hash == "hash-1"  # first-consent-wins: NOT overwritten
     assert p.ip_address is not None

--- a/frontend/src/hooks/participant/useAudioRecorder.test.ts
+++ b/frontend/src/hooks/participant/useAudioRecorder.test.ts
@@ -326,6 +326,38 @@ describe('useAudioRecorder — play() wrapper', () => {
     });
 });
 
+describe('useAudioRecorder — unmount cleanup (C2)', () => {
+    beforeEach(setupWebApiMocks);
+
+    it('detaches the MediaRecorder handlers on unmount so an auto-fired onstop cannot upload', async () => {
+        const onRecordingComplete = vi.fn().mockResolvedValue(undefined);
+        const { result, unmount } = renderHook(() =>
+            useAudioRecorder(makeProps({ onRecordingComplete }))
+        );
+
+        await act(async () => {
+            result.current.recording.start();
+            await Promise.resolve();
+        });
+
+        expect(result.current.status.state).toBe('recording');
+        expect(capturedMediaRecorder).not.toBeNull();
+        expect(capturedMediaRecorder?.onstop).not.toBeNull();
+
+        // Unmount while still recording.
+        unmount();
+
+        // The cleanup must null the recorder handlers so a browser-auto-fired
+        // onstop (which fires when the stream tracks end) cannot run the
+        // fire-and-forget upload after the component is gone. With the bug the
+        // handler stayed attached and the orphan upload could fire.
+        expect(capturedMediaRecorder?.onstop).toBeNull();
+        expect(capturedMediaRecorder?.ondataavailable).toBeNull();
+        expect(capturedMediaRecorder?.onerror).toBeNull();
+        expect(onRecordingComplete).not.toHaveBeenCalled();
+    });
+});
+
 describe('useAudioRecorder — setPlaybackSpeed wrapper', () => {
     beforeEach(setupWebApiMocks);
 

--- a/frontend/src/hooks/participant/useAudioRecorder.ts
+++ b/frontend/src/hooks/participant/useAudioRecorder.ts
@@ -310,8 +310,27 @@ export function useAudioRecorder(props: AudioRecorderProps): UseAudioRecorderRes
             clearIntervalRef(permissionCheckIntervalRef);
             cancelAnimationFrameRef(animationFrameRef);
             closeAudioContextRef(audioContextRef);
+            // Detach the recorder's handlers BEFORE stopping the stream: ending
+            // the tracks can auto-fire `onstop`, which would run a fire-and-forget
+            // upload after the component has unmounted (an invisible orphan
+            // recording). Nulling the handlers neutralises that.
+            const recorder = mediaRecorderRef.current;
+            if (recorder) {
+                recorder.onstop = null;
+                recorder.ondataavailable = null;
+                recorder.onerror = null;
+            }
+            // Pause live playback before revoking the object URL: revokeObjectURL
+            // does NOT halt an in-flight <audio> element, so ghost audio would
+            // otherwise keep playing after the UI has moved on.
+            detachAudioPlayer(audioPlayerRef.current);
             stopStreamRef(streamRef);
             revokeBlobPlayerSource(audioPlayerRef.current);
+            // Also revoke the tracked blob URL (the player's src may differ from,
+            // or be unset relative to, the last-created object URL).
+            if (audioUrlRef.current?.startsWith('blob:')) {
+                URL.revokeObjectURL(audioUrlRef.current);
+            }
         };
     }, []); // Empty deps - only run on mount/unmount
 

--- a/frontend/src/hooks/useSubmitStudy.test.ts
+++ b/frontend/src/hooks/useSubmitStudy.test.ts
@@ -209,4 +209,28 @@ describe('useSubmitStudy', () => {
         expect(result.current.isLoading).toBe(false);
         expect(result.current.isSuccess).toBe(true);
     });
+
+    it('a started autosave does not release the submitting guard held by a completed submit', async () => {
+        server.use(
+            http.post('/api/submit', () =>
+                HttpResponse.json({ success: true, confirmation_code: 'X' })
+            )
+        );
+
+        // Simulate a completed submission already in flight: it holds the guard.
+        useSessionStore.getState().setSubmitting(true);
+
+        const { result } = renderHook(() => useSubmitStudy(), {
+            wrapper: AllTheProviders,
+        });
+
+        await act(async () => {
+            // A concurrent non-completed autosave finishing mid-completion must
+            // NOT reset the guard (which would re-enable draft-autosave / allow a
+            // second completion while the final submission is still running).
+            await result.current.submit('started', { silent: true });
+        });
+
+        expect(useSessionStore.getState().isSubmitting).toBe(true);
+    });
 });

--- a/frontend/src/hooks/useSubmitStudy.ts
+++ b/frontend/src/hooks/useSubmitStudy.ts
@@ -242,8 +242,15 @@ export const useSubmitStudy = () => {
                 console.error(err);
                 setError(extractErrorMessage(err));
             } finally {
-                isSubmittingRef.current = false;
-                setSubmitting(false);
+                // Only release the concurrency guard for the status that
+                // acquired it (completed). A concurrent non-completed autosave
+                // finishing mid-completion must NOT reset the guard while the
+                // final submission is still in flight — that would re-enable
+                // draft-autosave / allow a second completion.
+                if (status === 'completed') {
+                    isSubmittingRef.current = false;
+                    setSubmitting(false);
+                }
                 if (!options?.silent) setIsLoading(false);
             }
         },


### PR DESCRIPTION
## Audit Wave C — participant-flow correctness

Third wave of the adversarially-verified audit. Genuine correctness defects on the participant / submission / audio path. C1 is the only one with a data-integrity impact (the duration metric + the legal consent record).

### Findings fixed
- **C1 · `record_consent` overwrites `consented_at` on every call (quality / medium)** — a re-POST (re-mount, retry, back-nav) reset the consent timestamp. `consented_at` is the start anchor of the median-duration metric, so resetting it produced artificially short or **negative** durations — and negatives are silently dropped, skewing the median by exclusion. It is also the legal record of when consent was given. Now **first-consent-wins** on `consented_at` *and* `consent_hash` (gated together so they can't desync); `language_used` / `ip_address` / `user_agent` still update.
- **C2 · audio keeps playing / orphan upload after `AudioRecorder` unmounts (stability / medium)** — the unmount cleanup now (1) nulls `mediaRecorder.onstop`/`ondataavailable`/`onerror` **before** stopping the stream, so a browser-auto-fired `onstop` on track-end can't run the fire-and-forget upload after the component is gone; (2) `detachAudioPlayer(...)` **before** `revokeBlobPlayerSource` (revokeObjectURL doesn't halt an in-flight `<audio>` → ghost audio); (3) revokes the tracked blob URL.
- **C3 · `useSubmitStudy` releases the concurrency guard too early (stability / low)** — the `finally` reset the guard for any status, so a concurrent non-completed autosave finishing mid-completion re-enabled draft-autosave / allowed a second completion. The guard is now released only by the status that acquired it (`completed`).
- **C4 · completed re-POST 422s instead of returning the prior confirmation (quality / low)** — after an operator edits the study, a retry of an already-completed submission failed `validate_distribution` (the stored Q-sort no longer matches) and returned 422. A read-only already-completed short-circuit now runs **before** distribution validation and returns the stored confirmation idempotently — without touching `_find_or_create_participant`'s row lock, link-usage increment, or consent ordering (a `study_id` guard preserves the cross-study invariant).

### Test updates
Two existing consent tests asserted `consent_hash` updates on re-consent (the old behaviour); they now assert first-consent-wins, keeping their real intent (UPDATE branch runs, one row, language still updates).

### Tests added
- Backend `test_participant_flow_correctness.py`: C1 (re-consent doesn't change `consented_at`/`consent_hash`), C4 (completed re-POST after a study edit → 200 + prior confirmation, not 422).
- Frontend: C3 (a `started` autosave doesn't release the guard a completed submit holds), C2 (unmount detaches the recorder handlers; oracle `AudioRecorder.test.tsx` unchanged).
- `make ci` green (lint, mypy, vulture, check-api, full suite incl. security, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)