### PR TITLE
ci: run the installation-docs coherence check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           args: --verbose --no-progress --config ./lychee.toml './docs/**/*.md' './README.md'
           fail: true
+      - name: Installation docs coherence
+        # Asserts the README/Makefile/compose demo path stays internally
+        # consistent (target names, the demo-up health-wait, the frontend
+        # healthcheck, …). It is part of `make check` but was not in CI, so the
+        # #311 demo-up refactor silently broke it while every CI job stayed
+        # green. Pure stdlib, reads repo files only — no setup needed.
+        run: python3 scripts/check_installation_docs.py
 
   backend-lint:
     name: Backend Lint & Quality


### PR DESCRIPTION
`check_installation_docs.py` asserts the README / Makefile / compose demo path stays internally consistent — the `make demo-*` target names, the demo-up health-wait, the frontend healthcheck, the seed/smoke tokens. It ships in `make check` but was **never in CI**.

That gap had teeth: the demo-up retry refactor (#311) broke this check, and every CI job stayed green — the break only surfaced when I ran `make check` by hand while working on the audio-storage doc (#313, which also carried the fix). Wiring the check in closes that class of Makefile/README/docs drift.

Added as a step in the `documentation-check` job, next to the Lychee link check — same "docs are correct" concern. The script is pure stdlib (`json`, `pathlib`) and reads repo files only, so it needs nothing beyond `actions/checkout`.

## Verification

`python3 scripts/check_installation_docs.py` → "Installation docs are coherent" on current main. YAML parses; the supply-chain pinning test (which scans workflows) still passes — the step adds no third-party action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
