### PR TITLE
perf(docker): speed up builds, startup and asset serving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,12 @@ run-frontend:
 seed:
 	cd backend && uv run python seed.py data/example-study.json
 
+# COMPOSE_BAKE delegates the build to buildx bake, which builds the backend and
+# frontend images in parallel instead of one after the other (ignored by Compose
+# older than 2.33). DOCKER_BUILDKIT=1 guarantees the cache mounts in both
+# Dockerfiles are honoured even if the daemon default was overridden.
 demo-up:
-	docker compose up --build -d --wait --wait-timeout 240
+	DOCKER_BUILDKIT=1 COMPOSE_BAKE=true docker compose up --build -d --wait --wait-timeout 240
 	@printf '\nQualis services are running.\nNext: make demo-seed\n\n'
 
 demo-seed:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,16 @@
+# syntax=docker/dockerfile:1.7
 FROM python:3.13-slim
 
 WORKDIR /app
+
+# UV_COMPILE_BYTECODE bakes the .pyc files for every dependency at build time,
+# so the first request doesn't pay for compiling them. UV_LINK_MODE=copy is
+# required because the uv cache lives on a BuildKit cache mount (a different
+# filesystem), where hardlinking would fail and emit a warning on every build.
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_CACHE_DIR=/cache/uv \
+    PYTHONUNBUFFERED=1
 
 # Runtime dependency for python-magic used by audio upload validation.
 RUN apt-get update \
@@ -8,24 +18,36 @@ RUN apt-get update \
         apt-get install -y --no-install-recommends libmagic1 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# Install uv. The version is pinned deliberately: with `:latest` this layer —
+# and therefore every layer below it, including the dependency sync — is
+# invalidated whenever upstream publishes a release, turning an unrelated
+# rebuild into a full dependency re-download.
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /usr/local/bin/uv
 
-# Install dependencies
-COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev
+# F-02-006 — drop root before anything writes to /app, so no later layer has to
+# `chown -R` the tree. A recursive chown after COPY duplicates every file it
+# touches (the venv included) into a new layer, inflating both build time and
+# image size. Fixed UID/GID so the BuildKit cache mount below can be owned by
+# this user.
+RUN groupadd --system --gid 1001 app \
+    && useradd --system --uid 1001 --gid app --home /app --shell /usr/sbin/nologin app \
+    && chown app:app /app \
+    && mkdir -p /cache/uv \
+    && chown -R app:app /cache
+USER app
+
+# Install dependencies. The cache mount keeps uv's download/build cache across
+# builds, so a lockfile change re-resolves without re-downloading the world.
+COPY --chown=app:app pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/cache/uv,uid=1001,gid=1001 \
+    uv sync --frozen --no-dev
 
 # Copy application code
-COPY . .
+COPY --chown=app:app . .
 
-# F-02-006 — drop root before CMD. The `app` user owns /app so `uv run`
-# can write to .venv and resolve project metadata; the system shell is
-# /usr/sbin/nologin to prevent interactive escalation if a future
-# attacker reaches `docker exec` privileges.
-RUN groupadd --system app \
-    && useradd --system --gid app --home /app --shell /usr/sbin/nologin app \
-    && chown -R app:app /app
-USER app
+# Pre-compile the application package too (UV_COMPILE_BYTECODE only covers the
+# venv), keeping first-request latency off the critical path.
+RUN .venv/bin/python -m compileall -q app
 
 # Run migrations and seed, then start the server.
 # Call the baked virtualenv directly instead of `uv run`: a bare `uv run`

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,6 +27,14 @@ class Settings(BaseSettings):
     # Database
     DATABASE_URL: str | None = None
 
+    # Connection-pool sizing. Leave unset to use the per-environment defaults
+    # in app.database (production stays conservative because managed Postgres
+    # plans cap concurrent connections around 5-10). Set explicitly when the
+    # database has headroom — a self-hosted or Docker Postgres allows 100, and
+    # an undersized pool serialises every concurrent request behind it.
+    DB_POOL_SIZE: int | None = None
+    DB_MAX_OVERFLOW: int | None = None
+
     # Frontend
     FRONTEND_URL: str = "http://localhost:5173"
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -33,14 +33,25 @@ if "sslmode=" in SQLALCHEMY_DATABASE_URL:
     q.pop("sslmode", None)
     SQLALCHEMY_DATABASE_URL = urlunparse(u._replace(query=urlencode(q, doseq=True)))
 
-# Pool sizing: production gets a larger pool; dev/test stays minimal
-# to fit within sandbox DB plans (~5-10 connection slots).
+# Pool sizing. Production stays conservative to fit sandbox DB plans (~5-10
+# connection slots); local/Docker runs target a self-hosted Postgres (100 slots
+# by default), where a 1+1 pool made every concurrent request queue behind two
+# connections. Both ends are overridable via DB_POOL_SIZE / DB_MAX_OVERFLOW so a
+# constrained deployment can dial them back down without a code change.
 _is_production = settings.ENVIRONMENT == "production"
+_default_pool_size = 3 if _is_production else 5
+_default_max_overflow = 2 if _is_production else 5
 
 engine_kwargs: dict[str, Any] = {
     "echo": False,
-    "pool_size": 3 if _is_production else 1,
-    "max_overflow": 2 if _is_production else 1,
+    "pool_size": (
+        _default_pool_size if settings.DB_POOL_SIZE is None else settings.DB_POOL_SIZE
+    ),
+    "max_overflow": (
+        _default_max_overflow
+        if settings.DB_MAX_OVERFLOW is None
+        else settings.DB_MAX_OVERFLOW
+    ),
     "pool_timeout": 30,
     "pool_recycle": 1800,
     "pool_pre_ping": True,  # Detect disconnected connections

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -14,6 +14,11 @@ services:
       interval: 5s
       timeout: 3s
       retries: 12
+      # Probe every second while starting so a restart is noticed promptly
+      # (Docker Engine 25+; older daemons ignore the key). Durability settings
+      # stay at the Postgres defaults here — unlike the dev Compose file.
+      start_interval: 1s
+      start_period: 30s
     restart: unless-stopped
 
   backend:
@@ -42,6 +47,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 12
+      start_interval: 1s
       start_period: 60s
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,15 @@
 services:
   db:
     image: postgres:16-alpine
+    # DEVELOPMENT ONLY — durability traded for speed. The 33 Alembic migrations
+    # and the demo seed are dominated by fsync latency; this data is disposable
+    # (`make demo-down` throws it away), so a crash losing it costs nothing.
+    # NEVER copy this to docker-compose.production.yml.
+    command: >
+      postgres
+      -c fsync=off
+      -c synchronous_commit=off
+      -c full_page_writes=off
     environment:
       POSTGRES_DB: qualis
       POSTGRES_USER: qualis
@@ -12,6 +21,12 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+      # Probe once a second while starting up: `interval` alone applies during
+      # boot too, so a service ready after 300ms still waited a full 5s to be
+      # noticed — repeated down a 4-service dependency chain. Requires Docker
+      # Engine 25+; older daemons ignore the key.
+      start_interval: 1s
+      start_period: 30s
 
   # Object storage for audio responses. The default demo seeds spoken audio
   # comments, which need an S3-compatible store. MinIO is reached internally by
@@ -33,6 +48,8 @@ services:
       interval: 5s
       timeout: 3s
       retries: 12
+      start_interval: 1s
+      start_period: 30s
 
   # One-shot: create the audio bucket, then exit.
   minio-init:
@@ -66,6 +83,11 @@ services:
       S3_SECRET_ACCESS_KEY: qualis-demo-secret
       S3_REGION: us-east-1
       S3_ADDRESSING_STYLE: path
+      # A local Postgres allows 100 connections; the conservative defaults
+      # (sized for managed sandbox plans) would queue every concurrent request
+      # behind a handful of connections.
+      DB_POOL_SIZE: "10"
+      DB_MAX_OVERFLOW: "10"
     depends_on:
       db:
         condition: service_healthy
@@ -82,13 +104,16 @@ services:
       interval: 5s
       timeout: 3s
       retries: 12
-      # On a cold first start the backend runs `uv sync` (dependency download)
-      # and Alembic migrations before serving /health — this can exceed the
-      # retry window (12 x 5s) on a fresh build. During start_period, failing
-      # probes do NOT mark the container unhealthy, so `make demo-up` no longer
-      # aborts the frontend on slow first boots. A probe that succeeds earlier
-      # flips the container healthy immediately.
-      start_period: 180s
+      start_interval: 1s
+      # On a cold first start the backend runs Alembic migrations before serving
+      # /health, which can exceed the retry window (12 x 5s). During
+      # start_period, failing probes do NOT mark the container unhealthy, so
+      # `make demo-up` no longer aborts the frontend on slow first boots. A
+      # probe that succeeds earlier flips the container healthy immediately.
+      # (The image no longer runs `uv sync` at container start — the CMD calls
+      # the baked venv directly — so this window no longer covers a dependency
+      # download.)
+      start_period: 120s
 
   frontend:
     build: ./frontend
@@ -106,7 +131,8 @@ services:
       interval: 2s
       timeout: 3s
       retries: 20
-      start_period: 5s
+      start_interval: 1s
+      start_period: 10s
 
 volumes:
   pgdata:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,10 +1,15 @@
+# syntax=docker/dockerfile:1.7
+
 # Build stage
 FROM node:24-alpine AS build
 
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+# The cache mount keeps npm's package store across builds: a lockfile change
+# then re-links from cache instead of re-downloading every tarball.
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --no-fund --no-audit
 
 COPY . .
 RUN npm run build

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,27 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # The upstream nginx image ships `gzip` commented out, so without this the
+    # whole bundle (~7 MB of JS/CSS/JSON) went over the wire uncompressed.
+    # `gzip_static` is a no-op unless the build also emits .gz files; keeping it
+    # off avoids surprising 404s on partially pre-compressed trees.
+    gzip on;
+    gzip_vary on;
+    gzip_comp_level 5;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_types
+        application/javascript
+        application/json
+        application/manifest+json
+        application/wasm
+        application/xml
+        image/svg+xml
+        text/css
+        text/javascript
+        text/plain
+        text/xml;
+
     # F-02-007 — Reject requests with unexpected Host headers. The official
     # nginx image renders this file through envsubst at container startup;
     # Docker Compose supplies a deployment-specific regex. The 444 status is
@@ -29,8 +50,27 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # SPA fallback — serve index.html for all non-file routes
+    # Vite emits content-hashed filenames under /assets/, so a given URL can
+    # never change content — cache it for a year and skip the revalidation
+    # round-trip entirely.
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # Translation bundles are NOT content-hashed (public/locales/<lang>/*.json
+    # ships under a stable path), so they only get a short cache with
+    # revalidation — a fixed typo must reach returning users.
+    location /locales/ {
+        add_header Cache-Control "public, max-age=300, must-revalidate";
+        try_files $uri =404;
+    }
+
+    # SPA fallback — serve index.html for all non-file routes.
+    # index.html itself must never be cached: it is the document that names the
+    # current hashed asset URLs, and a stale copy points at deleted files.
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
     }
 }


### PR DESCRIPTION
Four independent bottlenecks around the Docker demo path.

## Asset serving (`frontend/nginx.conf`)
- Enable `gzip`. The upstream nginx image ships it commented out, so the whole bundle (~7 MB of JS/CSS/JSON) went over the wire uncompressed.
- Cache `/assets/` for a year as `immutable` (Vite content-hashes those filenames), `/locales/` for 5 minutes with revalidation (those paths are **not** hashed — a fixed typo must reach returning users), and `index.html` not at all (it names the current hashed asset URLs, so a stale copy points at deleted files).

## Connection pool
- New `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` settings. The non-production default goes from 1+1 to 5+5, and the Docker demo uses 10+10: a local Postgres allows 100 connections, so the sandbox-sized default was queueing every concurrent request behind two of them. Production defaults are unchanged (3+2).

## Image builds
- BuildKit cache mounts for the uv and npm caches.
- Pin `uv` to 0.11.32 — `:latest` invalidated that layer and everything below it, including the dependency sync, on every upstream release.
- Create the `app` user before the copies and use `COPY --chown`, dropping the recursive `chown` that duplicated the whole tree (venv included) into an extra layer.
- `UV_COMPILE_BYTECODE` plus `compileall` on the app package.

## Container startup
- `start_interval` on every healthcheck (dev and production): `interval` alone also applies during boot, so a service ready in 300 ms still waited a full 5 s to be noticed — repeated down the dependency chain.
- Run the **dev** Postgres with `fsync` / `synchronous_commit` / `full_page_writes` off. The 33 migrations and the seed are fsync-bound and the data is disposable. Explicitly **not** applied to `docker-compose.production.yml`.
- Build both images in parallel via `COMPOSE_BAKE` in `make demo-up`.
- The backend `start_period` comment described a `uv sync` at container start that no longer happens; corrected and lowered 180s → 120s.

## Verification

Passed locally: `ruff check`, `ruff format --check`, `mypy app/` (83 files, 0 errors), YAML parse of both compose files, `check_installation_docs.py`, and the four `test_supply_chain_pinning.py` assertions replayed by hand (`USER app`, `groupadd`/`useradd`, `$host` guard, `return 444`).

**Not verified — needs a real run:** the authoring machine had no Docker daemon, no Postgres and no `node_modules`, so neither image was ever built and the backend test suite could not run (every error was a `Connect call failed` on `:5432`). Two plausible break points on first build: the `ghcr.io/astral-sh/uv:0.11.32` tag (derived from the latest PyPI version, not checked against the registry) and `start_interval`, which needs Docker Engine 25+ (older daemons ignore the key silently).

```
make demo-up && make demo-seed && make demo-smoke
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)