### PR TITLE
chore(dependabot): unblock the @types/node major line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,12 +69,6 @@ updates:
       # both together during the Tailwind v4 migration, never separately.
       - dependency-name: "tailwind-merge"
         update-types: ["version-update:semver-major"]
-      # @types/node must track the Node line the project actually runs
-      # (24 LTS — see .nvmrc, engines, backend/Dockerfile, ci.yml). #257
-      # moved the types to 26, which stops TypeScript from flagging APIs
-      # the runtime does not have. Lift when the project moves to Node 26.
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
       # @babel/core 8 is a coordinated migration, not a drop-in bump. The
       # toolchain still holds @babel/plugin-transform-runtime@7, whose
       # `peer @babel/core@^7.0.0-0` conflicts with core 8, so npm ci fails


### PR DESCRIPTION
The block was explicitly conditioned on the runtime move — *"Lift when the project moves to Node 26"* — which #300 completed. `engines`, `.nvmrc`, `frontend/Dockerfile` and CI are all on Node 26 now, so the 26.x types describe APIs that actually exist and Dependabot can track the `@types/node` major again.

Leaves the two babel entries and the pinned-transitive blocks (`mando`, `pydantic-core`) in place — those conditions still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)