### PR TITLE
ci: boot the production Compose stack with throwaway secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,94 @@ jobs:
         if: always()
         run: docker compose down --volumes
 
+  docker-production-stack:
+    name: Production Compose Stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # docker-compose.production.yml is never otherwise exercised: it gates every
+    # value behind `${VAR:?}`, so it cannot be started without a full secret set,
+    # and CI had none. That left its own risks unchecked — the production Postgres
+    # mount (same relocation as dev but a different file), the backend booting in
+    # ENVIRONMENT=production (stricter CORS, no fsync-off tuning), the Host
+    # allowlist that only exists in the production config, and the whole
+    # `${VAR:?}` interpolation itself. This job supplies throwaway secrets and
+    # boots it.
+    env:
+      # Real secrets are generated per-run below; these are the non-secret ones.
+      QUALIS_HTTP_PORT: "3000"
+      FRONTEND_URL: http://localhost:3000
+      ALLOWED_ORIGINS: http://localhost:3000
+      # nginx checks $host (port stripped) against this regex; allow loopback.
+      QUALIS_ALLOWED_HOST_PATTERN: "^(localhost|127[.]0[.]0[.]1)$"
+      ADMIN_EMAIL: admin@ci.example.com
+      COMPOSE_FILE: docker-compose.production.yml
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate throwaway secrets
+        # init_db refuses to bootstrap in ENVIRONMENT=production if ADMIN_PASSWORD
+        # is a known demo value, so a random one is required — which also means
+        # this job exercises that production guard for real. openssl rand keeps
+        # the secrets out of the workflow file and out of the logs.
+        run: |
+          {
+            echo "SECRET_KEY=$(openssl rand -hex 32)"
+            echo "IP_HASH_SALT=$(openssl rand -hex 16)"
+            echo "QUALIS_DB_PASSWORD=$(openssl rand -hex 16)"
+            echo "ADMIN_PASSWORD=$(openssl rand -hex 24)"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate the compose file parses and interpolates
+        # `config` fails loudly if any ${VAR:?} is unset or the YAML is malformed,
+        # separating a config error from a boot error in the next step.
+        run: docker compose config >/dev/null
+
+      - name: Build and start the production stack
+        run: docker compose up --build -d --wait --wait-timeout 240
+
+      - name: Assert the db runs PostgreSQL 18 with the production mount
+        run: |
+          set -e
+          pg_major=$(docker compose exec -T db postgres --version | grep -oE '[0-9]+' | head -1)
+          echo "db PostgreSQL: $pg_major"
+          [ "$pg_major" = "18" ] || { echo "expected PostgreSQL 18"; exit 1; }
+          # The production mount is /var/lib/postgresql; the live cluster must sit
+          # under it, at the relocated 18 PGDATA, or a `down` would drop the data.
+          docker compose exec -T db test -d /var/lib/postgresql/18/docker \
+            || { echo "PGDATA not under the mounted volume"; exit 1; }
+
+      - name: Smoke-test through the published port
+        # The frontend has no healthcheck in the production compose, so --wait
+        # only proved it started; this proves nginx actually serves and its
+        # /health proxy reaches the backend.
+        run: |
+          set -e
+          for path in / /health; do
+            code=$(curl -fsS -o /dev/null -w '%{http_code}' "http://127.0.0.1:3000$path")
+            echo "GET $path -> $code"
+            [ "$code" = "200" ] || { echo "expected 200 on $path"; exit 1; }
+          done
+
+      - name: Assert the Host allowlist rejects a foreign Host
+        # F-02-007 lives only in the production nginx config. Until now it was
+        # asserted statically (test_supply_chain_pinning); this is its first
+        # runtime check. A disallowed Host hits `return 444`, which closes the
+        # connection with no response, so curl fails — that failure is the pass.
+        run: |
+          set -e
+          if curl -fsS -o /dev/null -H 'Host: evil.example.com' http://127.0.0.1:3000/; then
+            echo "foreign Host was served — allowlist not enforced"; exit 1
+          fi
+          echo "foreign Host rejected as expected"
+
+      - name: Container logs on failure
+        if: failure()
+        run: docker compose logs --tail 200
+
+      - name: Tear down
+        if: always()
+        run: docker compose down --volumes
+
   frontend-lint:
     name: Frontend Lint & Quality
     runs-on: ubuntu-latest


### PR DESCRIPTION
`docker-compose.production.yml` was never started anywhere. It gates every value behind `${VAR:?}`, so it cannot boot without a full secret set, and CI had none. The dev `docker-stack` job (added in #262) covers the images and the dev compose file, but the production file has its own surface that nothing exercised.

This job generates throwaway secrets with `openssl rand` and boots the stack, covering what is production-only:

* **`${VAR:?}` interpolation** — a `config` step fails loudly if any of the nine required variables is unset or the YAML is malformed, separating a config error from a boot error.
* **`ENVIRONMENT=production`** — stricter CORS, and Postgres at default durability (no fsync-off tuning the dev file uses). The random `ADMIN_PASSWORD` is required, not incidental: `init_db` refuses to bootstrap in production if it recognises a demo password, so this exercises that guard end to end.
* **The production Postgres mount** — asserts both the major version (18) and that the live PGDATA (`/var/lib/postgresql/18/docker`) sits under the mounted volume. That relocation is the exact thing that, if the mount were wrong, would make `docker compose down` silently drop the data.
* **The Host allowlist (F-02-007)** — until now asserted only statically in `test_supply_chain_pinning`. This is its first runtime check: a foreign `Host` header hits `return 444`, the connection closes with no response, curl fails, and that failure is the pass.

## Verification

Not run locally — there is no Docker on the machine this was prepared on, which is the very gap the job closes. Its first real execution is this PR. What was checkable here passes: the YAML parses, all nine `${VAR:?}` are supplied, the Host regex matches loopback, and the supply-chain pinning test still passes (the job uses only `actions/checkout`, unpinned by policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
