### PR TITLE
ci: retry registry pulls in the production-stack job too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,20 @@ jobs:
         run: docker compose config >/dev/null
 
       - name: Build and start the production stack
-        run: docker compose up --build -d --wait --wait-timeout 240
+        # Same shape as demo-up: retry the network-bound build+pull (a Docker
+        # Hub hiccup on postgres:18-alpine or a Dockerfile base image should not
+        # fail the run), then start from local images with a single, un-retried
+        # health-wait so a genuinely unhealthy service fails once.
+        run: |
+          for i in 1 2 3; do
+            echo "==> build + pull (attempt $i/3)"
+            if docker compose build && docker compose pull --ignore-buildable; then
+              break
+            fi
+            if [ "$i" = 3 ]; then echo "build/pull failed after 3 attempts"; exit 1; fi
+            echo "   registry hiccup — retrying in $((i * 5))s"; sleep $((i * 5))
+          done
+          docker compose up -d --wait --wait-timeout 240
 
       - name: Assert the db runs PostgreSQL 18 with the production mount
         run: |


### PR DESCRIPTION
Follow-up to #311. The `docker-production-stack` job still ran `docker compose up --build -d --wait` as a single shot — the same shape that flaked on a Docker Hub `context deadline exceeded` in the dev job. It pulls fewer images (no MinIO; just `postgres:18-alpine` plus each Dockerfile's base image), so it is less exposed, but the failure mode is identical.

Applies the same split as demo-up: retry the network-bound `build` + `pull --ignore-buildable` up to 3× with linear backoff, then a single **un-retried** `up -d --wait` so a genuinely unhealthy service fails once rather than burning 3× the 240s wait-timeout.

## Verification

Not run here (no Docker on this machine); the retry loop was exercised against a stubbed `docker` — fail-twice-then-succeed proceeds to `up` — and the YAML parses. CI's own run of this job is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
