### PR TITLE
fix(security): patch the postcss advisory, accept the react-router one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,10 +219,19 @@ jobs:
         # xlsx CVEs are accepted: SheetJS Community has no fix and Qualis only
         # WRITES XLSX (analysisXlsxExport.ts), never parses untrusted input.
         # See SECURITY.md ("xlsx (SheetJS Community Edition)") for full rationale.
+        #
+        # GHSA-qwww-vcr4-c8h2 (react-router, high) is accepted: the CSRF bypass
+        # it describes is reachable only in React Server Components mode. Qualis
+        # is a client-side SPA — App.tsx mounts createBrowserRouter with
+        # RouterProvider and there is no server rendering, so the vulnerable
+        # path does not exist in this build. The fix ships in react-router 8.0,
+        # a major upgrade of the routing layer; revisit this entry when that
+        # migration is scheduled, and drop it as soon as we are on 8.x.
+        #
         # Fail only on high+ advisories outside the allowlist.
         run: |
           set -e
-          accepted='GHSA-4r6h-8v6p-xvw6|GHSA-5pgg-2g8v-p4x9'
+          accepted='GHSA-4r6h-8v6p-xvw6|GHSA-5pgg-2g8v-p4x9|GHSA-qwww-vcr4-c8h2'
           audit_json=$(npm audit --json) || true
           unknown=$(echo "$audit_json" | jq -r --arg a "$accepted" '
             [.vulnerabilities | to_entries[].value

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -94,9 +94,18 @@ jobs:
         # workflow uses the simpler --audit-level=high gate per the
         # plan spec — any finding above the allowlist is reflected
         # there too.
+        #
+        # GHSA-qwww-vcr4-c8h2 (react-router, high) is accepted: the CSRF
+        # bypass it describes is reachable only in React Server Components
+        # mode. Qualis is a client-side SPA — App.tsx mounts
+        # createBrowserRouter with RouterProvider and there is no server
+        # rendering, so the vulnerable path does not exist in this build.
+        # The fix ships in react-router 8.0, a major upgrade of the routing
+        # layer; revisit when that migration is scheduled. Keep this list in
+        # sync with the identical one in ci.yml.
         run: |
           set -e
-          accepted='GHSA-4r6h-8v6p-xvw6|GHSA-5pgg-2g8v-p4x9'
+          accepted='GHSA-4r6h-8v6p-xvw6|GHSA-5pgg-2g8v-p4x9|GHSA-qwww-vcr4-c8h2'
           audit_json=$(npm audit --json) || true
           unknown=$(echo "$audit_json" | jq -r --arg a "$accepted" '
             [.vulnerabilities | to_entries[].value

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11119,9 +11119,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -11915,9 +11915,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -11934,7 +11934,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },


### PR DESCRIPTION
Two high-severity npm advisories published **2026-07-24**, after `main` last went green. They fail both the `npm audit` job in `security-scans.yml` and the `Security SCA` step in `ci.yml` — the same check in two places. `main` is currently red because of them, as is #279.

| Advisory | Package | Was | Action |
|---|---|---|---|
| [`GHSA-r28c-9q8g-f849`](https://github.com/advisories/GHSA-r28c-9q8g-f849) | postcss | 8.5.15 | **patched** → 8.5.23 |
| [`GHSA-qwww-vcr4-c8h2`](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) | react-router | 7.18.1 | **accepted** |

## postcss — patched

Path traversal in source-map auto-loading via `sourceMappingURL`. The declared range was already `^8.4.35`, so the fix needed nothing but a lockfile move — past the 8.5.18 floor, carrying `nanoid` 3.3.12 → 3.3.16 with it. `package.json` is untouched.

Real exposure was low: postcss processes the project's own CSS at build time, not third-party input. The fix cost nothing, so it is applied rather than argued about.

## react-router — accepted

The CSRF bypass it describes is reachable **only in React Server Components mode**. Qualis is a client-side SPA: `App.tsx:83` mounts `createBrowserRouter` with `RouterProvider`, nothing renders on the server, so the vulnerable path does not exist in this build.

The fix ships in **react-router 8.0** — a major upgrade of the routing layer, on a dependency raised to 7.18.1 only hours ago in #254. Trading that migration, under time pressure, for a vulnerability this architecture cannot reach is the worse risk.

The GHSA is added to the `accepted` list in both workflows, each carrying the rationale and the condition for removal (drop it on the move to react-router 8.x). Recorded in-place rather than in `SECURITY.md`: the workflow comments point at a `SECURITY.md` allowlist section that does not actually exist, and whoever debugs this gate reads the workflow.

## Verification

The CI's exact npm-audit filter, replayed locally, reports *"All high+ advisories are within the SECURITY.md allowlist"*. Both workflow YAMLs parse (8 and 5 jobs). The frontend build succeeds on postcss 8.5.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)