### PR TITLE
test: audit Wave I — regression nets for link gating & session expiry

### DIFF
--- a/backend/tests/integration/test_recruitment.py
+++ b/backend/tests/integration/test_recruitment.py
@@ -1,10 +1,13 @@
 """Consolidated integration tests for recruitment links and collaborator invitations."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import User
+from app.models import RecruitmentLink, User
 
 
 @pytest.mark.asyncio
@@ -158,6 +161,93 @@ class TestRecruitment:
         links = response.json()
         assert len(links) == 1
         assert links[0]["capacity"] == 20
+
+    async def test_revoked_link_is_rejected(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        test_user: User,
+        auth_token_factory,
+        study_factory,
+        project_factory,
+        project_member_factory,
+    ):
+        """A deactivated (is_active=False) link must be denied at the study handler.
+
+        Regression net for the ``not link.is_active`` branch in
+        validate_link_token (audit I) — previously only the cross-study and
+        capacity branches had coverage.
+        """
+        ws = await project_factory(owner=test_user)
+        study = await study_factory(project=ws, owner=test_user)
+        headers = auth_token_factory(test_user)
+
+        response = await client.post(
+            f"/api/admin/recruitment/{study.slug}/links?count=1",
+            json={"type": "public"},
+            headers=headers,
+        )
+        token = response.json()[0]["token"]
+
+        # Control: the active link is accepted.
+        ok = await client.get(f"/api/study/{study.slug}?link_token={token}")
+        assert ok.status_code == 200
+
+        # Revoke the link server-side (is_active is not settable via the API).
+        result = await db.execute(
+            select(RecruitmentLink).where(RecruitmentLink.token == token)
+        )
+        link = result.scalar_one()
+        link.is_active = False
+        await db.commit()
+
+        denied = await client.get(f"/api/study/{study.slug}?link_token={token}")
+        assert denied.status_code == 403
+        assert "recruitment link" in denied.text.lower()
+
+    async def test_expired_link_is_rejected(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        test_user: User,
+        auth_token_factory,
+        study_factory,
+        project_factory,
+        project_member_factory,
+    ):
+        """A link whose expires_at is in the past must be denied at the handler.
+
+        Regression net for the ``expires_at < now`` branch in
+        validate_link_token (audit I).
+        """
+        ws = await project_factory(owner=test_user)
+        study = await study_factory(project=ws, owner=test_user)
+        headers = auth_token_factory(test_user)
+
+        response = await client.post(
+            f"/api/admin/recruitment/{study.slug}/links?count=1",
+            json={"type": "public"},
+            headers=headers,
+        )
+        token = response.json()[0]["token"]
+
+        # Backdate expiry server-side (expires_at is not settable via the API).
+        result = await db.execute(
+            select(RecruitmentLink).where(RecruitmentLink.token == token)
+        )
+        link = result.scalar_one()
+        link.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+        await db.commit()
+
+        denied = await client.get(f"/api/study/{study.slug}?link_token={token}")
+        assert denied.status_code == 403
+        assert "recruitment link" in denied.text.lower()
+
+        # Control: a future expiry is still accepted.
+        link.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+        await db.commit()
+        ok = await client.get(f"/api/study/{study.slug}?link_token={token}")
+        assert ok.status_code == 200
 
     async def test_create_excludes_server_controlled_fields(
         self,

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -1,8 +1,17 @@
 """Unit tests for SQLAlchemy models."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
-from app.models import Study, StudyState, User
+from app.models import (
+    SESSION_TTL_DAYS,
+    Participant,
+    ParticipantStatus,
+    Study,
+    StudyState,
+    User,
+)
 
 
 @pytest.mark.asyncio
@@ -43,6 +52,101 @@ async def test_study_new_fields(db, test_project):
     reloaded = result.scalar_one()
     assert reloaded.default_language == "fi"
     assert reloaded.show_statement_codes is True
+
+
+class TestParticipantIsExpired:
+    """Pure-property regression net for ``Participant.is_expired`` (audit I).
+
+    The property gates the resume endpoint (410) and submission service
+    (ValidationError); it had zero direct coverage. These tests pin every
+    branch in-memory (no DB) so a regression in the completed short-circuit,
+    the timestamp fallback chain, or the naive/aware tz handling is caught.
+    """
+
+    @staticmethod
+    def _participant(**kwargs: object) -> Participant:
+        # Construct in-memory; column server-defaults (status, created_at) are
+        # not applied without a flush, so every attribute under test is set
+        # explicitly by the caller.
+        return Participant(study_id=1, **kwargs)
+
+    def test_completed_session_never_expires(self):
+        """A completed session is never expired, even with an ancient timestamp."""
+        ancient = datetime.now(timezone.utc) - timedelta(days=SESSION_TTL_DAYS * 10)
+        p = self._participant(
+            status=ParticipantStatus.completed,
+            last_step_reached_at=ancient,
+            created_at=ancient,
+        )
+        assert p.is_expired is False
+
+    def test_recent_activity_not_expired(self):
+        """A started session active within the TTL window is not expired."""
+        recent = datetime.now(timezone.utc) - timedelta(days=SESSION_TTL_DAYS - 1)
+        p = self._participant(
+            status=ParticipantStatus.started,
+            last_step_reached_at=recent,
+        )
+        assert p.is_expired is False
+
+    def test_stale_last_step_expired(self):
+        """A started session inactive beyond the TTL is expired."""
+        stale = datetime.now(timezone.utc) - timedelta(days=SESSION_TTL_DAYS + 1)
+        p = self._participant(
+            status=ParticipantStatus.started,
+            last_step_reached_at=stale,
+        )
+        assert p.is_expired is True
+
+    def test_falls_back_to_consented_at(self):
+        """With no last_step_reached_at, a stale consented_at drives expiry."""
+        stale = datetime.now(timezone.utc) - timedelta(days=SESSION_TTL_DAYS + 1)
+        p = self._participant(
+            status=ParticipantStatus.started,
+            last_step_reached_at=None,
+            consented_at=stale,
+        )
+        assert p.is_expired is True
+
+    def test_falls_back_to_created_at(self):
+        """With no activity/consent timestamps, a stale created_at drives expiry."""
+        stale = datetime.now(timezone.utc) - timedelta(days=SESSION_TTL_DAYS + 1)
+        p = self._participant(
+            status=ParticipantStatus.started,
+            last_step_reached_at=None,
+            consented_at=None,
+            created_at=stale,
+        )
+        assert p.is_expired is True
+
+    def test_no_timestamps_not_expired(self):
+        """No reference timestamp at all → cannot be expired (returns False)."""
+        p = self._participant(
+            status=ParticipantStatus.started,
+            last_step_reached_at=None,
+            consented_at=None,
+            created_at=None,
+        )
+        assert p.is_expired is False
+
+    def test_naive_datetime_from_db_is_handled(self):
+        """A naive (tz-less) timestamp — as some DB drivers return — is compared
+        correctly rather than raising a naive/aware comparison TypeError."""
+        now_naive = datetime.now(timezone.utc).replace(tzinfo=None)
+        stale_naive = now_naive - timedelta(days=SESSION_TTL_DAYS + 1)
+        assert stale_naive.tzinfo is None
+        p = self._participant(
+            status=ParticipantStatus.started,
+            last_step_reached_at=stale_naive,
+        )
+        assert p.is_expired is True
+
+        fresh_naive = now_naive - timedelta(days=1)
+        p2 = self._participant(
+            status=ParticipantStatus.started,
+            last_step_reached_at=fresh_naive,
+        )
+        assert p2.is_expired is False
 
 
 def test_user_hashing_placeholder():


### PR DESCRIPTION
## Audit Wave I — test-gap nets

Pure test wave: two access-gating behaviours that already exist and are correct, but had **zero direct coverage**. No production code changes — these pin the behaviour so a future regression is caught.

### `Participant.is_expired` — 7 unit cases (`tests/unit/test_models.py`)
A multi-branch property that gates the resume endpoint (`410 Session has expired`) and the submission service (`ValidationError`). It had no direct test. New `TestParticipantIsExpired` covers, in-memory (no DB):
- completed sessions never expire (short-circuit), even with an ancient timestamp;
- a started session within / beyond the TTL window (`SESSION_TTL_DAYS`);
- the `last_step_reached_at → consented_at → created_at` fallback chain;
- the no-timestamp case (returns `False`, can't divide-by-nothing);
- **naive-vs-aware datetime handling** — some DB drivers return tz-less datetimes; the property normalises rather than raising a naive/aware comparison `TypeError`.

### `validate_link_token` — revoked + expired branches (`tests/integration/test_recruitment.py`)
Previously only the cross-study (security wave 3) and capacity (wave 5) branches of the token-validation chain were covered. Added:
- `test_revoked_link_is_rejected` — a deactivated link (`is_active=False`) → `403` at `GET /api/study/{slug}?link_token=`, with a positive control;
- `test_expired_link_is_rejected` — a link with a past `expires_at` → `403`, plus a future-expiry positive control.

`is_active` / `expires_at` are not settable via the create endpoint (guarded by `test_create_excludes_server_controlled_fields`), so the tests mutate them server-side then exercise the real participant-facing handler chain.

### Verification
- `make ci` green (lint + mypy/vulture/check-api/security/i18n + tests + build).
- New tests: 7 unit + 2 integration, all passing; existing recruitment/model tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)