### PR TITLE
ci(security): retry the semgrep install around the whole command

### DIFF
--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -141,7 +141,27 @@ jobs:
         # 1.95 imports pkg_resources at startup; Python 3.12+ slim envs
         # don't ship setuptools by default. Pin a recent version that
         # uses importlib.metadata instead.
-        run: pip install semgrep==1.150.0
+        #
+        # Retried at the shell level, not with pip's own --retries: that
+        # option already defaults to 5 and covers only *establishing* a
+        # connection. The 2026-07-24 failure on main was a stream that died
+        # mid-transfer (ProtocolError: IncompleteRead, 11 MB of 50 MB read),
+        # which pip surfaces instead of retrying. semgrep is a ~50 MB wheel,
+        # so a truncated download is the failure mode to expect. --timeout 60
+        # (default 15s) also gives a stalled socket room to recover.
+        run: |
+          set -e
+          for attempt in 1 2 3; do
+            if pip install --timeout 60 semgrep==1.150.0; then
+              exit 0
+            fi
+            if [ "$attempt" = "3" ]; then
+              echo "pip install semgrep failed after 3 attempts"
+              exit 1
+            fi
+            echo "attempt $attempt failed — retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
       - name: Run semgrep (OWASP Top Ten)
         # --error: exit non-zero on any finding (semgrep's own "error"
         # severity is high+). The OWASP Top Ten ruleset is the spec


### PR DESCRIPTION
`pip install semgrep==1.150.0` failed on `main` at 2026-07-24T17:47 ([run 30114377699](https://github.com/jvastenaekels/qualis/actions/runs/30114377699)):

```
ProtocolError: Connection broken:
IncompleteRead(11534336 bytes read, 38958289 more expected)
```

A plain re-run went green, so the wheel was fine — the transfer was not.

## Why not `pip --retries`

That option **already defaults to 5**, and it covers *"attempts to establish a new HTTP connection"*. The connection here was established and then died 11 MB into a ~50 MB wheel, which pip surfaces rather than retries. Adding `--retries` would have read like a fix while changing nothing.

The retry has to wrap the whole command, so a truncated download starts over. Three attempts, 10s/20s backoff, plus `--timeout 60` (default 15s) to give a stalled socket room before it is abandoned.

`if pip install; then` rather than `pip install && break` — the `if` form is explicitly exempt from `set -e`, so a failed attempt cannot abort the step before the retry fires.

## Verification

All three paths tested against a stubbed command:

| case | result |
|---|---|
| succeeds immediately | exits 0 |
| fails persistently | message + exit 1 after three attempts |
| fails twice, then succeeds | exits 0 on the third |

Workflow YAML parses with its five jobs.

## Note

This is the second instance of the same fragility, after the gitleaks download in #279. Both tool installs pull binaries over the network; nothing else in this workflow does, so this should close the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)