### PR TITLE
fix(admin): phase 1 of the UX audit remediation — five defects that misinform the researcher

### DIFF
--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -152,25 +152,19 @@ it('shows the Owner role label for the project owner', async () => {
 Run: `cd frontend && npx vitest run src/pages/admin/ProjectMembersPage.test.tsx -t 'Owner role label'`
 Expected: FAIL — "Unable to find an element with the text: Owner".
 
-- [ ] **Step 3: Add the owner item, disabled**
+- [ ] **Step 3: Render the owner's role as a static badge**
 
-Ownership transfer is not a dropdown action, so the item exists to *display* the value, not to offer it. Insert as the first child of `<SelectContent>` at `ProjectMembersPage.tsx:248`:
+> **Corrected after CI.** This step originally prescribed adding a `<SelectItem value="owner" disabled>` so `<SelectValue />` would have something to render. That is wrong: `SelectContent` is one shared JSX block instantiated per row, so the item appears in **every** row's dropdown — and the repo encodes the opposite as a deliberate invariant in two E2E tests (`e2e/admin/roles.spec.ts:405` and `:419`, "owner role is never offered in dropdowns"). CI caught it. The task's own review had flagged the phantom item and proposed the badge; it was deferred as visual noise. It was not.
 
-```tsx
-<SelectItem
-    value="owner"
-    disabled
-    className="text-xs font-bold py-2 rounded-lg m-1"
->
-    {t('admin.project.roles.owner', 'Owner')}
-</SelectItem>
-```
+Ownership transfer is not a dropdown action — a project has exactly one owner, and the owner row's `<Select>` is already unconditionally disabled (`ProjectMembersPage.tsx:231-235`). So render the value, don't offer it:
 
-Add the matching key to `frontend/public/locales/en/admin.json` under `admin.project.roles`:
+- When `member.role === 'owner'`, render a static badge carrying `t('admin.project.roles.owner', 'Owner')` instead of the `<Select>`, styled to match the existing owner pill (`bg-indigo-50 text-indigo-700`).
+- Leave `<SelectContent>` offering only `member` and `viewer`.
+- Leave the member/viewer rows untouched.
 
-```json
-"owner": "Owner"
-```
+This fixes the empty label, keeps `owner` out of every listbox, and removes a permanently-disabled combobox from the tab order.
+
+The key `admin.project.roles.owner` already exists in all nine locales — do not re-add it.
 
 - [ ] **Step 4: Run the tests to verify they pass**
 

--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1,0 +1,1469 @@
+# Admin UX Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 30 defects found in the 2026-07-26 admin-space UX audit — from data mislabelling that misleads researchers, down to alignment and typography inconsistencies.
+
+**Architecture:** Six independent phases, ordered by harm. Phase 1 fixes what actively misinforms the researcher; Phase 2 removes developer-facing text from the product; Phase 3 makes the admin keyboard- and screen-reader-usable; Phases 4–5 collapse four ad-hoc visual/verbal systems into one; Phase 6 is pixel finish. Each phase ships on its own and can be reviewed, merged, and released without the others.
+
+**Tech Stack:** React 19, TypeScript, Vite, Tailwind CSS, Radix UI, TanStack Table v8, Recharts, react-i18next, Vitest + Testing Library.
+
+## Global Constraints
+
+Every task inherits these. They come from `CLAUDE.md` and are non-negotiable.
+
+- **Inner loop:** run `make ci-fast` after every change (~38 s). Run `make ci` before pushing (~3–5 min). Never push on a failing `make ci`.
+- **No `any` in TypeScript.** Use `unknown` or a specific type. `// biome-ignore` only when genuinely unavoidable.
+- **Avoid non-null assertions (`!`).** Handle null explicitly.
+- **All user-facing strings** go through `useTranslation()` / `t()` with a key **and** an English fallback: `t('key', 'Fallback')`.
+- **The fallback string in `t(key, 'Fallback')` must match the canonical English label** in `frontend/public/locales/en/admin.json` character-for-character. Divergence is a defect (see Task 5.1).
+- **Locale parity:** participant namespace is strict (mandatory parity), admin is best-effort (warning only). Run `npm run i18n-check` and `npm run check-interpolations` after touching any locale file.
+- **Frontend tests:** Vitest with the `renderWithStore` helper; use `waitFor` for async state assertions. Hook logic tests live in `frontend/src/hooks/<area>/use<Name>.test.ts`.
+- **Formatting:** `npm run lint:fix` (frontend) auto-fixes. Do not hand-format.
+- **Admin header policy** (`CLAUDE.md` → "Admin header policy"): breadcrumb is the single source of truth for hierarchy; L2 page header carries the page's *function*, never the project/study title, except on entity entry-point pages.
+- **Naming canon:** one label per section, propagated to exactly three keys — `admin.sidebar.<s>`, `admin.breadcrumbs.<s>`, `admin.<s>.title`.
+- **Commit style:** conventional commits (`fix:`, `feat:`, `refactor:`, `style:`), one commit per task.
+
+---
+
+## File Structure
+
+No new modules. Three new files, everything else is modification.
+
+**Create:**
+- `frontend/src/lib/datetime.ts` — the single date/time formatting surface for the admin (Task 4.3). Owns every `Date` → string conversion so no component calls `toLocaleDateString()` directly.
+- `frontend/src/lib/datetime.test.ts` — its tests.
+- `frontend/src/components/ui/slug-input.tsx` — the prefixed-slug input, measuring its own prefix instead of guessing padding (Task 6.1).
+
+**Modify (by phase):**
+
+| Phase | Files |
+|---|---|
+| 1 — Correctness | `components/admin/dashboard/InteractiveDataView.columns.tsx`, `components/admin/dashboard/InteractiveDataView.tsx`, `pages/admin/ProjectMembersPage.tsx`, `pages/admin/ConcourseDetailPage.tsx`, `pages/admin/AnalysisPage.tsx`, `App.tsx` |
+| 2 — Text leaks | `public/locales/en/admin.json`, `components/admin/analysis/FactorVoicesPanel.tsx`, `pages/admin/ProjectMembersPage.tsx` |
+| 3 — Accessibility | `pages/admin/ConcourseDetailPage.tsx`, `components/admin/AdminDashboard.tsx`, `pages/admin/StudyDesignPage.tsx` (lock overlay), `pages/admin/RecruitmentPage.tsx`, `pages/LoginPage.tsx` |
+| 4 — Tokens | `pages/admin/*.tsx` (primary-button sweep), `lib/datetime.ts`, `public/locales/en/admin.json` |
+| 5 — Vocabulary | `public/locales/en/admin.json`, `public/locales/fr/admin.json`, sidebar/breadcrumb config in `components/admin/AdminLayout.tsx` |
+| 6 — Visual finish | `components/ui/slug-input.tsx`, `pages/admin/ProjectSettingsPage.tsx`, `pages/admin/CreateProjectPage.tsx`, `pages/admin/RecruitmentPage.tsx`, `pages/admin/DataPrivacyPage.tsx`, `styles/typography.css`, misc. |
+
+---
+
+# PHASE 1 — Correctness
+
+Five defects that make the UI state or the data wrong. Nothing else matters until these are gone.
+
+### Task 1.1: Responses table — headers misaligned with data
+
+**The defect:** the responses table renders **6 `<th>` for 7 `<td>`**. The `language` column's cells render but its header never does, so every value from column 2 onward sits under the wrong label: `Status → en`, `Consent → Completed`, `Duration → —`, `Submitted → 10m 19s`, and the actual submission date has no header at all. Verified live on 18 rows; the skew survives a re-render (clicking sort does not fix it).
+
+**Root cause is not yet established.** The production build strips React's dev warnings, so a duplicate-key warning — the leading hypothesis — is invisible there. The test below reproduces it in dev, where the warning will surface. Use superpowers:systematic-debugging.
+
+**Files:**
+- Test: `frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx`
+- Modify: `frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx:263-293` (conditional `language` column)
+- Modify: `frontend/src/components/admin/dashboard/InteractiveDataView.tsx:774-795` (thead render)
+
+**Interfaces:**
+- Consumes: `buildColumns({ t, currentLocale, duplicateIpGroups, showLanguageColumn, statusFilter, consentFilters, qualityFilter, stepFilter, stepLabels, toggleConsent, setStatusFilter, setStepFilter, setConsentFilters, setQualityFilter })` from `InteractiveDataView.columns.tsx`.
+- Produces: no signature change. The contract this task establishes is structural: `thead th count === tbody tr td count`, asserted by the test below.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+it('renders one header cell per data cell when the study is multilingual', async () => {
+    // A two-translation study is what turns showLanguageColumn on.
+    renderWithStore(<InteractiveDataView {...propsForStudyWithTranslations(['en', 'fr'])} />);
+
+    const table = await screen.findByRole('table');
+    const headerCells = within(table).getAllByRole('columnheader');
+    const firstBodyRow = within(table).getAllByRole('row')[1];
+    const bodyCells = within(firstBodyRow).getAllByRole('cell');
+
+    expect(headerCells).toHaveLength(bodyCells.length);
+});
+
+it('labels the language column', async () => {
+    renderWithStore(<InteractiveDataView {...propsForStudyWithTranslations(['en', 'fr'])} />);
+    expect(await screen.findByRole('columnheader', { name: /lang/i })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/admin/dashboard/InteractiveDataView.test.tsx -t 'header cell per data cell'`
+Expected: FAIL — `expected length 6 to be 7`. Watch the captured stderr: a React `Encountered two children with the same key` warning here confirms hypothesis (a).
+
+- [ ] **Step 3: Diagnose, in this order**
+
+(a) **Duplicate header key.** `InteractiveDataView.tsx:782` uses `key={header.id}`. If two columns resolve to the same id, React drops one `<th>` and the body — keyed by `cell.id` — keeps both. Log `table.getHeaderGroups()[0].headers.map(h => h.id)` and compare against `columns.map(c => c.id)`.
+
+(b) **Header returns nullish.** `flexRender` at `InteractiveDataView.tsx:787` renders nothing when `columnDef.header` is undefined — but the `<TableHead>` wrapper would still emit a `<th>`, so this explains an *empty* header, not a *missing* one. Rule it out by counting, not by looking.
+
+(c) **Column identity.** `columnHelper.accessor('language', …)` at `columns.tsx:265` — confirm `language` exists on the row type and that its generated id collides with nothing.
+
+Fix at the source the diagnosis points to. If it is (a), give the column an explicit stable `id` in `columns.tsx`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/admin/dashboard/InteractiveDataView.test.tsx`
+Expected: PASS, both tests.
+
+- [ ] **Step 5: Verify in the running app**
+
+With the demo stack up, open `/app/example-project/studies/bioeconomy-futures/data` and confirm the header row reads `Participant | Lang | Status | Consent | Flags | Duration | Submitted` and that `en`/`fr` sits under **Lang**, `Completed` under **Status**, `10m 19s` under **Duration**.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx \
+        frontend/src/components/admin/dashboard/InteractiveDataView.tsx \
+        frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+git commit -m "fix(data): render the language column header so table values match their labels"
+```
+
+---
+
+### Task 1.2: Member role select renders empty for owners
+
+**The defect:** `<SelectContent>` at `ProjectMembersPage.tsx:248-267` offers only `member` and `viewer`. When `member.role === 'owner'`, Radix's `<SelectValue />` finds no matching item and renders nothing — the owner sees a disabled, empty grey box where "Owner" belongs.
+
+**Files:**
+- Test: `frontend/src/pages/admin/ProjectMembersPage.test.tsx`
+- Modify: `frontend/src/pages/admin/ProjectMembersPage.tsx:236-267`
+
+**Interfaces:**
+- Consumes: `ProjectRole` (`'owner' | 'member' | 'viewer'`), `handleRoleChange(userId: number, role: ProjectRole): Promise<void>` — both already in this file.
+- Produces: no signature change.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('shows the Owner role label for the project owner', async () => {
+    renderWithStore(<ProjectMembersPage />, {
+        preloadedMembers: [{ user_id: 1, role: 'owner', user: { email: 'owner@example.com' } }],
+    });
+    expect(await screen.findByText('Owner')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/pages/admin/ProjectMembersPage.test.tsx -t 'Owner role label'`
+Expected: FAIL — "Unable to find an element with the text: Owner".
+
+- [ ] **Step 3: Add the owner item, disabled**
+
+Ownership transfer is not a dropdown action, so the item exists to *display* the value, not to offer it. Insert as the first child of `<SelectContent>` at `ProjectMembersPage.tsx:248`:
+
+```tsx
+<SelectItem
+    value="owner"
+    disabled
+    className="text-xs font-bold py-2 rounded-lg m-1"
+>
+    {t('admin.project.roles.owner', 'Owner')}
+</SelectItem>
+```
+
+Add the matching key to `frontend/public/locales/en/admin.json` under `admin.project.roles`:
+
+```json
+"owner": "Owner"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/admin/ProjectMembersPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/ProjectMembersPage.tsx \
+        frontend/src/pages/admin/ProjectMembersPage.test.tsx \
+        frontend/public/locales/en/admin.json
+git commit -m "fix(members): show the Owner label instead of an empty role select"
+```
+
+---
+
+### Task 1.3: Curation bar contradicts its own counter
+
+**The defect:** `ConcourseDetailPage.tsx:474-475` computes `progress = ((acceptedCt + rejectedCt) / totalCount) * 100` — 33/36 = 91.67 % — while line 486 displays `acceptedCt` (25) over `totalCount` (36) = 69 %. The number and the bar measure different things. On the demo data the bar reads nearly full next to a counter reading two-thirds.
+
+**Decision:** the bar tracks *reviewed* progress (accepted + rejected), which is the meaningful curation signal. So the **label** is what must change to match it, not the bar. Show both quantities explicitly rather than one silently.
+
+**Files:**
+- Test: `frontend/src/pages/admin/ConcourseDetailPage.test.tsx`
+- Modify: `frontend/src/pages/admin/ConcourseDetailPage.tsx:477-540`
+- Modify: `frontend/public/locales/en/admin.json`
+
+**Interfaces:**
+- Consumes: `concourse.items: Array<{ status: 'accepted' | 'rejected' | 'proposed' }>` — already in scope in the IIFE at line 463.
+- Produces: no signature change.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('states reviewed count and progress width consistently', () => {
+    // 25 accepted + 8 rejected + 3 proposed = 36
+    renderWithStore(<ConcourseDetailPage />, { preloadedConcourse: concourseWith(25, 8, 3) });
+
+    // The headline number is what the bar measures: 33 reviewed of 36.
+    expect(screen.getByText('33')).toBeInTheDocument();
+    expect(screen.getByTestId('curation-progress')).toHaveStyle({ width: '91.66666666666666%' });
+    // The Q-set size stays visible, but as its own labelled figure.
+    expect(screen.getByText(/25 accepted/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/pages/admin/ConcourseDetailPage.test.tsx -t 'reviewed count and progress'`
+Expected: FAIL — the headline currently renders `25`, and the bar has no test id.
+
+- [ ] **Step 3: Make the label describe the bar**
+
+Replace the `<p>` block at `ConcourseDetailPage.tsx:483-492` with:
+
+```tsx
+<p className="text-sm font-bold text-emerald-900">
+    {t('admin.concourse.qset_title', 'Curation')}
+    <span className="ml-2 text-lg font-black">{acceptedCt + rejectedCt}</span>
+    <span className="text-emerald-600 font-normal text-xs ml-1">
+        / {totalCount} {t('admin.concourse.items_label', 'items')}{' '}
+        {t('admin.concourse.qset_reviewed', 'reviewed')}
+    </span>
+</p>
+<p className="text-xs text-emerald-700 mt-0.5">
+    {t('admin.concourse.qset_accepted', '{{count}} accepted', { count: acceptedCt })}
+    {proposedCt > 0 && (
+        <>
+            {' · '}
+            {t('admin.concourse.qset_pending', '{{count}} items still to review', {
+                count: proposedCt,
+            })}
+        </>
+    )}
+</p>
+```
+
+Add `data-testid="curation-progress"` to the inner bar `<div>` at line 536.
+
+Add to `frontend/public/locales/en/admin.json` under `admin.concourse`:
+
+```json
+"qset_reviewed": "reviewed",
+"qset_accepted": "{{count}} accepted"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/admin/ConcourseDetailPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/ConcourseDetailPage.tsx \
+        frontend/src/pages/admin/ConcourseDetailPage.test.tsx \
+        frontend/public/locales/en/admin.json
+git commit -m "fix(concourse): make the curation counter describe what the progress bar measures"
+```
+
+---
+
+### Task 1.4: "Viewing run… / Back to current" shows on the current run
+
+**The defect:** after "Commit and interpret", the amber banner (`AnalysisPage.tsx:1073`) announces you are viewing a past run and offers "Back to current" (`:1095`), while the history entry 40 px above tags that very run **CURRENT**. The banner's visibility condition does not exclude the case where the selected run *is* the current one.
+
+**Files:**
+- Test: `frontend/src/pages/admin/AnalysisPage.test.tsx`
+- Modify: `frontend/src/pages/admin/AnalysisPage.tsx:1060-1100`
+
+**Interfaces:**
+- Consumes: the selected-run id from the `runId` search param and the run list already loaded by the interpret-phase hook (`frontend/src/hooks/admin/useInterpretPhase.ts`).
+- Produces: no signature change.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('hides the historical-run banner when the selected run is the current one', async () => {
+    renderWithStore(<AnalysisPage />, {
+        route: '?phase=interpret&runId=1',
+        preloadedRuns: [{ id: 1, is_current: true }],
+    });
+    await waitFor(() => expect(screen.queryByText(/viewing run from/i)).not.toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /back to current/i })).not.toBeInTheDocument();
+});
+
+it('shows the banner when an older run is selected', async () => {
+    renderWithStore(<AnalysisPage />, {
+        route: '?phase=interpret&runId=1',
+        preloadedRuns: [{ id: 1, is_current: false }, { id: 2, is_current: true }],
+    });
+    expect(await screen.findByText(/viewing run from/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify the first fails**
+
+Run: `cd frontend && npx vitest run src/pages/admin/AnalysisPage.test.tsx -t 'historical-run banner'`
+Expected: FAIL — the banner renders for the current run.
+
+- [ ] **Step 3: Gate the banner on the run actually being historical**
+
+Find the JSX condition wrapping the banner at `AnalysisPage.tsx:1060-1073` and require the selected run to differ from the current one — e.g. `selectedRun && !selectedRun.is_current && (…)`. Use whichever current-run flag the interpret hook already exposes; do not introduce a second source of truth for "which run is current".
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/admin/AnalysisPage.test.tsx`
+Expected: PASS, both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/AnalysisPage.tsx frontend/src/pages/admin/AnalysisPage.test.tsx
+git commit -m "fix(analysis): stop flagging the current run as a historical one"
+```
+
+---
+
+### Task 1.5: Unknown URLs fall through to React Router's debug screen
+
+**The defect:** any unmatched path under `/app/` renders React Router's unstyled default boundary — *"Unexpected Application Error! 404 Not Found — 💿 Hey developer 👋 You can provide a way better UX than this…"* — in Times, with no navigation. Reproduced on `/app/example-project/nonexistent-page` and `/app/admin/users`. `errorElement` exists at `App.tsx:192`, but a route that matches *nothing* never instantiates that layout, so the 404 surfaces at the router root, which has no boundary and no catch-all.
+
+**Files:**
+- Test: `frontend/src/App.routing.test.tsx` (create)
+- Modify: `frontend/src/App.tsx:83-360` (router array)
+
+**Interfaces:**
+- Consumes: `ErrorPage` from `@/pages/ErrorPage` — already exists and is already styled.
+- Produces: no signature change.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('renders the styled error page for an unknown admin URL', async () => {
+    renderWithStore(<RouterProvider router={router} />, { route: '/app/example-project/nope' });
+    expect(await screen.findByRole('heading', { name: /not found/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Hey developer/i)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/App.routing.test.tsx`
+Expected: FAIL — "Hey developer" is present.
+
+- [ ] **Step 3: Add a root catch-all**
+
+As the **last** entry of the `createBrowserRouter([...])` array in `App.tsx`:
+
+```tsx
+{
+    path: '*',
+    element: (
+        <PublicPageLayout>
+            <ErrorPage />
+        </PublicPageLayout>
+    ),
+},
+```
+
+Import `ErrorPage` alongside the other page imports. Keep it last — an earlier `path: '*'` would shadow every route below it.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/App.routing.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the real routes still resolve**
+
+Run: `make ci-fast`, then with the stack up visit `/app/example-project/dashboard`, `/hub`, and `/study/bioeconomy-futures` to confirm the catch-all did not swallow them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/App.routing.test.tsx
+git commit -m "fix(routing): serve the styled error page for unknown URLs"
+```
+
+---
+
+# PHASE 2 — Developer text in the product
+
+Three strings written for developers, shipped to researchers.
+
+### Task 2.1: Remove the API-status note from Account settings
+
+**The defect:** `admin.json:264` reads *"Email changes via the API are coming soon to this page; backend support is live."* — implementation status, in the product. The researcher does not know or care what the backend supports.
+
+**Files:**
+- Modify: `frontend/public/locales/en/admin.json:264`
+- Modify: `frontend/public/locales/fr/admin.json` (same key)
+
+- [ ] **Step 1: Rewrite the string to describe the user's situation**
+
+```json
+"email_locked": "Your email address can't be changed here yet. Contact your administrator to update it."
+```
+
+Translate the French key to match: `"Votre adresse e-mail ne peut pas encore être modifiée ici. Contactez votre administrateur pour la mettre à jour."`
+
+- [ ] **Step 2: Check parity**
+
+Run: `cd frontend && npm run i18n-check && npm run check-interpolations`
+Expected: no new warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/public/locales/en/admin.json frontend/public/locales/fr/admin.json
+git commit -m "fix(i18n): replace the API-status note on Account settings with user-facing copy"
+```
+
+---
+
+### Task 2.2: Stop showing the raw question key in Factor voices
+
+**The defect:** `FactorVoicesPanel.tsx:104` renders `{rec.question_key}` — a database identifier (`question_q_voice`) — as the label above each audio player, three times per factor.
+
+**Files:**
+- Test: `frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx`
+- Modify: `frontend/src/components/admin/analysis/FactorVoicesPanel.tsx:104`
+- Modify: `frontend/public/locales/en/admin.json`
+
+**Interfaces:**
+- Consumes: `rec.question_key: string` — the post-sort question identifier, already on the record.
+- Produces: no signature change.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('never renders the raw question key', () => {
+    renderWithStore(<FactorVoicesPanel {...propsWithRecording('question_q_voice')} />);
+    expect(screen.queryByText('question_q_voice')).not.toBeInTheDocument();
+});
+
+it('labels the recording with its human question label', () => {
+    renderWithStore(<FactorVoicesPanel {...propsWithRecording('question_q_voice')} />);
+    expect(screen.getByText('Spoken comment')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/admin/analysis/FactorVoicesPanel.test.tsx -t 'question key'`
+Expected: FAIL — the raw key is in the document.
+
+- [ ] **Step 3: Map key → label, with a safe default**
+
+Replace line 104 with a lookup that falls back to a generic label rather than to the key:
+
+```tsx
+{t(`admin.analysis.voices.question.${rec.question_key}`, t('admin.analysis.voices.question_default', 'Spoken comment'))}
+```
+
+Add to `admin.json` under `admin.analysis.voices`:
+
+```json
+"question_default": "Spoken comment",
+"question": { "question_q_voice": "Spoken comment on the Q-sort" }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/admin/analysis/FactorVoicesPanel.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/admin/analysis/FactorVoicesPanel.tsx \
+        frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx \
+        frontend/public/locales/en/admin.json
+git commit -m "fix(analysis): label recordings with a human question name, not the DB key"
+```
+
+---
+
+### Task 2.3: Replace the "No Name" fallback
+
+**The defect:** `Team members` prints the literal string "No Name" in bold as a user's name. The email is right there and is a better identifier.
+
+**Files:**
+- Test: `frontend/src/pages/admin/ProjectMembersPage.test.tsx`
+- Modify: `frontend/src/pages/admin/ProjectMembersPage.tsx` (the name cell, near the avatar block ending at line 221)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('falls back to the email when the member has no full name', () => {
+    renderWithStore(<ProjectMembersPage />, {
+        preloadedMembers: [{ user_id: 2, role: 'member', user: { email: 'nn@example.com', full_name: null } }],
+    });
+    expect(screen.queryByText(/no name/i)).not.toBeInTheDocument();
+    expect(screen.getByText('nn@example.com')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/pages/admin/ProjectMembersPage.test.tsx -t 'no full name'`
+Expected: FAIL — "No Name" renders.
+
+- [ ] **Step 3: Use the email as the display name**
+
+The removal handler at line 281 already does `member.user.full_name || member.user.email`. Apply the same expression in the name cell, and drop the "No Name" key from `admin.json`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/admin/ProjectMembersPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/ProjectMembersPage.tsx \
+        frontend/src/pages/admin/ProjectMembersPage.test.tsx \
+        frontend/public/locales/en/admin.json
+git commit -m "fix(members): show the email instead of a 'No Name' placeholder"
+```
+
+---
+
+# PHASE 3 — Accessibility and interaction
+
+### Task 3.1: Row actions are invisible but tabbable
+
+**The defect:** each concourse row carries four 32×32 buttons (History, Comments, Edit, Delete). Three sit at `opacity: 0`, revealed by `group-hover` only — no `group-focus-within`. Across 36 statements that is ~108 tab stops on invisible targets, and the actions are undiscoverable on touch. "Edit" is permanently at `opacity-50` on `text-slate-400`, roughly 1.4:1 against white.
+
+**Files:**
+- Test: `frontend/src/pages/admin/ConcourseDetailPage.test.tsx`
+- Modify: `frontend/src/pages/admin/ConcourseDetailPage.tsx` (row action group)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('reveals row actions on keyboard focus, not only on hover', async () => {
+    const user = userEvent.setup();
+    renderWithStore(<ConcourseDetailPage />, { preloadedConcourse: concourseWith(1, 0, 0) });
+
+    const edit = screen.getAllByRole('button', { name: /edit/i })[0];
+    await user.tab();
+    // Walk focus to the row action and assert the group is no longer transparent.
+    edit.focus();
+    expect(edit.closest('[data-row-actions]')).not.toHaveClass('opacity-0');
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/pages/admin/ConcourseDetailPage.test.tsx -t 'keyboard focus'`
+Expected: FAIL.
+
+- [ ] **Step 3: Reveal on focus, and raise the resting contrast**
+
+On the desktop action group (`hidden sm:flex items-center gap-1 flex-shrink-0`), add `data-row-actions` and pair every `group-hover:opacity-100` with `group-focus-within:opacity-100`. Raise the resting state of the always-visible Edit button from `opacity-50` + `text-slate-400` to `text-slate-500` at full opacity (4.6:1 — clears AA).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/admin/ConcourseDetailPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Verify by keyboard in the app**
+
+Tab through the concourse list. Every focused control must be visible at the moment it takes focus.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/admin/ConcourseDetailPage.tsx frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+git commit -m "fix(a11y): reveal concourse row actions on keyboard focus"
+```
+
+---
+
+### Task 3.2: The Design lock overlay is a trap
+
+**The defect:** the "This study is active. Switch to draft mode to edit." overlay has no close button, does not respond to Escape, and offers a single action whose side effect is heavy — moving a live study to draft suspends collection. Structurally it is a plain `<div>` (`absolute inset-0 z-50 bg-white/60 backdrop-blur-md … pt-24`) with no `role="dialog"`, no `aria-modal`, and an orphan `<h3>`. Its icon is a green globe, which signals neither locking nor caution. Net effect: a researcher cannot *read* their own configuration without suspending data collection.
+
+**Files:**
+- Test: `frontend/src/pages/admin/StudyDesignPage.test.tsx`
+- Modify: `frontend/src/pages/admin/StudyDesignPage.tsx` (the overlay renders here, not in `components/admin/designer/`)
+- Modify: `frontend/public/locales/en/admin.json:1544-1545`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+it('exposes the lock notice as a dialog', () => {
+    renderWithStore(<StudyDesignPage />, { preloadedStudy: activeStudy });
+    expect(screen.getByRole('dialog')).toHaveAccessibleName(/active/i);
+});
+
+it('can be dismissed to read the configuration read-only', async () => {
+    const user = userEvent.setup();
+    renderWithStore(<StudyDesignPage />, { preloadedStudy: activeStudy });
+    await user.click(screen.getByRole('button', { name: /view read-only/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run -t 'lock notice'`
+Expected: FAIL — no dialog role, no dismiss affordance.
+
+- [ ] **Step 3: Make it a real dialog with two ways out**
+
+Use the existing Radix `Dialog` primitive rather than a hand-rolled overlay: it brings `role="dialog"`, `aria-modal`, focus trapping, Escape handling and a labelled close button for free. Give it two buttons — a secondary **"View read-only"** that dismisses the overlay and leaves the (non-editable) configuration legible, and the existing **"Draft mode"** as the deliberate, destructive-ish action. Swap the green globe for a lock icon in amber; keep the heading text.
+
+Add to `admin.json` under the designer lock section:
+
+```json
+"view_read_only": "View read-only"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run -t 'lock notice'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/StudyDesignPage.tsx \
+        frontend/src/pages/admin/StudyDesignPage.test.tsx \
+        frontend/public/locales/en/admin.json
+git commit -m "fix(a11y): make the design lock a dismissible dialog with a read-only escape"
+```
+
+---
+
+### Task 3.3: Clickable cards that the keyboard cannot reach
+
+**The defect:** `AdminDashboard.tsx:381` and `:513` are `<Card className="group cursor-pointer" onClick={…}>` — divs. The concourse card next to them is a real `<button>`. So on one dashboard, one card is keyboard-operable and its neighbour is not.
+
+**Files:**
+- Test: `frontend/src/components/admin/AdminDashboard.test.tsx`
+- Modify: `frontend/src/components/admin/AdminDashboard.tsx:381-382`, `:513-514`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('exposes study cards as keyboard-operable controls', async () => {
+    const user = userEvent.setup();
+    renderWithStore(<AdminDashboard />, { preloadedStudies: [demoStudy] });
+
+    const card = screen.getByRole('button', { name: /bioeconomy futures/i });
+    card.focus();
+    await user.keyboard('{Enter}');
+    expect(mockNavigate).toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/admin/AdminDashboard.test.tsx -t 'keyboard-operable'`
+Expected: FAIL — no button with that name.
+
+- [ ] **Step 3: Give the cards button semantics**
+
+Wrap the card content in a `<button type="button">` (as the concourse card at line 667 already does), or add `role="button"`, `tabIndex={0}` and an `onKeyDown` handling Enter and Space. Prefer the real element. Keep the visual result identical.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/admin/AdminDashboard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/admin/AdminDashboard.tsx frontend/src/components/admin/AdminDashboard.test.tsx
+git commit -m "fix(a11y): make dashboard study cards keyboard-operable"
+```
+
+---
+
+### Task 3.4: Unlabelled switches
+
+**The defect:** both switches in `Access → Access rules` return an empty accessible name. A screen reader announces "switch" with no indication of what it toggles.
+
+**Files:**
+- Modify: `frontend/src/pages/admin/RecruitmentPage.tsx:376-390`, `:465-…`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('gives every access-rule switch an accessible name', () => {
+    renderWithStore(<RecruitmentPage />, { preloadedStudy: activeStudy });
+    expect(screen.getByRole('switch', { name: /require a password/i })).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: /limit collection window/i })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/pages/admin/RecruitmentPage.test.tsx -t 'accessible name'`
+Expected: FAIL.
+
+- [ ] **Step 3: Wire the labels**
+
+Each `<Label htmlFor="password-toggle">` / `htmlFor="window-toggle"` already exists and the ids match — but Radix's `Switch` renders a `<button>`, which `htmlFor` does not label. Add an explicit `aria-labelledby` on each `Switch` pointing at its `Label`'s `id`, or add `aria-label` with the same string the label shows.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/admin/RecruitmentPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/RecruitmentPage.tsx frontend/src/pages/admin/RecruitmentPage.test.tsx
+git commit -m "fix(a11y): give access-rule switches accessible names"
+```
+
+---
+
+### Task 3.5: Heading hierarchy and the Login form
+
+**The defect:** on the Dashboard the outline runs `h1 → h3` (Concourse) `→ h2` (Studies) `→ h3` — a skipped level and an out-of-order heading. On Login, the visible "Sign in" is a plain `div` while the real `h1` is visually hidden, so the visual title is not a heading; the submit button says "Continue" under a title reading "Sign in"; there is no link to `/register`, which exists; and the password placeholder is `••••••••`, which mimics a filled field.
+
+**Files:**
+- Modify: `frontend/src/components/admin/AdminDashboard.tsx` (Concourse card heading level)
+- Modify: `frontend/src/pages/LoginPage.tsx`
+- Test: `frontend/src/pages/LoginPage.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+it('uses the visible title as the page heading', () => {
+    renderWithStore(<LoginPage />);
+    expect(screen.getByRole('heading', { level: 1, name: 'Sign in' })).toBeVisible();
+});
+
+it('labels the submit button with the action it performs', () => {
+    renderWithStore(<LoginPage />);
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+});
+
+it('offers a route to registration', () => {
+    renderWithStore(<LoginPage />);
+    expect(screen.getByRole('link', { name: /create an account/i })).toHaveAttribute('href', '/register');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/pages/LoginPage.test.tsx`
+Expected: FAIL on all three.
+
+- [ ] **Step 3: Fix both surfaces**
+
+*Login:* promote the visible "Sign in" to the `h1` and delete the hidden duplicate; relabel the button `t('auth.login.submit', 'Sign in')`; add a "Create an account" link to `/register` under the form; clear the password placeholder (an empty field should look empty).
+
+*Dashboard:* raise the Concourse card title from `h3` to `h2` so it sits at the same level as "Studies", keeping document order `h1 → h2 → h2 → h3`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/LoginPage.test.tsx src/components/admin/AdminDashboard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/LoginPage.tsx frontend/src/pages/LoginPage.test.tsx \
+        frontend/src/components/admin/AdminDashboard.tsx frontend/public/locales/en/admin.json
+git commit -m "fix(a11y): repair heading hierarchy and login form affordances"
+```
+
+---
+
+# PHASE 4 — Design tokens
+
+### Task 4.1: One primary button colour
+
+**The defect:** four primary fills coexist — `bg-indigo-600` ×32, `bg-amber-500` ×6, `bg-slate-900` ×4, `bg-emerald-600` ×1. The sharpest case: inside one card on `Access`, "New access link" is indigo and the empty-state "Create access link" is near-black, for the same action.
+
+**Decision:** `indigo-600` is the primary (32 of 43 uses). `amber` survives **only** as the warning/destructive-adjacent variant on the design lock and archive actions; `slate-900` and `emerald-600` as primary fills go away.
+
+**Files:**
+- Modify: every file matched by the sweep below.
+
+- [ ] **Step 1: Inventory before touching anything**
+
+```bash
+cd frontend/src && grep -rn "bg-slate-900\|bg-emerald-600\|bg-amber-500" --include=*.tsx pages/admin components/admin
+```
+
+Record each hit and decide: primary → `Button` default variant; warning → keep amber; destructive → the destructive variant.
+
+- [ ] **Step 2: Write the guard test**
+
+```tsx
+// frontend/src/components/ui/button.test.tsx
+it('renders the default variant with the single primary fill', () => {
+    render(<Button>Go</Button>);
+    expect(screen.getByRole('button')).toHaveClass('bg-indigo-600');
+});
+```
+
+- [ ] **Step 3: Replace ad-hoc fills with variants**
+
+Route every primary action through `<Button>`'s default variant instead of a hand-written `className`. In particular, make the empty-state "Create access link" on `RecruitmentPage` use the same variant as "New access link".
+
+- [ ] **Step 4: Verify no stray primaries remain**
+
+```bash
+cd frontend/src && grep -rn "bg-slate-900\|bg-emerald-600" --include=*.tsx pages/admin components/admin
+```
+Expected: no hits, or only documented non-button uses.
+
+- [ ] **Step 5: Run the full check and commit**
+
+```bash
+make ci-fast
+git add frontend/src
+git commit -m "style(admin): collapse four primary button fills into one"
+```
+
+---
+
+### Task 4.2: One capitalisation rule
+
+**The defect:** "Add Item" and "Bulk Import" (Title Case) sit beside "Create study", "Import study", "Add study" (sentence case).
+
+**Decision:** sentence case everywhere — it is the majority and it reads better at 13 px.
+
+**Files:**
+- Modify: `frontend/public/locales/en/admin.json`
+
+- [ ] **Step 1: Find every Title-Cased action label**
+
+```bash
+cd frontend/public/locales/en && python3 -c "
+import json, re
+d = json.load(open('admin.json'))
+def walk(o, p=''):
+    if isinstance(o, dict):
+        for k, v in o.items(): walk(v, f'{p}.{k}')
+    elif isinstance(o, str) and re.match(r'^([A-Z][a-z]+ )+[A-Z][a-z]+$', o):
+        print(f'{p}: {o}')
+walk(d)"
+```
+
+- [ ] **Step 2: Rewrite each to sentence case**
+
+"Add Item" → "Add item", "Bulk Import" → "Bulk import", "Draft Mode" → "Draft mode". Leave proper nouns and acronyms alone ("Export CSV", "Setup 2FA" → "Set up 2FA" — that one is also a grammar fix).
+
+- [ ] **Step 3: Mirror in French, then check parity**
+
+Run: `cd frontend && npm run i18n-check && npm run check-interpolations`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/public/locales
+git commit -m "style(i18n): use sentence case for every action label"
+```
+
+---
+
+### Task 4.3: One date/time format
+
+**The defect:** four formats ship today — `1 minute ago`, `7/26/2026` (from a bare `toLocaleDateString()` at `ProjectMembersPage.tsx:271`), `Jul 26, 17:25` (24 h) and `Jul 26, 2026, 05:38 PM` (12 h). The last two appear on the same Analysis screen.
+
+**Decision:** one module, three functions, 24-hour clock, locale-aware via the active i18n language rather than the browser's.
+
+**Files:**
+- Create: `frontend/src/lib/datetime.ts`, `frontend/src/lib/datetime.test.ts`
+- Modify: `pages/admin/ProjectMembersPage.tsx:271`, `pages/admin/AnalysisPage.tsx`, `components/admin/dashboard/InteractiveDataView.columns.tsx`, `components/admin/dashboard/RecentActivityCard.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { formatDate, formatDateTime, formatRelative } from './datetime';
+
+describe('datetime', () => {
+    const d = new Date('2026-07-26T17:25:00Z');
+
+    it('formats a date without a clock', () => {
+        expect(formatDate(d, 'en')).toBe('26 Jul 2026');
+    });
+
+    it('formats date and time on a 24-hour clock', () => {
+        expect(formatDateTime(d, 'en')).toBe('26 Jul 2026, 17:25');
+    });
+
+    it('formats a relative time for the recent past', () => {
+        expect(formatRelative(new Date(Date.now() - 60_000), 'en')).toBe('1 minute ago');
+    });
+
+    it('follows the active app locale, not the browser', () => {
+        expect(formatDate(d, 'fr')).toBe('26 juil. 2026');
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/lib/datetime.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+```ts
+// frontend/src/lib/datetime.ts
+type Locale = string;
+
+export function formatDate(value: Date | string, locale: Locale): string {
+    return new Intl.DateTimeFormat(locale, {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+    }).format(typeof value === 'string' ? new Date(value) : value);
+}
+
+export function formatDateTime(value: Date | string, locale: Locale): string {
+    return new Intl.DateTimeFormat(locale, {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+    }).format(typeof value === 'string' ? new Date(value) : value);
+}
+
+export function formatRelative(value: Date | string, locale: Locale): string {
+    const date = typeof value === 'string' ? new Date(value) : value;
+    const seconds = Math.round((date.getTime() - Date.now()) / 1000);
+    const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+    const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+        ['year', 31_536_000],
+        ['month', 2_592_000],
+        ['day', 86_400],
+        ['hour', 3_600],
+        ['minute', 60],
+    ];
+    for (const [unit, size] of units) {
+        if (Math.abs(seconds) >= size) return rtf.format(Math.round(seconds / size), unit);
+    }
+    return rtf.format(Math.round(seconds), 'second');
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/lib/datetime.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Replace every call site**
+
+```bash
+cd frontend/src && grep -rn "toLocaleDateString\|toLocaleTimeString\|toLocaleString" --include=*.tsx pages components
+```
+
+Replace each with `formatDate` / `formatDateTime`, passing the active i18n language (`i18n.language`). Keep `formatRelative` for the "N minutes ago" surfaces on the dashboard and study overview.
+
+- [ ] **Step 6: Run the full check and commit**
+
+```bash
+make ci-fast
+git add frontend/src
+git commit -m "refactor(admin): route every date through one 24-hour, locale-aware formatter"
+```
+
+---
+
+# PHASE 5 — Vocabulary and naming canon
+
+### Task 5.1: One word per concept
+
+**The defect:** four words for people (*Team members*, *collaborators*, *researchers*, *users* — all four on the Team members screen alone); five names for the access screen (sidebar *Access*, route `/recruitment`, card *Recruitment links*, button *New access link*, empty state *Create access link*); three for collection state (*Active*, *Collecting responses*, *COLLECTING DATA*); and *Locale breakdown* as a heading over a *Language* column.
+
+**Decision — the canonical terms:**
+
+| Concept | Canonical | Retire |
+|---|---|---|
+| A person with project access | **member** | collaborator, researcher, user |
+| The access-configuration screen | **Access** | Recruitment (UI copy only — the route stays) |
+| A shareable participation link | **access link** | recruitment link |
+| A study collecting responses | **Active** | Collecting responses, Collecting data |
+| Language of a response | **Language** | Locale |
+
+**Files:**
+- Modify: `frontend/public/locales/en/admin.json`, `frontend/public/locales/fr/admin.json`
+
+- [ ] **Step 1: Find every occurrence of a retired term**
+
+```bash
+cd frontend/public/locales/en && grep -n "collaborator\|researcher\|Locale\|Recruitment\|Collecting" admin.json
+```
+
+- [ ] **Step 2: Rewrite to the canonical term**
+
+Work key by key. Do not change route paths, API fields, or component names — copy only.
+
+- [ ] **Step 3: Check that no retired term survives in the UI**
+
+```bash
+cd frontend/public/locales/en && grep -n "collaborator\|Locale breakdown\|Collecting data" admin.json
+```
+Expected: no hits.
+
+- [ ] **Step 4: Mirror in French, check parity, commit**
+
+```bash
+cd frontend && npm run i18n-check && npm run check-interpolations
+git add frontend/public/locales
+git commit -m "style(i18n): one canonical term per concept across the admin"
+```
+
+---
+
+### Task 5.2: Restore the naming canon across sidebar, breadcrumb and title
+
+**The defect:** the project settings page shows sidebar "Project settings" / breadcrumb "**Settings**" / H1 "Project settings"; the study settings page shows sidebar "Study settings" / breadcrumb "**Settings**" / H1 "**Settings**". Two different pages therefore carry an identical breadcrumb leaf. `CLAUDE.md` requires all three keys to carry the same label.
+
+**Files:**
+- Modify: `frontend/public/locales/en/admin.json` (`admin.sidebar.*`, `admin.breadcrumbs.*`, `admin.*.title`)
+- Modify: `frontend/src/components/admin/AdminLayout.tsx` (breadcrumb `mapping` table)
+- Test: `frontend/src/components/admin/AdminLayout.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('uses the same label in sidebar, breadcrumb and page title', () => {
+    renderWithStore(<AdminLayout />, { route: '/app/example-project/settings' });
+    expect(screen.getByRole('navigation', { name: /breadcrumb/i })).toHaveTextContent('Project settings');
+});
+
+it('distinguishes study settings from project settings in the breadcrumb', () => {
+    renderWithStore(<AdminLayout />, { route: '/app/example-project/studies/s/settings' });
+    expect(screen.getByRole('navigation', { name: /breadcrumb/i })).toHaveTextContent('Study settings');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/admin/AdminLayout.test.tsx -t 'same label'`
+Expected: FAIL — both breadcrumbs read "Settings".
+
+- [ ] **Step 3: Align the three keys per section**
+
+For each admin section, set `admin.sidebar.<s>`, `admin.breadcrumbs.<s>` and `admin.<s>.title` to the same string. Project settings → "Project settings"; study settings → "Study settings". Update the `mapping` table in `AdminLayout.tsx` so the `settings` segment resolves by context rather than to a bare "Settings".
+
+- [ ] **Step 4: Audit every fallback against the JSON**
+
+The code fallback must equal the canonical English label. Sweep for mismatches:
+
+```bash
+cd frontend/src && grep -rno "t('admin\.[a-z_.]*', *'[^']*'" --include=*.tsx . | head -60
+```
+
+Fix each mismatch by making the fallback match the JSON.
+
+**Also sweep for the opposite defect — `t()` calls with no fallback at all**, which the grep above cannot surface by construction (it only matches calls that already have one). `InteractiveDataView.columns.tsx` alone has 11, including `admin.data.table.lang` at line 273:
+
+```bash
+cd frontend/src && grep -rnoE "t\('admin\.[a-z_.]*'\)" --include=*.tsx . | head -60
+```
+
+Add the canonical English label as the fallback for each.
+
+*(The `ConcourseDetailPage.tsx:484` `'Q-set'` / `'Curation'` divergence originally listed here was already retired by Phase 1 Task 1.3.)*
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/admin/AdminLayout.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/admin/AdminLayout.tsx \
+        frontend/src/components/admin/AdminLayout.test.tsx \
+        frontend/public/locales
+git commit -m "fix(admin): restore the sidebar/breadcrumb/title naming canon"
+```
+
+---
+
+### Task 5.3: Remove duplicated actions and titles
+
+**The defect:** "Create study" (page header) and "Add study" (section header) are the same action 160 px apart, in different button styles. "Team members" is the H1 *and* the card title below it, with the same icon. The study title renders twice, stacked, on `Design` — which also violates the admin header policy, since the L2 header should carry the page's function ("Design"), not the study name already in the breadcrumb. And `Study settings` states "Study must be archived before deletion" twice, 60 px apart.
+
+**Files:**
+- Modify: `components/admin/AdminDashboard.tsx` (drop one of the two study-creation buttons)
+- Modify: `pages/admin/ProjectMembersPage.tsx` (drop the redundant card title)
+- Modify: the Design page header (L2 header → "Design")
+- Modify: `pages/admin/GeneralSettingsPage.tsx` (drop the duplicated archive-before-delete note and its stray `*`)
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+it('offers exactly one study-creation action', () => {
+    renderWithStore(<AdminDashboard />, { preloadedStudies: [demoStudy] });
+    expect(screen.getAllByRole('button', { name: /(create|add) study/i })).toHaveLength(1);
+});
+
+it('does not repeat the page title as a card title', () => {
+    renderWithStore(<ProjectMembersPage />);
+    expect(screen.getAllByText('Team members')).toHaveLength(1);
+});
+
+it('states the archive precondition once', () => {
+    renderWithStore(<GeneralSettingsPage />, { preloadedStudy: activeStudy });
+    expect(screen.getAllByText(/must be archived before deletion/i)).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run -t 'exactly one study-creation'`
+Expected: FAIL.
+
+- [ ] **Step 3: Remove the duplicates**
+
+Keep the page-header "Create study" and drop the section-level "Add study" (the page header is the established home for primary actions). Drop the "Team members" card title, keeping the H1 and the descriptive sub-line. On `Design`, set the L2 header to the page function per the header policy. Delete the duplicated deletion note under the button.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run -t 'exactly one study-creation'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src
+git commit -m "fix(admin): remove duplicated actions, titles and notices"
+```
+
+---
+
+# PHASE 6 — Visual finish
+
+### Task 6.1: A slug input that measures its own prefix
+
+**The defect:** the same prefixed-input pattern ships with two hard-coded paddings, and both are wrong. `ProjectSettingsPage.tsx:177` and `CreateProjectPage.tsx:167` use `pl-32` (128 px) for an `/app/` prefix ~60 px wide, leaving a 68 px gap. `RecruitmentPage.tsx:266` uses `pl-14` (56 px) for a `/study` prefix exactly 56 px wide, so the text collides with the prefix and reads `/studybioeconomy-futures`.
+
+**Files:**
+- Create: `frontend/src/components/ui/slug-input.tsx`, `frontend/src/components/ui/slug-input.test.tsx`
+- Modify: `pages/admin/ProjectSettingsPage.tsx:177`, `pages/admin/CreateProjectPage.tsx:167`, `pages/admin/RecruitmentPage.tsx:266`
+
+**Interfaces:**
+- Produces: `SlugInput` — props `{ prefix: string; value: string; onChange: (v: string) => void; disabled?: boolean; className?: string; id?: string }`. Consumed by all three pages above.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('keeps a gutter between the prefix and the value', () => {
+    render(<SlugInput prefix="/app/" value="example-project" onChange={() => {}} />);
+    const input = screen.getByRole('textbox');
+    const prefix = screen.getByText('/app/');
+    // The input's text must start after the prefix, with breathing room.
+    const gap = input.getBoundingClientRect().left + parseFloat(getComputedStyle(input).paddingLeft)
+              - prefix.getBoundingClientRect().right;
+    expect(gap).toBeGreaterThanOrEqual(8);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/ui/slug-input.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement, measuring rather than guessing**
+
+Render the prefix in an absolutely-positioned span, measure it with a ref + `ResizeObserver`, and set the input's `paddingLeft` to `prefixWidth + 12`. No `pl-*` class. jsdom reports zero-width layout, so also assert the computed style is driven by the measured value rather than a constant.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/ui/slug-input.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Adopt it at all three call sites, then verify in the browser**
+
+Confirm `/app/ example-project` and `/study/ bioeconomy-futures` both read with one clean gutter, at 1440 px and 768 px.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/ui/slug-input.tsx frontend/src/components/ui/slug-input.test.tsx \
+        frontend/src/pages/admin/ProjectSettingsPage.tsx \
+        frontend/src/pages/admin/CreateProjectPage.tsx \
+        frontend/src/pages/admin/RecruitmentPage.tsx
+git commit -m "fix(ui): measure the slug prefix instead of hard-coding its padding"
+```
+
+---
+
+### Task 6.2: Align the two access-rule switches
+
+**The defect:** the two settings rows in `Access → Access rules` are built differently, so their switches sit 17 px apart horizontally and their labels use different weights. Row 1 (`RecruitmentPage.tsx:358`): `flex items-center justify-between gap-4 p-4 bg-slate-50/50 rounded-xl border border-slate-100`, label `font-bold`, description `text-slate-500`. Row 2 (`:447`): `flex items-start justify-between gap-4`, no padding, no surface, label `font-black`, description `text-slate-400 font-medium`.
+
+**Files:**
+- Modify: `frontend/src/pages/admin/RecruitmentPage.tsx:356-391`, `:446-465`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('renders both access-rule rows with the same container treatment', () => {
+    renderWithStore(<RecruitmentPage />, { preloadedStudy: activeStudy });
+    const rows = screen.getAllByTestId('access-rule-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].className).toBe(rows[1].className);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/pages/admin/RecruitmentPage.test.tsx -t 'same container treatment'`
+Expected: FAIL — classes differ.
+
+- [ ] **Step 3: Give both rows one shape**
+
+Apply row 1's treatment to both — it is the more legible of the two — with `data-testid="access-rule-row"`, `items-center`, label `font-bold text-slate-700`, description `text-xs text-slate-500`. Extract a small local `AccessRuleRow` component so the two cannot drift again.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/pages/admin/RecruitmentPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/RecruitmentPage.tsx frontend/src/pages/admin/RecruitmentPage.test.tsx
+git commit -m "style(access): align both access-rule rows on one row component"
+```
+
+---
+
+### Task 6.3: Fix the orphaned tile and the stat-tile split
+
+**The defect:** `DataPrivacyPage.tsx:401` lays 4 tiles into `grid-cols-2 sm:grid-cols-3`, so "Anonymised" drops alone onto a second row beside two empty cells. Its `0` is indigo while the three neighbouring zeros are black, with no semantic reason. Line 461 puts 2 tiles into `grid-cols-2`, making them 390 px wide against 253 px above — same component, different size. Separately, `Data privacy` labels tiles in UPPERCASE while `Data` and `Overview` use sentence case with an icon.
+
+**Files:**
+- Modify: `frontend/src/pages/admin/DataPrivacyPage.tsx:401`, `:461`, and the tile component
+- Test: `frontend/src/pages/admin/DataPrivacyPage.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('lays the four participant tiles on one row at desktop width', () => {
+    renderWithStore(<DataPrivacyPage />, { preloadedStudy: activeStudy });
+    expect(screen.getByTestId('participants-snapshot')).toHaveClass('sm:grid-cols-4');
+});
+
+it('does not colour a zero differently from its neighbours', () => {
+    renderWithStore(<DataPrivacyPage />, { preloadedStudy: activeStudy });
+    const values = screen.getAllByTestId('stat-value');
+    const colours = new Set(values.map((v) => v.className.match(/text-\w+-\d+/)?.[0]));
+    expect(colours.size).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/pages/admin/DataPrivacyPage.test.tsx`
+Expected: FAIL on both.
+
+- [ ] **Step 3: Fix grid, colour and label case**
+
+Change line 401 to `grid grid-cols-2 sm:grid-cols-4 gap-4`. Drop the indigo on the "Anonymised" value so all four read the same. Give the "Audio storage" grid the same tile width as the snapshot grid rather than stretching two tiles across the full row. Switch the tile labels from uppercase to the sentence-case-with-icon treatment used on `Data` and `Overview`, so one stat tile exists in the product rather than two.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/pages/admin/DataPrivacyPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/DataPrivacyPage.tsx frontend/src/pages/admin/DataPrivacyPage.test.tsx
+git commit -m "style(privacy): unify the stat tiles and stop orphaning the fourth"
+```
+
+---
+
+### Task 6.4: Raise the typographic floor
+
+**The defect:** `--font-size-2xs` resolves to 10–11 px and is used **235 times**. Alongside it sit 16 arbitrary values outside the scale: `text-[9px]` ×10 (including the "Recently completed" status badge), `text-[10px]` ×3, `text-[8px]` ×1, `text-[13px]` ×2. The scale itself is well built — it is simply being bypassed.
+
+**Files:**
+- Modify: `frontend/src/styles/typography.css:7`
+- Modify: every file with a bracketed font size
+
+- [ ] **Step 1: Inventory**
+
+```bash
+cd frontend/src && grep -rn "text-\[[0-9]*px\]" --include=*.tsx . | sort
+```
+
+- [ ] **Step 2: Raise the floor**
+
+In `typography.css:7`, lift `--font-size-2xs` to `clamp(0.6875rem, 0.66rem + 0.16vw, 0.75rem)` — 11 px to 12 px. That keeps the fluid behaviour and puts the smallest text in the product at the readability floor rather than below it.
+
+- [ ] **Step 3: Replace every bracketed size with a scale step**
+
+`text-[8px]`, `text-[9px]`, `text-[10px]` → `text-2xs`. `text-[13px]` → `text-sm`. No bracketed font size survives.
+
+- [ ] **Step 4: Verify nothing overflows at the larger size**
+
+```bash
+make ci-fast
+```
+Then check the densest surfaces at 1440 px and 768 px: the concourse list, the responses table, the participant metadata rows. Badges must not wrap.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src
+git commit -m "style(type): raise the smallest text to 11px and remove off-scale sizes"
+```
+
+---
+
+### Task 6.5: Raise the contrast floor
+
+**The defect:** `text-slate-400` (2.85:1 on white) ×200 and `text-slate-300` (1.68:1) ×35 — both below the 4.5:1 AA threshold for body text. They carry real content: participant metadata, the responses table's `—` values, the "36 / 36 items" counter, the slug-change warning on project settings.
+
+**Files:**
+- Modify: files matched by the sweep
+
+- [ ] **Step 1: Inventory by role**
+
+```bash
+cd frontend/src && grep -rn "text-slate-300\|text-slate-400" --include=*.tsx pages/admin components/admin
+```
+
+Sort each hit into **text** (must reach 4.5:1) or **decorative icon** (3:1 is acceptable for non-text).
+
+- [ ] **Step 2: Promote the text hits**
+
+`text-slate-400` → `text-slate-500` (4.6:1). `text-slate-300` on text → `text-slate-500`. Leave purely decorative icon strokes alone, but never let an icon be the sole carrier of information — the 10 px `lucide-monitor` glyph between two `·` separators on the study overview and data rows is `aria-hidden` and unlabelled, so either give it a visible text label or remove it and its orphan separators.
+
+- [ ] **Step 3: Verify the important small print**
+
+The slug-change warning ("Changing the slug will update all your research dashboard links") is consequential copy currently rendered in the page's most discreet style. Give it the same weight as other inline warnings.
+
+- [ ] **Step 4: Run the full check and commit**
+
+```bash
+make ci
+git add frontend/src
+git commit -m "style(a11y): raise muted text to the AA contrast threshold"
+```
+
+---
+
+### Task 6.6: The frozen clear-date button on Access
+
+**The defect:** found by the Phase 1 whole-branch review and machine-verified by recompiling with `babel-plugin-react-compiler`. `RecruitmentPage.tsx:514` and `:552` have the same React Compiler exposure that caused Phase 1's Task 1.1 defect: `accessForm` is a react-hook-form `UseFormReturn`, a `useRef`-backed object with stable identity that RHF mutates in place — structurally identical to a TanStack `table`. The whole "Collection window" section compiles into one memo block keyed on `accessForm`, `isArchived`, `showWindowPickers` and `t`, none of which change when a form field does:
+
+```js
+if ($[187] !== accessForm || $[188] !== isArchived || $[189] !== showWindowPickers || $[190] !== t) {
+    t75 = showWindowPickers && <>… {accessForm.watch("startDate") && !isArchived && <button …/>} …</>;
+```
+
+So on **Access → Access rules**, enabling the collection window and typing a start date leaves the clear-✕ button frozen at whatever it last evaluated to — absent when it should appear, or lingering after the date is cleared. Both dates, both directions.
+
+**The fix is NOT `'use no memo'`.** Hoist the watched values to the component body, where the compiler emits un-memoized reads that the JSX can then key on:
+
+```tsx
+const startDate = accessForm.watch('startDate');
+const endDate = accessForm.watch('endDate');
+```
+
+(Verified: `slugForm.formState.isSubmitting || !slugForm.formState.isDirty` in the same file compiles to a plain `const` recomputed every render, which is why the Save buttons never had this problem.) `useWatch({ control, name })` works equally well.
+
+**Files:**
+- Modify: `frontend/src/pages/admin/RecruitmentPage.tsx:514`, `:552`
+- Test: `frontend/src/pages/admin/RecruitmentPage.test.tsx`
+
+- [ ] **Step 1: Reproduce**
+
+With the demo stack up, open Access → Access rules, enable "Limit collection window", and type a start date. The clear-✕ does not appear.
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+it('shows the clear button once a start date is entered', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<RecruitmentPage />);
+    await user.click(await screen.findByRole('switch', { name: /limit collection window/i }));
+    await user.type(screen.getByLabelText(/start date/i), '2026-08-01');
+    expect(await screen.findByRole('button', { name: /clear start date/i })).toBeVisible();
+});
+```
+
+Note Vitest does not run the React Compiler pass, so this test will not reproduce the compiler freeze — it guards the behaviour, not the mechanism. Reproduce the mechanism in E2E (`playwright.config.ts` starts `npm run dev`, which does run the compiler), as Task 1.1 did.
+
+- [ ] **Step 3: Hoist the watched values**
+
+- [ ] **Step 4: Verify in the browser** — both dates, both directions (appearing and clearing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/RecruitmentPage.tsx frontend/src/pages/admin/RecruitmentPage.test.tsx
+git commit -m "fix(access): unfreeze the clear-date buttons under React Compiler memoization"
+```
+
+---
+
+### Task 6.7: Charts mounting at zero size
+
+**The defect:** loading the `Data` screen logs the Recharts warning *"The width(-1) and height(-1) of chart should be greater than 0"* five times — charts are mounting inside collapsed containers. Harmless today, but it is console noise that will mask a real warning later.
+
+**Files:**
+- Modify: `frontend/src/components/admin/dashboard/charts/QuestionDistributionCharts.tsx`
+
+- [ ] **Step 1: Reproduce**
+
+Open `/app/example-project/studies/bioeconomy-futures/data` with the console open and confirm the warnings.
+
+- [ ] **Step 2: Give the responsive container a floor**
+
+Set an explicit `minWidth` / `minHeight` on the chart's `ResponsiveContainer`, or defer mounting until its accordion section is actually open.
+
+- [ ] **Step 3: Verify a clean console**
+
+Reload the page. Expected: no Recharts warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/admin/dashboard/charts/QuestionDistributionCharts.tsx
+git commit -m "fix(charts): stop mounting charts into zero-size containers"
+```
+
+---
+
+## Deferred — needs a design decision, not a fix
+
+These came out of the audit but are judgement calls, not defects with an obvious right answer. Each needs your call before it becomes a task.
+
+1. **Red/green factor scores** (`Analysis`). In Q-methodology −1.78 means "strongly disagree", not "bad". Red/green imports a value judgement the method does not make, and it is the worst pairing for colour blindness (~8 % of men). A diverging blue↔orange scale would carry the same sign information without the moral overtone — but this changes how every published figure from Qualis looks.
+2. **Unexplained `⚠` and `D` markers** (`Analysis` → Preview range, Statements). Both need a legend; the question is whether that is a tooltip, a footnote, or a legend row.
+3. **The Kaiser criterion line** is the least salient element of the scree plot, competing with four gridlines of similar weight — a decision rule should out-rank its own gridlines.
+4. **The interpretive narrative field** (`F1 narrative`) is an italic grey placeholder with no border. It is the central function of the interpret screen and looks like static text; making it look editable is a small change with a real effect on whether the feature gets used.
+5. **Truncated public URL** on `Overview` (`http://localhost:3000/study/b:`). The field is too narrow to read the link it exists to share.
+6. **The native `<audio>` player** in Factor voices is the only unstyled control in the product, while `components/admin/AudioPlayer.tsx` exists. Adopting it is straightforward; whether the custom player is good enough to carry research audio is your call.
+7. **Sidebar at 768 px** stays expanded at 255 px, taking a third of the viewport. Auto-collapsing below `lg` is the obvious move but changes the tablet experience.
+8. **No read-only mode for an active study's design.** Task 3.2 adds an escape hatch from the lock overlay; a genuine read-only rendering of the design is the larger, better fix.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every audit finding maps to a task: A1→1.1, A2→1.2, A3→1.4, A4→1.5, A5→1.3; B (three text leaks)→2.1–2.3; C (primary colours→4.1, capitalisation→4.2, vocabulary→5.1, naming canon→5.2, dates→4.3, card widths and H1 icon treatments→noted in 6.3's tile unification and 5.3's header work); D (slug prefixes→6.1, switch alignment→6.2, privacy grid→6.3, typography→6.4, contrast→6.5, duplications→5.3); E (row actions→3.1, design lock→3.2, clickable cards→3.3, switch labels→3.4, headings and login→3.5). The Recharts warnings found during planning became 6.7, and the React Compiler defect on Access — found by Phase 1's whole-branch review — became 6.6. Eight items with no single right answer are parked in "Deferred" rather than pretended into tasks.
+
+**Two gaps I am naming rather than hiding.** The three differing card widths (1095 / 895 / 745 px across Access, Study settings, Account settings) and the three H1 icon treatments (bare, grey square, blue square) are real inconsistencies with no task of their own — they want a single page-shell decision, which belongs with the deferred design calls above. Fold them in once the shell is decided.
+
+**Placeholders.** None. Task 1.1 is the only task that does not name its fix, and deliberately so: the production build hides the diagnostic signal, so the task ships a reproduction test plus three ordered hypotheses instead of a guess dressed as an answer.
+
+**Type consistency.** `formatDate` / `formatDateTime` / `formatRelative` (Task 4.3) keep the same signatures at every call site. `SlugInput`'s prop names (Task 6.1) match its three adoptions. `buildColumns`' parameter object (Task 1.1) is quoted from the current source.

--- a/frontend/e2e/admin/analysis-workflow.spec.ts
+++ b/frontend/e2e/admin/analysis-workflow.spec.ts
@@ -10,8 +10,10 @@
 import { test, expect } from '../fixtures/db-setup';
 import { testDataBuilders, gridConfig23 } from '../fixtures/test-data';
 
-// Analysis can be CPU-bound on a fresh DB — give it room
-test.setTimeout(120_000);
+// Analysis can be CPU-bound on a fresh DB — give it room. Test 1 commits
+// two runs (the historical-run banner needs a study with a history), so it
+// pays that cost twice.
+test.setTimeout(180_000);
 
 // -------------------------------------------------------------------------
 // Test 1 — Full happy-path: seed study + 8 participants, run analysis,
@@ -198,31 +200,63 @@ test('full analysis workflow: run → results → history', async ({ page, testD
     const historyHeader = page.getByRole('button', { name: /analysis history/i });
     await expect(historyHeader).toBeVisible({ timeout: 10_000 });
 
-    // Wait for at least one dated run entry in the panel body
-    const runEntry = page
-        .getByRole('button', {
-            name: /load analysis run from/i,
-        })
-        .first();
-    await expect(runEntry).toBeVisible({ timeout: 15_000 });
+    // Wait for the dated run entry in the panel body — exactly one so far.
+    const runEntries = page.getByRole('button', { name: /load analysis run from/i });
+    await expect(runEntries.first()).toBeVisible({ timeout: 15_000 });
+    await expect(runEntries).toHaveCount(1);
 
     // -----------------------------------------------------------------------
-    // 10. Verify history persistence: click the run, see historical banner,
-    //     then click "Back to current"
+    // 10. Historical-run banner + "Back to current".
+    //
+    //     The amber banner announces a run that is NOT the study's most
+    //     recent one (Task 1.4) — a study with a single run can never show
+    //     it, and must not: the sole run *is* current, and the history panel
+    //     tags it CURRENT 40px above. So commit a second run first, then
+    //     exercise both directions of the real journey:
+    //       latest run selected  → no banner
+    //       older run selected   → banner + working escape hatch
     // -----------------------------------------------------------------------
-    await runEntry.click();
+    // Second commit. We're back on the Explore phase (the URL carries no
+    // ?phase), where the CTA sits outside the Advanced accordion. Pin
+    // n_factors to 2 again so both runs have the same shape.
+    const advancedTrigger2 = page.getByRole('button', { name: /advanced configuration/i });
+    await expect(advancedTrigger2).toBeVisible({ timeout: 10_000 });
+    await advancedTrigger2.click();
+    const factorsSelect2 = page.getByRole('combobox', { name: /factors/i });
+    await expect(factorsSelect2).toBeEnabled({ timeout: 10_000 });
+    await factorsSelect2.click();
+    const secondOption2 = page.getByRole('option', { name: '2' });
+    if (await secondOption2.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await secondOption2.click();
+    }
 
-    // The historical-run amber banner should appear
-    const historyBanner = page.getByText(/viewing run from/i).first();
+    const secondRunButton = page.getByRole('button', { name: /commit and interpret/i });
+    await expect(secondRunButton).toBeEnabled({ timeout: 10_000 });
+    await secondRunButton.click();
+
+    // Once the commit lands, the history panel lists both runs, newest first.
+    await expect(runEntries).toHaveCount(2, { timeout: 60_000 });
+
+    // The page now shows the just-committed run, which IS the latest — the
+    // banner must stay away. Assert a positive marker of the loaded interpret
+    // phase first, so the absence assertion can't pass on a blank page.
+    // (`getByTestId` targets the banner's data-testid; the error state carries
+    // a second "Back to current" button with the same accessible name, so
+    // every banner assertion below is scoped to this element.)
+    const historyBanner = page.getByTestId('run-banner');
+    await expect(page.getByRole('button', { name: /^export$/i })).toBeVisible({
+        timeout: 30_000,
+    });
+    await expect(historyBanner).toBeHidden();
+
+    // Now load the older run from history — that one IS historical.
+    await runEntries.nth(1).click();
     await expect(historyBanner).toBeVisible({ timeout: 15_000 });
+    await expect(historyBanner).toContainText(/viewing run from/i);
 
-    // Click "Back to current" to dismiss the banner
-    const backButton = page.getByRole('button', { name: /back to current/i });
-    await expect(backButton).toBeVisible();
-    await backButton.click();
-
-    // Banner must disappear after dismissal
-    await expect(historyBanner).not.toBeVisible({ timeout: 10_000 });
+    // "Back to current" (the banner's own, not the error state's) dismisses it.
+    await historyBanner.getByRole('button', { name: /back to current/i }).click();
+    await expect(historyBanner).toBeHidden({ timeout: 10_000 });
 });
 
 // -------------------------------------------------------------------------

--- a/frontend/e2e/admin/data-table-columns.spec.ts
+++ b/frontend/e2e/admin/data-table-columns.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E: Responses table header/body column parity (Task 1.1)
+ *
+ * This is the RED/GREEN guard the earlier Vitest-only regression test could
+ * not provide: Qualis compiles JSX through the React Compiler
+ * (`vite.config.ts` — `babel({ presets: [reactCompilerPreset()] })`), and
+ * `npm run dev` (this suite's webServer, see playwright.config.ts) runs the
+ * same `vite.config.ts` as `npm run build`. Vitest's config does not apply
+ * that babel pass, so a compiler-memoization bug is invisible to it no
+ * matter how the component is rendered — only a suite that boots the real
+ * dev/build pipeline (this one) can catch a regression here.
+ *
+ * The bug this guards: with a multilingual study, `showLanguageColumn` adds
+ * a `language` column. The React Compiler was auto-memoizing the header
+ * row's JSX keyed only on the stable `table` object reference (which never
+ * changes across renders — TanStack Table mutates it in place), so the
+ * header froze at whatever column set existed on first render while the
+ * body kept recomputing — 6 `<th>` for 7 `<td>`, silently misaligning every
+ * subsequent column with the wrong label.
+ */
+
+import { test, expect } from '../fixtures/db-setup';
+import { testDataBuilders } from '../fixtures/test-data';
+
+test.describe('Responses table column parity', () => {
+    test('renders one header cell per data cell, with a visible language column, for a multilingual study', async ({
+        page,
+        testDb,
+        authToken,
+    }) => {
+        // Activation requires every statement to carry a translation in
+        // every declared study language, so the default (English-only)
+        // statement fixtures need a French translation added too.
+        const bilingualStatements = testDataBuilders.statements(23).map((statement) => ({
+            ...statement,
+            translations: [
+                ...statement.translations,
+                { language_code: 'fr', text: `${statement.translations[0].text} (FR)` },
+            ],
+        }));
+
+        const study = (await testDb.createStudy(
+            authToken,
+            testDataBuilders.study({
+                slug: `data-columns-${Date.now()}`,
+                state: 'active',
+                statements: bilingualStatements,
+                translations: [
+                    {
+                        language_code: 'en',
+                        title: 'Column Parity Study',
+                        description: 'Test study description',
+                        instructions: 'Test instructions',
+                        objective: 'Test study objective',
+                        condition_of_instruction: 'Condition of instruction',
+                        consent_title: 'Informed Consent',
+                        consent_description: 'Please read and accept the terms to proceed.',
+                    },
+                    {
+                        language_code: 'fr',
+                        title: 'Étude de parité des colonnes',
+                        description: 'Description de test',
+                        instructions: 'Instructions de test',
+                        objective: 'Objectif de test',
+                        condition_of_instruction: "Condition de l'instruction",
+                        consent_title: 'Consentement éclairé',
+                        consent_description: 'Veuillez lire et accepter les conditions.',
+                    },
+                ],
+            })
+        )) as { slug: string };
+
+        await testDb.createParticipant(authToken, study.slug, { language_used: 'en' });
+
+        await testDb.loginToAdminUI(page);
+        const projectSlug = testDb.getWorkspaceSlug();
+        await page.goto(`/app/${projectSlug}/studies/${study.slug}/data`);
+
+        const table = page.locator('table');
+        await expect(table).toBeVisible({ timeout: 15000 });
+        await expect(table.locator('tbody tr')).toHaveCount(1);
+
+        // The regression: a "Lang" header column that exists in the body
+        // (every <td> renders) but never appears in the <thead>.
+        await expect(table.getByRole('columnheader', { name: /lang/i })).toBeVisible();
+
+        const headerCount = await table.locator('thead th').count();
+        const bodyCellCount = await table.locator('tbody tr').first().locator('td').count();
+        expect(headerCount).toBe(bodyCellCount);
+    });
+});

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -426,6 +426,8 @@
             "bulk_status_success": "{{count}} Einträge aktualisiert",
             "bulk_status_error": "Einige Einträge konnten nicht aktualisiert werden",
             "qset_title": "Kuratierung",
+            "qset_reviewed_of": "{{total}} Einträge geprüft",
+            "qset_accepted": "{{count}} akzeptiert",
             "qset_pending": "{{count}} Einträge noch zu prüfen",
             "qset_complete": "Alle Einträge geprüft",
             "show_pending": "Zu prüfen",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -426,7 +426,7 @@
             "bulk_status_success": "{{count}} items updated",
             "bulk_status_error": "Failed to update some items",
             "qset_title": "Curation",
-            "qset_reviewed": "reviewed",
+            "qset_reviewed_of": "{{total}} items reviewed",
             "qset_accepted": "{{count}} accepted",
             "qset_pending": "{{count}} items still to review",
             "qset_complete": "All items reviewed",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -426,6 +426,8 @@
             "bulk_status_success": "{{count}} items updated",
             "bulk_status_error": "Failed to update some items",
             "qset_title": "Curation",
+            "qset_reviewed": "reviewed",
+            "qset_accepted": "{{count}} accepted",
             "qset_pending": "{{count}} items still to review",
             "qset_complete": "All items reviewed",
             "show_pending": "To review",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -426,6 +426,8 @@
             "bulk_status_success": "{{count}} elementos actualizados",
             "bulk_status_error": "Error al actualizar algunos elementos",
             "qset_title": "Curación",
+            "qset_reviewed_of": "{{total}} elementos revisados",
+            "qset_accepted": "{{count}} aceptados",
             "qset_pending": "{{count}} elementos por revisar",
             "qset_complete": "Todos los elementos revisados",
             "show_pending": "Por revisar",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -338,6 +338,8 @@
             "bulk_status_success": "{{count}} kohdetta päivitetty",
             "bulk_status_error": "Joidenkin kohteiden päivitys epäonnistui",
             "qset_title": "Kuratointi",
+            "qset_reviewed_of": "{{total}} kohdetta tarkistettu",
+            "qset_accepted": "{{count}} hyväksytty",
             "qset_pending": "{{count}} kohdetta vielä tarkistettavana",
             "qset_complete": "Kaikki kohteet tarkistettu",
             "show_pending": "Tarkistettavat",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -338,7 +338,7 @@
             "bulk_status_success": "{{count}} éléments mis à jour",
             "bulk_status_error": "Échec de la mise à jour de certains éléments",
             "qset_title": "Curation",
-            "qset_reviewed": "examiné(s)",
+            "qset_reviewed_of": "{{total}} élément(s) examiné(s)",
             "qset_accepted": "{{count}} accepté(s)",
             "qset_pending": "{{count}} items encore à examiner",
             "qset_complete": "Tous les items ont été examinés",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -338,6 +338,8 @@
             "bulk_status_success": "{{count}} éléments mis à jour",
             "bulk_status_error": "Échec de la mise à jour de certains éléments",
             "qset_title": "Curation",
+            "qset_reviewed": "examiné(s)",
+            "qset_accepted": "{{count}} accepté(s)",
             "qset_pending": "{{count}} items encore à examiner",
             "qset_complete": "Tous les items ont été examinés",
             "show_pending": "À examiner",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -426,6 +426,8 @@
             "bulk_status_success": "{{count}} voci aggiornate",
             "bulk_status_error": "Aggiornamento di alcune voci non riuscito",
             "qset_title": "Curazione",
+            "qset_reviewed_of": "{{total}} voci revisionate",
+            "qset_accepted": "{{count}} accettate",
             "qset_pending": "{{count}} voci ancora da rivedere",
             "qset_complete": "Tutte le voci revisionate",
             "show_pending": "Da rivedere",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -426,6 +426,8 @@
             "bulk_status_success": "{{count}} items bijgewerkt",
             "bulk_status_error": "Sommige items bijwerken mislukt",
             "qset_title": "Curatie",
+            "qset_reviewed_of": "{{total}} items beoordeeld",
+            "qset_accepted": "{{count}} geaccepteerd",
             "qset_pending": "{{count}} items nog te beoordelen",
             "qset_complete": "Alle items beoordeeld",
             "show_pending": "Te beoordelen",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -426,6 +426,8 @@
       "bulk_status_success": "Zaktualizowano {{count}} elementów",
       "bulk_status_error": "Nie udało się zaktualizować niektórych elementów",
       "qset_title": "Kuracja",
+      "qset_reviewed_of": "{{total}} elementów przejrzanych",
+      "qset_accepted": "{{count}} zaakceptowanych",
       "qset_pending": "{{count}} elementów do przejrzenia",
       "qset_complete": "Wszystkie elementy przejrzane",
       "show_pending": "Do przejrzenia",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -426,6 +426,8 @@
             "bulk_status_success": "{{count}} itens atualizados",
             "bulk_status_error": "Falha ao atualizar alguns itens",
             "qset_title": "Curadoria",
+            "qset_reviewed_of": "{{total}} itens revistos",
+            "qset_accepted": "{{count}} aceites",
             "qset_pending": "{{count}} itens ainda por rever",
             "qset_complete": "Todos os itens revistos",
             "show_pending": "Por rever",

--- a/frontend/src/App.routing.test.tsx
+++ b/frontend/src/App.routing.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Routing-level tests for the router config exported from App.tsx.
+ *
+ * These exercise the REAL route array (not a hand-built duplicate) via
+ * react-router's own matching engine, so a route added, removed, or
+ * reordered in App.tsx is verified here without any drift between the
+ * "real" config and a test double of it.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { createMemoryRouter, matchRoutes, RouterProvider } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { routes } from './App';
+import i18n from './test-utils/i18n-test';
+
+describe('router: unknown URLs', () => {
+    it('renders the styled error page for an unknown admin URL instead of the router default screen', async () => {
+        const testRouter = createMemoryRouter(routes, {
+            initialEntries: ['/app/example-project/nope'],
+        });
+
+        render(
+            <I18nextProvider i18n={i18n}>
+                <RouterProvider router={testRouter} />
+            </I18nextProvider>
+        );
+
+        // Positive assertion: the app's own styled error page rendered (not a
+        // blank screen, which would make the "Hey developer" absence below
+        // vacuously true).
+        expect(await screen.findByRole('heading', { name: /not found/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /go to home/i })).toBeInTheDocument();
+
+        // Negative assertion: react-router's unstyled default error boundary
+        // (the "💿 Hey developer" screen) did not take over.
+        expect(screen.queryByText(/Hey developer/i)).not.toBeInTheDocument();
+    });
+});
+
+describe('router: real routes still resolve after the catch-all is added', () => {
+    // matchRoutes walks the exact same `routes` array App.tsx passes to
+    // createBrowserRouter. For each real path we assert the deepest matched
+    // route is the intended leaf, not the trailing `path: '*'` catch-all —
+    // guarding against a future reorder shadowing everything below it.
+    it.each([
+        { path: '/', label: 'landing page' },
+        { path: '/login', label: 'login page' },
+        { path: '/hub', label: 'researcher hub' },
+        { path: '/app/example-project/dashboard', label: 'project dashboard' },
+        { path: '/study/bioeconomy-futures', label: 'participant study layout' },
+        { path: '/study/bioeconomy-futures/welcome', label: 'participant welcome step' },
+    ])('$label ($path) does not fall through to the catch-all', ({ path }) => {
+        const matches = matchRoutes(routes, path);
+
+        expect(matches).not.toBeNull();
+        const deepest = matches?.[matches.length - 1];
+        expect(deepest?.route.path).not.toBe('*');
+    });
+
+    it('matches an unknown top-level URL only against the trailing catch-all route', () => {
+        const matches = matchRoutes(routes, '/app/example-project/nope');
+
+        expect(matches).not.toBeNull();
+        const deepest = matches?.[matches.length - 1];
+        expect(deepest?.route.path).toBe('*');
+    });
+
+    it('keeps the catch-all as the last entry so it cannot shadow any other route', () => {
+        const catchAllIndex = routes.findIndex((route) => route.path === '*');
+
+        expect(catchAllIndex).toBe(routes.length - 1);
+    });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@
  */
 
 import { lazy } from 'react';
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, Navigate, type RouteObject, RouterProvider } from 'react-router-dom';
 import { ApiError } from './api/client';
 import ErrorBoundary from './components/ErrorBoundary';
 
@@ -80,7 +80,11 @@ const AdminDashboard = lazy(() =>
 );
 import { DesignerSkeleton } from '@/components/admin/DashboardSkeleton';
 
-const router = createBrowserRouter([
+// Exported so App.routing.test.tsx can build a createMemoryRouter over this
+// exact config — see frontend/src/App.routing.test.tsx for why: testing
+// routing behaviour (which unmatched paths render) requires exercising the
+// real route tree, not a hand-built duplicate that could drift from it.
+export const routes: RouteObject[] = [
     {
         path: '/',
         element: (
@@ -358,7 +362,22 @@ const router = createBrowserRouter([
             },
         ],
     },
-]);
+    // Catch-all: any path that matches nothing above. Must stay last — an
+    // earlier `path: '*'` would shadow every route below it. Without this,
+    // an unmatched path (e.g. a typo'd admin URL) falls through to
+    // react-router's unstyled default error boundary instead of the app's
+    // own styled ErrorPage.
+    {
+        path: '*',
+        element: (
+            <PublicPageLayout>
+                <ErrorPage error={new ApiError(404, 'Page not found')} />
+            </PublicPageLayout>
+        ),
+    },
+];
+
+const router = createBrowserRouter(routes);
 
 import { ViewportProvider } from '@/contexts/ViewportContext';
 import { usePlatformConfigBootstrap } from '@/hooks/usePlatformConfigBootstrap';

--- a/frontend/src/components/admin/analysis/AnalysisHistory.test.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistory.test.tsx
@@ -124,7 +124,12 @@ describe('AnalysisHistoryPanel', () => {
         });
 
         renderWithProviders(
-            <AnalysisHistoryPanel slug="test-study" currentRunId={null} onLoadRun={vi.fn()} />
+            <AnalysisHistoryPanel
+                slug="test-study"
+                viewedRunId={null}
+                latestRunId={null}
+                onLoadRun={vi.fn()}
+            />
         );
 
         expect(screen.getByText(/No previous analyses for this study yet/i)).toBeInTheDocument();
@@ -151,7 +156,12 @@ describe('AnalysisHistoryPanel', () => {
         const onLoadRun = vi.fn();
 
         renderWithProviders(
-            <AnalysisHistoryPanel slug="test-study" currentRunId={null} onLoadRun={onLoadRun} />
+            <AnalysisHistoryPanel
+                slug="test-study"
+                viewedRunId={null}
+                latestRunId={null}
+                onLoadRun={onLoadRun}
+            />
         );
 
         // The row button loads the run (identified by its aria-label or text)
@@ -185,7 +195,12 @@ describe('AnalysisHistoryPanel', () => {
         const onLoadRun = vi.fn();
 
         renderWithProviders(
-            <AnalysisHistoryPanel slug="test-study" currentRunId={null} onLoadRun={onLoadRun} />
+            <AnalysisHistoryPanel
+                slug="test-study"
+                viewedRunId={null}
+                latestRunId={null}
+                onLoadRun={onLoadRun}
+            />
         );
 
         // Click the trash icon
@@ -226,7 +241,12 @@ describe('AnalysisHistoryPanel', () => {
         });
 
         renderWithProviders(
-            <AnalysisHistoryPanel slug="test-study" currentRunId={null} onLoadRun={vi.fn()} />
+            <AnalysisHistoryPanel
+                slug="test-study"
+                viewedRunId={null}
+                latestRunId={null}
+                onLoadRun={vi.fn()}
+            />
         );
 
         expect(screen.getByText('CENTROID')).toBeInTheDocument();
@@ -235,8 +255,8 @@ describe('AnalysisHistoryPanel', () => {
         expect(screen.getByText('manual')).toBeInTheDocument();
     });
 
-    // ── Test 5: Current tag shown when currentRunId matches a run ──────────
-    it('shows "current" tag on the run matching currentRunId', () => {
+    // ── Test 5: Current tag shown when latestRunId matches a run ──────────
+    it('shows "current" tag on the run matching latestRunId', () => {
         const run = makeRun({ id: 99 });
         mockListRunsHook.mockReturnValue({
             data: [run],
@@ -246,9 +266,112 @@ describe('AnalysisHistoryPanel', () => {
         });
 
         renderWithProviders(
-            <AnalysisHistoryPanel slug="test-study" currentRunId={99} onLoadRun={vi.fn()} />
+            <AnalysisHistoryPanel
+                slug="test-study"
+                viewedRunId={null}
+                latestRunId={99}
+                onLoadRun={vi.fn()}
+            />
         );
 
         expect(screen.getByText('current')).toBeInTheDocument();
+    });
+
+    // ── Tests 6-7: the post-delete bounce keys off `viewedRunId` ───────────
+    // `viewedRunId` (what the parent is displaying) and `latestRunId` (the
+    // study's most recent run) diverge whenever an older run is being viewed.
+    // Guarding the bounce on the wrong one breaks in both directions: it
+    // leaves the parent rendering a deleted run, and it ejects the analyst
+    // from a run that still exists. Both directions are pinned here.
+
+    /** Deletes the row for `runId`, confirming the AlertDialog. */
+    async function deleteRun(runId: number, runs: AnalysisRunSummary[]) {
+        const index = runs.findIndex((r) => r.id === runId);
+        if (index === -1) throw new Error(`run ${runId} not in the rendered list`);
+        const deleteButtons = screen.getAllByRole('button', {
+            name: /Delete this analysis run/i,
+        });
+        const target = deleteButtons[index];
+        if (!target) throw new Error(`no delete button at index ${index}`);
+        await userEvent.click(target);
+        await userEvent.click(screen.getByRole('button', { name: /^Delete$/ }));
+    }
+
+    it('signals the parent with (null, null) when the deleted run is the one being viewed', async () => {
+        // Newest first — the panel sorts ran_at descending, so this is also
+        // the rendered order.
+        const runs = [
+            makeRun({ id: 99, ran_at: '2025-03-02T10:00:00Z' }),
+            makeRun({ id: 42, ran_at: '2025-03-01T10:00:00Z' }),
+        ];
+        mockListRunsHook.mockReturnValue({
+            data: runs,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+        });
+        const mockMutate = vi.fn((_args, callbacks) => {
+            callbacks.onSuccess();
+        });
+        mockDeleteRunMutation.mockReturnValue({ mutate: mockMutate, isPending: false });
+
+        const onLoadRun = vi.fn();
+        renderWithProviders(
+            <AnalysisHistoryPanel
+                slug="test-study"
+                viewedRunId={42}
+                latestRunId={99}
+                onLoadRun={onLoadRun}
+            />
+        );
+
+        await deleteRun(42, runs);
+
+        await waitFor(() => {
+            expect(mockMutate).toHaveBeenCalledWith(
+                { slug: 'test-study', runId: 42 },
+                expect.any(Object)
+            );
+        });
+        expect(onLoadRun).toHaveBeenCalledWith(null, null);
+    });
+
+    it('leaves the parent alone when the deleted run is not the one being viewed', async () => {
+        const runs = [
+            makeRun({ id: 99, ran_at: '2025-03-02T10:00:00Z' }),
+            makeRun({ id: 42, ran_at: '2025-03-01T10:00:00Z' }),
+        ];
+        mockListRunsHook.mockReturnValue({
+            data: runs,
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+        });
+        const mockMutate = vi.fn((_args, callbacks) => {
+            callbacks.onSuccess();
+        });
+        mockDeleteRunMutation.mockReturnValue({ mutate: mockMutate, isPending: false });
+
+        const onLoadRun = vi.fn();
+        renderWithProviders(
+            <AnalysisHistoryPanel
+                slug="test-study"
+                viewedRunId={42}
+                latestRunId={99}
+                onLoadRun={onLoadRun}
+            />
+        );
+
+        // Delete the study's latest run (99) while viewing the older one (42).
+        await deleteRun(99, runs);
+
+        await waitFor(() => {
+            expect(mockMutate).toHaveBeenCalledWith(
+                { slug: 'test-study', runId: 99 },
+                expect.any(Object)
+            );
+        });
+        // Run 42 is still there — the parent must not be bounced off it.
+        expect(onLoadRun).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
@@ -25,7 +25,23 @@ import { EmptyState } from '@/components/ui/empty-state';
 
 interface AnalysisHistoryPanelProps {
     slug: string;
-    currentRunId: number | null;
+    /**
+     * The run the parent is currently displaying, or `null` when it isn't
+     * displaying one (explore phase, empty state, error state).
+     *
+     * Drives the post-delete bounce only: deleting *this* run would leave the
+     * parent rendering a run that no longer exists, so the panel signals it
+     * via `onLoadRun(null, null)`.
+     */
+    viewedRunId: number | null;
+    /**
+     * The study's most recent run, or `null` when unknown / not applicable.
+     *
+     * Drives the CURRENT tag only. Deliberately NOT `viewedRunId`: loading an
+     * older entry from history must not retag that row as "current", which is
+     * the contradiction Task 1.4 exists to remove.
+     */
+    latestRunId: number | null;
     onLoadRun: (result: AnalysisResult, run: AnalysisRunSummary) => void;
 }
 
@@ -48,7 +64,12 @@ function truncate(str: string, maxLen: number): string {
     return `${str.slice(0, maxLen)}…`;
 }
 
-export function AnalysisHistoryPanel({ slug, currentRunId, onLoadRun }: AnalysisHistoryPanelProps) {
+export function AnalysisHistoryPanel({
+    slug,
+    viewedRunId,
+    latestRunId,
+    onLoadRun,
+}: AnalysisHistoryPanelProps) {
     const { t } = useTranslation();
     const queryClient = useQueryClient();
 
@@ -131,10 +152,15 @@ export function AnalysisHistoryPanel({ slug, currentRunId, onLoadRun }: Analysis
                     toast.success(t('admin.analysis.history.deleted', 'Analysis run deleted.'));
                     setDeleteTargetId(null);
                     queryClient.invalidateQueries({ queryKey: listQueryKey });
-                    // If the deleted run is the one currently displayed,
-                    // the parent is notified via currentRunId becoming stale —
-                    // the caller clears the banner when currentRunId no longer exists.
-                    if (currentRunId === targetId) {
+                    // Deleting the run the parent is *displaying* would leave it
+                    // rendering a run that no longer exists (stale factor arrays,
+                    // a narrative editor and an Export menu that 404s). Signal it
+                    // with `(null, null)` so it can bounce back to explore.
+                    // Guarded on `viewedRunId`, never on `latestRunId`: those two
+                    // differ whenever an older run is being viewed, and using the
+                    // latter both misses this case and ejects the analyst from a
+                    // run that is still there.
+                    if (viewedRunId === targetId) {
                         onLoadRun(
                             null as unknown as AnalysisResult,
                             null as unknown as AnalysisRunSummary
@@ -235,7 +261,7 @@ export function AnalysisHistoryPanel({ slug, currentRunId, onLoadRun }: Analysis
                                             <span className="text-xs font-semibold text-slate-700">
                                                 {formatDateTime(run.ran_at)}
                                             </span>
-                                            {currentRunId === run.id && (
+                                            {latestRunId === run.id && (
                                                 <span className="text-2xs bg-indigo-100 text-indigo-700 font-black rounded-full px-1.5 py-0.5 uppercase tracking-wide">
                                                     {t(
                                                         'admin.analysis.history.current_tag',

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * InteractiveDataView.test.tsx
+ *
+ * Guards the responses table's header/body cell parity (Task 1.1). The
+ * regression: with a multilingual study, `showLanguageColumn` adds a
+ * `language` column whose body cells render but whose header did not —
+ * leaving every column from "Status" onward reading under the wrong
+ * label. Root cause was a React Compiler auto-memoization bug in the
+ * thead render (InteractiveDataView.tsx), not the column definitions in
+ * InteractiveDataView.columns.tsx — see the fix's doc comment on
+ * ResponsesTable for the full mechanism. These tests can't reproduce the
+ * compiler-specific defect directly (Vitest doesn't run the React
+ * Compiler babel pass — see vitest.config.ts vs vite.config.ts), but they
+ * pin the structural contract the bug violated: header count must match
+ * body cell count, and the language column must have a visible header.
+ */
+
+import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DumpParticipant, DumpResponse } from './types';
+import InteractiveDataView from './InteractiveDataView';
+
+const { mockDumpQuery } = vi.hoisted(() => ({ mockDumpQuery: vi.fn() }));
+
+vi.mock('@/api/generated', () => ({
+    useGetStudyDumpApiAdminStudiesSlugDumpGet: () => mockDumpQuery(),
+    getGetStudyDumpApiAdminStudiesSlugDumpGetQueryKey: (slug: string) => ['dump', slug],
+}));
+vi.mock('@/api/mutator', () => ({ customInstance: vi.fn() }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function makeParticipant(over: Partial<DumpParticipant> = {}): DumpParticipant {
+    return {
+        id: 'abcd1234',
+        db_id: 1,
+        duration_seconds: 619,
+        scores: [],
+        placements: {},
+        presort: {},
+        postsort: {},
+        language: 'en',
+        is_discarded: false,
+        created_at: '2026-01-01T00:00:00Z',
+        submitted_at: '2026-01-01T00:10:19Z',
+        status: 'completed',
+        ...over,
+    } as DumpParticipant;
+}
+
+// A two-translation study is what turns showLanguageColumn on
+// (useInteractiveDataView.ts: `showLanguageColumn = data.study.translations.length > 1`).
+function dumpResponseWithTranslations(langs: string[]): DumpResponse {
+    return {
+        study: {
+            slug: 'demo',
+            statements: [],
+            translations: langs.map((lang) => ({ lang, title: `Study (${lang})` })),
+            presort_config: {},
+            postsort_config: {},
+            state: 'active',
+            rough_sort_enabled: true,
+        },
+        participants: [makeParticipant()],
+        statement_id_to_index: {},
+    } as unknown as DumpResponse;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockDumpQuery.mockReturnValue({
+        data: dumpResponseWithTranslations(['en', 'fr']),
+        isLoading: false,
+        error: null,
+    });
+});
+
+describe('InteractiveDataView — responses table header/body alignment', () => {
+    it('renders one header cell per data cell when the study is multilingual', async () => {
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+
+        const table = await screen.findByRole('table');
+        const headerCells = within(table).getAllByRole('columnheader');
+        const firstBodyRow = within(table).getAllByRole('row')[1];
+        const bodyCells = within(firstBodyRow).getAllByRole('cell');
+
+        expect(headerCells).toHaveLength(bodyCells.length);
+    });
+
+    it('labels the language column', async () => {
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+
+        expect(await screen.findByRole('columnheader', { name: /lang/i })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -13,12 +13,15 @@
  * leaving every column from "Status" onward reading under the wrong
  * label. Root cause was a React Compiler auto-memoization bug in the
  * thead render (InteractiveDataView.tsx), not the column definitions in
- * InteractiveDataView.columns.tsx — see the fix's doc comment on
- * ResponsesTable for the full mechanism. These tests can't reproduce the
- * compiler-specific defect directly (Vitest doesn't run the React
- * Compiler babel pass — see vitest.config.ts vs vite.config.ts), but they
- * pin the structural contract the bug violated: header count must match
- * body cell count, and the language column must have a visible header.
+ * InteractiveDataView.columns.tsx — see the `'use no memo'` doc comment at
+ * the top of InteractiveDataView for the full mechanism. These tests can't
+ * reproduce the compiler-specific defect directly (Vitest doesn't run the
+ * React Compiler babel pass — see vitest.config.ts vs vite.config.ts), but
+ * they pin the structural contract the bug violated: header count must
+ * match body cell count, and the language column must have a visible
+ * header. The compiler-specific RED/GREEN guard lives in
+ * frontend/e2e/admin/data-table-columns.spec.ts, which runs against the
+ * real `npm run dev` pipeline (React Compiler included).
  */
 
 import { renderWithProviders, screen, within } from '@/test-utils/test-utils';

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -1,6 +1,9 @@
 import type { ParticipantRead } from '@/api/model';
+import type { TFunction } from 'i18next';
 import { type ReactNode, useState } from 'react';
-import { flexRender } from '@tanstack/react-table';
+import { flexRender, type Table as ReactTable } from '@tanstack/react-table';
+import type { DumpParticipant } from './types';
+import type { buildColumns } from './InteractiveDataView.columns';
 import {
     Table,
     TableBody,
@@ -107,6 +110,189 @@ function CollapsibleSection({
                 <div className="pt-2 pb-1">{children}</div>
             </Collapsible.Content>
         </Collapsible.Root>
+    );
+}
+
+interface ResponsesTableProps {
+    table: ReactTable<DumpParticipant>;
+    columns: ReturnType<typeof buildColumns>;
+    liveCount: number;
+    hasActiveFilters: boolean;
+    clearAllFilters: () => void;
+    handleViewParticipant: (participant: DumpParticipant) => void;
+    pagination: { pageIndex: number; pageSize: number };
+    t: TFunction;
+}
+
+/**
+ * ResponsesTable — thead/tbody/pagination for the interactive data view.
+ *
+ * Root cause of the header/body column-count mismatch (Task 1.1): the React
+ * Compiler auto-memoizes JSX expressions by inferring their reactive
+ * dependencies from what identifiers they read. `table` (from
+ * `useReactTable`) is a *stable* object for the component's lifetime —
+ * TanStack Table signals updates by mutating it via `setOptions`, never by
+ * returning a new reference — so an expression like
+ * `table.getHeaderGroups().map(...)` appears, to the compiler, to depend
+ * on nothing but that never-changing reference. The compiler then caches
+ * it forever after the first render that reaches it, even though the
+ * *content* of `getHeaderGroups()` depends on `columns`, which does
+ * change (e.g. when `showLanguageColumn` flips true). The row body
+ * happened to keep working only by accident, because its own JSX also
+ * reads `columns.length` in the empty-state branch, giving the compiler a
+ * real dependency to key on — the header row has no such reference, so it
+ * freezes at whichever column set existed on the first qualifying render,
+ * silently dropping a `<th>` while every `<td>` keeps rendering.
+ *
+ * `"use no memo"` opts this component out of that auto-memoization so
+ * `table`'s methods are called fresh on every render, matching normal
+ * (uncompiled) React semantics — the same semantics the test suite already
+ * exercises, since Vitest's config does not run the React Compiler babel
+ * pass.
+ */
+function ResponsesTable({
+    table,
+    columns,
+    liveCount,
+    hasActiveFilters,
+    clearAllFilters,
+    handleViewParticipant,
+    pagination,
+    t,
+}: ResponsesTableProps) {
+    'use no memo';
+    return (
+        <div className="bg-white border border-slate-200 shadow-xl shadow-slate-200/50 overflow-x-auto ring-1 ring-slate-100 rounded-xl sm:rounded-2xl">
+            <Table className="min-w-[800px]">
+                <TableHeader className="bg-slate-50/80">
+                    {table.getHeaderGroups().map((headerGroup) => (
+                        <TableRow
+                            key={headerGroup.id}
+                            className="hover:bg-transparent border-slate-100"
+                        >
+                            {headerGroup.headers.map((header) => (
+                                <TableHead
+                                    key={header.id}
+                                    className="h-14 text-xs font-semibold text-slate-600 px-2 sm:px-6 whitespace-nowrap"
+                                >
+                                    {header.isPlaceholder
+                                        ? null
+                                        : flexRender(
+                                              header.column.columnDef.header,
+                                              header.getContext()
+                                          )}
+                                </TableHead>
+                            ))}
+                        </TableRow>
+                    ))}
+                </TableHeader>
+                <TableBody>
+                    {table.getRowModel().rows.length ? (
+                        table.getRowModel().rows.map((row) => (
+                            <TableRow
+                                key={row.id}
+                                className={cn(
+                                    'cursor-pointer hover:bg-indigo-50/40 transition-all border-slate-50 group border-b last:border-0',
+                                    !!row.original.is_discarded && 'opacity-60 grayscale-[0.5]'
+                                )}
+                                onClick={() => handleViewParticipant(row.original)}
+                            >
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell
+                                        key={cell.id}
+                                        className="px-2 sm:px-6 py-4 sm:py-5 whitespace-nowrap"
+                                    >
+                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        ))
+                    ) : (
+                        <TableRow>
+                            <TableCell colSpan={columns.length} className="h-64 text-center">
+                                {liveCount === 0 ? (
+                                    // Wave E (E2): migrated to <EmptyState>.
+                                    <EmptyState
+                                        icon={Inbox}
+                                        title={t(
+                                            'admin.data.empty.no_participants_title',
+                                            'No participants yet'
+                                        )}
+                                        body={t(
+                                            'admin.data.empty.no_participants_desc',
+                                            'Share your study link to start collecting responses.'
+                                        )}
+                                        variant="inline"
+                                    />
+                                ) : (
+                                    <div className="flex flex-col items-center justify-center gap-4 text-slate-400">
+                                        <div className="p-4 bg-slate-50 rounded-full">
+                                            <Search className="w-8 h-8 opacity-20" />
+                                        </div>
+                                        <p className="font-bold">
+                                            {t('admin.data.search.no_results')}
+                                        </p>
+                                        {hasActiveFilters && (
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                onClick={clearAllFilters}
+                                                className="mt-2"
+                                            >
+                                                {t('admin.data.filters.clear_all', 'Clear filters')}
+                                            </Button>
+                                        )}
+                                    </div>
+                                )}
+                            </TableCell>
+                        </TableRow>
+                    )}
+                </TableBody>
+            </Table>
+
+            {/* Pagination */}
+            {table.getPageCount() > 1 && (
+                <div className="flex items-center justify-between px-6 py-3 border-t border-slate-100">
+                    <p className="text-xs text-slate-500 font-medium">
+                        {t(
+                            'admin.data.pagination.showing',
+                            'Showing {{from}}–{{to}} of {{total}}',
+                            {
+                                from: pagination.pageIndex * pagination.pageSize + 1,
+                                to: Math.min(
+                                    (pagination.pageIndex + 1) * pagination.pageSize,
+                                    table.getRowCount()
+                                ),
+                                total: table.getRowCount(),
+                            }
+                        )}
+                    </p>
+                    <div className="flex items-center gap-2">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => table.previousPage()}
+                            disabled={!table.getCanPreviousPage()}
+                            className="h-8 w-8 p-0 rounded-lg"
+                        >
+                            <ChevronLeft className="h-4 w-4" />
+                        </Button>
+                        <span className="text-xs font-bold text-slate-600 min-w-[4rem] text-center">
+                            {pagination.pageIndex + 1} / {table.getPageCount()}
+                        </span>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => table.nextPage()}
+                            disabled={!table.getCanNextPage()}
+                            className="h-8 w-8 p-0 rounded-lg"
+                        >
+                            <ChevronRight className="h-4 w-4" />
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </div>
     );
 }
 
@@ -769,147 +955,16 @@ export default function InteractiveDataView({
                 </AlertDialog>
 
                 {/* Table View */}
-                <div className="bg-white border border-slate-200 shadow-xl shadow-slate-200/50 overflow-x-auto ring-1 ring-slate-100 rounded-xl sm:rounded-2xl">
-                    <Table className="min-w-[800px]">
-                        <TableHeader className="bg-slate-50/80">
-                            {table.getHeaderGroups().map((headerGroup) => (
-                                <TableRow
-                                    key={headerGroup.id}
-                                    className="hover:bg-transparent border-slate-100"
-                                >
-                                    {headerGroup.headers.map((header) => (
-                                        <TableHead
-                                            key={header.id}
-                                            className="h-14 text-xs font-semibold text-slate-600 px-2 sm:px-6 whitespace-nowrap"
-                                        >
-                                            {header.isPlaceholder
-                                                ? null
-                                                : flexRender(
-                                                      header.column.columnDef.header,
-                                                      header.getContext()
-                                                  )}
-                                        </TableHead>
-                                    ))}
-                                </TableRow>
-                            ))}
-                        </TableHeader>
-                        <TableBody>
-                            {table.getRowModel().rows.length ? (
-                                table.getRowModel().rows.map((row) => (
-                                    <TableRow
-                                        key={row.id}
-                                        className={cn(
-                                            'cursor-pointer hover:bg-indigo-50/40 transition-all border-slate-50 group border-b last:border-0',
-                                            !!row.original.is_discarded &&
-                                                'opacity-60 grayscale-[0.5]'
-                                        )}
-                                        onClick={() => handleViewParticipant(row.original)}
-                                    >
-                                        {row.getVisibleCells().map((cell) => (
-                                            <TableCell
-                                                key={cell.id}
-                                                className="px-2 sm:px-6 py-4 sm:py-5 whitespace-nowrap"
-                                            >
-                                                {flexRender(
-                                                    cell.column.columnDef.cell,
-                                                    cell.getContext()
-                                                )}
-                                            </TableCell>
-                                        ))}
-                                    </TableRow>
-                                ))
-                            ) : (
-                                <TableRow>
-                                    <TableCell
-                                        colSpan={columns.length}
-                                        className="h-64 text-center"
-                                    >
-                                        {liveCount === 0 ? (
-                                            // Wave E (E2): migrated to <EmptyState>.
-                                            <EmptyState
-                                                icon={Inbox}
-                                                title={t(
-                                                    'admin.data.empty.no_participants_title',
-                                                    'No participants yet'
-                                                )}
-                                                body={t(
-                                                    'admin.data.empty.no_participants_desc',
-                                                    'Share your study link to start collecting responses.'
-                                                )}
-                                                variant="inline"
-                                            />
-                                        ) : (
-                                            <div className="flex flex-col items-center justify-center gap-4 text-slate-400">
-                                                <div className="p-4 bg-slate-50 rounded-full">
-                                                    <Search className="w-8 h-8 opacity-20" />
-                                                </div>
-                                                <p className="font-bold">
-                                                    {t('admin.data.search.no_results')}
-                                                </p>
-                                                {hasActiveFilters && (
-                                                    <Button
-                                                        variant="outline"
-                                                        size="sm"
-                                                        onClick={clearAllFilters}
-                                                        className="mt-2"
-                                                    >
-                                                        {t(
-                                                            'admin.data.filters.clear_all',
-                                                            'Clear filters'
-                                                        )}
-                                                    </Button>
-                                                )}
-                                            </div>
-                                        )}
-                                    </TableCell>
-                                </TableRow>
-                            )}
-                        </TableBody>
-                    </Table>
-
-                    {/* Pagination */}
-                    {table.getPageCount() > 1 && (
-                        <div className="flex items-center justify-between px-6 py-3 border-t border-slate-100">
-                            <p className="text-xs text-slate-500 font-medium">
-                                {t(
-                                    'admin.data.pagination.showing',
-                                    'Showing {{from}}\u2013{{to}} of {{total}}',
-                                    {
-                                        from: pagination.pageIndex * pagination.pageSize + 1,
-                                        to: Math.min(
-                                            (pagination.pageIndex + 1) * pagination.pageSize,
-                                            table.getRowCount()
-                                        ),
-                                        total: table.getRowCount(),
-                                    }
-                                )}
-                            </p>
-                            <div className="flex items-center gap-2">
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={() => table.previousPage()}
-                                    disabled={!table.getCanPreviousPage()}
-                                    className="h-8 w-8 p-0 rounded-lg"
-                                >
-                                    <ChevronLeft className="h-4 w-4" />
-                                </Button>
-                                <span className="text-xs font-bold text-slate-600 min-w-[4rem] text-center">
-                                    {pagination.pageIndex + 1} / {table.getPageCount()}
-                                </span>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={() => table.nextPage()}
-                                    disabled={!table.getCanNextPage()}
-                                    className="h-8 w-8 p-0 rounded-lg"
-                                >
-                                    <ChevronRight className="h-4 w-4" />
-                                </Button>
-                            </div>
-                        </div>
-                    )}
-                </div>
+                <ResponsesTable
+                    table={table}
+                    columns={columns}
+                    liveCount={liveCount}
+                    hasActiveFilters={hasActiveFilters}
+                    clearAllFilters={clearAllFilters}
+                    handleViewParticipant={handleViewParticipant}
+                    pagination={pagination}
+                    t={t}
+                />
             </CollapsibleSection>
 
             {/* Section 3: Key statistics */}

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -1,9 +1,6 @@
 import type { ParticipantRead } from '@/api/model';
-import type { TFunction } from 'i18next';
 import { type ReactNode, useState } from 'react';
-import { flexRender, type Table as ReactTable } from '@tanstack/react-table';
-import type { DumpParticipant } from './types';
-import type { buildColumns } from './InteractiveDataView.columns';
+import { flexRender } from '@tanstack/react-table';
 import {
     Table,
     TableBody,
@@ -113,194 +110,55 @@ function CollapsibleSection({
     );
 }
 
-interface ResponsesTableProps {
-    table: ReactTable<DumpParticipant>;
-    columns: ReturnType<typeof buildColumns>;
-    liveCount: number;
-    hasActiveFilters: boolean;
-    clearAllFilters: () => void;
-    handleViewParticipant: (participant: DumpParticipant) => void;
-    pagination: { pageIndex: number; pageSize: number };
-    t: TFunction;
-}
-
-/**
- * ResponsesTable — thead/tbody/pagination for the interactive data view.
- *
- * Root cause of the header/body column-count mismatch (Task 1.1): the React
- * Compiler auto-memoizes JSX expressions by inferring their reactive
- * dependencies from what identifiers they read. `table` (from
- * `useReactTable`) is a *stable* object for the component's lifetime —
- * TanStack Table signals updates by mutating it via `setOptions`, never by
- * returning a new reference — so an expression like
- * `table.getHeaderGroups().map(...)` appears, to the compiler, to depend
- * on nothing but that never-changing reference. The compiler then caches
- * it forever after the first render that reaches it, even though the
- * *content* of `getHeaderGroups()` depends on `columns`, which does
- * change (e.g. when `showLanguageColumn` flips true). The row body
- * happened to keep working only by accident, because its own JSX also
- * reads `columns.length` in the empty-state branch, giving the compiler a
- * real dependency to key on — the header row has no such reference, so it
- * freezes at whichever column set existed on the first qualifying render,
- * silently dropping a `<th>` while every `<td>` keeps rendering.
- *
- * `"use no memo"` opts this component out of that auto-memoization so
- * `table`'s methods are called fresh on every render, matching normal
- * (uncompiled) React semantics — the same semantics the test suite already
- * exercises, since Vitest's config does not run the React Compiler babel
- * pass.
- */
-function ResponsesTable({
-    table,
-    columns,
-    liveCount,
-    hasActiveFilters,
-    clearAllFilters,
-    handleViewParticipant,
-    pagination,
-    t,
-}: ResponsesTableProps) {
-    'use no memo';
-    return (
-        <div className="bg-white border border-slate-200 shadow-xl shadow-slate-200/50 overflow-x-auto ring-1 ring-slate-100 rounded-xl sm:rounded-2xl">
-            <Table className="min-w-[800px]">
-                <TableHeader className="bg-slate-50/80">
-                    {table.getHeaderGroups().map((headerGroup) => (
-                        <TableRow
-                            key={headerGroup.id}
-                            className="hover:bg-transparent border-slate-100"
-                        >
-                            {headerGroup.headers.map((header) => (
-                                <TableHead
-                                    key={header.id}
-                                    className="h-14 text-xs font-semibold text-slate-600 px-2 sm:px-6 whitespace-nowrap"
-                                >
-                                    {header.isPlaceholder
-                                        ? null
-                                        : flexRender(
-                                              header.column.columnDef.header,
-                                              header.getContext()
-                                          )}
-                                </TableHead>
-                            ))}
-                        </TableRow>
-                    ))}
-                </TableHeader>
-                <TableBody>
-                    {table.getRowModel().rows.length ? (
-                        table.getRowModel().rows.map((row) => (
-                            <TableRow
-                                key={row.id}
-                                className={cn(
-                                    'cursor-pointer hover:bg-indigo-50/40 transition-all border-slate-50 group border-b last:border-0',
-                                    !!row.original.is_discarded && 'opacity-60 grayscale-[0.5]'
-                                )}
-                                onClick={() => handleViewParticipant(row.original)}
-                            >
-                                {row.getVisibleCells().map((cell) => (
-                                    <TableCell
-                                        key={cell.id}
-                                        className="px-2 sm:px-6 py-4 sm:py-5 whitespace-nowrap"
-                                    >
-                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                    </TableCell>
-                                ))}
-                            </TableRow>
-                        ))
-                    ) : (
-                        <TableRow>
-                            <TableCell colSpan={columns.length} className="h-64 text-center">
-                                {liveCount === 0 ? (
-                                    // Wave E (E2): migrated to <EmptyState>.
-                                    <EmptyState
-                                        icon={Inbox}
-                                        title={t(
-                                            'admin.data.empty.no_participants_title',
-                                            'No participants yet'
-                                        )}
-                                        body={t(
-                                            'admin.data.empty.no_participants_desc',
-                                            'Share your study link to start collecting responses.'
-                                        )}
-                                        variant="inline"
-                                    />
-                                ) : (
-                                    <div className="flex flex-col items-center justify-center gap-4 text-slate-400">
-                                        <div className="p-4 bg-slate-50 rounded-full">
-                                            <Search className="w-8 h-8 opacity-20" />
-                                        </div>
-                                        <p className="font-bold">
-                                            {t('admin.data.search.no_results')}
-                                        </p>
-                                        {hasActiveFilters && (
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={clearAllFilters}
-                                                className="mt-2"
-                                            >
-                                                {t('admin.data.filters.clear_all', 'Clear filters')}
-                                            </Button>
-                                        )}
-                                    </div>
-                                )}
-                            </TableCell>
-                        </TableRow>
-                    )}
-                </TableBody>
-            </Table>
-
-            {/* Pagination */}
-            {table.getPageCount() > 1 && (
-                <div className="flex items-center justify-between px-6 py-3 border-t border-slate-100">
-                    <p className="text-xs text-slate-500 font-medium">
-                        {t(
-                            'admin.data.pagination.showing',
-                            'Showing {{from}}–{{to}} of {{total}}',
-                            {
-                                from: pagination.pageIndex * pagination.pageSize + 1,
-                                to: Math.min(
-                                    (pagination.pageIndex + 1) * pagination.pageSize,
-                                    table.getRowCount()
-                                ),
-                                total: table.getRowCount(),
-                            }
-                        )}
-                    </p>
-                    <div className="flex items-center gap-2">
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => table.previousPage()}
-                            disabled={!table.getCanPreviousPage()}
-                            className="h-8 w-8 p-0 rounded-lg"
-                        >
-                            <ChevronLeft className="h-4 w-4" />
-                        </Button>
-                        <span className="text-xs font-bold text-slate-600 min-w-[4rem] text-center">
-                            {pagination.pageIndex + 1} / {table.getPageCount()}
-                        </span>
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => table.nextPage()}
-                            disabled={!table.getCanNextPage()}
-                            className="h-8 w-8 p-0 rounded-lg"
-                        >
-                            <ChevronRight className="h-4 w-4" />
-                        </Button>
-                    </div>
-                </div>
-            )}
-        </div>
-    );
-}
-
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — JSX shell: complexity is structural (many conditional render branches for filter badges, stat cards, table pagination) not algorithmic; matchers, cells and columns extracted to helpers/sub-components above
 export default function InteractiveDataView({
     slug,
     participants: initialParticipants,
 }: InteractiveDataViewProps) {
+    /**
+     * Root cause of the responses-table header/body column-count mismatch
+     * (Task 1.1): the React Compiler auto-memoizes JSX expressions by
+     * inferring their reactive dependencies from what identifiers they
+     * read. `table` (from `useReactTable`, below) is a *stable* object for
+     * this component's lifetime — TanStack Table signals updates by
+     * mutating it via `setOptions`, never by returning a new reference —
+     * so an expression like `table.getHeaderGroups().map(...)` appears, to
+     * the compiler, to depend on nothing but that never-changing
+     * reference. The compiler then caches it forever after the first
+     * render that reaches it, even though the *content* of
+     * `getHeaderGroups()` depends on `columns`, which does change (e.g.
+     * when `showLanguageColumn` flips true). The row body happened to keep
+     * working only by accident, because its own JSX also reads
+     * `columns.length` in the empty-state branch, giving the compiler a
+     * real dependency to key on — the header row has no such reference, so
+     * it freezes at whichever column set existed on the first qualifying
+     * render, silently dropping a `<th>` while every `<td>` keeps
+     * rendering.
+     *
+     * `"use no memo"` opts this component out of that auto-memoization so
+     * `table`'s methods are called fresh on every render, matching normal
+     * (uncompiled) React semantics.
+     *
+     * The directive must live here, on the component that *consumes* the
+     * table instance — not on a child it renders. An earlier version of
+     * this fix extracted the table JSX into a child component and put the
+     * directive there; that un-compiled the child correctly, but this
+     * (still-compiled) parent kept memoizing the *element* it passed to
+     * that child, e.g.:
+     *
+     *   t130 = ($[317] !== clearAllFilters || ... || $[324] !== table)
+     *       ? <ResponsesTable table={table} ... />
+     *       : $[325]; // reused element — child never re-renders
+     *
+     * `sorting` and `globalFilter` were in neither the child's props nor
+     * that dependency list, so sorting/searching left the element
+     * reference unchanged, React bailed out of the subtree, and the
+     * child's own `"use no memo"` never got a chance to run — sort and
+     * search stayed frozen even after the header/body fix. Per TanStack
+     * Table's own guidance, the opt-out belongs on the component holding
+     * the table instance.
+     */
+    'use no memo';
     const { t, i18n } = useTranslation();
     const {
         status: { isLoading, error },
@@ -955,16 +813,147 @@ export default function InteractiveDataView({
                 </AlertDialog>
 
                 {/* Table View */}
-                <ResponsesTable
-                    table={table}
-                    columns={columns}
-                    liveCount={liveCount}
-                    hasActiveFilters={hasActiveFilters}
-                    clearAllFilters={clearAllFilters}
-                    handleViewParticipant={handleViewParticipant}
-                    pagination={pagination}
-                    t={t}
-                />
+                <div className="bg-white border border-slate-200 shadow-xl shadow-slate-200/50 overflow-x-auto ring-1 ring-slate-100 rounded-xl sm:rounded-2xl">
+                    <Table className="min-w-[800px]">
+                        <TableHeader className="bg-slate-50/80">
+                            {table.getHeaderGroups().map((headerGroup) => (
+                                <TableRow
+                                    key={headerGroup.id}
+                                    className="hover:bg-transparent border-slate-100"
+                                >
+                                    {headerGroup.headers.map((header) => (
+                                        <TableHead
+                                            key={header.id}
+                                            className="h-14 text-xs font-semibold text-slate-600 px-2 sm:px-6 whitespace-nowrap"
+                                        >
+                                            {header.isPlaceholder
+                                                ? null
+                                                : flexRender(
+                                                      header.column.columnDef.header,
+                                                      header.getContext()
+                                                  )}
+                                        </TableHead>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableHeader>
+                        <TableBody>
+                            {table.getRowModel().rows.length ? (
+                                table.getRowModel().rows.map((row) => (
+                                    <TableRow
+                                        key={row.id}
+                                        className={cn(
+                                            'cursor-pointer hover:bg-indigo-50/40 transition-all border-slate-50 group border-b last:border-0',
+                                            !!row.original.is_discarded &&
+                                                'opacity-60 grayscale-[0.5]'
+                                        )}
+                                        onClick={() => handleViewParticipant(row.original)}
+                                    >
+                                        {row.getVisibleCells().map((cell) => (
+                                            <TableCell
+                                                key={cell.id}
+                                                className="px-2 sm:px-6 py-4 sm:py-5 whitespace-nowrap"
+                                            >
+                                                {flexRender(
+                                                    cell.column.columnDef.cell,
+                                                    cell.getContext()
+                                                )}
+                                            </TableCell>
+                                        ))}
+                                    </TableRow>
+                                ))
+                            ) : (
+                                <TableRow>
+                                    <TableCell
+                                        colSpan={columns.length}
+                                        className="h-64 text-center"
+                                    >
+                                        {liveCount === 0 ? (
+                                            // Wave E (E2): migrated to <EmptyState>.
+                                            <EmptyState
+                                                icon={Inbox}
+                                                title={t(
+                                                    'admin.data.empty.no_participants_title',
+                                                    'No participants yet'
+                                                )}
+                                                body={t(
+                                                    'admin.data.empty.no_participants_desc',
+                                                    'Share your study link to start collecting responses.'
+                                                )}
+                                                variant="inline"
+                                            />
+                                        ) : (
+                                            <div className="flex flex-col items-center justify-center gap-4 text-slate-400">
+                                                <div className="p-4 bg-slate-50 rounded-full">
+                                                    <Search className="w-8 h-8 opacity-20" />
+                                                </div>
+                                                <p className="font-bold">
+                                                    {t('admin.data.search.no_results')}
+                                                </p>
+                                                {hasActiveFilters && (
+                                                    <Button
+                                                        variant="outline"
+                                                        size="sm"
+                                                        onClick={clearAllFilters}
+                                                        className="mt-2"
+                                                    >
+                                                        {t(
+                                                            'admin.data.filters.clear_all',
+                                                            'Clear filters'
+                                                        )}
+                                                    </Button>
+                                                )}
+                                            </div>
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                        </TableBody>
+                    </Table>
+
+                    {/* Pagination */}
+                    {table.getPageCount() > 1 && (
+                        <div className="flex items-center justify-between px-6 py-3 border-t border-slate-100">
+                            <p className="text-xs text-slate-500 font-medium">
+                                {t(
+                                    'admin.data.pagination.showing',
+                                    'Showing {{from}}–{{to}} of {{total}}',
+                                    {
+                                        from: pagination.pageIndex * pagination.pageSize + 1,
+                                        to: Math.min(
+                                            (pagination.pageIndex + 1) * pagination.pageSize,
+                                            table.getRowCount()
+                                        ),
+                                        total: table.getRowCount(),
+                                    }
+                                )}
+                            </p>
+                            <div className="flex items-center gap-2">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => table.previousPage()}
+                                    disabled={!table.getCanPreviousPage()}
+                                    className="h-8 w-8 p-0 rounded-lg"
+                                >
+                                    <ChevronLeft className="h-4 w-4" />
+                                </Button>
+                                <span className="text-xs font-bold text-slate-600 min-w-[4rem] text-center">
+                                    {pagination.pageIndex + 1} / {table.getPageCount()}
+                                </span>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => table.nextPage()}
+                                    disabled={!table.getCanNextPage()}
+                                    className="h-8 w-8 p-0 rounded-lg"
+                                >
+                                    <ChevronRight className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </div>
             </CollapsibleSection>
 
             {/* Section 3: Key statistics */}

--- a/frontend/src/hooks/admin/useExplorePhase.test.ts
+++ b/frontend/src/hooks/admin/useExplorePhase.test.ts
@@ -14,6 +14,8 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AllTheProviders } from '@/test-utils/test-utils';
 import type { PreviewRangeRow } from '@/api/model/previewRangeRow';
 import { useExplorePhase } from './useExplorePhase';
@@ -286,6 +288,67 @@ describe('useExplorePhase', () => {
 
         await waitFor(() => expect(mockListAnalysisRuns).toHaveBeenCalled());
         expect(onCommit).not.toHaveBeenCalled();
+    });
+
+    // ── Task 1.4 review round 1 ──────────────────────────────────────
+    // AnalysisPage's own runs-list query (which both the interpret-phase
+    // banner and AnalysisHistoryPanel's CURRENT tag read to determine the
+    // study's actual latest run) shares this exact cache entry. A plain
+    // `invalidateQueries` only marks it stale and kicks off a second,
+    // independent background refetch with no ordering guarantee against
+    // the `onCommit` navigation right below it — so InterpretShell could
+    // render the just-committed run before that refetch lands, reading a
+    // pre-commit list and wrongly treating the new run as historical.
+    it('seeds the runs-list query cache with the fresh list (not just invalidates it) on a successful commit', async () => {
+        const mockMutate = vi.fn(
+            (_vars: unknown, opts?: { onSuccess?: (data: { n_factors: number }) => void }) => {
+                opts?.onSuccess?.({ n_factors: 3 });
+            }
+        );
+        mockAnalysisMutationHook.mockReturnValue({ mutate: mockMutate, isPending: false });
+        mockEigenvaluesHook.mockReturnValue(makeLoadedEigenvalues());
+        const freshRuns = [
+            {
+                id: 99,
+                ran_at: '2026-04-29T10:00:00Z',
+                n_factors: 3,
+                extraction_method: 'pca',
+                rotation_method: 'varimax',
+                flagging_mode: 'auto',
+            },
+            {
+                id: 50,
+                ran_at: '2026-04-28T10:00:00Z',
+                n_factors: 2,
+                extraction_method: 'pca',
+                rotation_method: 'varimax',
+                flagging_mode: 'auto',
+            },
+        ];
+        mockListAnalysisRuns.mockResolvedValue(freshRuns);
+
+        // A dedicated QueryClient, kept in scope so the test can inspect its
+        // cache directly afterwards — `AllTheProviders` creates its own
+        // internal client with no way to reach back into it.
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        const wrapper = ({ children }: { children: ReactNode }) =>
+            createElement(QueryClientProvider, { client: queryClient }, children);
+
+        const onCommit = vi.fn();
+        const { result } = renderHook(() => useExplorePhase('test-study', onCommit), { wrapper });
+
+        await waitFor(() => expect(result.current.hasEigenvalues).toBe(true));
+
+        await act(async () => {
+            result.current.handleRunAnalysis();
+        });
+
+        await waitFor(() => expect(onCommit).toHaveBeenCalledWith(99));
+
+        // The cache already holds the fresh list by the time onCommit fires
+        // — not merely marked stale for some later, unordered refetch to
+        // fill in.
+        expect(queryClient.getQueryData(mockGetListAnalysisRunsQueryKey())).toEqual(freshRuns);
     });
 
     describe('judgmental rotation', () => {

--- a/frontend/src/hooks/admin/useExplorePhase.test.ts
+++ b/frontend/src/hooks/admin/useExplorePhase.test.ts
@@ -351,6 +351,48 @@ describe('useExplorePhase', () => {
         expect(queryClient.getQueryData(mockGetListAnalysisRunsQueryKey())).toEqual(freshRuns);
     });
 
+    // ── Task 1.4 review round 2 ──────────────────────────────────────
+    // Seeding the cache (above) covers the happy path, but it is the only
+    // thing that marks the runs list as needing a refresh. If the raw
+    // follow-up fetch throws — no retry budget, unlike the query client's
+    // own — nothing marks it stale, and with staleTime 5 min +
+    // refetchOnWindowFocus:false the history panel keeps rendering the
+    // pre-commit list under a "Analysis complete" toast. Invalidating in
+    // the catch restores the recovery path without regressing the seeding.
+    it('invalidates the runs-list query when the follow-up fetch fails', async () => {
+        const mockMutate = vi.fn(
+            (_vars: unknown, opts?: { onSuccess?: (data: { n_factors: number }) => void }) => {
+                opts?.onSuccess?.({ n_factors: 3 });
+            }
+        );
+        mockAnalysisMutationHook.mockReturnValue({ mutate: mockMutate, isPending: false });
+        mockEigenvaluesHook.mockReturnValue(makeLoadedEigenvalues());
+        mockListAnalysisRuns.mockRejectedValue(new Error('Network'));
+
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        const wrapper = ({ children }: { children: ReactNode }) =>
+            createElement(QueryClientProvider, { client: queryClient }, children);
+
+        const onCommit = vi.fn();
+        const { result } = renderHook(() => useExplorePhase('test-study', onCommit), { wrapper });
+
+        await waitFor(() => expect(result.current.hasEigenvalues).toBe(true));
+
+        await act(async () => {
+            result.current.handleRunAnalysis();
+        });
+
+        await waitFor(() => {
+            expect(invalidateSpy).toHaveBeenCalledWith({
+                queryKey: mockGetListAnalysisRunsQueryKey(),
+            });
+        });
+        // The failure is still non-fatal for routing: no run id was learned,
+        // so the analyst stays on Explore rather than being sent nowhere.
+        expect(onCommit).not.toHaveBeenCalled();
+    });
+
     describe('judgmental rotation', () => {
         it('manualRotations is empty by default', () => {
             const { result } = renderHook(() => useExplorePhase('test-study', vi.fn()), {

--- a/frontend/src/hooks/admin/useExplorePhase.ts
+++ b/frontend/src/hooks/admin/useExplorePhase.ts
@@ -307,13 +307,23 @@ export function useExplorePhase(slug: string, onCommit: (runId: number) => void)
                             n: data.n_factors,
                         })
                     );
-                    // Invalidate the runs list so the history panel refreshes when the
-                    // analyst returns. Then fetch the fresh runId so the caller can route.
+                    // Fetch the fresh runs list, then seed the query cache with it
+                    // directly (setQueryData) rather than merely invalidating and
+                    // relying on a separate background refetch. AnalysisPage's own
+                    // `runsQuery` reads this exact cache entry to decide which run
+                    // is "current" for the interpret-phase banner and the history
+                    // panel's CURRENT tag; a plain invalidate races an unrelated
+                    // refetch against the navigation below, so InterpretShell could
+                    // render the just-committed run before that refetch lands and
+                    // wrongly flag it as historical — the very contradiction this
+                    // banner exists to avoid. Writing the data we already fetched
+                    // straight into the cache makes it available the instant we
+                    // navigate, with no second round-trip.
                     const runsQueryKey =
                         getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey(slug);
-                    queryClient.invalidateQueries({ queryKey: runsQueryKey });
                     try {
                         const runs = await listAnalysisRunsApiAdminStudiesSlugAnalysisRunsGet(slug);
+                        queryClient.setQueryData(runsQueryKey, runs);
                         const fresh = runs.length > 0 ? (runs[0] ?? null) : null;
                         if (fresh) onCommit(fresh.id);
                     } catch {

--- a/frontend/src/hooks/admin/useExplorePhase.ts
+++ b/frontend/src/hooks/admin/useExplorePhase.ts
@@ -327,7 +327,16 @@ export function useExplorePhase(slug: string, onCommit: (runId: number) => void)
                         const fresh = runs.length > 0 ? (runs[0] ?? null) : null;
                         if (fresh) onCommit(fresh.id);
                     } catch {
-                        // Non-fatal: the analyst can navigate via history.
+                        // The seeding fetch failed (it is a raw call, with none
+                        // of the query client's retry budget). Nothing has
+                        // written the new run into the cache, so fall back to
+                        // invalidating: without it the list stays "fresh" for
+                        // staleTime (5 min, no refetch-on-focus) and the
+                        // history panel below the success toast keeps showing
+                        // the pre-commit list — reading, to the analyst, as
+                        // "it did not save", with a duplicate run as the
+                        // natural next move.
+                        queryClient.invalidateQueries({ queryKey: runsQueryKey });
                     }
                 },
                 onError: (error) => {

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithProviders, screen, waitFor } from '@/test-utils/test-utils';
+import { renderWithProviders, screen, waitFor, within } from '@/test-utils/test-utils';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import AnalysisPage from './AnalysisPage';
@@ -990,6 +990,121 @@ describe('AnalysisPage', () => {
         // the URL has flipped to interpret.
         await waitFor(() => {
             expect(screen.getByTestId('interpret-phase')).toBeInTheDocument();
+        });
+    });
+
+    // ── Historical-run banner (Task 1.4) ────────────────────────────
+    // The amber "Viewing run from … / Back to current" banner must only
+    // appear when the selected run is NOT the study's most recent one.
+    // "Most recent" is derived from the same runs list + `ran_at`
+    // ordering AnalysisHistoryPanel already uses for its own CURRENT tag
+    // and useExplorePhase already uses to find "the fresh run" right
+    // after a commit — not a per-run `is_current` field (the API exposes
+    // no such thing).
+    describe('historical-run banner (Task 1.4)', () => {
+        it('hides the historical-run banner when the selected run is the current one', async () => {
+            mockEigenvaluesHook.mockReturnValue({
+                data: mockEigenvalues,
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+                refetch: vi.fn(),
+            });
+            mockGetRunHook.mockReturnValue({
+                data: mockRun,
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+            });
+            // Run 42 is the only run on record, so it is trivially also the
+            // most recent one.
+            mockListRunsHook.mockReturnValue({
+                data: [
+                    {
+                        id: 42,
+                        ran_at: mockRun.ran_at,
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                ],
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+            });
+
+            renderWithProviders(<AnalysisPage />, {
+                initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+            });
+
+            // Sanity check: we actually reached the loaded (non-error,
+            // non-loading) interpret branch — the only branch that can
+            // render the run banner. Without this, an assertion of absence
+            // could pass vacuously because the page never got there.
+            expect(await screen.findByRole('button', { name: /export/i })).toBeInTheDocument();
+
+            expect(screen.queryByTestId('run-banner')).not.toBeInTheDocument();
+            expect(screen.queryByText(/viewing run from/i)).not.toBeInTheDocument();
+        });
+
+        it('shows the historical-run banner when an older run is selected', async () => {
+            mockEigenvaluesHook.mockReturnValue({
+                data: mockEigenvalues,
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+                refetch: vi.fn(),
+            });
+            mockGetRunHook.mockReturnValue({
+                data: mockRun, // id 42, ran_at 2026-04-29T12:00:00Z
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+            });
+            // Run 99 was created after run 42, so 42 is now historical.
+            mockListRunsHook.mockReturnValue({
+                data: [
+                    {
+                        id: 42,
+                        ran_at: '2026-04-29T12:00:00Z',
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                    {
+                        id: 99,
+                        ran_at: '2026-04-29T13:00:00Z',
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                ],
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+            });
+
+            renderWithProviders(<AnalysisPage />, {
+                initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+            });
+
+            // Scoped to the banner itself: the page has a second, unrelated
+            // "Back to current" affordance in its error state, which shares
+            // the same accessible name. Asserting inside the banner element
+            // (rather than a bare screen.getByRole) means this test can only
+            // pass by matching the banner, not that other affordance.
+            const banner = await screen.findByTestId('run-banner');
+            expect(within(banner).getByText(/viewing run from/i)).toBeInTheDocument();
+            expect(
+                within(banner).getByRole('button', { name: /back to current/i })
+            ).toBeInTheDocument();
         });
     });
 });

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -754,6 +754,132 @@ describe('AnalysisPage', () => {
         expect(screen.getByRole('button', { name: /commit and interpret/i })).toBeInTheDocument();
     });
 
+    // ── Delete wiring: viewedRunId vs latestRunId (review round 2) ──
+    // InterpretShell feeds AnalysisHistoryPanel two different run ids —
+    // `viewedRunId` (what this view renders, drives the post-delete bounce)
+    // and `latestRunId` (the study's most recent run, drives the CURRENT
+    // tag). They diverge exactly when an older run is being viewed, and the
+    // panel's own suite cannot catch a swap at this call site. Both
+    // directions are pinned here, at the wiring.
+
+    describe('post-delete bounce wiring (two runs, older one viewed)', () => {
+        /** Interpret phase on run 42, with run 99 as the study's latest. */
+        function setupTwoRunsViewingOlder() {
+            mockEigenvaluesHook.mockReturnValue({
+                data: mockEigenvalues,
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+                refetch: vi.fn(),
+            });
+            mockGetRunHook.mockReturnValue({
+                data: mockRun, // id 42 — older than 99
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+            });
+            mockListRunsHook.mockReturnValue({
+                data: [
+                    {
+                        id: 42,
+                        ran_at: '2026-04-29T12:00:00Z',
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                    {
+                        id: 99,
+                        ran_at: '2026-04-29T13:00:00Z', // the study's latest run
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                ],
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+            });
+            const mockDeleteMutate = vi.fn((_vars: unknown, opts?: { onSuccess?: () => void }) => {
+                opts?.onSuccess?.();
+            });
+            mockDeleteRunMutation.mockReturnValue({
+                mutate: mockDeleteMutate,
+                isPending: false,
+            });
+            return mockDeleteMutate;
+        }
+
+        /**
+         * Deletes the history row at `rowIndex` (the panel sorts ran_at
+         * descending, so 0 = run 99, 1 = run 42) and confirms the dialog.
+         */
+        async function deleteHistoryRow(rowIndex: number) {
+            const deleteButtons = screen.getAllByLabelText(/Delete this analysis run/i);
+            const target = deleteButtons[rowIndex];
+            if (!target) throw new Error(`no delete button at row ${rowIndex}`);
+            await userEvent.click(target);
+            await userEvent.click(await screen.findByRole('button', { name: /^Delete$/ }));
+        }
+
+        it('bounces to Explore when the run being viewed is deleted, even though it is not the latest', async () => {
+            const mockDeleteMutate = setupTwoRunsViewingOlder();
+
+            renderWithProviders(<AnalysisPage />, {
+                initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+            });
+
+            await waitFor(() => {
+                expect(screen.getByTestId('interpret-phase')).toBeInTheDocument();
+            });
+
+            // Row 1 is run 42 — the one this view is displaying.
+            await deleteHistoryRow(1);
+            expect(mockDeleteMutate).toHaveBeenCalledWith(
+                { slug: 'test-study', runId: 42 },
+                expect.any(Object)
+            );
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('interpret-phase')).not.toBeInTheDocument();
+            });
+            expect(
+                screen.getByRole('button', { name: /commit and interpret/i })
+            ).toBeInTheDocument();
+        });
+
+        it('stays on the run being viewed when a different (latest) run is deleted', async () => {
+            const mockDeleteMutate = setupTwoRunsViewingOlder();
+
+            renderWithProviders(<AnalysisPage />, {
+                initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+            });
+
+            await waitFor(() => {
+                expect(screen.getByTestId('interpret-phase')).toBeInTheDocument();
+            });
+
+            // Row 0 is run 99 — the study's latest, but NOT what we're viewing.
+            await deleteHistoryRow(0);
+            expect(mockDeleteMutate).toHaveBeenCalledWith(
+                { slug: 'test-study', runId: 99 },
+                expect.any(Object)
+            );
+
+            // Run 42 still exists, so the analyst must still be on it. Assert
+            // a positive marker of the loaded interpret branch (not just the
+            // sr-only phase marker) so this cannot pass on a blank render.
+            expect(await screen.findByRole('button', { name: /export/i })).toBeInTheDocument();
+            expect(screen.getByTestId('interpret-phase')).toBeInTheDocument();
+            expect(
+                screen.queryByRole('button', { name: /commit and interpret/i })
+            ).not.toBeInTheDocument();
+        });
+    });
+
     // ── Focus / Overview mode toggle (Task 24) ─────────────────────
 
     it('Interpret phase renders Focus mode by default', async () => {
@@ -1044,6 +1170,63 @@ describe('AnalysisPage', () => {
             // non-loading) interpret branch — the only branch that can
             // render the run banner. Without this, an assertion of absence
             // could pass vacuously because the page never got there.
+            expect(await screen.findByRole('button', { name: /export/i })).toBeInTheDocument();
+
+            expect(screen.queryByTestId('run-banner')).not.toBeInTheDocument();
+            expect(screen.queryByText(/viewing run from/i)).not.toBeInTheDocument();
+        });
+
+        it('hides the historical-run banner when the latest of several runs is selected', async () => {
+            // The headline post-commit journey: run 99 was just committed on
+            // top of run 42, and the page lands on 99. The single-run case
+            // above cannot tell "the latest run wins" apart from "any run with
+            // no history wins" — this one can.
+            mockEigenvaluesHook.mockReturnValue({
+                data: mockEigenvalues,
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+                refetch: vi.fn(),
+            });
+            mockGetRunHook.mockReturnValue({
+                data: { ...mockRun, id: 99, ran_at: '2026-04-29T13:00:00Z' },
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+            });
+            mockListRunsHook.mockReturnValue({
+                data: [
+                    {
+                        id: 42,
+                        ran_at: '2026-04-29T12:00:00Z',
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                    {
+                        id: 99,
+                        ran_at: '2026-04-29T13:00:00Z', // the just-committed run
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                ],
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+            });
+
+            renderWithProviders(<AnalysisPage />, {
+                initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=99`],
+            });
+
+            // Sanity check: we reached the loaded interpret branch, the only
+            // one that can render the banner — otherwise the absence
+            // assertions below would pass vacuously.
             expect(await screen.findByRole('button', { name: /export/i })).toBeInTheDocument();
 
             expect(screen.queryByTestId('run-banner')).not.toBeInTheDocument();

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -1106,5 +1106,125 @@ describe('AnalysisPage', () => {
                 within(banner).getByRole('button', { name: /back to current/i })
             ).toBeInTheDocument();
         });
+
+        // ── Review round 1 fixes ────────────────────────────────────
+        // Two findings from the first review pass on Task 1.4:
+        // (1) AnalysisHistoryPanel's own CURRENT tag was still wired to
+        //     `runId` (whichever run is being viewed), not to the study's
+        //     actual latest run — so browsing to an older run from history
+        //     retagged *that* row CURRENT, reproducing the exact
+        //     contradiction this task exists to remove, just reached via
+        //     the history panel instead of a post-commit banner.
+        // (2) The banner could silently render as "hidden" (i.e. claim the
+        //     viewed run is current) before the runs list had loaded at
+        //     all — a worse failure than the one being fixed, since it
+        //     actively hides a needed warning rather than wrongly showing
+        //     an unneeded one.
+
+        it('tags the study’s actual latest run CURRENT in the history panel, not whichever run is being viewed', async () => {
+            mockEigenvaluesHook.mockReturnValue({
+                data: mockEigenvalues,
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+                refetch: vi.fn(),
+            });
+            mockGetRunHook.mockReturnValue({
+                data: mockRun, // id 42 — the run being viewed, but NOT the latest
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+            });
+            mockListRunsHook.mockReturnValue({
+                data: [
+                    {
+                        id: 42,
+                        ran_at: '2026-04-29T12:00:00Z',
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                    {
+                        id: 99,
+                        ran_at: '2026-04-29T13:00:00Z', // later — the actual latest run
+                        extraction_method: 'pca',
+                        n_factors: 2,
+                        rotation_method: 'varimax',
+                        flagging_mode: 'auto',
+                    },
+                ],
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+            });
+
+            renderWithProviders(<AnalysisPage />, {
+                initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+            });
+
+            // AnalysisHistoryPanel sorts its rows by ran_at descending, so the
+            // most recent run (99) renders first, the older one (42) second.
+            // Each row's own clickable area is a <button> whose accessible
+            // name is derived from that row's `ran_at` — using role/order
+            // instead of the formatted date string keeps this test immune
+            // to the test runner's timezone.
+            const rows = await screen.findAllByRole('button', {
+                name: /load analysis run from/i,
+            });
+            expect(rows).toHaveLength(2);
+            const [latestRow, historicalRow] = rows;
+            if (!latestRow || !historicalRow) throw new Error('expected two history rows');
+
+            // The actual latest run (99) is tagged CURRENT...
+            expect(within(latestRow).getByText(/^current$/i)).toBeInTheDocument();
+            // ...and the run being viewed (42, historical) is NOT — even
+            // though it's the one driving the page's `runId`.
+            expect(within(historicalRow).queryByText(/^current$/i)).not.toBeInTheDocument();
+        });
+
+        it('does not render the success view (nor silently hide the banner) while the runs list is still loading', async () => {
+            mockEigenvaluesHook.mockReturnValue({
+                data: mockEigenvalues,
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+                refetch: vi.fn(),
+            });
+            // The run-by-id fetch has already resolved...
+            mockGetRunHook.mockReturnValue({
+                data: mockRun,
+                isLoading: false,
+                isSuccess: true,
+                isError: false,
+                error: null,
+            });
+            // ...but the separate runs-list query (which `latestRun` and the
+            // history panel's CURRENT tag both depend on) has not settled
+            // yet — this is the ordinary shape of a fresh direct navigation
+            // to `?phase=interpret&runId=42` (bookmark, shared link,
+            // refresh), where the two fetches race.
+            mockListRunsHook.mockReturnValue({
+                data: undefined,
+                isLoading: true,
+                isSuccess: false,
+                isError: false,
+            });
+
+            renderWithProviders(<AnalysisPage />, {
+                initialEntries: [`${ANALYSIS_PATH}?phase=interpret&runId=42`],
+            });
+
+            // Still shows the run-loading indicator...
+            expect(await screen.findByText(/loading run/i)).toBeInTheDocument();
+            // ...and crucially has NOT fallen through to the success view,
+            // which is the only place that could wrongly render with a
+            // silently-assumed-current (banner absent) state.
+            expect(screen.queryByRole('button', { name: /export/i })).not.toBeInTheDocument();
+            expect(screen.queryByTestId('run-banner')).not.toBeInTheDocument();
+        });
     });
 });

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -177,6 +177,12 @@ export default function AnalysisPage() {
         query: { enabled: !!slug },
     });
     const runs = runsQuery.data ?? [];
+    // Has the runs list resolved at least once (success OR error)? Distinct from
+    // `runs.length > 0` — a study with zero prior runs legitimately has an empty
+    // *loaded* list. InterpretShell needs this to avoid treating "haven't heard
+    // back yet" as "this run has no history", which would silently (and
+    // wrongly) tag any run as current before the list is known.
+    const runsListLoaded = runsQuery.isSuccess || runsQuery.isError;
 
     // ── Empty-state contract: not enough participants for factor analysis ──
     // Wave A — UX progressive-disclosure audit. The configuration card walls
@@ -232,6 +238,7 @@ export default function AnalysisPage() {
                 onBackToExplore={navigateToExplore}
                 onFocusChange={setFocusFromCanvas}
                 runs={runs}
+                runsListLoaded={runsListLoaded}
                 compareTo={compareTo}
                 onPin={handlePin}
                 onUnpin={handleUnpin}
@@ -797,11 +804,13 @@ interface InterpretShellProps {
     onBackToExplore: () => void;
     onFocusChange: (factor: number) => void;
     runs: AnalysisRunSummary[];
+    runsListLoaded: boolean;
     compareTo: number | null;
     onPin: (runId: number) => void;
     onUnpin: () => void;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSX shell with multiple loading/error/success gates (run fetch, runs-list fetch, historical-run banner) plus focus/overview mode toggle, export menu, and compare-pin picker; all logic lives in useInterpretPhase/useExplorePhase
 function InterpretShell({
     slug,
     runId,
@@ -811,6 +820,7 @@ function InterpretShell({
     onBackToExplore,
     onFocusChange,
     runs,
+    runsListLoaded,
     compareTo,
     onPin,
     onUnpin,
@@ -944,7 +954,14 @@ function InterpretShell({
     const { showFactorNarratives, setShowFactorNarratives } = interpret;
 
     // ── Loading / error gates ────────────────────────────────────────
-    if (interpret.isLoading) {
+    // Also wait on the runs list (`runsListLoaded`): the historical-run
+    // determination below and the history panel's CURRENT tag both need
+    // `latestRun`, which is only meaningful once the runs list has actually
+    // resolved. Without this, a fresh direct navigation to a historical run
+    // (bookmark, shared link, refresh) can render the success branch with
+    // `runs=[]` before the list arrives, silently — and wrongly — treating
+    // the unresolved case as "current" and hiding a banner that should show.
+    if (interpret.isLoading || !runsListLoaded) {
         return (
             <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
                 <StudyPageHeader
@@ -1075,7 +1092,7 @@ function InterpretShell({
             {/* Analysis history */}
             <AnalysisHistoryPanel
                 slug={slug}
-                currentRunId={runId}
+                currentRunId={latestRun?.id ?? null}
                 onLoadRun={(_result, summary) => {
                     if (summary) {
                         onSelectHistoricalRun(summary.id);

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -920,6 +920,24 @@ function InterpretShell({
         return summary as AnalysisRunSummary;
     }, [run]);
 
+    // ── latestRun — the study's most-recently-run analysis, derived from
+    //   the same `ran_at`-descending ordering AnalysisHistoryPanel already
+    //   applies to its list and useExplorePhase already relies on
+    //   (`runs[0]`) to find "the fresh run" right after a commit. This is
+    //   the run banner's notion of "current". It is deliberately NOT the
+    //   same thing as AnalysisHistoryPanel's own `currentRunId` prop —
+    //   that prop is just this view's `runId`, i.e. always the selected
+    //   run by construction, so comparing against it could never tell
+    //   "just committed" apart from "loaded an older entry from history".
+    const latestRun = useMemo<AnalysisRunSummary | null>(() => {
+        return runs.reduce<AnalysisRunSummary | null>((latest, candidate) => {
+            if (!latest) return candidate;
+            return new Date(candidate.ran_at).getTime() > new Date(latest.ran_at).getTime()
+                ? candidate
+                : latest;
+        }, null);
+    }, [runs]);
+
     // ── Per-analyst, per-study UI preference for showing per-factor narratives.
     // Owned by useInterpretPhase so the localStorage contract (default-true,
     // per-slug key, quota/private-mode safe) is covered by hook tests.
@@ -996,6 +1014,11 @@ function InterpretShell({
         );
     }
 
+    // The run banner should only announce a *historical* run — one that
+    // isn't the study's most recent analysis. `run` is narrowed non-null
+    // by the gate above.
+    const isViewingHistoricalRun = latestRun !== null && run.id !== latestRun.id;
+
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
             <StudyPageHeader
@@ -1064,37 +1087,44 @@ function InterpretShell({
                 }}
             />
 
-            {/* Run banner */}
-            <div className="flex items-center gap-3 px-4 py-2.5 bg-amber-50 border border-amber-200 rounded-xl text-sm text-amber-800">
-                <History className="size-4 flex-shrink-0" aria-hidden="true" />
-                <span className="flex-1">
-                    {t(
-                        'admin.analysis.history.viewing_banner',
-                        'Viewing run from {{date}}: {{extraction}} · {{n}}F · {{rotation}}',
-                        {
-                            date: new Date(run.ran_at).toLocaleString(undefined, {
-                                year: 'numeric',
-                                month: 'short',
-                                day: 'numeric',
-                                hour: '2-digit',
-                                minute: '2-digit',
-                            }),
-                            extraction: run.extraction_method.toUpperCase(),
-                            n: run.n_factors,
-                            rotation: run.rotation_method,
-                        }
-                    )}
-                </span>
-                <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={onBackToExplore}
-                    className="gap-1.5 shrink-0 text-amber-700 border-amber-300 hover:bg-amber-100"
+            {/* Run banner — only for a genuinely historical run; the
+                study's most recent run needs no "back to current" escape
+                hatch, since it already is current (see isViewingHistoricalRun). */}
+            {isViewingHistoricalRun && (
+                <div
+                    className="flex items-center gap-3 px-4 py-2.5 bg-amber-50 border border-amber-200 rounded-xl text-sm text-amber-800"
+                    data-testid="run-banner"
                 >
-                    <X className="size-3.5" aria-hidden="true" />
-                    {t('admin.analysis.history.back_to_current', 'Back to current')}
-                </Button>
-            </div>
+                    <History className="size-4 flex-shrink-0" aria-hidden="true" />
+                    <span className="flex-1">
+                        {t(
+                            'admin.analysis.history.viewing_banner',
+                            'Viewing run from {{date}}: {{extraction}} · {{n}}F · {{rotation}}',
+                            {
+                                date: new Date(run.ran_at).toLocaleString(undefined, {
+                                    year: 'numeric',
+                                    month: 'short',
+                                    day: 'numeric',
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                }),
+                                extraction: run.extraction_method.toUpperCase(),
+                                n: run.n_factors,
+                                rotation: run.rotation_method,
+                            }
+                        )}
+                    </span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={onBackToExplore}
+                        className="gap-1.5 shrink-0 text-amber-700 border-amber-300 hover:bg-amber-100"
+                    >
+                        <X className="size-3.5" aria-hidden="true" />
+                        {t('admin.analysis.history.back_to_current', 'Back to current')}
+                    </Button>
+                </div>
+            )}
 
             {/* Mode toggle — Focus (FactorCanvas) by default, Overview restores
                 the legacy four-tab layout. Sits above the results card. */}

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -214,7 +214,8 @@ export default function AnalysisPage() {
                 />
                 <AnalysisHistoryPanel
                     slug={slug}
-                    currentRunId={null}
+                    viewedRunId={null}
+                    latestRunId={null}
                     onLoadRun={(_result, run) => {
                         // The legacy callback signature passes (result, run); we
                         // only need the id to route. The panel may also call this
@@ -782,7 +783,8 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
             {/* Analysis history */}
             <AnalysisHistoryPanel
                 slug={slug}
-                currentRunId={null}
+                viewedRunId={null}
+                latestRunId={null}
                 onLoadRun={(_result, run) => {
                     if (run) onSelectHistoricalRun(run.id);
                 }}
@@ -934,11 +936,13 @@ function InterpretShell({
     //   the same `ran_at`-descending ordering AnalysisHistoryPanel already
     //   applies to its list and useExplorePhase already relies on
     //   (`runs[0]`) to find "the fresh run" right after a commit. This is
-    //   the run banner's notion of "current". It is deliberately NOT the
-    //   same thing as AnalysisHistoryPanel's own `currentRunId` prop —
-    //   that prop is just this view's `runId`, i.e. always the selected
-    //   run by construction, so comparing against it could never tell
-    //   "just committed" apart from "loaded an older entry from history".
+    //   the run banner's notion of "current", and it is what the history
+    //   panel's `latestRunId` (CURRENT tag) is fed below. It is deliberately
+    //   NOT this view's `runId` — that is always the selected run by
+    //   construction, so comparing against it could never tell "just
+    //   committed" apart from "loaded an older entry from history". The panel
+    //   still receives `runId` separately, as `viewedRunId`, for its
+    //   post-delete bounce.
     const latestRun = useMemo<AnalysisRunSummary | null>(() => {
         return runs.reduce<AnalysisRunSummary | null>((latest, candidate) => {
             if (!latest) return candidate;
@@ -1022,7 +1026,8 @@ function InterpretShell({
                 </div>
                 <AnalysisHistoryPanel
                     slug={slug}
-                    currentRunId={null}
+                    viewedRunId={null}
+                    latestRunId={null}
                     onLoadRun={(_r, summary) => {
                         if (summary) onSelectHistoricalRun(summary.id);
                     }}
@@ -1092,13 +1097,20 @@ function InterpretShell({
             {/* Analysis history */}
             <AnalysisHistoryPanel
                 slug={slug}
-                currentRunId={latestRun?.id ?? null}
+                // Two distinct signals, deliberately not the same value:
+                // `viewedRunId` is what this view is displaying (drives the
+                // post-delete bounce below), `latestRunId` is the study's most
+                // recent run (drives the panel's CURRENT tag). They diverge
+                // exactly when an older run is being viewed.
+                viewedRunId={runId}
+                latestRunId={latestRun?.id ?? null}
                 onLoadRun={(_result, summary) => {
                     if (summary) {
                         onSelectHistoricalRun(summary.id);
                     } else {
-                        // Panel may pass `(null, null)` after deleting the
-                        // currently-displayed run — bounce back to explore.
+                        // Panel passes `(null, null)` after deleting the run
+                        // this view is displaying — bounce back to explore
+                        // rather than keep rendering a deleted run.
                         onBackToExplore();
                     }
                 }}

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -1,0 +1,198 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import ConcourseDetailPage from './ConcourseDetailPage';
+import type { ConcourseDetailPageApi } from '@/hooks/admin/useConcourseDetailPage';
+import type { ConcourseDetailRead, ConcourseItemRead, ConcourseItemStatus } from '@/api/model';
+
+// Radix Select triggers a compose-refs loop in React 19 + happy-dom — stub it
+// (same approach as ProjectMembersPage.remove-member-dialog.test.tsx).
+vi.mock('@/components/ui/select', () => ({
+    Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+        <button type="button">{children}</button>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+        <div data-value={value}>{children}</div>
+    ),
+    SelectValue: () => null,
+}));
+
+const { mockUseConcourseDetailPage } = vi.hoisted(() => ({
+    mockUseConcourseDetailPage: vi.fn(),
+}));
+
+// The page's own JSX is what's under test — bypass its logic hook entirely so
+// the test controls `concourse.items` directly, with no query/router/API
+// plumbing to fake out.
+vi.mock('@/hooks/admin/useConcourseDetailPage', () => ({
+    useConcourseDetailPage: mockUseConcourseDetailPage,
+}));
+
+let nextItemId = 1;
+function makeItem(status: ConcourseItemStatus): ConcourseItemRead {
+    const id = nextItemId++;
+    return {
+        id,
+        code: `C${id}`,
+        status,
+        version: 1,
+        display_order: id,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+    };
+}
+
+/** Builds a concourse with the given accepted / rejected / proposed item counts. */
+function concourseWith(accepted: number, rejected: number, proposed: number): ConcourseDetailRead {
+    nextItemId = 1;
+    return {
+        id: 42,
+        project_id: 1,
+        title: 'Demo concourse',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        items: [
+            ...Array.from({ length: accepted }, () => makeItem('accepted')),
+            ...Array.from({ length: rejected }, () => makeItem('rejected')),
+            ...Array.from({ length: proposed }, () => makeItem('proposed')),
+        ],
+    };
+}
+
+/**
+ * Full ConcourseDetailPageApi fixture. Only `concourse` varies per test — the
+ * curation panel derives its counts from `concourse.items` alone (see the IIFE
+ * in ConcourseDetailPage.tsx), everything else here just needs to satisfy the
+ * page's prop contract without crashing the render.
+ */
+function baseApi(concourse: ConcourseDetailRead): ConcourseDetailPageApi {
+    return {
+        id: concourse.id,
+        canEdit: false,
+        memberNames: {},
+        concourse,
+        isLoading: false,
+        tags: [],
+        statusLabel: (status) => status,
+        langDisplayName: (code) => code,
+        filterStatus: 'all',
+        setFilterStatus: vi.fn(),
+        filterTag: 'all',
+        setFilterTag: vi.fn(),
+        searchQuery: '',
+        setSearchQuery: vi.fn(),
+        activeLocale: '',
+        setActiveLocale: vi.fn(),
+        languages: [],
+        missingCountByLang: {},
+        commonLanguages: [],
+        addLangOpen: false,
+        setAddLangOpen: vi.fn(),
+        newLangCode: '',
+        setNewLangCode: vi.fn(),
+        confirmAddLanguage: vi.fn(),
+        filteredItems: [],
+        selectedItems: new Set(),
+        setSelectedItems: vi.fn(),
+        toggleSelectItem: vi.fn(),
+        toggleSelectAll: vi.fn(),
+        bulkActionPending: false,
+        bulkConfirm: null,
+        setBulkConfirm: vi.fn(),
+        handleBulkStatusChange: vi.fn(),
+        addItemOpen: false,
+        setAddItemOpen: vi.fn(),
+        openAddItemDialog: vi.fn(),
+        newCode: '',
+        setNewCode: vi.fn(),
+        newText: '',
+        setNewText: vi.fn(),
+        newSource: '',
+        setNewSource: vi.fn(),
+        newTagIds: [],
+        setNewTagIds: vi.fn(),
+        newItemLocale: '',
+        setNewItemLocale: vi.fn(),
+        handleAddItem: vi.fn(),
+        isCreatingItem: false,
+        editingItem: null,
+        setEditingItem: vi.fn(),
+        editCode: '',
+        setEditCode: vi.fn(),
+        editText: '',
+        setEditText: vi.fn(),
+        editSource: '',
+        setEditSource: vi.fn(),
+        editChangeNote: '',
+        setEditChangeNote: vi.fn(),
+        editTagIds: [],
+        setEditTagIds: vi.fn(),
+        startEdit: vi.fn(),
+        saveEdit: vi.fn(),
+        isUpdatingItem: false,
+        changeStatus: vi.fn(),
+        deleteConfirmId: null,
+        setDeleteConfirmId: vi.fn(),
+        handleDelete: vi.fn(),
+        isDeletingItem: false,
+        importOpen: false,
+        setImportOpen: vi.fn(),
+        openImportDialog: vi.fn(),
+        importText: '',
+        setImportText: vi.fn(),
+        importPrefix: 'C',
+        setImportPrefix: vi.fn(),
+        importLocale: '',
+        setImportLocale: vi.fn(),
+        handleImport: vi.fn(),
+        isImporting: false,
+        tagManagerOpen: false,
+        setTagManagerOpen: vi.fn(),
+        newTagName: '',
+        setNewTagName: vi.fn(),
+        newTagColor: '#6366f1',
+        setNewTagColor: vi.fn(),
+        deleteTagId: null,
+        setDeleteTagId: vi.fn(),
+        handleCreateTag: vi.fn(),
+        handleDeleteTag: vi.fn(),
+        isCreatingTag: false,
+        isDeletingTag: false,
+        sheetItemId: null,
+        sheetItemCode: '',
+        sheetTab: 'history',
+        openSheet: vi.fn(),
+        closeSheet: vi.fn(),
+        exportCsv: vi.fn(),
+    };
+}
+
+describe('ConcourseDetailPage curation panel', () => {
+    it('states reviewed count and progress width consistently', () => {
+        // 25 accepted + 8 rejected + 3 proposed = 36 items.
+        mockUseConcourseDetailPage.mockReturnValue(baseApi(concourseWith(25, 8, 3)));
+
+        renderWithProviders(<ConcourseDetailPage />);
+
+        const bar = screen.getByTestId('curation-progress');
+        // Scope the count assertions to the curation panel (bar's grandparent —
+        // bar -> progress track -> panel) so "33"/"25" cannot be satisfied by
+        // some unrelated element on the page.
+        const panel = bar.parentElement?.parentElement;
+        if (!panel) throw new Error('curation panel wrapper not found');
+        const panelScope = within(panel);
+
+        // The headline number is what the bar measures: 33 reviewed of 36.
+        expect(panelScope.getByText('33')).toBeInTheDocument();
+        expect(bar).toHaveStyle({ width: '91.66666666666666%' });
+        // The Q-set size stays visible, but as its own labelled figure.
+        expect(panelScope.getByText(/25 accepted/i)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -485,10 +485,19 @@ export default function ConcourseDetailPage() {
                                             <span className="ml-2 text-lg font-black">
                                                 {acceptedCt + rejectedCt}
                                             </span>
+                                            {/* One key for the whole fragment, rather than
+                                                a noun key and a participle key concatenated:
+                                                a translator must be able to reorder them,
+                                                and in several locales has to. The count
+                                                above stays a typographic figure — it is what
+                                                the progress bar measures. */}
                                             <span className="text-emerald-600 font-normal text-xs ml-1">
-                                                / {totalCount}{' '}
-                                                {t('admin.concourse.items_label', 'items')}{' '}
-                                                {t('admin.concourse.qset_reviewed', 'reviewed')}
+                                                /{' '}
+                                                {t(
+                                                    'admin.concourse.qset_reviewed_of',
+                                                    '{{total}} items reviewed',
+                                                    { total: totalCount }
+                                                )}
                                             </span>
                                         </p>
                                         <p className="text-xs text-emerald-700 mt-0.5">

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -481,26 +481,32 @@ export default function ConcourseDetailPage() {
                                     <CheckSquare className="size-4 text-emerald-600 shrink-0" />
                                     <div>
                                         <p className="text-sm font-bold text-emerald-900">
-                                            {t('admin.concourse.qset_title', 'Q-set')}
+                                            {t('admin.concourse.qset_title', 'Curation')}
                                             <span className="ml-2 text-lg font-black">
-                                                {acceptedCt}
+                                                {acceptedCt + rejectedCt}
                                             </span>
                                             <span className="text-emerald-600 font-normal text-xs ml-1">
                                                 / {totalCount}{' '}
-                                                {t('admin.concourse.items_label', 'items')}
+                                                {t('admin.concourse.items_label', 'items')}{' '}
+                                                {t('admin.concourse.qset_reviewed', 'reviewed')}
                                             </span>
                                         </p>
                                         <p className="text-xs text-emerald-700 mt-0.5">
-                                            {proposedCt > 0
-                                                ? t(
-                                                      'admin.concourse.qset_pending',
-                                                      '{{count}} items still to review',
-                                                      { count: proposedCt }
-                                                  )
-                                                : t(
-                                                      'admin.concourse.qset_complete',
-                                                      'All items reviewed'
-                                                  )}
+                                            {t(
+                                                'admin.concourse.qset_accepted',
+                                                '{{count}} accepted',
+                                                { count: acceptedCt }
+                                            )}
+                                            {proposedCt > 0 && (
+                                                <>
+                                                    {' · '}
+                                                    {t(
+                                                        'admin.concourse.qset_pending',
+                                                        '{{count}} items still to review',
+                                                        { count: proposedCt }
+                                                    )}
+                                                </>
+                                            )}
                                         </p>
                                     </div>
                                 </div>
@@ -534,6 +540,7 @@ export default function ConcourseDetailPage() {
                             {/* Progress bar */}
                             <div className="mt-2.5 h-1.5 rounded-full bg-emerald-100 overflow-hidden">
                                 <div
+                                    data-testid="curation-progress"
                                     className="h-full rounded-full bg-emerald-500 transition-all duration-500"
                                     style={{ width: `${progress}%` }}
                                 />

--- a/frontend/src/pages/admin/ProjectMembersPage.test.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ProjectMembersPage from './ProjectMembersPage';
 import { useAuthStore } from '@/store/useAuthStore';
@@ -87,5 +88,22 @@ describe('ProjectMembersPage role select', () => {
         // screen.findByText('Owner') would pass even without the fix.
         const ownerRow = await screen.findByRole('row', { name: /grace hopper/i });
         expect(within(ownerRow).getByText('Owner')).toBeInTheDocument();
+    });
+
+    it('never offers the owner role as an option in a member/viewer row dropdown', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<ProjectMembersPage />);
+
+        // Ada Lovelace is a plain member, so her row's role Select is
+        // interactive for the (owner) current user. Ownership transfer is
+        // not a dropdown action: the listbox must offer member/viewer only.
+        const memberRow = await screen.findByRole('row', { name: /ada lovelace/i });
+        await user.click(within(memberRow).getByRole('combobox'));
+
+        // The listbox is portalled, so options are asserted globally rather
+        // than scoped to the row.
+        expect(await screen.findByRole('option', { name: /^member$/i })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /^viewer$/i })).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: /^owner$/i })).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/admin/ProjectMembersPage.test.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.test.tsx
@@ -1,3 +1,9 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
 import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ProjectMembersPage from './ProjectMembersPage';

--- a/frontend/src/pages/admin/ProjectMembersPage.test.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.test.tsx
@@ -1,0 +1,85 @@
+import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ProjectMembersPage from './ProjectMembersPage';
+import { useAuthStore } from '@/store/useAuthStore';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// Deliberately NOT mocking '@/components/ui/select' here (unlike the
+// remove-member-dialog test file): the real Radix Select's value-rendering
+// path (SelectValue resolving against SelectContent's items) is exactly what
+// this test needs to exercise. It has been verified stable in this
+// React 19 + happy-dom environment for this page.
+
+const { removeMember, refetchMembers } = vi.hoisted(() => ({
+    removeMember: vi.fn().mockResolvedValue({}),
+    refetchMembers: vi.fn(),
+}));
+
+vi.mock('@/api/generated', () => ({
+    useGetProjectApiAdminProjectsSlugGet: () => ({
+        data: { id: 1, slug: 'demo', title: 'Demo Project' },
+        isLoading: false,
+    }),
+    useListProjectMembersApiAdminProjectsSlugMembersGet: () => ({
+        data: {
+            items: [
+                {
+                    user_id: 11,
+                    role: 'member',
+                    joined_at: '2024-01-01T00:00:00Z',
+                    user: { full_name: 'Ada Lovelace', email: 'ada@x.io' },
+                },
+                {
+                    user_id: 12,
+                    role: 'owner',
+                    joined_at: '2024-01-01T00:00:00Z',
+                    user: { full_name: 'Grace Hopper', email: 'grace@x.io' },
+                },
+            ],
+        },
+        isLoading: false,
+        refetch: refetchMembers,
+    }),
+    useRemoveProjectMemberApiAdminProjectsSlugMembersUserIdDelete: () => ({
+        mutateAsync: removeMember,
+        isPending: false,
+    }),
+    useUpdateProjectMemberApiAdminProjectsSlugMembersUserIdPatch: () => ({
+        mutateAsync: vi.fn(),
+        isPending: false,
+    }),
+    useCreateInvitationApiAdminProjectsSlugInvitationsPost: () => ({
+        mutateAsync: vi.fn(),
+        isPending: false,
+    }),
+}));
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    return {
+        ...actual,
+        useLoaderData: () => ({ slug: 'demo' }),
+        useNavigate: () => vi.fn(),
+    };
+});
+
+describe('ProjectMembersPage role select', () => {
+    beforeEach(() => {
+        removeMember.mockReset().mockResolvedValue({});
+        useAuthStore.setState({
+            user: { id: 12, email: 'grace@x.io', is_superuser: false },
+            isAuthenticated: true,
+        });
+    });
+
+    it('shows the Owner role label for the project owner', async () => {
+        renderWithProviders(<ProjectMembersPage />);
+
+        // Scope to the owner's own row: the page also renders an unrelated
+        // "Owner" legend in the permissions-matrix card, so an unscoped
+        // screen.findByText('Owner') would pass even without the fix.
+        const ownerRow = await screen.findByRole('row', { name: /grace hopper/i });
+        expect(within(ownerRow).getByText('Owner')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -220,62 +220,68 @@ export default function ProjectMembersPage() {
                                                 </div>
                                             </TableCell>
                                             <TableCell>
-                                                <Select
-                                                    value={member.role}
-                                                    onValueChange={(val) =>
-                                                        handleRoleChange(
-                                                            member.user_id,
-                                                            val as ProjectRole
-                                                        )
-                                                    }
-                                                    disabled={
-                                                        !isOwner ||
-                                                        member.user_id === currentUser?.id
-                                                    }
-                                                >
-                                                    <SelectTrigger
+                                                {member.role === 'owner' ? (
+                                                    // Ownership transfer is not a dropdown
+                                                    // action (a project has exactly one
+                                                    // owner), so the owner's role renders
+                                                    // as a static badge rather than a
+                                                    // permanently-disabled Select — that
+                                                    // also keeps "owner" out of every
+                                                    // row's dropdown listbox.
+                                                    <span
                                                         className={cn(
-                                                            'w-[120px] h-8 rounded-lg text-xs font-bold border-none shadow-none focus:ring-0',
-                                                            member.role === 'owner'
-                                                                ? 'bg-indigo-50 text-indigo-700'
-                                                                : member.role === 'member'
-                                                                  ? 'bg-emerald-50 text-emerald-700'
-                                                                  : 'bg-slate-100 text-slate-600'
+                                                            'inline-flex h-8 w-[120px] items-center justify-center rounded-lg text-xs font-bold',
+                                                            'bg-indigo-50 text-indigo-700'
                                                         )}
                                                     >
-                                                        <SelectValue />
-                                                    </SelectTrigger>
-                                                    <SelectContent className="rounded-xl border-white/20 glass shadow-2xl">
-                                                        <SelectItem
-                                                            value="owner"
-                                                            disabled
-                                                            className="text-xs font-bold py-2 rounded-lg m-1"
-                                                        >
-                                                            {t(
-                                                                'admin.project.roles.owner',
-                                                                'Owner'
+                                                        {t('admin.project.roles.owner', 'Owner')}
+                                                    </span>
+                                                ) : (
+                                                    <Select
+                                                        value={member.role}
+                                                        onValueChange={(val) =>
+                                                            handleRoleChange(
+                                                                member.user_id,
+                                                                val as ProjectRole
+                                                            )
+                                                        }
+                                                        disabled={
+                                                            !isOwner ||
+                                                            member.user_id === currentUser?.id
+                                                        }
+                                                    >
+                                                        <SelectTrigger
+                                                            className={cn(
+                                                                'w-[120px] h-8 rounded-lg text-xs font-bold border-none shadow-none focus:ring-0',
+                                                                member.role === 'member'
+                                                                    ? 'bg-emerald-50 text-emerald-700'
+                                                                    : 'bg-slate-100 text-slate-600'
                                                             )}
-                                                        </SelectItem>
-                                                        <SelectItem
-                                                            value="member"
-                                                            className="text-xs font-bold py-2 rounded-lg m-1"
                                                         >
-                                                            {t(
-                                                                'admin.project.roles.member',
-                                                                'Member'
-                                                            )}
-                                                        </SelectItem>
-                                                        <SelectItem
-                                                            value="viewer"
-                                                            className="text-xs font-bold py-2 rounded-lg m-1"
-                                                        >
-                                                            {t(
-                                                                'admin.project.roles.viewer',
-                                                                'Viewer'
-                                                            )}
-                                                        </SelectItem>
-                                                    </SelectContent>
-                                                </Select>
+                                                            <SelectValue />
+                                                        </SelectTrigger>
+                                                        <SelectContent className="rounded-xl border-white/20 glass shadow-2xl">
+                                                            <SelectItem
+                                                                value="member"
+                                                                className="text-xs font-bold py-2 rounded-lg m-1"
+                                                            >
+                                                                {t(
+                                                                    'admin.project.roles.member',
+                                                                    'Member'
+                                                                )}
+                                                            </SelectItem>
+                                                            <SelectItem
+                                                                value="viewer"
+                                                                className="text-xs font-bold py-2 rounded-lg m-1"
+                                                            >
+                                                                {t(
+                                                                    'admin.project.roles.viewer',
+                                                                    'Viewer'
+                                                                )}
+                                                            </SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                )}
                                             </TableCell>
                                             <TableCell className="text-xs font-medium text-slate-400">
                                                 {new Date(member.joined_at).toLocaleDateString()}

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -247,6 +247,16 @@ export default function ProjectMembersPage() {
                                                     </SelectTrigger>
                                                     <SelectContent className="rounded-xl border-white/20 glass shadow-2xl">
                                                         <SelectItem
+                                                            value="owner"
+                                                            disabled
+                                                            className="text-xs font-bold py-2 rounded-lg m-1"
+                                                        >
+                                                            {t(
+                                                                'admin.project.roles.owner',
+                                                                'Owner'
+                                                            )}
+                                                        </SelectItem>
+                                                        <SelectItem
                                                             value="member"
                                                             className="text-xs font-bold py-2 rounded-lg m-1"
                                                         >


### PR DESCRIPTION
## Summary

Phase 1 of the remediation plan added in `docs/superpowers/plans/2026-07-26-admin-ux-remediation.md`, written after walking the admin space on a fresh Docker instance. This phase fixes only the defects that make the UI actively **misinform the researcher**; phases 2–6 (developer-facing text, accessibility, design tokens, vocabulary, visual finish) remain.

## Changes

- **Responses table headers were misaligned with their data** (`Data`). The table rendered 6 `<th>` for 7 `<td>`, so every value from column 2 on sat under the wrong label — a researcher read `Status: en`, `Duration: —`, `Submitted: 10m 19s`. The cause was not the expected duplicate React key: `babel-plugin-react-compiler` auto-memoized `table.getHeaderGroups()` on the TanStack table's object identity, which never changes because the table mutates in place. Fixed with `'use no memo'` on the component, plus an E2E column-parity guard — E2E is the only harness here that runs the compiler pass.
- **The member role select rendered empty for owners** (`Team members`). `SelectContent` offered only `member` and `viewer`, so Radix had no item to render for `owner` and showed a blank disabled box.
- **The curation bar contradicted its own counter** (`Concourse`). The bar showed 91.67% (reviewed) beside a headline reading 25/36 (accepted). The label now describes what the bar measures, with the Q-set size kept as its own figure.
- **The "Viewing run… / Back to current" banner appeared on the current run** (`Analysis`), directly under a history entry tagging that same run CURRENT. Review also found the history panel's CURRENT tag tracked the *loaded* run rather than the latest, so the prop was split into `viewedRunId` (delete guard) and `latestRunId` (tag).
- **Unknown URLs fell through to React Router's debug screen** — *"Hey developer 👋 You can provide a way better UX than this"*, unstyled, no navigation. A root catch-all now serves the app's own error page.
- Adds the six-phase remediation plan to `docs/`.

## Checklist

- [ ] `make ci` passes locally — **frontend is green (183 files / 1518 tests, biome + tsc clean); backend `pytest` fails on a local Postgres credential issue that reproduces identically on `main` with a clean tree.** No backend file is touched by this branch.
- [x] Tests cover new/changed behavior — 6 new test files/specs; each fix was observed RED before GREEN, and assertions are scoped to avoid the vacuous-pass traps this codebase invites (an unrelated "Owner" legend, two "Back to current" affordances).
- [x] Translation keys added to all locales — `qset_reviewed_of` and `qset_accepted` in all nine admin locales; `i18n-check` and `check-interpolations` clean.
- [x] API client regenerated if backend schemas changed — not applicable, no backend schema change.

**Please let CI run the E2E suite.** It could not be executed locally: Playwright boots its own backend, which cannot reach the local Postgres, and running it against the demo stack would wipe it via `global-teardown`. One commit repairs an E2E test that this branch's own behaviour change invalidated — validated by reading its locators against the current components, not by running it.

Also verified: all five fixes were checked in the browser against a Docker stack rebuilt from this branch. Each task went through an independent review; two needed a fix round, and the whole-branch review caught a regression in the Analysis fix that no per-task review could see.

## Related Issue

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)