### PR TITLE
fix(hub): show projects and cross-project studies on the Researcher Hub

### DIFF
--- a/backend/app/routers/admin/studies.py
+++ b/backend/app/routers/admin/studies.py
@@ -103,6 +103,45 @@ async def list_studies(
     )
 
 
+# Declared before "/{slug}" so the literal path is not captured as a slug.
+@router.get("/across-projects", response_model=list[StudyListRead])
+async def list_studies_across_projects(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[Study]:
+    """Every study in the projects the current user belongs to.
+
+    The Researcher Hub lists projects together with their studies before any
+    single project is selected, so it cannot use the list endpoint above — that
+    one is scoped to one project via the X-Project-ID header and 400s without
+    it. This returns all studies the user can reach, each carrying project_id so
+    the client can group them by project.
+
+    Access mirrors the projects list: membership-based, not superuser-wide, so a
+    superuser sees only the projects they actually belong to. Loading options
+    match the per-project list (participant_count is a column_property computed
+    in the query; statements/recruitment_links are never serialised by
+    StudyListRead, so they are lazyloaded to keep them off the query).
+    """
+    query = (
+        select(Study)
+        .join(ProjectMember, ProjectMember.project_id == Study.project_id)
+        .where(ProjectMember.user_id == current_user.id)
+        .options(
+            selectinload(Study.project),
+            lazyload(Study.statements),
+            lazyload(Study.recruitment_links),
+        )
+        .order_by(Study.created_at.desc())
+        # A safety cap; a single researcher's study count sits far below this,
+        # and the hub groups whatever it receives. Documented rather than paged
+        # because the hub has no pagination affordance.
+        .limit(500)
+    )
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
 @router.get("/{slug}", response_model=StudyRead)
 async def get_study(
     study: Study = Depends(check_study_permission(StudyRole.viewer)),

--- a/backend/tests/integration/test_studies.py
+++ b/backend/tests/integration/test_studies.py
@@ -172,6 +172,81 @@ class TestStudyAdmin:
         assert "statements" not in item
         assert "recruitment_links" not in item
 
+    async def test_across_projects_returns_studies_without_project_header(
+        self,
+        client: AsyncClient,
+        test_user: User,
+        seed_study: Study,
+        auth_token_factory,
+    ):
+        """The Researcher Hub case: no X-Project-ID, yet studies come back.
+
+        The per-project list endpoint 400s without the header; this one must
+        not, and every study must carry project_id so the hub can group them.
+        """
+        headers = auth_token_factory(test_user)  # deliberately no X-Project-ID
+        response = await client.get(
+            "/api/admin/studies/across-projects", headers=headers
+        )
+        assert response.status_code == 200
+        studies = response.json()
+        assert isinstance(studies, list)
+        item = next(s for s in studies if s["slug"] == seed_study.slug)
+        assert item["project_id"] == seed_study.project_id
+        # Same lighter shape as the per-project list (audit H1).
+        assert "translations" in item
+        assert "statements" not in item
+
+    async def test_across_projects_is_membership_scoped(
+        self,
+        client: AsyncClient,
+        auth_token_factory,
+        user_factory,
+        project_factory,
+        study_factory,
+    ):
+        """A user sees studies only in projects they belong to.
+
+        Access mirrors the projects list — membership-based, not superuser-wide.
+        An outsider with their own project must not see another user's study.
+        """
+        owner = await user_factory()
+        outsider = await user_factory()
+        owner_project = await project_factory(owner=owner)
+        owner_study = await study_factory(project=owner_project, owner=owner)
+        # The outsider has a project of their own, so an empty result would be
+        # ambiguous; give them one study to prove the endpoint returns theirs
+        # and only theirs.
+        outsider_project = await project_factory(owner=outsider)
+        outsider_study = await study_factory(project=outsider_project, owner=outsider)
+
+        response = await client.get(
+            "/api/admin/studies/across-projects",
+            headers=auth_token_factory(outsider),
+        )
+        assert response.status_code == 200
+        slugs = {s["slug"] for s in response.json()}
+        assert outsider_study.slug in slugs
+        assert owner_study.slug not in slugs
+
+    async def test_across_projects_path_not_shadowed_by_slug(
+        self,
+        client: AsyncClient,
+        test_user: User,
+        auth_token_factory,
+    ):
+        """`/across-projects` must resolve to its own route, not `/{slug}`.
+
+        It is declared before the slug route; a regression that reordered them
+        would turn this into a study lookup for slug "across-projects" (404).
+        """
+        response = await client.get(
+            "/api/admin/studies/across-projects",
+            headers=auth_token_factory(test_user),
+        )
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
     async def test_update_study(
         self,
         client: AsyncClient,

--- a/backend/vulture_whitelist.py
+++ b/backend/vulture_whitelist.py
@@ -81,6 +81,7 @@ revoke_recruitment_link
 
 # admin/studies.py
 list_studies
+list_studies_across_projects
 validate_study
 change_study_state
 delete_study

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -824,6 +824,37 @@
         }
       }
     },
+    "/api/admin/studies/across-projects": {
+      "get": {
+        "tags": [
+          "admin-studies"
+        ],
+        "summary": "List Studies Across Projects",
+        "description": "Every study in the projects the current user belongs to.\n\nThe Researcher Hub lists projects together with their studies before any\nsingle project is selected, so it cannot use the list endpoint above \u2014 that\none is scoped to one project via the X-Project-ID header and 400s without\nit. This returns all studies the user can reach, each carrying project_id so\nthe client can group them by project.\n\nAccess mirrors the projects list: membership-based, not superuser-wide, so a\nsuperuser sees only the projects they actually belong to. Loading options\nmatch the per-project list (participant_count is a column_property computed\nin the query; statements/recruitment_links are never serialised by\nStudyListRead, so they are lazyloaded to keep them off the query).",
+        "operationId": "list_studies_across_projects_api_admin_studies_across_projects_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/StudyListRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Studies Across Projects Api Admin Studies Across Projects Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/admin/studies/{slug}": {
       "get": {
         "tags": [

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -158,6 +158,7 @@ import type {
     StorageUsageResponse,
     StudyDumpResponse,
     StudyImportResponse,
+    StudyListRead,
     StudyRead,
     StudyStatsRead,
     SubmissionResultResponse,
@@ -1941,6 +1942,176 @@ export function useListStudiesApiAdminStudiesGet<
     queryClient?: QueryClient
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
     const queryOptions = getListStudiesApiAdminStudiesGetQueryOptions(params, options);
+
+    const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
+        queryKey: DataTag<QueryKey, TData, TError>;
+    };
+
+    query.queryKey = queryOptions.queryKey;
+
+    return query;
+}
+
+/**
+ * Every study in the projects the current user belongs to.
+
+The Researcher Hub lists projects together with their studies before any
+single project is selected, so it cannot use the list endpoint above — that
+one is scoped to one project via the X-Project-ID header and 400s without
+it. This returns all studies the user can reach, each carrying project_id so
+the client can group them by project.
+
+Access mirrors the projects list: membership-based, not superuser-wide, so a
+superuser sees only the projects they actually belong to. Loading options
+match the per-project list (participant_count is a column_property computed
+in the query; statements/recruitment_links are never serialised by
+StudyListRead, so they are lazyloaded to keep them off the query).
+ * @summary List Studies Across Projects
+ */
+export const listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet = (signal?: AbortSignal) => {
+    return customInstance<StudyListRead[]>({
+        url: `/api/admin/studies/across-projects`,
+        method: 'GET',
+        signal,
+    });
+};
+
+export const getListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetQueryKey = () => {
+    return [`/api/admin/studies/across-projects`] as const;
+};
+
+export const getListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetQueryOptions = <
+    TData = Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>,
+    TError = unknown,
+>(options?: {
+    query?: Partial<
+        UseQueryOptions<
+            Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>,
+            TError,
+            TData
+        >
+    >;
+}) => {
+    const { query: queryOptions } = options ?? {};
+
+    const queryKey =
+        queryOptions?.queryKey ??
+        getListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetQueryKey();
+
+    const queryFn: QueryFunction<
+        Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>
+    > = ({ signal }) => listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet(signal);
+
+    return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+        Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>,
+        TError,
+        TData
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type ListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetQueryResult = NonNullable<
+    Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>
+>;
+export type ListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetQueryError = unknown;
+
+export function useListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet<
+    TData = Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>,
+    TError = unknown,
+>(
+    options: {
+        query: Partial<
+            UseQueryOptions<
+                Awaited<
+                    ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>
+                >,
+                TError,
+                TData
+            >
+        > &
+            Pick<
+                DefinedInitialDataOptions<
+                    Awaited<
+                        ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>
+                    >,
+                    TError,
+                    Awaited<
+                        ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>
+                    >
+                >,
+                'initialData'
+            >;
+    },
+    queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet<
+    TData = Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>,
+    TError = unknown,
+>(
+    options?: {
+        query?: Partial<
+            UseQueryOptions<
+                Awaited<
+                    ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>
+                >,
+                TError,
+                TData
+            >
+        > &
+            Pick<
+                UndefinedInitialDataOptions<
+                    Awaited<
+                        ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>
+                    >,
+                    TError,
+                    Awaited<
+                        ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>
+                    >
+                >,
+                'initialData'
+            >;
+    },
+    queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+export function useListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet<
+    TData = Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>,
+    TError = unknown,
+>(
+    options?: {
+        query?: Partial<
+            UseQueryOptions<
+                Awaited<
+                    ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>
+                >,
+                TError,
+                TData
+            >
+        >;
+    },
+    queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+/**
+ * @summary List Studies Across Projects
+ */
+
+export function useListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet<
+    TData = Awaited<ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>>,
+    TError = unknown,
+>(
+    options?: {
+        query?: Partial<
+            UseQueryOptions<
+                Awaited<
+                    ReturnType<typeof listStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet>
+                >,
+                TError,
+                TData
+            >
+        >;
+    },
+    queryClient?: QueryClient
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+    const queryOptions =
+        getListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetQueryOptions(options);
 
     const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & {
         queryKey: DataTag<QueryKey, TData, TError>;
@@ -15954,6 +16125,230 @@ export const getListStudiesApiAdminStudiesGetResponseMock = (
     ...overrideResponse,
 });
 
+export const getListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetResponseMock =
+    (): StudyListRead[] =>
+        Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({
+            slug: faker.helpers.fromRegExp('^[a-z0-9-]+$'),
+            state: faker.helpers.arrayElement([
+                faker.helpers.arrayElement(Object.values(StudyState)),
+                undefined,
+            ]),
+            grid_config: Array.from(
+                { length: faker.number.int({ min: 1, max: 10 }) },
+                (_, i) => i + 1
+            ).map(() => ({
+                score: faker.number.int({ min: -10, max: 10 }),
+                capacity: faker.number.int({ min: undefined, max: undefined }),
+            })),
+            presort_config: {},
+            postsort_config: {},
+            branding: faker.helpers.arrayElement([
+                faker.helpers.arrayElement([
+                    {
+                        logo_url: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 500 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        accent_color: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 50 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        primary_color: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 50 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        partners: faker.helpers.arrayElement([
+                            Array.from(
+                                { length: faker.number.int({ min: 1, max: 10 }) },
+                                (_, i) => i + 1
+                            ).map(() => ({
+                                id: faker.string.alpha({ length: { min: 10, max: 20 } }),
+                                name: faker.string.alpha({ length: { min: 10, max: 20 } }),
+                                logo_url: faker.string.alpha({ length: { min: 10, max: 20 } }),
+                                url: faker.helpers.arrayElement([
+                                    faker.helpers.arrayElement([
+                                        faker.string.alpha({ length: { min: 10, max: 20 } }),
+                                        null,
+                                    ]),
+                                    undefined,
+                                ]),
+                            })),
+                            undefined,
+                        ]),
+                    },
+                    null,
+                ]),
+                undefined,
+            ]),
+            default_language: faker.helpers.arrayElement([
+                faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 5 } }),
+                    null,
+                ]),
+                undefined,
+            ]),
+            show_statement_codes: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+            randomize_statement_order: faker.helpers.arrayElement([
+                faker.datatype.boolean(),
+                undefined,
+            ]),
+            symmetry_lock: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+            rough_sort_enabled: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+            distribution_mode: faker.helpers.arrayElement([
+                faker.helpers.arrayElement(Object.values(DistributionMode)),
+                undefined,
+            ]),
+            start_date: faker.helpers.arrayElement([
+                faker.helpers.arrayElement([
+                    `${faker.date.past().toISOString().split('.')[0]}Z`,
+                    null,
+                ]),
+                undefined,
+            ]),
+            end_date: faker.helpers.arrayElement([
+                faker.helpers.arrayElement([
+                    `${faker.date.past().toISOString().split('.')[0]}Z`,
+                    null,
+                ]),
+                undefined,
+            ]),
+            data_retention_months: faker.helpers.arrayElement([
+                faker.helpers.arrayElement([faker.number.int({ min: 1, max: 240 }), null]),
+                undefined,
+            ]),
+            id: faker.number.int({ min: undefined, max: undefined }),
+            project_id: faker.number.int({ min: undefined, max: undefined }),
+            project: faker.helpers.arrayElement([
+                faker.helpers.arrayElement([
+                    {
+                        id: faker.number.int({ min: undefined, max: undefined }),
+                        title: faker.string.alpha({ length: { min: 10, max: 20 } }),
+                        slug: faker.string.alpha({ length: { min: 10, max: 20 } }),
+                        created_at: `${faker.date.past().toISOString().split('.')[0]}Z`,
+                    },
+                    null,
+                ]),
+                undefined,
+            ]),
+            created_at: `${faker.date.past().toISOString().split('.')[0]}Z`,
+            updated_at: `${faker.date.past().toISOString().split('.')[0]}Z`,
+            translations: faker.helpers.arrayElement([
+                Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(
+                    () => ({
+                        language_code: faker.helpers.fromRegExp('^[a-z]{2}(-[A-Z]{2})?$'),
+                        title: faker.string.alpha({ length: { min: 10, max: 200 } }),
+                        description: faker.helpers.arrayElement([
+                            faker.string.alpha({ length: { min: 10, max: 5000 } }),
+                            undefined,
+                        ]),
+                        instructions: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 5000 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        subtitle: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 200 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        objective: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 5000 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        condition_of_instruction: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 1000 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        pre_instruction: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 1000 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        consent_title: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 200 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        consent_description: faker.helpers.arrayElement([
+                            faker.helpers.arrayElement([
+                                faker.string.alpha({ length: { min: 10, max: 5000 } }),
+                                null,
+                            ]),
+                            undefined,
+                        ]),
+                        ui_labels: faker.helpers.arrayElement([{}, undefined]),
+                        process_steps: faker.helpers.arrayElement([
+                            Array.from(
+                                { length: faker.number.int({ min: 1, max: 10 }) },
+                                (_, i) => i + 1
+                            ).map(() => ({
+                                id: faker.string.alpha({ length: { min: 10, max: 20 } }),
+                                title: faker.string.alpha({ length: { min: 10, max: 100 } }),
+                                description: faker.string.alpha({ length: { min: 10, max: 500 } }),
+                                icon: faker.string.alpha({ length: { min: 10, max: 20 } }),
+                                color: faker.helpers.arrayElement([
+                                    faker.helpers.arrayElement([
+                                        faker.string.alpha({ length: { min: 10, max: 20 } }),
+                                        null,
+                                    ]),
+                                    undefined,
+                                ]),
+                            })),
+                            undefined,
+                        ]),
+                        methodology_tips: faker.helpers.arrayElement([
+                            Array.from(
+                                { length: faker.number.int({ min: 1, max: 10 }) },
+                                (_, i) => i + 1
+                            ).map(() => faker.string.alpha({ length: { min: 10, max: 20 } })),
+                            undefined,
+                        ]),
+                        step_help: faker.helpers.arrayElement([
+                            {
+                                [faker.string.alphanumeric(5)]: {
+                                    [faker.string.alphanumeric(5)]: faker.string.alpha({
+                                        length: { min: 10, max: 20 },
+                                    }),
+                                },
+                            },
+                            undefined,
+                        ]),
+                        id: faker.number.int({ min: undefined, max: undefined }),
+                        study_id: faker.number.int({ min: undefined, max: undefined }),
+                    })
+                ),
+                undefined,
+            ]),
+            requires_password: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+            participant_count: faker.helpers.arrayElement([
+                faker.number.int({ min: undefined, max: undefined }),
+                undefined,
+            ]),
+        }));
+
 export const getGetStudyApiAdminStudiesSlugGetResponseMock = (
     overrideResponse: Partial<StudyRead> = {}
 ): StudyRead => ({
@@ -20384,6 +20779,32 @@ export const getListStudiesApiAdminStudiesGetMockHandler = (
     );
 };
 
+export const getListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetMockHandler = (
+    overrideResponse?:
+        | StudyListRead[]
+        | ((
+              info: Parameters<Parameters<typeof http.get>[1]>[0]
+          ) => Promise<StudyListRead[]> | StudyListRead[]),
+    options?: RequestHandlerOptions
+) => {
+    return http.get(
+        '*/api/admin/studies/across-projects',
+        async (info) => {
+            return new HttpResponse(
+                JSON.stringify(
+                    overrideResponse !== undefined
+                        ? typeof overrideResponse === 'function'
+                            ? await overrideResponse(info)
+                            : overrideResponse
+                        : getListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetResponseMock()
+                ),
+                { status: 200, headers: { 'Content-Type': 'application/json' } }
+            );
+        },
+        options
+    );
+};
+
 export const getGetStudyApiAdminStudiesSlugGetMockHandler = (
     overrideResponse?:
         | StudyRead
@@ -23004,6 +23425,7 @@ export const getQualisAPIMock = () => [
     getTwofaDisableConfirmApi2faDisableConfirmPostMockHandler(),
     getCreateStudyApiAdminStudiesPostMockHandler(),
     getListStudiesApiAdminStudiesGetMockHandler(),
+    getListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGetMockHandler(),
     getGetStudyApiAdminStudiesSlugGetMockHandler(),
     getUpdateStudyApiAdminStudiesSlugPatchMockHandler(),
     getDeleteStudyApiAdminStudiesSlugDeleteMockHandler(),

--- a/frontend/src/pages/ResearcherHub.test.tsx
+++ b/frontend/src/pages/ResearcherHub.test.tsx
@@ -2,11 +2,14 @@ import { renderWithProviders, screen } from '@/test-utils/test-utils';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import ResearcherHub from './ResearcherHub';
 
-const { mockUseAuthStore, mockUseAdminStore, mockStudiesHook } = vi.hoisted(() => ({
-    mockUseAuthStore: vi.fn(),
-    mockUseAdminStore: vi.fn(),
-    mockStudiesHook: vi.fn(),
-}));
+const { mockUseAuthStore, mockUseAdminStore, mockProjectsHook, mockStudiesHook } = vi.hoisted(
+    () => ({
+        mockUseAuthStore: vi.fn(),
+        mockUseAdminStore: vi.fn(),
+        mockProjectsHook: vi.fn(),
+        mockStudiesHook: vi.fn(),
+    })
+);
 
 vi.mock('@/store/useAuthStore', () => ({
     useAuthStore: mockUseAuthStore,
@@ -16,22 +19,26 @@ vi.mock('@/store/useAdminStore', () => ({
     useAdminStore: mockUseAdminStore,
 }));
 
+// The hub owns its data now: projects and studies come from the generated
+// query hooks, not from the store (which ProjectSwitcher populates only inside
+// AdminLayout — never on /hub, which was the empty-state bug).
 vi.mock('@/api/generated', () => ({
-    useListStudiesApiAdminStudiesGet: mockStudiesHook,
+    useListProjectsApiAdminProjectsGet: mockProjectsHook,
+    useListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet: mockStudiesHook,
 }));
 
 describe('ResearcherHub', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockUseAuthStore.mockReturnValue({
-            projects: [],
             user: { email: 'researcher@example.test', full_name: 'Researcher' },
         });
         mockUseAdminStore.mockReturnValue({
             setActiveStudy: vi.fn(),
             setActiveProject: vi.fn(),
         });
-        mockStudiesHook.mockReturnValue({ data: { items: [] } });
+        mockProjectsHook.mockReturnValue({ data: { items: [] } });
+        mockStudiesHook.mockReturnValue({ data: [] });
     });
 
     it('shows a focused zero-project landing page without duplicate create actions', () => {
@@ -44,5 +51,60 @@ describe('ResearcherHub', () => {
             screen.getByText('Create a project before adding concourses, Q-sets, or studies.')
         ).toBeInTheDocument();
         expect(screen.getAllByRole('button', { name: /new project/i })).toHaveLength(1);
+    });
+
+    it('renders the project card when projects exist, not the empty state', () => {
+        // Regression guard for the /hub empty-state bug: the hub used to read
+        // projects from the store, which is empty on this route, so a researcher
+        // with a project saw "start your first project" anyway.
+        mockProjectsHook.mockReturnValue({
+            data: {
+                items: [
+                    {
+                        id: 7,
+                        title: 'Climate Perceptions',
+                        slug: 'climate-perceptions',
+                        user_role: 'owner',
+                    },
+                ],
+            },
+        });
+
+        renderWithProviders(<ResearcherHub />);
+
+        expect(screen.getByText('Climate Perceptions')).toBeInTheDocument();
+        expect(
+            screen.queryByRole('heading', { name: 'Start your first research project' })
+        ).not.toBeInTheDocument();
+    });
+
+    it('groups a study under its project using project_id from the cross-project feed', () => {
+        // Regression guard for the study-count bug: the hub can only show per-
+        // project study counts if it receives studies from every project at once,
+        // each carrying project_id. This is the shape the across-projects endpoint
+        // returns (a bare array, not a paginated {items}).
+        mockProjectsHook.mockReturnValue({
+            data: {
+                items: [
+                    { id: 7, title: 'Climate Perceptions', slug: 'climate', user_role: 'owner' },
+                ],
+            },
+        });
+        mockStudiesHook.mockReturnValue({
+            data: [
+                {
+                    id: 42,
+                    project_id: 7,
+                    slug: 'winter-sort',
+                    state: 'active',
+                    participant_count: 12,
+                    translations: [{ language_code: 'en', title: 'Winter Sort' }],
+                },
+            ],
+        });
+
+        renderWithProviders(<ResearcherHub />);
+
+        expect(screen.getByText('Winter Sort')).toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/ResearcherHub.tsx
+++ b/frontend/src/pages/ResearcherHub.tsx
@@ -14,16 +14,30 @@ import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
-import { useListStudiesApiAdminStudiesGet } from '@/api/generated';
+import {
+    useListProjectsApiAdminProjectsGet,
+    useListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet,
+} from '@/api/generated';
 
 export default function ResearcherHub() {
-    const { projects, user } = useAuthStore();
+    const { user } = useAuthStore();
     const { setActiveStudy, setActiveProject } = useAdminStore();
     const navigate = useNavigate();
     const { t, i18n } = useTranslation();
 
-    const { data: allStudiesData } = useListStudiesApiAdminStudiesGet();
-    const allStudies = allStudiesData?.items;
+    // Own the queries rather than reading the store. The store's `projects` is
+    // populated by ProjectSwitcher, which mounts only inside AdminLayout — never
+    // on /hub — so a fresh login here saw an empty store and the "no projects"
+    // empty state despite having projects. And study counts need every project's
+    // studies at once: the per-project list endpoint 400s without an
+    // X-Project-ID header (none is selected on /hub), so it is replaced by the
+    // cross-project endpoint that returns all reachable studies with project_id.
+    // Both queries share React Query's cache with RequireAdmin's own projects
+    // fetch, so landing here adds at most one request.
+    const { data: projectsData } = useListProjectsApiAdminProjectsGet();
+    const projects = projectsData?.items;
+
+    const { data: allStudies } = useListStudiesAcrossProjectsApiAdminStudiesAcrossProjectsGet();
     const hasProjects = !!projects?.length;
 
     const handleProjectClick = (projectSlug: string, projectId: number) => {

--- a/openapi.json
+++ b/openapi.json
@@ -824,6 +824,37 @@
         }
       }
     },
+    "/api/admin/studies/across-projects": {
+      "get": {
+        "tags": [
+          "admin-studies"
+        ],
+        "summary": "List Studies Across Projects",
+        "description": "Every study in the projects the current user belongs to.\n\nThe Researcher Hub lists projects together with their studies before any\nsingle project is selected, so it cannot use the list endpoint above \u2014 that\none is scoped to one project via the X-Project-ID header and 400s without\nit. This returns all studies the user can reach, each carrying project_id so\nthe client can group them by project.\n\nAccess mirrors the projects list: membership-based, not superuser-wide, so a\nsuperuser sees only the projects they actually belong to. Loading options\nmatch the per-project list (participant_count is a column_property computed\nin the query; statements/recruitment_links are never serialised by\nStudyListRead, so they are lazyloaded to keep them off the query).",
+        "operationId": "list_studies_across_projects_api_admin_studies_across_projects_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/StudyListRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Studies Across Projects Api Admin Studies Across Projects Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/admin/studies/{slug}": {
       "get": {
         "tags": [


### PR DESCRIPTION
A logged-in researcher with a project saw **"Start your first research project"** on `/hub`, and — even when projects did show — per-project study counts were wrong. Two coupled causes, both from the hub reading data it does not own.

## Root cause

1. **Projects came from the auth store**, which is populated by `ProjectSwitcher`. That component mounts only inside `AdminLayout`, but `/hub` renders under `PublicPageLayout` — so on a fresh login (empty store) the hub fell through to its no-projects empty state despite the user having projects. It only "worked" after visiting an `/admin/*` page first, or from a persisted store on a repeat visit.

2. **Studies came from the per-project list endpoint** (`GET /api/admin/studies`), which requires an `X-Project-ID` header. No project is selected on `/hub`, so the request 400'd and every project card showed zero studies. Even with a project selected it could only ever have shown *one* project's studies, since the hub aggregates across all of them client-side (`allStudies.filter(s => s.project_id === project.id)`).

## Fix

The hub now owns both queries instead of depending on a sibling component's side effect.

**Backend** — new `GET /api/admin/studies/across-projects`:
- No `X-Project-ID` needed; returns every study in the projects the user belongs to, each carrying `project_id` for the hub's existing grouping.
- Declared **before** `/{slug}` so the literal path is not captured as a slug.
- Access **mirrors the projects list**: membership-scoped, not superuser-wide.
- Returns the same lighter `StudyListRead` as the per-project list (audit H1 shape).
- Three integration tests: the no-header hub case, membership isolation, and the path-ordering guard.

**Frontend**:
- `ResearcherHub` reads projects from `useListProjectsApiAdminProjectsGet` — the same query `RequireAdmin` already runs for its access check, so React Query serves it from cache with no extra request — and studies from the new cross-project hook. Only `user` still comes from the store.
- Two new hub tests guard the regressions directly: a project renders its card (not the empty state), and a study groups under its project by `project_id`.

## Verification

End to end in a browser (Chromium) against a seeded study: a **fresh login with an empty localStorage** lands on `/hub` showing the project card, `1 study | 1 active | 18`, and the study title — zero JS errors. (Screenshot reproduced locally.)

- Backend: `test_studies.py` 12 passed (3 new); ruff + mypy clean on the router.
- Frontend: 1494 vitest passed (2 new hub guards); biome, tsc, i18n, and API-client sync all green. The generated client was regenerated from the production spec (test routes correctly excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
