### PR TITLE
chore(frontend): move TypeScript to the 6.0 line

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -95,7 +95,7 @@
                 "orval": "^7.17.2",
                 "postcss": "^8.4.35",
                 "tailwindcss": "^3.4.1",
-                "typescript": "^5.9.3",
+                "typescript": "^6.0.3",
                 "vite": "^8.0.0",
                 "vitest": "^4.1.5"
             },
@@ -6788,6 +6788,20 @@
                 "node": ">=18"
             }
         },
+        "node_modules/dependency-tree/node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -7682,6 +7696,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/filing-cabinet/node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/fill-range": {
@@ -11620,6 +11648,28 @@
                 "node": ">=10.17.0"
             }
         },
+        "node_modules/orval/node_modules/tsconfck": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.2.tgz",
+            "integrity": "sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==",
+            "deprecated": "unmaintained",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tsconfck": "bin/tsconfck.js"
+            },
+            "engines": {
+                "node": "^14.13.1 || ^16 || >=18"
+            },
+            "peerDependencies": {
+                "typescript": "^4.3.5 || ^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/outvariant": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -12132,6 +12182,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/precinct/node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/pretty-format": {
@@ -14423,27 +14487,6 @@
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "license": "Apache-2.0"
         },
-        "node_modules/tsconfck": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.2.tgz",
-            "integrity": "sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "tsconfck": "bin/tsconfck.js"
-            },
-            "engines": {
-                "node": "^14.13.1 || ^16 || >=18"
-            },
-            "peerDependencies": {
-                "typescript": "^4.3.5 || ^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/tsconfig-paths": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -14665,9 +14708,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -118,7 +118,7 @@
         "orval": "^7.17.2",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^8.0.0",
         "vitest": "^4.1.5"
     },


### PR DESCRIPTION
One line in `package.json`: `typescript` `^5.9.3` → `^6.0.3`.

## Why this was missed

TypeScript's `latest` tag jumped from the 5 line straight to `7.0.2`. The 6 line is stable — `6.0.2`, now `6.0.3` — but never carried the tag, so both `npm view typescript version` and `npm outdated` report only 7.0.2 and stay silent about it. The earlier dependency review leaned on those two commands, which is exactly why it did not surface.

It matters because 6.x sits inside dependency-cruiser's supported range (`typescript >=5.0.4 <7`) and 7 does not. 6.0.3 is therefore the newest version this toolchain can actually consume.

## No speed change, and none expected

`tsc -b --force`: 12.38 s on 5.9.3, 13.03 s on 6.0.3 — inside the noise. The 5.4x measured on 7.0.2 comes from the native Go port, not from the 6 line, which runs the same JavaScript compiler as 5.9.

## What it does buy

* **5.9 is a closed line** now that 6 and 7 are published. 6.0 is the one still receiving fixes.
* **6.x is the transition line** — it warns about everything 7 removes. It emits nothing on this codebase, which independently confirms the code is already 7-ready (consistent with 7.0.2 compiling clean once `baseUrl` was dropped in #262).

## Why not 7

The 7.0 package no longer ships the compiler as JavaScript. Measured on a clean install:

```
                       TypeScript 6.0.3    TypeScript 7.0.2
package exports              2248                  2
lib/ size                    24 MB              20 KB
createProgram             function          undefined
resolveModuleName         function          undefined
```

The only remaining exports are `version` and `versionMajorMinor`; `lib/` is reduced to a launcher that execs a native binary from `vendor/`. The CLI is unaffected — `tsc -b` works, and faster — but every tool that consumed TypeScript *as a library* gets an empty object.

dependency-cruiser is one of those: it imports the compiler to read tsconfigs, apply `moduleResolution: "bundler"`, resolve the `@/*` aliases and follow `import type` edges. Hence its refusal — "support for typescript@>=7 will follow when its API is published and stable". The pinned 17.4.3 is worse than a refusal: it reports `0 modules cruised` and exits 0, so the architecture contract would pass while checking nothing. knip 6 solved the same problem by dropping TypeScript for oxc.

## Lockfile note

npm nests a private `typescript@5.9.3` under `dependency-tree`, `filing-cabinet` and `precinct` — madge's dependency chain, which caps at `<6`. That is npm resolving the peer conflict correctly, and madge is a local visualisation helper (`npm run visualize:deps`), not a CI gate. dependency-cruiser resolves the root 6.0.3 and still cruises all 868 modules.

## Verified locally

tsc, biome, dependency-cruiser, knip, i18n, interpolation parity, API-client sync, `npm run build`, and 1492 vitest tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
