### PR TITLE
fix(security): accept the brace-expansion DoS advisory (dev/write-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,21 @@ jobs:
         # a major upgrade of the routing layer; revisit this entry when that
         # migration is scheduled, and drop it as soon as we are on 8.x.
         #
+        # GHSA-mh99-v99m-4gvg (brace-expansion, high) is accepted: an
+        # unbounded-expansion DoS from a maliciously crafted brace pattern.
+        # Every instance is dev/build tooling (orval, spectral, glob/minimatch)
+        # or exceljs's archiver on the XLSX write path — none expands an
+        # untrusted pattern, so the trigger does not exist here (same
+        # write-only/trusted-input basis as xlsx). Fix is brace-expansion
+        # 5.0.8, but three majors are in the tree (1.1.16 / 2.1.2 / 5.0.7) and
+        # a global override collides with the minimatch@3.1.5 → 1.1.16 pin,
+        # risking a broken toolchain for an untriggerable DoS. Keep in sync
+        # with security-scans.yml.
+        #
         # Fail only on high+ advisories outside the allowlist.
         run: |
           set -e
-          accepted='GHSA-4r6h-8v6p-xvw6|GHSA-5pgg-2g8v-p4x9|GHSA-qwww-vcr4-c8h2'
+          accepted='GHSA-4r6h-8v6p-xvw6|GHSA-5pgg-2g8v-p4x9|GHSA-qwww-vcr4-c8h2|GHSA-mh99-v99m-4gvg'
           audit_json=$(npm audit --json) || true
           unknown=$(echo "$audit_json" | jq -r --arg a "$accepted" '
             [.vulnerabilities | to_entries[].value

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -108,11 +108,24 @@ jobs:
         # createBrowserRouter with RouterProvider and there is no server
         # rendering, so the vulnerable path does not exist in this build.
         # The fix ships in react-router 8.0, a major upgrade of the routing
-        # layer; revisit when that migration is scheduled. Keep this list in
-        # sync with the identical one in ci.yml.
+        # layer; revisit when that migration is scheduled.
+        #
+        # GHSA-mh99-v99m-4gvg (brace-expansion, high) is accepted: an
+        # unbounded-expansion DoS triggered by a maliciously crafted brace
+        # pattern. Every instance in the tree is dev/build tooling (orval
+        # codegen, spectral OpenAPI linting, glob/minimatch) or exceljs's
+        # archiver on the XLSX *write* path — none expands an untrusted,
+        # attacker-supplied pattern, so the trigger does not exist here (same
+        # write-only/trusted-input basis as the xlsx acceptance above). The
+        # fix is brace-expansion 5.0.8, but the tree holds three majors
+        # (1.1.16 / 2.1.2 / 5.0.7) and a global override collides with the
+        # existing minimatch@3.1.5 → 1.1.16 pin, risking a broken dev
+        # toolchain for an untriggerable DoS. Revisit if a shipped/runtime
+        # path ever expands untrusted braces. Keep this list in sync with the
+        # identical one in ci.yml.
         run: |
           set -e
-          accepted='GHSA-4r6h-8v6p-xvw6|GHSA-5pgg-2g8v-p4x9|GHSA-qwww-vcr4-c8h2'
+          accepted='GHSA-4r6h-8v6p-xvw6|GHSA-5pgg-2g8v-p4x9|GHSA-qwww-vcr4-c8h2|GHSA-mh99-v99m-4gvg'
           audit_json=$(npm audit --json) || true
           unknown=$(echo "$audit_json" | jq -r --arg a "$accepted" '
             [.vulnerabilities | to_entries[].value


### PR DESCRIPTION
[GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (brace-expansion, high) was published **2026-07-24** and now fails the npm-audit gate in both `ci.yml` and `security-scans.yml` — on main and on any open PR, unrelated to what the PR changes (it surfaced on #301, a one-line dependabot.yml edit). It is an unbounded-expansion DoS triggered by a maliciously crafted brace pattern.

## Accepted, not patched

Every instance in the tree is **dev/build tooling** (orval codegen, spectral OpenAPI linting, glob/minimatch) or **exceljs's archiver on the XLSX write path** — none expands an untrusted, attacker-supplied pattern, so the trigger does not exist here. Same write-only / trusted-input basis the codebase already uses for the xlsx advisories.

The fix is brace-expansion 5.0.8, but the tree holds three majors (1.1.16 / 2.1.2 / 5.0.7); 1.x and 2.x have no in-line patch, so clearing it needs a global override to 5.0.8, which collides with the existing `minimatch@3.1.5 → 1.1.16` pin and risks breaking the dev toolchain across four majors — a poor trade for a DoS that cannot be triggered here. Verified a naive override does not even re-resolve cleanly.

Added to the `accepted` allowlist in both workflows, kept in sync, each with rationale and revisit condition.

**Verified:** the CI's exact npm-audit filter, replayed locally, reports *"All high+ advisories are within the allowlist"*; both YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)