### PR TITLE
chore(dependabot): create the configured labels, block two major lines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,22 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-zoom-pan-pinch"
         update-types: ["version-update:semver-major"]
+      # tailwind-merge v3 supports Tailwind CSS v4 only — its published
+      # README says "if you use Tailwind v3, use tailwind-merge v2.6.0".
+      # Nothing enforces this: there is no peerDependency on tailwindcss
+      # and no type error, so CI goes green while class merging silently
+      # mis-handles the utilities renamed between v3 and v4 (shadow-sm →
+      # shadow-xs, outline-none → outline-hidden, …). PR #190 was blocked
+      # for exactly this. Paired with the tailwindcss entry above: lift
+      # both together during the Tailwind v4 migration, never separately.
+      - dependency-name: "tailwind-merge"
+        update-types: ["version-update:semver-major"]
+      # @types/node must track the Node line the project actually runs
+      # (24 LTS — see .nvmrc, engines, backend/Dockerfile, ci.yml). #257
+      # moved the types to 26, which stops TypeScript from flagging APIs
+      # the runtime does not have. Lift when the project moves to Node 26.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Two fixes to the dependency-update process, both surfaced while triaging the 13 open Dependabot PRs.

## Labels

`dependabot.yml` asks for `dependencies`, `backend`, `frontend` and `ci`. **None existed** — the repository had only GitHub's defaults plus release-please's. Dependabot therefore posted *"The following labels could not be found"* on every PR it opened, which is where its comment budget went instead of anything useful.

The four labels are now created on the repository, so no config change is needed here.

## Two major lines blocked

Joining the existing zod / zustand / tailwindcss / react-zoom-pan-pinch entries:

- **`tailwind-merge`** — v3 supports Tailwind CSS v4 only, and the project is deliberately staying on Tailwind v3. Nothing mechanical catches this: no `peerDependency`, no type error, so CI passes while class merging silently mis-handles the utilities renamed between v3 and v4 (`shadow-sm` → `shadow-xs`, `outline-none` → `outline-hidden`, …). This is why #190 is blocked. Deliberately paired with the `tailwindcss` entry — lifting one without the other reintroduces the mismatch.
- **`@types/node`** — must track the Node line the project runs. `.nvmrc`, `engines`, `backend/Dockerfile` and `ci.yml` all say 24 LTS; #257 moved the types to 26, so TypeScript stopped flagging APIs absent at runtime. Realigned on the 24 line in #265.

Both entries carry the rationale and the condition for lifting them.

Once this merges, #190 can be closed — the ignore rule stops Dependabot recreating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)