### PR TITLE
fix(release): sync package-lock.json version (unbreak main after 0.7.4)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "qualis",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "qualis",
-            "version": "0.7.3",
+            "version": "0.7.4",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,16 @@
           "path": "frontend/package.json",
           "jsonpath": "$.version"
         },
+        {
+          "type": "json",
+          "path": "frontend/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "frontend/package-lock.json",
+          "jsonpath": "$.packages[''].version"
+        },
         "CITATION.cff"
       ]
     }


### PR DESCRIPTION
The 0.7.4 release (#248) turned **main red**. The release bumped `frontend/package.json` to 0.7.4 but left `frontend/package-lock.json` at 0.7.3 in both its version fields (`$.version` and `$.packages[''].version`) — release-please was set up to update package.json but not the lockfile.

The `Installation docs coherence` check (wired into CI in #314) caught it:

```
ERROR: frontend/package-lock.json version '0.7.3' does not match frontend/package.json '0.7.4'
ERROR: frontend/package-lock.json packages[''].version '0.7.3' does not match frontend/package.json '0.7.4'
```

That is the check doing exactly what it was added for — the inconsistency is real, and it would have shipped silently before #314 made the check visible in CI.

## Fix

- **Unblock main**: bump the two version fields in package-lock.json to 0.7.4. Edited the two lines directly rather than regenerating the lockfile, so the diff is exactly the version metadata (2 lines).
- **Prevent recurrence**: add package-lock.json to release-please's `extra-files` (`$.version` and `$.packages[''].version`) so every future release bumps all three files in lockstep.

## Caveat

The `$.packages[''].version` jsonpath targets the empty-string package key. If release-please's json updater does not resolve it, the next release PR will fail this same coherence check in CI — self-correcting, but worth a glance at the 0.7.5 release PR to confirm both lockfile fields moved.

## Verification

`python3 scripts/check_installation_docs.py` → "Installation docs are coherent". release-please-config.json remains valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
