### PR TITLE
docs(deployment): audio storage decision guide (+ fix docs-check after #311)

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -205,6 +205,57 @@ For the full set (audio, S3, SMTP, Sentry, rate-limiting), see [`../reference/co
 
 ---
 
+## Audio storage (object storage)
+
+Audio is optional. Spoken feedback and `text_audio` questions need
+S3-compatible object storage; everything else — presort, sorting, postsort
+text, exports, analysis — runs without it. When the `S3_*` variables are
+unset, Qualis starts in **storage-optional mode**: audio-enabled studies
+degrade silently to text-only, with no error shown to participants (see
+[`running-without-s3.md`](running-without-s3.md) for the capability matrix).
+
+The production Compose file deliberately does **not** bundle a storage server,
+unlike the dev stack — which ships MinIO purely so `make demo-up` works with
+zero setup. Choose per deployment:
+
+| Situation | Recommendation |
+| --------- | -------------- |
+| **No audio** | Leave the `S3_*` variables unset. Storage-optional mode handles it; nothing to run or back up. |
+| **Audio, least operations** | A **managed** S3-compatible service — Cloudflare R2, Backblaze B2, AWS S3, or the object-storage add-on of your platform (Scalingo, Clever Cloud). Durable and backed up by the provider; R2/B2 have no egress fees. |
+| **Audio + data sovereignty / air-gapped / you already run object storage** | **Self-hosted MinIO**, accepting the operational burden below. |
+
+**Why self-hosted MinIO is not the default.** It is viable, but it is a
+stateful service you take responsibility for:
+
+- Its data needs its own backup schedule, separate from Postgres. A single
+  MinIO node is a single point of failure for every audio recording.
+- MinIO ships breaking changes between releases — the reason the dev images
+  are pinned to a dated tag rather than `:latest`. Each upgrade is a change to
+  review, not a free bump.
+- Playback uses presigned URLs handed to the browser, so the store must be
+  reachable **from the browser**, not just from the backend. That means a
+  public hostname with its own TLS — see `S3_PUBLIC_ENDPOINT_URL` below.
+
+**Configuration.** Whichever backend you pick, set:
+
+```bash
+S3_ENDPOINT_URL=https://<storage-host>          # where the backend uploads
+S3_PUBLIC_ENDPOINT_URL=https://<browser-host>   # where the browser plays back
+                                                # (defaults to S3_ENDPOINT_URL)
+S3_BUCKET_NAME=qualis-audio
+S3_ACCESS_KEY_ID=                               # credential from your provider
+S3_SECRET_ACCESS_KEY=                           # credential from your provider
+S3_REGION=us-east-1                             # or the provider's region
+S3_ADDRESSING_STYLE=auto                        # 'path' for MinIO, 'virtual' for most managed S3
+```
+
+`S3_PUBLIC_ENDPOINT_URL` matters when the store is reached internally at one
+host but served to the browser at another (the dev stack uploads to
+`http://minio:9000` and plays back from `http://localhost:9000`). For a managed
+service the two are usually the same public host, so it can be omitted.
+
+---
+
 ## Account onboarding & public registration
 
 Three ways an account comes into being:

--- a/scripts/check_installation_docs.py
+++ b/scripts/check_installation_docs.py
@@ -85,7 +85,10 @@ def check_demo_make_targets() -> list[str]:
     backend_dockerfile = _read("backend/Dockerfile")
     errors: list[str] = []
 
-    if "docker compose up --build -d --wait --wait-timeout" not in makefile:
+    # demo-up builds/pulls (retried) then starts with a health-wait as a
+    # separate step, so --build is no longer on the `up` line. What this guard
+    # exists to protect is the health-wait itself.
+    if "docker compose up -d --wait --wait-timeout" not in makefile:
         errors.append("Makefile demo-up does not wait for service health")
 
     frontend_marker = "\n  frontend:\n"


### PR DESCRIPTION
The deployment guide said audio needs S3-compatible storage but did not help an operator **choose** how to provide it. The production Compose file deliberately ships without a storage server (unlike dev, which bundles MinIO for a zero-setup demo), so the decision is real and was undocumented.

## What this adds

A new **"Audio storage (object storage)"** section after the required-env-vars table:

- A decision table — **no audio** → storage-optional mode (nothing to run); **audio, least ops** → a managed S3-compatible service (R2, B2, AWS S3, platform add-on); **audio + sovereignty / air-gapped** → self-hosted MinIO.
- Why self-hosted MinIO is *not* the default: separate backup schedule + single point of failure, breaking changes between MinIO releases (the reason the dev images are pinned), and browser-reachable playback via `S3_PUBLIC_ENDPOINT_URL`.
- A configuration block with the `S3_*` variables and what each does.
- A link to the existing `running-without-s3` capability matrix.

## Also in here (a regression fix I found while validating the doc)

Running `check_installation_docs.py` surfaced that the **demo-up retry refactor (#311) broke it**: the script asserted the old one-shot `docker compose up --build -d --wait --wait-timeout` string, which #311 split into a retried build/pull plus a separate health-wait. The health-wait it guards is still present (`up -d --wait --wait-timeout`); the check now matches that form.

That script is **not run in CI** (it is part of `make check`), which is why #311 went green while quietly breaking it. Worth wiring into CI so this class of Makefile/docs drift is caught — noted in the commit, not done here.

## Verification

`python3 scripts/check_installation_docs.py` → "Installation docs are coherent". The doc link to `running-without-s3.md` resolves (same directory); the CI "Documentation Links" (Lychee) job is the authoritative link check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
