### PR TITLE
fix: audit Wave E — lifecycle & cross-entity integrity (5 findings)

### DIFF
--- a/backend/app/routers/admin/lifecycle.py
+++ b/backend/app/routers/admin/lifecycle.py
@@ -11,7 +11,7 @@ enforcement. Designed to support the GDPR data-minimisation principle
 """
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
@@ -166,8 +166,12 @@ async def get_data_inventory(
     t_row = (await db.execute(timeline_q)).one()
 
     now = datetime.now(UTC)
-    cutoff_1y = now.replace(year=now.year - 1)
-    cutoff_2y = now.replace(year=now.year - 2)
+    # timedelta (not now.replace(year=...)) so this read-only endpoint does not
+    # crash on Feb 29, where replacing the year lands on a non-existent date
+    # (audit E4). A ~1-day drift near leap years is immaterial for these
+    # "older than ~1y / ~2y" retention counts.
+    cutoff_1y = now - timedelta(days=365)
+    cutoff_2y = now - timedelta(days=730)
 
     older_q = select(
         func.count(Participant.id)
@@ -294,8 +298,20 @@ async def bulk_anonymise_old_participants(
         if p.anonymised_at is not None:
             skipped += 1
             continue
+        participant_id = p.id
         await StudyDataService.anonymise_participant(db, p)
         anonymised += 1
+        # Per-row audit: anonymise_participant commits each row independently, so
+        # a mid-loop failure must not lose the trail of erasures already done.
+        # Mirrors the admin-mediated erase_personal_data path (F-05-008; audit E2).
+        log_admin_action(
+            actor_user_id=current_user.id,
+            action="erase_personal_data",
+            resource="participant",
+            resource_id=participant_id,
+            study_slug=study.slug,
+            mode="bulk_anonymise",
+        )
 
     log_admin_action(
         actor_user_id=current_user.id,

--- a/backend/app/routers/admin/projects.py
+++ b/backend/app/routers/admin/projects.py
@@ -413,6 +413,30 @@ async def delete_project(
     deleted_id = project.id
     deleted_slug = project.slug
     try:
+        # Concourse memos are polymorphic on (parent_type, parent_id) with NO DB
+        # foreign key, so the ON DELETE CASCADE that removes this project's
+        # concourses leaves orphan memo entries/comments behind — escaping GDPR
+        # cleanup (audit E1). Run the Python cleanup for each concourse first, in
+        # this same transaction. Query ids explicitly: project.concourses is
+        # lazy='raise'. (Study memos can't exist here — deletion is blocked above
+        # while any study remains.)
+        from app.models import Concourse, MemoParentType
+        from app.services.memo_service import MemoService
+
+        concourse_ids = (
+            (
+                await db.execute(
+                    select(Concourse.id).where(Concourse.project_id == project.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for concourse_id in concourse_ids:
+            await MemoService.cleanup_for_parent(
+                db, parent_type=MemoParentType.concourse, parent_id=concourse_id
+            )
+
         await db.delete(project)
         await db.commit()
     except Exception as e:

--- a/backend/app/routers/admin/studies.py
+++ b/backend/app/routers/admin/studies.py
@@ -354,6 +354,11 @@ async def sync_all_stale_statements(
                 db, study, entry["statement_id"]
             )
         except Exception:
+            # Roll back this statement's partial DML so the AsyncSession is clean
+            # for the next iteration; otherwise the next execute() raises
+            # PendingRollbackError and aborts the whole best-effort batch (audit
+            # E3). Already-synced statements are durable via their own commit.
+            await db.rollback()
             logger.warning("Failed to sync statement %s", entry["statement_id"])
 
     # Return refreshed study

--- a/backend/app/services/concourse_service.py
+++ b/backend/app/services/concourse_service.py
@@ -200,6 +200,34 @@ class ConcourseService:
 
     @staticmethod
     async def _attach_tags(db: AsyncSession, item_id: int, tag_ids: list[int]) -> None:
+        # Reject tag ids that don't belong to this item's project (audit E5):
+        # without this, a member of project A could attach — and, via the item
+        # response, read the name of — a tag from project B (cross-project IDOR).
+        # The project is derived from the item's concourse, so callers (which have
+        # already verified the concourse belongs to their project) need no change.
+        if tag_ids:
+            project_id = (
+                await db.execute(
+                    select(Concourse.project_id)
+                    .join(ConcourseItem, ConcourseItem.concourse_id == Concourse.id)
+                    .where(ConcourseItem.id == item_id)
+                )
+            ).scalar_one()
+            valid_ids = set(
+                (
+                    await db.execute(
+                        select(ConcourseTag.id).where(
+                            ConcourseTag.id.in_(tag_ids),
+                            ConcourseTag.project_id == project_id,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            if valid_ids != set(tag_ids):
+                raise NotFoundError("ConcourseTag")
+
         await db.execute(
             delete(ConcourseItemTag).where(ConcourseItemTag.item_id == item_id)
         )

--- a/backend/tests/integration/test_lifecycle_integrity.py
+++ b/backend/tests/integration/test_lifecycle_integrity.py
@@ -1,0 +1,110 @@
+# Qualis - Open-source platform for conducting Q-methodology research
+# Copyright (C) 2025 Julien Vastenekels
+# Licensed under the GNU Affero General Public License v3.0 or later.
+
+"""Audit Wave E — lifecycle & cross-entity integrity (E5 security, E1 GDPR).
+
+E2/E3/E4 (all low-severity) are covered by the existing data-lifecycle /
+study tests for no-regression; their fixes are self-evident (per-row audit
+logging, a rollback in an except, and a leap-safe timedelta cutoff).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.exceptions import NotFoundError
+from app.models import MemoEntry, MemoParentType, Project, User
+from app.schemas.concourses import (
+    ConcourseCreate,
+    ConcourseItemCreate,
+    ConcourseItemTranslationCreate,
+    ConcourseTagCreate,
+)
+from app.services.concourse_service import ConcourseService
+
+
+@pytest.mark.asyncio
+async def test_attach_cross_project_tag_is_rejected(
+    db: AsyncSession, test_user: User, test_project: Project, project_factory
+) -> None:
+    """E5: a tag from another project cannot be attached to an item.
+
+    Without the guard, a member of project A could attach — and, via the item
+    response, read the name of — a tag belonging to project B (cross-project IDOR).
+    """
+    concourse_a = await ConcourseService.create_concourse(
+        db, test_project.id, ConcourseCreate(title="A", description=""), test_user.id
+    )
+    project_b = await project_factory(owner=test_user)
+    tag_b = await ConcourseService.create_tag(
+        db, project_b.id, ConcourseTagCreate(name="B-tag", color="#abcdef")
+    )
+
+    cross = ConcourseItemCreate(
+        code="X1",
+        translations=[ConcourseItemTranslationCreate(language_code="en", text="x")],
+        tag_ids=[tag_b.id],
+    )
+    with pytest.raises(NotFoundError):
+        await ConcourseService.create_item(db, concourse_a.id, cross, test_user.id)
+
+    # A same-project tag still attaches fine.
+    tag_a = await ConcourseService.create_tag(
+        db, test_project.id, ConcourseTagCreate(name="A-tag", color="#123456")
+    )
+    ok = ConcourseItemCreate(
+        code="X2",
+        translations=[ConcourseItemTranslationCreate(language_code="en", text="y")],
+        tag_ids=[tag_a.id],
+    )
+    item = await ConcourseService.create_item(db, concourse_a.id, ok, test_user.id)
+    assert item is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_project_cleans_up_concourse_memos(
+    db: AsyncSession,
+    test_user: User,
+    test_project: Project,
+    client,
+    auth_token_factory,
+) -> None:
+    """E1: deleting a project removes its concourses' polymorphic memo rows.
+
+    Memos are keyed on (parent_type, parent_id) with NO DB foreign key, so the
+    ON DELETE CASCADE that removes the concourses would otherwise leave orphan
+    memo entries behind — escaping GDPR cleanup.
+    """
+    concourse = await ConcourseService.create_concourse(
+        db, test_project.id, ConcourseCreate(title="C", description=""), test_user.id
+    )
+    concourse_id = concourse.id
+    db.add(
+        MemoEntry(
+            parent_type=MemoParentType.concourse,
+            parent_id=concourse_id,
+            title="note",
+            body="sensitive memo body",
+            created_by=test_user.id,
+        )
+    )
+    await db.commit()
+
+    memo_stmt = select(MemoEntry).where(
+        MemoEntry.parent_type == MemoParentType.concourse,
+        MemoEntry.parent_id == concourse_id,
+    )
+    before = (await db.execute(memo_stmt)).scalars().all()
+    assert len(before) == 1
+
+    headers = auth_token_factory(test_user)
+    resp = await client.delete(
+        f"/api/admin/projects/{test_project.slug}", headers=headers
+    )
+    assert resp.status_code in (200, 204), resp.text
+
+    after = (await db.execute(memo_stmt)).scalars().all()
+    assert after == [], "concourse memo entries must be cleaned up, not orphaned"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1671,7 +1671,7 @@ wheels = [
 
 [[package]]
 name = "qualis-backend"
-version = "0.7.2"
+version = "0.7.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "qualis",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "qualis",
-            "version": "0.7.2",
+            "version": "0.7.3",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",


### PR DESCRIPTION
## Audit Wave E — lifecycle & cross-entity integrity

Fifth (and final correctness) wave of the adversarially-verified audit. Backend lifecycle / cross-entity defects where a failure or cascade leaves orphaned rows, a missing audit trail, or a cross-tenant leak.

### Findings fixed
- **E1 · project delete orphans concourse memos (stability / medium, GDPR)** — memos are polymorphic on `(parent_type, parent_id)` with **no DB foreign key**, so the `ON DELETE CASCADE` that removes a deleted project's concourses left orphan memo entries/comments behind, escaping GDPR cleanup. `delete_project` now runs `MemoService.cleanup_for_parent` for each concourse first, in the same transaction (ids queried explicitly — `project.concourses` is `lazy='raise'`).
- **E5 · cross-project tag injection (security / medium, IDOR)** — `_attach_tags` attached any `tag_id` without checking project ownership, so a member of project A could attach (and, via the item response, read the name of) a tag from project B. It now validates the tag set against the item's project (derived from the item's concourse, so callers are unchanged) and raises `NotFoundError` otherwise.
- **E2 · bulk anonymisation audit trail (stability / low)** — `anonymise_participant` commits each row independently, but `log_admin_action` ran only after the loop, so a mid-loop failure lost the trail of erasures already done. Now logs per participant inside the loop (F-05-008).
- **E3 · sync-all-stale swallows errors without rollback (stability / low)** — a failed per-statement sync left the `AsyncSession` pending-rollback, so the next iteration raised `PendingRollbackError` and aborted the whole best-effort batch. Added `await db.rollback()` in the except.
- **E4 · data-inventory crashes on Feb 29 (stability / low)** — `datetime.replace(year=now.year-1)` raises on a leap day; switched both cutoffs to `timedelta`.

### Tests
- `test_lifecycle_integrity.py`: cross-project-tag rejection (E5) + project-delete memo-cleanup (E1). E2/E3/E4 (low) are covered by the existing data-lifecycle / study tests for no-regression; their fixes are self-evident.
- `make ci` green (lint, mypy, vulture, full suite incl. security + IDOR harness, build).

### Also in this PR (unrelated, blocking)
`chore(release): sync lockfile versions to 0.7.3` — the v0.7.3 release (#240) bumped `package.json` / `pyproject.toml` to 0.7.3 but **release-please left both lockfiles at 0.7.2**, turning the version-match check (and all CI) red on `main`. Synced `package-lock.json` + `uv.lock`. No dependency changes. (Worth fixing release-please's config so lockfiles bump automatically.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)