### PR TITLE
ci(security): fail loudly when the gitleaks download does not succeed

### DIFF
--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -37,7 +37,14 @@ jobs:
         run: |
           set -e
           GITLEAKS_VERSION=8.21.2
-          curl -sSL -o /tmp/gitleaks.tar.gz \
+          # --fail makes curl exit non-zero on an HTTP error instead of writing
+          # the error body to the output file, where it only surfaced later as
+          # `gzip: stdin: not in gzip format` from tar — a message that names
+          # the symptom and hides the cause. --retry covers the transient
+          # release-download failures the runners hit (see the 2026-07-24
+          # failure on main, green on a plain re-run).
+          curl -sSL --fail --retry 3 --retry-delay 5 --retry-all-errors \
+            -o /tmp/gitleaks.tar.gz \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           mkdir -p /tmp/gitleaks
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp/gitleaks


### PR DESCRIPTION
The Gitleaks job fetched its binary with `curl -sSL`, without `--fail`. curl then exits 0 on an HTTP error and writes the error body to `/tmp/gitleaks.tar.gz`, so the failure surfaced one line later as `gzip: stdin: not in gzip format` from tar — a message naming the symptom while hiding the cause.

It cost a round of investigation on `main` at 2026-07-24T16:27 ([run 30109134748](https://github.com/jvastenaekels/qualis/actions/runs/30109134748)), where the job read as a **secret-scan failure** but was in fact a download that never happened.

## Both paths reproduced

Against a deliberately wrong asset URL:

| | behaviour |
|---|---|
| **before** | curl exits **0**, writes ASCII into the `.tar.gz`, tar fails with `gzip: stdin: not in gzip format` |
| **after** | curl exits **22**, `The requested URL returned error: 404`, no file written, `set -e` stops the step on the real cause |

## Retries

Also added `--retry 3 --retry-delay 5 --retry-all-errors`. The observed failure was transient — a plain re-run went green, and the asset returns HTTP 200 — so retrying removes the class of flake that prompted this. `--retry-all-errors` extends retries to 4xx, which costs ~15s on a genuinely missing asset and buys resilience on the transient states the runners actually hit.

## Verification

The full command downloads, extracts, and reports `gitleaks version` 8.21.2. The workflow YAML parses with its five jobs intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)