### PR TITLE
chore(docker): pin MinIO images to dated releases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,10 @@ services:
   # the backend at http://minio:9000 and served to the browser at
   # http://localhost:9000 (see S3_PUBLIC_ENDPOINT_URL on the backend).
   minio:
-    image: minio/minio:latest
+    # Pinned to a dated release rather than :latest — MinIO ships breaking
+    # changes between releases, and an unpinned demo silently drifts to a
+    # different server on any machine that pulls later. Bump deliberately.
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: qualis
@@ -57,7 +60,7 @@ services:
 
   # One-shot: create the audio bucket, then exit.
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
The demo stack pulled `minio/minio:latest` and `minio/mc:latest`. Pin both to the dated release each tag currently resolves to.

## This changes nothing today

Verified against the Docker Hub registry — the pinned tags and `latest` are the same image:

```
minio/minio  latest = RELEASE.2025-09-07T16-13-09Z  ->  sha256:14cea493d9a34af32f5
minio/mc     latest = RELEASE.2025-08-13T08-35-41Z  ->  sha256:a7fe349ef4bd8521fb8
```

So this is a lock on what already runs, not an upgrade or a downgrade.

## Why it is worth locking

`RELEASE.2025-09-07T16-13-09Z` is the most recent release published for `minio/minio`, and `RELEASE.2025-08-13T08-35-41Z` for `minio/mc` — MinIO has published nothing since. That is exactly the situation where `latest` is dangerous rather than convenient: whenever publishing resumes, the jump could be large, and MinIO narrowed its community offering over that same period. An unpinned demo would drift to a different server on any machine that pulls after that, silently, with no signal that anything changed.

Scope is the demo stack only — `docker-compose.production.yml` does not run MinIO.

## Newly verifiable

When this branch was first written, no CI job started MinIO, so a broken tag would only have surfaced for whoever ran `make demo-up` next. The `docker-stack` job added in #262 now builds the images and brings the whole Compose stack up on every PR, so these tags are exercised here.

Rebased onto current main; the earlier base predated #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
