### PR TITLE
fix: audit Wave F — export hardening (3 findings)

### DIFF
--- a/backend/app/schemas/studies.py
+++ b/backend/app/schemas/studies.py
@@ -163,7 +163,10 @@ class StatementUpdate(BaseModel):
 class GridColumn(BaseModel):
     """Schema defining a column in the sorting grid."""
 
-    score: int
+    # Bounded to match the participant-side grid_score (QSortEntryInput, +-10),
+    # so the grid can't declare a score the .dat export's 3-char field (audit F2)
+    # — or downstream analysis — can't represent.
+    score: int = Field(ge=-10, le=10)
     capacity: int
 
 

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -25,6 +25,22 @@ class _AudioMapEntry(TypedDict):
     size_kb: float
 
 
+def _csv_safe(value: str) -> str:
+    """Neutralize spreadsheet formula injection in a free-text CSV cell.
+
+    A cell beginning with ``= + - @`` (or a leading tab / carriage return) is
+    interpreted as a formula by Excel / Google Sheets; prefixing it with an
+    apostrophe forces it to be read as text. Applied ONLY to participant- or
+    admin-controlled FREE-TEXT cells (card comments, presort/postsort answers,
+    discard reasons, statement text) — NOT to numeric / system cells such as
+    Q-sort scores, which legitimately start with '-' and must stay numeric for
+    downstream analysis (audit F1).
+    """
+    if value and value[0] in ("=", "+", "-", "@", "\t", "\r"):
+        return "'" + value
+    return value
+
+
 class ExportService:
     """Service for exporting study results."""
 
@@ -168,13 +184,15 @@ class ExportService:
                 p.ip_address or "",
                 p.user_agent or "",
                 "True" if p.is_discarded else "False",
-                p.discard_reason or "",
+                _csv_safe(p.discard_reason or ""),
             ]
 
             # Presort
             for k in presort_keys:
                 val = p.presort_answers.get(k)
-                row.append(get_value_label(presort_fields, k, val, header_lang))
+                row.append(
+                    _csv_safe(get_value_label(presort_fields, k, val, header_lang))
+                )
 
             # Build audio recordings map by question_key
             audio_map: dict[str, _AudioMapEntry] = {}
@@ -191,11 +209,19 @@ class ExportService:
                         size_kb=round(audio_rec.file_size_bytes / 1024, 2),
                     )
                 except Exception as e:
-                    # Log error but don't fail export
+                    # Log but don't fail the export. Still record a sentinel entry
+                    # so a fetch failure (URL unavailable) is distinguishable from a
+                    # genuine "no recording" empty cell (audit F3) — the row keeps
+                    # the known duration/size.
                     logger.warning(
                         "Failed to generate presigned URL for %s: %s",
                         audio_rec.s3_key,
                         e,
+                    )
+                    audio_map[audio_rec.question_key] = _AudioMapEntry(
+                        url="ERROR_URL_UNAVAILABLE",
+                        duration=audio_rec.duration_seconds,
+                        size_kb=round(audio_rec.file_size_bytes / 1024, 2),
                     )
 
             # Build card comments map from qsort_entries
@@ -213,9 +239,9 @@ class ExportService:
                 score = scores_map.get(s.id)
                 row.append(str(score) if score is not None else "")
 
-                # Text Comment
+                # Text Comment (participant free text — neutralise formulas)
                 comment = comments_map.get(s.id, "")
-                row.append(comment)
+                row.append(_csv_safe(comment))
 
                 # Audio (URL, Duration, FileSize)
                 audio_key = f"card_{s.id}"
@@ -232,7 +258,9 @@ class ExportService:
             # Postsort
             for k in postsort_keys:
                 val = p.postsort_answers.get(k)
-                row.append(get_value_label(postsort_fields, k, val, header_lang))
+                row.append(
+                    _csv_safe(get_value_label(postsort_fields, k, val, header_lang))
+                )
 
             # Postsort Audio (missing_statement, etc.)
             if audio_enabled:
@@ -522,13 +550,13 @@ class ExportService:
         writer.writerow(header)
 
         for statement in sorted(study.statements, key=lambda x: x.display_order):
-            row = [statement.code]
+            row = [_csv_safe(statement.code)]
             trans_map = {
                 trans.language_code: trans.text.replace("\n", " ")
                 for trans in statement.translations
             }
             for lang_code in langs:
-                row.append(trans_map.get(lang_code, ""))
+                row.append(_csv_safe(trans_map.get(lang_code, "")))
             writer.writerow(row)
 
         return output.getvalue()
@@ -602,12 +630,11 @@ class ExportService:
                         s.id,
                     )
                     score = 0
-                # We use 2 chars per score
-                # If score is positive, add a space. If negative, it has the minus.
-                if score >= 0:
-                    scores_str += f" {score}"
-                else:
-                    scores_str += str(score)
+                # Fixed 3-char field per score so PQMethod's column-offset parse
+                # stays aligned across the full +-10 grid_score range (audit F2):
+                # the old 2-char format produced a 3-char field for |score| >= 10,
+                # silently shifting every subsequent column.
+                scores_str += f"{score:>3d}"
 
             body_lines.append(f"{pid}{scores_str}")
 

--- a/backend/tests/unit/test_export_service.py
+++ b/backend/tests/unit/test_export_service.py
@@ -146,9 +146,9 @@ class TestRosettaStone:
         pos_0 = scores_section.find(" 0")
         pos_neg1 = scores_section.find("-1")
         pos_1 = scores_section.rfind(" 1")  # Use rfind to get the last " 1"
-        assert (
-            pos_0 < pos_neg1 < pos_1
-        ), f"Scores not in definition order: 0@{pos_0}, -1@{pos_neg1}, 1@{pos_1}"
+        assert pos_0 < pos_neg1 < pos_1, (
+            f"Scores not in definition order: 0@{pos_0}, -1@{pos_neg1}, 1@{pos_1}"
+        )
 
     def test_sta_file_uses_statement_definition_order(self):
         """
@@ -288,6 +288,72 @@ class TestSymmetry:
             assert "test-export.ans" in file_list
 
 
+class TestExportHardening:
+    """Audit Wave F — CSV formula injection (F1), .dat width (F2), audio sentinel (F3)."""
+
+    def test_f1_free_text_formula_neutralized_but_scores_not(self):
+        statements = [MockStatement(id=1, code="s1", display_order=0)]
+        entry = MockQSortEntry(statement_id=1, grid_score=-1)
+        entry.card_comment = "=SUM(A1:A9)"  # spreadsheet-formula injection attempt
+        participant = MockParticipant([entry])
+        study = MockStudy(statements)
+
+        csv_content = ExportService.generate_csv(study, [participant])
+
+        # The participant free-text cell is prefixed with ' (forced to text).
+        assert "'=SUM(A1:A9)" in csv_content
+        # The negative Q-sort score is a number, NOT escaped — stays analysable.
+        assert "'-1" not in csv_content
+
+    def test_f2_dat_uses_constant_3char_field_for_double_digit_scores(self):
+        statements = [
+            MockStatement(id=1, code="s1", display_order=0),
+            MockStatement(id=2, code="s2", display_order=1),
+            MockStatement(id=3, code="s3", display_order=2),
+        ]
+        entries = [
+            MockQSortEntry(statement_id=1, grid_score=10),
+            MockQSortEntry(statement_id=2, grid_score=-10),
+            MockQSortEntry(statement_id=3, grid_score=1),
+        ]
+        participant = MockParticipant(entries)
+        study = MockStudy(statements)
+        sorted_statements = sorted(statements, key=lambda s: s.display_order)
+
+        dat = ExportService._generate_dat(study, [participant], sorted_statements)
+        scores_section = dat.strip().split("\n")[1][8:]  # after the 8-char PID
+
+        # Constant 3-char field per score keeps PQMethod's column offsets aligned
+        # even at the +-10 extremes (which the old 2-char format broke).
+        assert scores_section == " 10-10  1"
+        assert len(scores_section) == 9
+
+    def test_f3_audio_url_failure_emits_sentinel_not_blank(self, monkeypatch):
+        from app.services import export_service as export_mod
+
+        statements = [MockStatement(id=5, code="s5", display_order=0)]
+        participant = MockParticipant([MockQSortEntry(statement_id=5, grid_score=0)])
+        audio = MagicMock()
+        audio.question_key = "card_5"
+        audio.s3_key = "audio/x.webm"
+        audio.duration_seconds = 12.5
+        audio.file_size_bytes = 2048
+        participant.audio_recordings = [audio]
+        study = MockStudy(statements)
+
+        # Force presigned-URL generation to fail.
+        monkeypatch.setattr(
+            export_mod.storage_service,
+            "generate_presigned_url",
+            MagicMock(side_effect=Exception("boom")),
+        )
+
+        csv_content = ExportService.generate_csv(study, [participant])
+
+        # A fetch failure is distinguishable from a genuine "no recording" blank.
+        assert "ERROR_URL_UNAVAILABLE" in csv_content
+
+
 class TestRenderMemoMd:
     """Unit tests for ExportService.render_memo_md (pure function, no DB required)."""
 
@@ -375,7 +441,11 @@ class TestRenderMemoMd:
         assert "## Limitations" in result
         # The body line should NOT appear (body is empty)
         lines = result.split("\n")
-        body_lines = [ln for ln in lines if ln and ln not in ("## Limitations\n", "## Limitations")]
+        body_lines = [
+            ln
+            for ln in lines
+            if ln and ln not in ("## Limitations\n", "## Limitations")
+        ]
         # There should be no line between the ## heading and the blank separator
         # containing arbitrary user-supplied text — only the header, blank sep, footer.
         assert not any(ln.strip() == "" and "Forced" in ln for ln in lines)
@@ -528,7 +598,10 @@ class TestRenderMemoDiscussionMd:
         result = ExportService.render_memo_discussion_md(memo, {7: "alice@example.com"})
 
         assert "[resolved]" in result
-        assert "- alice@example.com · 2026-04-15 10:00 [resolved]: Agreed, closing." in result
+        assert (
+            "- alice@example.com · 2026-04-15 10:00 [resolved]: Agreed, closing."
+            in result
+        )
 
     def test_deleted_comment_shows_placeholder(self) -> None:
         """A deleted comment renders as '[deleted comment]' regardless of its body."""
@@ -652,7 +725,8 @@ class TestRenderMemoDiscussionMd:
             comments=[comment],
         )
         memo = MemoRead(
-            parent_type="study", parent_id=1,
+            parent_type="study",
+            parent_id=1,
             entries=[entry_no_comments, entry_with_comment],
         )
         result = ExportService.render_memo_discussion_md(memo, {7: "alice@example.com"})

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8950,6 +8950,8 @@
         "properties": {
           "score": {
             "type": "integer",
+            "maximum": 10.0,
+            "minimum": -10.0,
             "title": "Score"
           },
           "capacity": {

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -15451,7 +15451,7 @@ export const getCreateStudyApiAdminStudiesPostResponseMock = (
     ]),
     grid_config: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(
         () => ({
-            score: faker.number.int({ min: undefined, max: undefined }),
+            score: faker.number.int({ min: -10, max: 10 }),
             capacity: faker.number.int({ min: undefined, max: undefined }),
         })
     ),
@@ -15736,7 +15736,7 @@ export const getListStudiesApiAdminStudiesGetResponseMock = (
                 { length: faker.number.int({ min: 1, max: 10 }) },
                 (_, i) => i + 1
             ).map(() => ({
-                score: faker.number.int({ min: undefined, max: undefined }),
+                score: faker.number.int({ min: -10, max: 10 }),
                 capacity: faker.number.int({ min: undefined, max: undefined }),
             })),
             presort_config: {},
@@ -16045,7 +16045,7 @@ export const getGetStudyApiAdminStudiesSlugGetResponseMock = (
     ]),
     grid_config: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(
         () => ({
-            score: faker.number.int({ min: undefined, max: undefined }),
+            score: faker.number.int({ min: -10, max: 10 }),
             capacity: faker.number.int({ min: undefined, max: undefined }),
         })
     ),
@@ -16326,7 +16326,7 @@ export const getUpdateStudyApiAdminStudiesSlugPatchResponseMock = (
     ]),
     grid_config: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(
         () => ({
-            score: faker.number.int({ min: undefined, max: undefined }),
+            score: faker.number.int({ min: -10, max: 10 }),
             capacity: faker.number.int({ min: undefined, max: undefined }),
         })
     ),
@@ -16610,7 +16610,7 @@ export const getChangeStudyStateApiAdminStudiesSlugStatePostResponseMock = (
     ]),
     grid_config: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(
         () => ({
-            score: faker.number.int({ min: undefined, max: undefined }),
+            score: faker.number.int({ min: -10, max: 10 }),
             capacity: faker.number.int({ min: undefined, max: undefined }),
         })
     ),
@@ -16891,7 +16891,7 @@ export const getImportFromConcourseApiAdminStudiesSlugImportConcoursePostRespons
     ]),
     grid_config: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(
         () => ({
-            score: faker.number.int({ min: undefined, max: undefined }),
+            score: faker.number.int({ min: -10, max: 10 }),
             capacity: faker.number.int({ min: undefined, max: undefined }),
         })
     ),
@@ -17196,7 +17196,7 @@ export const getSyncStatementFromConcourseApiAdminStudiesSlugSyncStatementStatem
             { length: faker.number.int({ min: 1, max: 10 }) },
             (_, i) => i + 1
         ).map(() => ({
-            score: faker.number.int({ min: undefined, max: undefined }),
+            score: faker.number.int({ min: -10, max: 10 }),
             capacity: faker.number.int({ min: undefined, max: undefined }),
         })),
         presort_config: {},
@@ -17488,7 +17488,7 @@ export const getSyncAllStaleStatementsApiAdminStudiesSlugSyncAllStalePostRespons
     ]),
     grid_config: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(
         () => ({
-            score: faker.number.int({ min: undefined, max: undefined }),
+            score: faker.number.int({ min: -10, max: 10 }),
             capacity: faker.number.int({ min: undefined, max: undefined }),
         })
     ),

--- a/frontend/src/api/model/gridColumn.ts
+++ b/frontend/src/api/model/gridColumn.ts
@@ -9,6 +9,10 @@
  * Schema defining a column in the sorting grid.
  */
 export interface GridColumn {
+    /**
+     * @minimum -10
+     * @maximum 10
+     */
     score: number;
     capacity: number;
 }

--- a/openapi.json
+++ b/openapi.json
@@ -8950,6 +8950,8 @@
         "properties": {
           "score": {
             "type": "integer",
+            "maximum": 10.0,
+            "minimum": -10.0,
             "title": "Score"
           },
           "capacity": {


### PR DESCRIPTION
## Audit Wave F — export hardening

Sixth wave of the adversarially-verified audit. Hardens the data-export path.

### Findings fixed
- **F1 · CSV formula injection (security / medium)** — exported CSVs wrote participant/admin free text without neutralizing formula prefixes, so a `card_comment` (or presort/postsort answer, discard reason, statement text) beginning with `= + - @` becomes an **active formula** when the researcher opens the CSV in Excel/Sheets. A single `_csv_safe` helper now prefixes such cells with an apostrophe (text). It is applied **only to free-text cells** — numeric/system cells (Q-sort scores, sizes, tokens) are left alone so negative scores stay numeric for analysis. (Dropped the `user_agent` sub-claim: it's hashed before storage.)
- **F2 · PQMethod `.dat` width (quality / low)** — scores used a 2-char field, which became a **3-char field for `|score| >= 10`**, shifting PQMethod's column-offset parse and silently corrupting external analysis. Now a constant `f"{score:>3d}"` (3-char) field. `GridColumn.score` is also bounded to `±10` to match the participant-side `grid_score` (API client regenerated).
- **F3 · audio-URL failure indistinguishable from "no recording" (quality / low)** — a per-recording presigned-URL failure rendered as an empty cell, identical to a genuine absence. The cell now carries an `ERROR_URL_UNAVAILABLE` sentinel plus the known duration/size.

### Tests
- `TestExportHardening`: free-text formula neutralised while a negative score stays numeric (F1); constant 3-char `.dat` field at `±10` (F2); audio-URL-failure sentinel (F3). All existing export tests still pass (the `.dat` order test's substring assertions tolerate the wider field).
- `make ci` green (lint, mypy, vulture, check-api, full suite, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)