### PR TITLE
chore(dependabot): block pydantic-core and babel/plugin-transform-runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,14 @@ updates:
     # bump to mando>=0.8 produces an unsolvable pip resolution and breaks
     # the Scalingo deploy (PR #132 did exactly this). Its version is
     # dictated by radon — never bump it independently.
+    #
+    # `pydantic-core` is pinned exactly by pydantic (2.13.4 requires
+    # `pydantic-core==2.46.4`). A standalone bump to 2.47.0 is unsatisfiable
+    # and fails the Dependency Sync gate (PR #287). Its version is dictated
+    # by pydantic — it moves when pydantic moves, never on its own.
     ignore:
       - dependency-name: "mando"
+      - dependency-name: "pydantic-core"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -76,6 +82,12 @@ updates:
       # move the whole babel set together, or after Rolldown drops the babel
       # bridge, then lift this.
       - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      # @babel/plugin-transform-runtime is the other half of that same set.
+      # Its 8.0 `peer @babel/core@^8.0.0` is the mirror conflict: with core
+      # pinned at 7 (above), transform-runtime 8 fails npm ci ERESOLVE the
+      # other way (PR #288). Lift together with @babel/core, never alone.
+      - dependency-name: "@babel/plugin-transform-runtime"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Two dependencies whose versions are dictated by a parent, not chosen independently — each opened a PR that cannot resolve.

- **pydantic-core** (pip): pinned exactly by pydantic (2.13.4 requires `pydantic-core==2.46.4`). The standalone 2.47.0 bump is unsatisfiable, failing Dependency Sync (#287). Joins `mando`, the existing radon-pinned transitive.
- **@babel/plugin-transform-runtime** (npm): its 8.0 `peer @babel/core@^8` mirrors the @babel/core block — with core held at 7, transform-runtime 8 fails npm ci ERESOLVE the other way (#288). Both babel entries lift together or not at all.

Closes #287. Closes #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)