### PR TITLE
docs: index the three operator pages missing from the table of contents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@ Practical guides for accomplishing specific goals.
 |-------|-------------|
 | [Deployment](guides/deployment.md) | Deploy to Scalingo, Render, or Docker |
 | [S3 Setup](guides/s3-setup.md) | Configure S3-compatible storage for audio recordings |
+| [Running without S3](guides/running-without-s3.md) | What still works with no object storage, and what degrades |
+| [Running without SMTP](guides/running-without-smtp.md) | What still works with no mail server, and what degrades |
 
 ### For Contributors
 
@@ -58,6 +60,7 @@ Dry, accurate technical descriptions of the system.
 | [Admin Dashboard](reference/admin-dashboard.md) | Page-by-page catalog of the admin UI |
 | [Frontend Components](reference/components.md) | Sorting primitives + component index |
 | [Study Configuration Format](reference/study-configuration-format.md) | JSON import/export format specification |
+| [GDPR Memo for Self-Hosters](reference/gdpr-self-hosters.md) | Controls the software provides, for the operator's own DPIA and DPA |
 
 ---
 


### PR DESCRIPTION
`running-without-s3.md`, `running-without-smtp.md` and `gdpr-self-hosters.md` were not linked from `docs/README.md`, the entry point for the whole documentation set.

They were not orphaned: `storage_mode.py:16` and `smtp_mode.py:17` point to them from their startup log lines, `SECURITY.md` cites the GDPR memo, and tests assert all three exist. But that only surfaces them **once the operator has already hit the situation**. "Can I run Qualis without object storage?" and "what does the software give me for my DPIA?" are questions asked while choosing infrastructure — before anything is deployed, before any log line is read.

The two capability matrices join **For Operators** alongside Deployment and S3 Setup; the GDPR memo joins **Reference**.

Every markdown page under `docs/` is now reachable from the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)