### PR TITLE
fix: audit Wave G — analysis audit-trail & degeneracy warnings (G3, G4; G1/G2 deferred)

### DIFF
--- a/backend/app/routers/admin/analysis.py
+++ b/backend/app/routers/admin/analysis.py
@@ -333,12 +333,18 @@ async def run_factor_analysis(
                 factor_mean_se=bootstrap_raw["factor_mean_se"],
             )
         except (ValueError, np.linalg.LinAlgError) as e:
-            # Non-fatal: log and continue. The regular result is still
-            # returned without bootstrap data.
+            # Non-fatal: log and continue. The regular result is still returned
+            # without bootstrap data — but record the attempt in the persisted
+            # warnings so a failed bootstrap is distinguishable from one that was
+            # never requested (audit G3).
             logger.warning(
                 "Bootstrap failed for study=%s: %s — returning result without bootstrap.",
                 study.slug,
                 e,
+            )
+            result["warnings"].append(
+                f"Bootstrap stability ({body.bootstrap_iterations} iterations) "
+                f"could not be computed and was skipped: {e}"
             )
 
     analysis_result = AnalysisResult(
@@ -382,9 +388,11 @@ async def run_factor_analysis(
         notes=None,
         factor_notes={},
         manual_rotations=manual_rotations_payload,
-        bootstrap_iterations=body.bootstrap_iterations
-        if bootstrap_payload is not None
-        else None,
+        # Persist the REQUESTED iteration count unconditionally so an attempted-
+        # but-failed bootstrap (count set, result null) is distinguishable from
+        # one never requested (both null) — audit G3. bootstrap_result stays
+        # guarded (null when the bootstrap failed or was not requested).
+        bootstrap_iterations=body.bootstrap_iterations,
         bootstrap_result=bootstrap_payload.model_dump(mode="json")
         if bootstrap_payload is not None
         else None,

--- a/backend/app/services/analysis_service.py
+++ b/backend/app/services/analysis_service.py
@@ -1127,6 +1127,17 @@ def run_analysis(
     warnings: list[str] = []
     if extraction == "pca":
         unrotated = extract_pca(cor_mat, n_factors)
+        # Detect degenerate (zero-variance) factor columns: requesting more
+        # factors than the data rank clamps eigenvalues to ~0, yielding all-zero
+        # loading columns, NaN z-scores and variance_explained=0 with no signal.
+        # PCA previously emitted no warning here, unlike the centroid path (G4).
+        for f in range(unrotated.shape[1]):
+            if not np.any(np.abs(unrotated[:, f]) > 1e-9):
+                warnings.append(
+                    f"Factor {f + 1} is degenerate (near-zero variance) — the data "
+                    f"likely supports fewer than {n_factors} factors; consider "
+                    f"requesting fewer."
+                )
     elif extraction == "centroid":
         unrotated, warnings = extract_centroid(cor_mat, n_factors)
     else:

--- a/backend/tests/unit/test_analysis_service.py
+++ b/backend/tests/unit/test_analysis_service.py
@@ -447,6 +447,22 @@ class TestRunAnalysis:
         with pytest.raises(ValueError, match="cannot exceed"):
             run_analysis(dataset, n_factors=10)
 
+    def test_pca_over_factorization_warns_on_degenerate_factor(self):
+        """Audit G4: PCA over-factorization must surface a degeneracy warning
+        (the centroid path already does; PCA was silent)."""
+        # 4 participants forming 2 collinear pairs → correlation matrix rank 2.
+        # Requesting 3 factors leaves factor 3 with ~zero variance (degenerate).
+        v = np.array([-2, -1, 0, 1, 2, 0], dtype=float)
+        w = np.array([2, 1, 0, -1, -2, 0], dtype=float)
+        dataset = np.column_stack([v, v, w, w])  # (6 statements, 4 participants)
+
+        result = run_analysis(dataset, n_factors=3, extraction="pca", rotation="none")
+
+        assert any("degenerate" in msg.lower() for msg in result["warnings"]), (
+            f"expected a degeneracy warning for the over-factorized PCA run; "
+            f"got warnings={result['warnings']}"
+        )
+
     def test_invalid_extraction_raises(self, dataset):
         with pytest.raises(ValueError, match="Unknown extraction"):
             run_analysis(dataset, n_factors=2, extraction="invalid")


### PR DESCRIPTION
## Audit Wave G — analysis pipeline (G3, G4)

Seventh wave. The backend analysis-correctness/transparency items. **G1 and G2 (frontend manual-flagging UX) are intentionally deferred** — see below.

### Findings fixed (backend)
- **G3 · failed bootstrap leaves no trace (quality / low)** — a requested-but-failed bootstrap persisted identically to one never requested (`bootstrap_iterations` NULL, no warning), so a reviewer auditing why a solution lacks stability CIs couldn't tell it was attempted and failed. The run now persists the **requested** `bootstrap_iterations` unconditionally (attempted-and-failed = count + null result; never-requested = both null) and appends a human-readable warning to the persisted result.
- **G4 · PCA over-factorization silently degenerate (stability / low)** — requesting more factors than the data rank clamps eigenvalues to ~0, yielding all-zero loading columns, NaN z-scores and `variance_explained=0` with no signal. The centroid path already warned for the equivalent case; the PCA path was silent. `run_analysis` now detects degenerate (near-zero) factor columns on the PCA branch and appends a warning.

### Deferred: G1 + G2 (frontend manual-flagging UX)
G1 (the Explorer "Manual" flagging option always sends empty `manual_flags` → 400) and G2 (interpret-view flag toggles mutate local state that's never persisted) are both symptoms of the **manual-flagging feature being incomplete**. The code says so explicitly:

> `// manual flagging is being re-thought in PR 4 with the canvas. For now, we keep a light local-state copy ... so the FactorLoadingsTable still has somewhere to write toggles.`

The explore phase POSTs `manualFlags` but nothing populates it; the interpret phase populates a separate local state that's never POSTed — the two are disconnected. Rather than unilaterally remove/gate UI in a feature you're actively redesigning (and risk conflicting with the PR-4 canvas rework), these are left for that focused frontend pass. Happy to do the minimal "remove the dead Manual option / make the interpret table read-only" fix if you'd prefer it now.

### Tests
- A degenerate over-factorized PCA run surfaces the G4 warning.
- The lipset validation oracle (1e-4 qmethod reproduction) and the bootstrap integration tests pass unchanged.
- `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)