### PR TITLE
ci: retry registry pulls in demo-up so a Docker Hub hiccup does not fail CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,23 @@ seed:
 # older than 2.33). DOCKER_BUILDKIT=1 guarantees the cache mounts in both
 # Dockerfiles are honoured even if the daemon default was overridden.
 demo-up:
-	DOCKER_BUILDKIT=1 COMPOSE_BAKE=true docker compose up --build -d --wait --wait-timeout 240
+	@# Registry pulls are the one flaky part in CI: a Docker Hub hiccup
+	@# ("context deadline exceeded") on any base image or the db/minio/mc
+	@# services fails the whole run. Isolate that network step and retry only it
+	@# — BuildKit caches, so a retry after a partial pull is cheap. `build`
+	@# covers the Dockerfile base images; `pull --ignore-buildable` covers the
+	@# image:-only services. The health-wait below then starts from local images
+	@# only, so a genuinely unhealthy service still fails once, not three times.
+	@for i in 1 2 3; do \
+		echo "==> build + pull (attempt $$i/3)"; \
+		if DOCKER_BUILDKIT=1 COMPOSE_BAKE=true docker compose build \
+			&& docker compose pull --ignore-buildable; then \
+			break; \
+		fi; \
+		if [ "$$i" = 3 ]; then echo "build/pull failed after 3 attempts"; exit 1; fi; \
+		echo "   registry hiccup — retrying in $$((i * 5))s"; sleep $$((i * 5)); \
+	done
+	docker compose up -d --wait --wait-timeout 240
 	@printf '\nQualis services are running.\nNext: make demo-seed\n\n'
 
 demo-seed:


### PR DESCRIPTION
The `docker-stack` job failed once on #309 with `Get "https://registry-1.docker.io/v2/": context deadline exceeded` — a transient Docker Hub timeout while pulling the db/minio/mc images. A re-run went straight green, so the images are fine; the job was just brittle. `make demo-up` ran `docker compose up --build` as a single shot, so any registry hiccup on a base image or an image:-only service took the whole run down.

## Fix

`demo-up` now splits the network-bound work from the health-wait:

- **Build + pull** — `docker compose build` (pulls each Dockerfile's base image) then `docker compose pull --ignore-buildable` (the db/minio/mc `image:` services) — is retried up to 3× with linear backoff. BuildKit caches, so a retry after a partial pull re-uses what already came down.
- **`up -d --wait`** then starts from local images only. It is **not** retried: a genuinely unhealthy service should fail once, not burn 3× the 240s wait-timeout.

## Notes

- `--ignore-buildable` needs Compose 2.22+; CI runs 2.38.2 and the install script ships current Compose.
- The same one-shot pattern also lives in the `docker-production-stack` job (added in #309). It could take the same treatment — left out here to keep this change to the one target that actually flaked.

## Verification

Not run here — there is no Docker on the machine this was prepared on, which is the environment the flake lives in. What is checkable passes: `make -n demo-up` parses, and the retry loop was exercised against a stubbed `docker` — fail-twice-then-succeed proceeds to `up`, fail-three-times exits 1 without reaching `up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
