### PR TITLE
chore: move the Node toolchain to 26, aligning engines with @types/node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: "26"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
@@ -262,7 +262,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: "26"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
@@ -300,7 +300,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: "26"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
@@ -384,7 +384,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: "26"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: "26"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/krypton
+26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Open-source platform for conducting Q-methodology research. Monorepo with a Fast
 
 - **Backend:** Python 3.14, FastAPI, SQLAlchemy (async), PostgreSQL 18, Alembic, Pydantic
 - **Frontend:** React 19, TypeScript, Vite, Tailwind CSS, Radix UI, dnd-kit, react-hook-form, Zustand, react-i18next
-- **Tooling:** uv (Python), npm (Node 24), Biome (lint/format), Ruff (Python lint/format), Vitest, Playwright
+- **Tooling:** uv (Python), npm (Node 26), Biome (lint/format), Ruff (Python lint/format), Vitest, Playwright
 
 ## Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export
 # Toolchain versions CI exercises. Keep in sync with .python-version, .nvmrc,
 # backend/Dockerfile, docker-compose.yml and .github/workflows/ci.yml.
 PYTHON_VERSION := 3.14
-NODE_MAJOR := 24
+NODE_MAJOR := 26
 POSTGRES_MAJOR := 18
 
 # Fail early, and say why. Without this the toolchain mismatch only surfaces

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -8,7 +8,7 @@ For the architectural overview, see [`../explanation/architecture.md`](../explan
 
 ## Prerequisites
 
-- Git, GNU Make, Python 3.14, [uv](https://docs.astral.sh/uv/), Node.js 24,
+- Git, GNU Make, Python 3.14, [uv](https://docs.astral.sh/uv/), Node.js 26,
   PostgreSQL 18, and a Unix-like environment (Linux, macOS, or WSL).
   These are the versions CI exercises; `make install` checks them and stops
   with a clear message if the toolchain does not match.

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -20,7 +20,7 @@ Developer setup has moved out of the tutorials section into the contributing gui
 ## Prerequisites
 
 - **Researchers:** A modern web browser (Chrome, Firefox, Safari, or Edge). No software installation required if using a hosted instance.
-- **Developers:** Git, Python 3.14, Node.js 24, and PostgreSQL 18 — the versions CI exercises. See the [Development Workflow guide](../contributing/development.md) for full setup instructions.
+- **Developers:** Git, Python 3.14, Node.js 26, and PostgreSQL 18 — the versions CI exercises. See the [Development Workflow guide](../contributing/development.md) for full setup instructions.
 
 ## How to Use These Tutorials
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Build stage
-FROM node:24-alpine AS build
+FROM node:26-alpine AS build
 
 WORKDIR /app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -100,7 +100,7 @@
                 "vitest": "^4.1.5"
             },
             "engines": {
-                "node": "24.x"
+                "node": "26.x"
             }
         },
         "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
     "version": "0.7.3",
     "type": "module",
     "engines": {
-        "node": "24.x"
+        "node": "26.x"
     },
     "scripts": {
         "dev": "vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "qualis-root",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qualis-root",
+      "version": "0.7.1",
       "hasInstallScript": true,
       "dependencies": {
         "immer": "^11.1.3"
       },
       "engines": {
-        "node": "24.x"
+        "node": "26.x"
       }
     },
     "node_modules/immer": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "echo 'Postinstall root skipping'"
   },
   "engines": {
-    "node": "24.x"
+    "node": "26.x"
   },
   "dependencies": {
     "immer": "^11.1.3"


### PR DESCRIPTION
#257 moved `@types/node` to 26 while `engines` / `.nvmrc` / Dockerfile / CI stayed on 24, so the types described APIs the declared runtime did not have. Rather than pin the types back, this aligns the whole toolchain on 26 so `engines: 26.x` is actually true where it runs.

## Every Node-version declaration, moved together

| Site | 24 → 26 |
|---|---|
| `package.json` + `frontend/package.json` engines | `26.x` (both lockfile mirrors regenerated) |
| `.nvmrc` | `lts/krypton` → `26` |
| `frontend/Dockerfile` build stage | `node:26-alpine` |
| `ci.yml` (4×) + `security-scans.yml` (1×) | `node-version: "26"` |
| `Makefile` preflight `NODE_MAJOR` | `26` |
| CLAUDE.md, docs/tutorials, docs/contributing | Node.js 26 |

## Why this is low-risk

**No production Node runtime is affected.** The backend is Python; the frontend Dockerfile uses Node only to *build* the SPA, which nginx then serves as static files. Node here is dev + CI + build-time only.

Node 26.5.0 is **Current, not yet LTS** (LTS lands Oct 2026), which is why `.nvmrc` uses the bare major `26` — there is no `lts/*` codename to point at yet. Given there is no prod runtime, adopting a pre-LTS release for tooling is a deliberate, contained choice.

The `@types/node` major is currently blocked in `dependabot.yml`; that block can be lifted now that the runtime matches — left as a follow-up rather than bundled here.

## Verification

`make preflight` silent on Node 26, `npm ci`, `tsc -b`, biome, and the frontend build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)