### PR TITLE
fix(admin): phase 2 of the UX audit remediation — developer text in the product

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -44,3 +44,9 @@ f0b3fdeb01383e097ee397522bc49c08f4fa9037:backend/app/routers/audio.py:generic-ap
 f24b53762abfb2f3952a5538aa8809f206ad3498:backend/tests/integration/test_api_error_hygiene.py:generic-api-key:59
 070c67d0cadf553d87abce8b43bf6b6b3c059ca2:.gitleaksignore:generic-api-key:34
 323f1cada0cc7cf0adc9621e3804b8b731ea65bc:.gitleaksignore:generic-api-key:34
+
+# Q-methodology question keys, minted by QuestionBuilder as `q_${Date.now()}`.
+# The timestamp reads as a high-entropy token to the generic-api-key rule. These
+# are test fixtures deliberately shaped like the keys real studies produce — the
+# whole point of the cases they appear in.
+77258e669aea9b6eb7cb0bdd15cfd9219388d9b3:frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx:generic-api-key:566

--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -424,6 +424,8 @@ git commit -m "fix(i18n): replace the API-status note on Account settings with u
 
 **The defect:** `FactorVoicesPanel.tsx:104` renders `{rec.question_key}` — a database identifier (`question_q_voice`) — as the label above each audio player, three times per factor.
 
+> **Superseded by the Phase 2 fix wave.** The static key→label table prescribed in Step 3 shipped, then was removed: it had one entry, it existed only because of the demo seeder, and it disagreed with the label the same recording carries on the participant Post-Sort tab. `FactorVoicesPanel` now resolves the researcher's own `postsort_config.questions[<id>].label` through the shared `resolveAudioQuestionLabel` helper. No props signature change was needed — the panel already receives `slug`.
+
 **Files:**
 - Test: `frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx`
 - Modify: `frontend/src/components/admin/analysis/FactorVoicesPanel.tsx:104`
@@ -1482,8 +1484,6 @@ These came out of the audit but are judgement calls, not defects with an obvious
 4. **The interpretive narrative field** (`F1 narrative`) is an italic grey placeholder with no border. It is the central function of the interpret screen and looks like static text; making it look editable is a small change with a real effect on whether the feature gets used.
 5. **Truncated public URL** on `Overview` (`http://localhost:3000/study/b:`). The field is too narrow to read the link it exists to share.
 6. **The native `<audio>` player** in Factor voices is the only unstyled control in the product, while `components/admin/AudioPlayer.tsx` exists. Adopting it is straightforward; whether the custom player is good enough to carry research audio is your call.
-
-9. **Audio question labels are ambiguous when a study has more than one.** Task 2.2 stopped the raw `question_key` from reaching the screen, but since keys are researcher-generated per study (`q_<Date.now()>`), a static lookup can never be complete: two audio questions both render as "Spoken comment". The durable fix is to thread the researcher's own configured label — `postsort_config.questions[key].label`, already a `MultilangString` — through to `FactorVoicesPanel`. That needs a props signature change, which is why it was not folded into 2.2.
 7. **Sidebar at 768 px** stays expanded at 255 px, taking a third of the viewport. Auto-collapsing below `lg` is the obvious move but changes the tablet experience.
 8. **No read-only mode for an active study's design.** Task 3.2 adds an escape hatch from the lock overlay; a genuine read-only rendering of the design is the larger, better fix.
 

--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -528,6 +528,41 @@ git commit -m "fix(members): show the email instead of a 'No Name' placeholder"
 
 ---
 
+### Task 2.4: The same raw-key leak on the participant detail page
+
+**The defect:** found by Task 2.2's review. `ParticipantDetailContent.tsx:565-591` renders `question_key` directly for any key that is not one of `card_N`, `missing_statement`, or `general_comment` — the identical defect Task 2.2 fixed in `FactorVoicesPanel`. Since `question_key` is researcher-generated (`q_<Date.now()>`, `QuestionBuilder.tsx:964`), every custom post-sort question on this screen prints its raw identifier.
+
+**Files:**
+- Modify: `frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx:565-591`
+- Test: `frontend/src/components/admin/dashboard/ParticipantDetailContent.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('never renders a raw question key', () => {
+    renderWithProviders(<ParticipantDetailContent {...propsWithAnswer('q_1737849283000')} />);
+    expect(screen.queryByText('q_1737849283000')).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run it, confirm it fails with the raw key present**
+
+- [ ] **Step 3: Apply the same safe-default lookup Task 2.2 established**
+
+Reuse `admin.analysis.factor_voices.question_default` if the label fits, or add a sibling default in this screen's own namespace. The rule is the one from Task 2.2: an unmapped key falls back to a generic human label, never to the identifier.
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx \
+        frontend/src/components/admin/dashboard/ParticipantDetailContent.test.tsx
+git commit -m "fix(participants): stop rendering raw question keys on the detail page"
+```
+
+---
+
 # PHASE 3 — Accessibility and interaction
 
 ### Task 3.1: Row actions are invisible but tabbable
@@ -1447,6 +1482,8 @@ These came out of the audit but are judgement calls, not defects with an obvious
 4. **The interpretive narrative field** (`F1 narrative`) is an italic grey placeholder with no border. It is the central function of the interpret screen and looks like static text; making it look editable is a small change with a real effect on whether the feature gets used.
 5. **Truncated public URL** on `Overview` (`http://localhost:3000/study/b:`). The field is too narrow to read the link it exists to share.
 6. **The native `<audio>` player** in Factor voices is the only unstyled control in the product, while `components/admin/AudioPlayer.tsx` exists. Adopting it is straightforward; whether the custom player is good enough to carry research audio is your call.
+
+9. **Audio question labels are ambiguous when a study has more than one.** Task 2.2 stopped the raw `question_key` from reaching the screen, but since keys are researcher-generated per study (`q_<Date.now()>`), a static lookup can never be complete: two audio questions both render as "Spoken comment". The durable fix is to thread the researcher's own configured label — `postsort_config.questions[key].label`, already a `MultilangString` — through to `FactorVoicesPanel`. That needs a props signature change, which is why it was not folded into 2.2.
 7. **Sidebar at 768 px** stays expanded at 255 px, taking a third of the viewport. Auto-collapsing below `lg` is the obvious move but changes the tablet experience.
 8. **No read-only mode for an active study's design.** Task 3.2 adds an escape hatch from the lock overlay; a genuine read-only rendering of the design is the larger, better fix.
 

--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1105,6 +1105,15 @@ cd frontend/src && grep -rnoE "t\('admin\.[a-z_.]*'\)" --include=*.tsx . | head 
 
 Add the canonical English label as the fallback for each.
 
+**Most important: resolve every `t()` key against the locale JSON.** Phase 2's whole-branch review found **twelve `t()` calls whose keys exist in neither `en/admin.json` nor `en/participant.json`** — i18next then renders the raw dotted key path as UI text, which is the purest instance of the defect class Phase 2 set out to remove. Confirmed sites include:
+
+- `components/auth/RequireAdmin.tsx:53-54` — the full-screen access-denied gate renders `common.errors.access_denied.title` and `…message`
+- `components/admin/dashboard/InteractiveDataView.tsx:809` — the destructive confirm button of "clear all participants" reads `common.confirm_delete`
+- `pages/admin/ProjectMembersPage.tsx:87,96` — changing a member's role toasts `admin.projects.settings.team.role_update_success` / `…role_update_error`
+- `hooks/admin/useStudyDesignPage.ts:484`, `pages/ErrorPage.helpers.ts:43,44,87,88`, `pages/RegistrationPage.tsx:151`, `hooks/participant/useFineSort.ts:464` (a participant-facing `window.confirm`)
+
+Note the `t('key') || 'Fallback'` guard used at ~17 sites (e.g. `PostSortConfigEditor.tsx:504-604`) is **inert**: `t()` returns the key itself on a miss, which is truthy, so `||` never fires. Write the check as a script that loads the locale JSON and asserts every key referenced in source resolves — then wire it into `npm run i18n-check` so this cannot regress.
+
 *(The `ConcourseDetailPage.tsx:484` `'Q-set'` / `'Curation'` divergence originally listed here was already retired by Phase 1 Task 1.3.)*
 
 - [ ] **Step 5: Run the tests to verify they pass**

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -2171,6 +2171,7 @@
                 "postsort": "Nachsortierungsfragen",
                 "no_answers": "Keine Antworten für diesen Abschnitt aufgezeichnet.",
                 "question_default": "Gesprochene Antwort",
+                "answer_default": "Antwort",
                 "categories": {
                     "identity": "Identität & Kontakt",
                     "questions": "Fragebogenantworten",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -2170,6 +2170,7 @@
                 "presort": "Vorsortierungsfragen",
                 "postsort": "Nachsortierungsfragen",
                 "no_answers": "Keine Antworten für diesen Abschnitt aufgezeichnet.",
+                "question_default": "Gesprochene Antwort",
                 "categories": {
                     "identity": "Identität & Kontakt",
                     "questions": "Fragebogenantworten",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -632,10 +632,7 @@
                 "audio_label": "Aufnahme: {{key}} von {{participant}}",
                 "url_unavailable": "Audio-URL nicht verfügbar.",
                 "comments_label": "Kartenkommentare",
-                "question_default": "Gesprochener Kommentar",
-                "question": {
-                    "question_q_voice": "Gesprochener Kommentar zur Q-Sortierung"
-                }
+                "question_default": "Gesprochener Kommentar"
             },
             "factor_note": {
                 "label": "Faktorinterpretation",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Persönliche Informationen",
                 "email": "E-Mail-Adresse",
-                "email_locked": "E-Mail-Änderungen über diese Seite sind in Kürze verfügbar; die Backend-Unterstützung ist bereits aktiv.",
+                "email_locked": "Ihre E-Mail-Adresse kann hier noch nicht geändert werden. Wenden Sie sich an Ihren Administrator, um sie zu aktualisieren.",
                 "name": "Vollständiger Name",
                 "save": "Speichern",
                 "saving": "Wird gespeichert...",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -631,7 +631,11 @@
                 "context_aria": "Über dieses Panel",
                 "audio_label": "Aufnahme: {{key}} von {{participant}}",
                 "url_unavailable": "Audio-URL nicht verfügbar.",
-                "comments_label": "Kartenkommentare"
+                "comments_label": "Kartenkommentare",
+                "question_default": "Gesprochener Kommentar",
+                "question": {
+                    "question_q_voice": "Gesprochener Kommentar zur Q-Sortierung"
+                }
             },
             "factor_note": {
                 "label": "Faktorinterpretation",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -634,10 +634,7 @@
                 "audio_label": "Recording: {{key}} by {{participant}}",
                 "url_unavailable": "Audio URL not available.",
                 "comments_label": "Card comments",
-                "question_default": "Spoken comment",
-                "question": {
-                    "question_q_voice": "Spoken comment on the Q-sort"
-                }
+                "question_default": "Spoken comment"
             },
             "factor_note": {
                 "label": "Factor narrative",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -633,7 +633,11 @@
                 "context_aria": "About this panel",
                 "audio_label": "Recording: {{key}} by {{participant}}",
                 "url_unavailable": "Audio URL not available.",
-                "comments_label": "Card comments"
+                "comments_label": "Card comments",
+                "question_default": "Spoken comment",
+                "question": {
+                    "question_q_voice": "Spoken comment on the Q-sort"
+                }
             },
             "factor_note": {
                 "label": "Factor narrative",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -2172,6 +2172,7 @@
                 "presort": "Pre-Sort Questions",
                 "postsort": "Post-Sort Questions",
                 "no_answers": "No answers recorded for this section.",
+                "question_default": "Spoken response",
                 "categories": {
                     "identity": "Identity & Contact",
                     "questions": "Questionnaire Responses",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -2173,6 +2173,7 @@
                 "postsort": "Post-Sort Questions",
                 "no_answers": "No answers recorded for this section.",
                 "question_default": "Spoken response",
+                "answer_default": "Response",
                 "categories": {
                     "identity": "Identity & Contact",
                     "questions": "Questionnaire Responses",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Personal information",
                 "email": "Email address",
-                "email_locked": "Email changes via the API are coming soon to this page; backend support is live.",
+                "email_locked": "Your email address can't be changed here yet. Contact your administrator to update it.",
                 "name": "Full name",
                 "save": "Save",
                 "saving": "Saving...",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -2171,6 +2171,7 @@
                 "postsort": "Preguntas post-clasificación",
                 "no_answers": "No se registraron respuestas para esta sección.",
                 "question_default": "Respuesta oral",
+                "answer_default": "Respuesta",
                 "categories": {
                     "identity": "Identidad y contacto",
                     "questions": "Respuestas del cuestionario",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Información personal",
                 "email": "Dirección de correo electrónico",
-                "email_locked": "Los cambios de correo electrónico a través de la API llegarán pronto a esta página; el soporte del servidor ya está activo.",
+                "email_locked": "Su dirección de correo electrónico aún no se puede cambiar aquí. Póngase en contacto con su administrador para actualizarla.",
                 "name": "Nombre completo",
                 "save": "Guardar",
                 "saving": "Guardando...",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -2170,6 +2170,7 @@
                 "presort": "Preguntas pre-clasificación",
                 "postsort": "Preguntas post-clasificación",
                 "no_answers": "No se registraron respuestas para esta sección.",
+                "question_default": "Respuesta oral",
                 "categories": {
                     "identity": "Identidad y contacto",
                     "questions": "Respuestas del cuestionario",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -631,7 +631,11 @@
                 "context_aria": "Acerca de este panel",
                 "audio_label": "Grabación: {{key}} por {{participant}}",
                 "url_unavailable": "URL de audio no disponible.",
-                "comments_label": "Comentarios de tarjetas"
+                "comments_label": "Comentarios de tarjetas",
+                "question_default": "Comentario oral",
+                "question": {
+                    "question_q_voice": "Comentario oral sobre la clasificación Q"
+                }
             },
             "factor_note": {
                 "label": "Narrativa del factor",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -632,10 +632,7 @@
                 "audio_label": "Grabación: {{key}} por {{participant}}",
                 "url_unavailable": "URL de audio no disponible.",
                 "comments_label": "Comentarios de tarjetas",
-                "question_default": "Comentario oral",
-                "question": {
-                    "question_q_voice": "Comentario oral sobre la clasificación Q"
-                }
+                "question_default": "Comentario oral"
             },
             "factor_note": {
                 "label": "Narrativa del factor",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -568,7 +568,11 @@
                 "context_aria": "About this panel",
                 "audio_label": "Recording: {{key}} by {{participant}}",
                 "url_unavailable": "Audio URL not available.",
-                "comments_label": "Card comments"
+                "comments_label": "Card comments",
+                "question_default": "Puhuttu kommentti",
+                "question": {
+                    "question_q_voice": "Puhuttu kommentti Q-sortista"
+                }
             },
             "factor_note": {
                 "label": "Factor narrative",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -569,10 +569,7 @@
                 "audio_label": "Recording: {{key}} by {{participant}}",
                 "url_unavailable": "Audio URL not available.",
                 "comments_label": "Card comments",
-                "question_default": "Puhuttu kommentti",
-                "question": {
-                    "question_q_voice": "Puhuttu kommentti Q-sortista"
-                }
+                "question_default": "Puhuttu kommentti"
             },
             "factor_note": {
                 "label": "Factor narrative",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -2110,6 +2110,7 @@
                 "postsort": "Jälkilajittelu",
                 "presort": "Esilajittelu",
                 "no_answers": "Tähän osioon ei ole kirjattu vastauksia.",
+                "question_default": "Puhuttu vastaus",
                 "categories": {
                     "identity": "Henkilö- ja yhteystiedot",
                     "questions": "Kyselyvastaukset",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -173,7 +173,7 @@
             "personal": {
                 "title": "Henkilökohtaiset tiedot",
                 "email": "Sähköpostiosoite",
-                "email_locked": "Sähköpostin vaihto API:n kautta on tulossa pian tälle sivulle; taustatuki on jo käytössä.",
+                "email_locked": "Sähköpostiosoitettasi ei voi vielä muuttaa täällä. Ota yhteyttä järjestelmänvalvojaan sen päivittämiseksi.",
                 "name": "Koko nimi",
                 "save": "Tallenna",
                 "saving": "Tallennetaan...",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -2111,6 +2111,7 @@
                 "presort": "Esilajittelu",
                 "no_answers": "Tähän osioon ei ole kirjattu vastauksia.",
                 "question_default": "Puhuttu vastaus",
+                "answer_default": "Vastaus",
                 "categories": {
                     "identity": "Henkilö- ja yhteystiedot",
                     "questions": "Kyselyvastaukset",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -173,7 +173,7 @@
             "personal": {
                 "title": "Informations personnelles",
                 "email": "Adresse e-mail",
-                "email_locked": "La modification de l'e-mail via l'API arrivera bientôt sur cette page ; le support back-end est déjà en place.",
+                "email_locked": "Votre adresse e-mail ne peut pas encore être modifiée ici. Contactez votre administrateur pour la mettre à jour.",
                 "name": "Nom complet",
                 "save": "Enregistrer",
                 "saving": "Enregistrement...",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -544,10 +544,7 @@
                 "audio_label": "Enregistrement : {{key}} par {{participant}}",
                 "url_unavailable": "URL audio non disponible.",
                 "comments_label": "Commentaires sur les cartes",
-                "question_default": "Commentaire oral",
-                "question": {
-                    "question_q_voice": "Commentaire oral sur le tri Q"
-                }
+                "question_default": "Commentaire oral"
             },
             "factor_note": {
                 "label": "Narration du facteur",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -543,7 +543,11 @@
                 "context_aria": "À propos de ce panneau",
                 "audio_label": "Enregistrement : {{key}} par {{participant}}",
                 "url_unavailable": "URL audio non disponible.",
-                "comments_label": "Commentaires sur les cartes"
+                "comments_label": "Commentaires sur les cartes",
+                "question_default": "Commentaire oral",
+                "question": {
+                    "question_q_voice": "Commentaire oral sur le tri Q"
+                }
             },
             "factor_note": {
                 "label": "Narration du facteur",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -2171,6 +2171,7 @@
                 "postsort": "Questions Post-Sort",
                 "no_answers": "Aucune réponse enregistrée pour cette section.",
                 "question_default": "Réponse orale",
+                "answer_default": "Réponse",
                 "categories": {
                     "identity": "Identité & Contact",
                     "questions": "Réponses au questionnaire",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -2170,6 +2170,7 @@
                 "presort": "Questions Pré-Sort",
                 "postsort": "Questions Post-Sort",
                 "no_answers": "Aucune réponse enregistrée pour cette section.",
+                "question_default": "Réponse orale",
                 "categories": {
                     "identity": "Identité & Contact",
                     "questions": "Réponses au questionnaire",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -631,7 +631,11 @@
                 "context_aria": "Informazioni su questo pannello",
                 "audio_label": "Registrazione: {{key}} di {{participant}}",
                 "url_unavailable": "URL audio non disponibile.",
-                "comments_label": "Commenti alle affermazioni"
+                "comments_label": "Commenti alle affermazioni",
+                "question_default": "Commento parlato",
+                "question": {
+                    "question_q_voice": "Commento parlato sulla classificazione Q"
+                }
             },
             "factor_note": {
                 "label": "Narrativa del fattore",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -2170,6 +2170,7 @@
                 "presort": "Domande pre-classificazione",
                 "postsort": "Domande post-classificazione",
                 "no_answers": "Nessuna risposta registrata per questa sezione.",
+                "question_default": "Risposta parlata",
                 "categories": {
                     "identity": "Identità e contatto",
                     "questions": "Risposte al questionario",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -632,10 +632,7 @@
                 "audio_label": "Registrazione: {{key}} di {{participant}}",
                 "url_unavailable": "URL audio non disponibile.",
                 "comments_label": "Commenti alle affermazioni",
-                "question_default": "Commento parlato",
-                "question": {
-                    "question_q_voice": "Commento parlato sulla classificazione Q"
-                }
+                "question_default": "Commento parlato"
             },
             "factor_note": {
                 "label": "Narrativa del fattore",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -2171,6 +2171,7 @@
                 "postsort": "Domande post-classificazione",
                 "no_answers": "Nessuna risposta registrata per questa sezione.",
                 "question_default": "Risposta parlata",
+                "answer_default": "Risposta",
                 "categories": {
                     "identity": "Identità e contatto",
                     "questions": "Risposte al questionario",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Informazioni personali",
                 "email": "Indirizzo e-mail",
-                "email_locked": "Il tuo indirizzo email non può ancora essere modificato qui. Contatta il tuo amministratore per aggiornarlo.",
+                "email_locked": "Il suo indirizzo email non può ancora essere modificato qui. Contatti il suo amministratore per aggiornarlo.",
                 "name": "Nome completo",
                 "save": "Salva",
                 "saving": "Salvataggio in corso...",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Informazioni personali",
                 "email": "Indirizzo e-mail",
-                "email_locked": "La modifica dell'e-mail tramite API sarà presto disponibile su questa pagina; il supporto backend è attivo.",
+                "email_locked": "Il tuo indirizzo email non può ancora essere modificato qui. Contatta il tuo amministratore per aggiornarlo.",
                 "name": "Nome completo",
                 "save": "Salva",
                 "saving": "Salvataggio in corso...",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -2170,6 +2170,7 @@
                 "presort": "Voorsorteringsvragen",
                 "postsort": "Nasorteringsvragen",
                 "no_answers": "Geen antwoorden geregistreerd voor dit gedeelte.",
+                "question_default": "Gesproken antwoord",
                 "categories": {
                     "identity": "Identiteit & contact",
                     "questions": "Vragenlijstantwoorden",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -632,10 +632,7 @@
                 "audio_label": "Opname: {{key}} door {{participant}}",
                 "url_unavailable": "Audio-URL niet beschikbaar.",
                 "comments_label": "Kaartcommentaren",
-                "question_default": "Gesproken commentaar",
-                "question": {
-                    "question_q_voice": "Gesproken commentaar over de Q-sortering"
-                }
+                "question_default": "Gesproken commentaar"
             },
             "factor_note": {
                 "label": "Factornarratief",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Persoonlijke informatie",
                 "email": "E-mailadres",
-                "email_locked": "Je e-mailadres kan hier nog niet worden gewijzigd. Neem contact op met je beheerder om deze bij te werken.",
+                "email_locked": "Uw e-mailadres kan hier nog niet worden gewijzigd. Neem contact op met uw beheerder om deze bij te werken.",
                 "name": "Volledige naam",
                 "save": "Opslaan",
                 "saving": "Opslaan...",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -631,7 +631,11 @@
                 "context_aria": "Over dit paneel",
                 "audio_label": "Opname: {{key}} door {{participant}}",
                 "url_unavailable": "Audio-URL niet beschikbaar.",
-                "comments_label": "Kaartcommentaren"
+                "comments_label": "Kaartcommentaren",
+                "question_default": "Gesproken commentaar",
+                "question": {
+                    "question_q_voice": "Gesproken commentaar over de Q-sortering"
+                }
             },
             "factor_note": {
                 "label": "Factornarratief",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Persoonlijke informatie",
                 "email": "E-mailadres",
-                "email_locked": "Uw e-mailadres kan hier nog niet worden gewijzigd. Neem contact op met uw beheerder om deze bij te werken.",
+                "email_locked": "Uw e-mailadres kan hier nog niet worden gewijzigd. Neem contact op met uw beheerder om het bij te werken.",
                 "name": "Volledige naam",
                 "save": "Opslaan",
                 "saving": "Opslaan...",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Persoonlijke informatie",
                 "email": "E-mailadres",
-                "email_locked": "E-mailwijzigingen via de API komen binnenkort naar deze pagina; backendondersteuning is actief.",
+                "email_locked": "Je e-mailadres kan hier nog niet worden gewijzigd. Neem contact op met je beheerder om deze bij te werken.",
                 "name": "Volledige naam",
                 "save": "Opslaan",
                 "saving": "Opslaan...",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -2171,6 +2171,7 @@
                 "postsort": "Nasorteringsvragen",
                 "no_answers": "Geen antwoorden geregistreerd voor dit gedeelte.",
                 "question_default": "Gesproken antwoord",
+                "answer_default": "Antwoord",
                 "categories": {
                     "identity": "Identiteit & contact",
                     "questions": "Vragenlijstantwoorden",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -631,7 +631,11 @@
         "context_aria": "O tym panelu",
         "audio_label": "Nagranie: {{key}} — {{participant}}",
         "url_unavailable": "URL audio niedostępny.",
-        "comments_label": "Komentarze do kart"
+        "comments_label": "Komentarze do kart",
+        "question_default": "Komentarz głosowy",
+        "question": {
+          "question_q_voice": "Komentarz głosowy do sortowania Q"
+        }
       },
       "factor_note": {
         "label": "Interpretacja czynnika",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -2170,6 +2170,7 @@
         "presort": "Pytania wstępne",
         "postsort": "Pytania końcowe",
         "no_answers": "Brak zapisanych odpowiedzi dla tej sekcji.",
+        "question_default": "Odpowiedź głosowa",
         "categories": {
           "identity": "Tożsamość i kontakt",
           "questions": "Odpowiedzi na pytania",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -261,7 +261,7 @@
       "personal": {
         "title": "Dane osobowe",
         "email": "Adres e-mail",
-        "email_locked": "Zmiana adresu e-mail przez API będzie wkrótce dostępna na tej stronie; obsługa serwerowa jest już aktywna.",
+        "email_locked": "Twój adres e-mail nie może być jeszcze zmieniony tutaj. Skontaktuj się z administratorem, aby go zaktualizować.",
         "name": "Imię i nazwisko",
         "save": "Zapisz",
         "saving": "Zapisywanie...",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -632,10 +632,7 @@
         "audio_label": "Nagranie: {{key}} — {{participant}}",
         "url_unavailable": "URL audio niedostępny.",
         "comments_label": "Komentarze do kart",
-        "question_default": "Komentarz głosowy",
-        "question": {
-          "question_q_voice": "Komentarz głosowy do sortowania Q"
-        }
+        "question_default": "Komentarz głosowy"
       },
       "factor_note": {
         "label": "Interpretacja czynnika",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -2171,6 +2171,7 @@
         "postsort": "Pytania końcowe",
         "no_answers": "Brak zapisanych odpowiedzi dla tej sekcji.",
         "question_default": "Odpowiedź głosowa",
+        "answer_default": "Odpowiedź",
         "categories": {
           "identity": "Tożsamość i kontakt",
           "questions": "Odpowiedzi na pytania",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Informações pessoais",
                 "email": "Endereço de email",
-                "email_locked": "Seu endereço de e-mail ainda não pode ser alterado aqui. Entre em contato com seu administrador para atualizá-lo.",
+                "email_locked": "O seu endereço de e-mail ainda não pode ser alterado aqui. Contacte o seu administrador para o atualizar.",
                 "name": "Nome completo",
                 "save": "Guardar",
                 "saving": "A guardar...",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -2171,6 +2171,7 @@
                 "postsort": "Perguntas de pós-classificação",
                 "no_answers": "Não foram registadas respostas para esta secção.",
                 "question_default": "Resposta oral",
+                "answer_default": "Resposta",
                 "categories": {
                     "identity": "Identidade e contacto",
                     "questions": "Respostas ao questionário",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -2170,6 +2170,7 @@
                 "presort": "Perguntas de pré-classificação",
                 "postsort": "Perguntas de pós-classificação",
                 "no_answers": "Não foram registadas respostas para esta secção.",
+                "question_default": "Resposta oral",
                 "categories": {
                     "identity": "Identidade e contacto",
                     "questions": "Respostas ao questionário",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -261,7 +261,7 @@
             "personal": {
                 "title": "Informações pessoais",
                 "email": "Endereço de email",
-                "email_locked": "As alterações de email via API chegam em breve a esta página; o suporte no servidor já está disponível.",
+                "email_locked": "Seu endereço de e-mail ainda não pode ser alterado aqui. Entre em contato com seu administrador para atualizá-lo.",
                 "name": "Nome completo",
                 "save": "Guardar",
                 "saving": "A guardar...",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -632,10 +632,7 @@
                 "audio_label": "Gravação: {{key}} por {{participant}}",
                 "url_unavailable": "URL de áudio não disponível.",
                 "comments_label": "Comentários às afirmações",
-                "question_default": "Comentário oral",
-                "question": {
-                    "question_q_voice": "Comentário oral sobre a classificação Q"
-                }
+                "question_default": "Comentário oral"
             },
             "factor_note": {
                 "label": "Interpretação do fator",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -631,7 +631,11 @@
                 "context_aria": "Sobre este painel",
                 "audio_label": "Gravação: {{key}} por {{participant}}",
                 "url_unavailable": "URL de áudio não disponível.",
-                "comments_label": "Comentários às afirmações"
+                "comments_label": "Comentários às afirmações",
+                "question_default": "Comentário oral",
+                "question": {
+                    "question_q_voice": "Comentário oral sobre a classificação Q"
+                }
             },
             "factor_note": {
                 "label": "Interpretação do fator",

--- a/frontend/src/components/admin/analysis/FactorCanvas.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorCanvas.test.tsx
@@ -26,6 +26,14 @@ vi.mock('@/api/generated', () => ({
     useListCommentsForParticipantsApiAdminStudiesSlugAnalysisCommentsGet: mockCommentsHook,
     useUpdateAnalysisRunApiAdminStudiesSlugAnalysisRunsRunIdPatch: mockUpdateHook,
     getListAnalysisRunsApiAdminStudiesSlugAnalysisRunsGetQueryKey: mockListRunsKey,
+    // FactorVoicesPanel reads the study's postsort_config to label audio
+    // recordings with the researcher's own question wording.
+    useGetStudyApiAdminStudiesSlugGet: () => ({
+        data: undefined,
+        isLoading: false,
+        isSuccess: false,
+        isError: false,
+    }),
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx
@@ -141,8 +141,12 @@ describe('FactorVoicesPanel', () => {
         expect(screen.getByText('Carol')).toBeInTheDocument();
         expect(screen.getByText('Dave')).toBeInTheDocument();
 
-        expect(screen.getAllByText('post_sort_q1')).toHaveLength(2);
-        expect(screen.getByText('post_sort_q2')).toBeInTheDocument();
+        // 'post_sort_q1'/'post_sort_q2' are unmapped researcher-configured
+        // keys (Task 2.2): every recording shows the generic fallback label,
+        // never the raw key.
+        expect(screen.queryByText('post_sort_q1')).not.toBeInTheDocument();
+        expect(screen.queryByText('post_sort_q2')).not.toBeInTheDocument();
+        expect(screen.getAllByText('Spoken comment')).toHaveLength(3);
     });
 
     // ── Test 3: factor filtering — factor-1 participant NOT in factor-2 panel ─
@@ -374,6 +378,77 @@ describe('FactorVoicesPanel', () => {
             });
 
             expect(screen.queryByLabelText(/Δloading/i)).toBeNull();
+        });
+    });
+
+    // ── Question key → human label (Task 2.2) ──────────────────────────────
+    describe('question label lookup (Task 2.2)', () => {
+        it('never renders the raw question key', async () => {
+            const participants = [makeParticipant(90, 'Omar', [1])];
+            const recordings = [
+                makeRecording(900, 90, 'question_q_voice', 'https://cdn.example.com/rec900.webm'),
+            ];
+
+            mockAudiosHook.mockReturnValue(dataOk(recordings));
+            mockCommentsHook.mockReturnValue(emptyOk<ParticipantCardComment>());
+
+            renderWithProviders(
+                <FactorVoicesPanel slug="demo-study" factorIndex={0} participants={participants} />
+            );
+
+            await waitFor(() => {
+                expect(screen.getByText('Omar')).toBeInTheDocument();
+            });
+
+            expect(screen.queryByText('question_q_voice')).not.toBeInTheDocument();
+        });
+
+        it('labels the recording with its human question label', async () => {
+            const participants = [makeParticipant(91, 'Priya', [1])];
+            const recordings = [
+                makeRecording(901, 91, 'question_q_voice', 'https://cdn.example.com/rec901.webm'),
+            ];
+
+            mockAudiosHook.mockReturnValue(dataOk(recordings));
+            mockCommentsHook.mockReturnValue(emptyOk<ParticipantCardComment>());
+
+            renderWithProviders(
+                <FactorVoicesPanel slug="demo-study" factorIndex={0} participants={participants} />
+            );
+
+            await waitFor(() => {
+                expect(screen.getByText('Priya')).toBeInTheDocument();
+            });
+
+            expect(screen.getByText('Spoken comment on the Q-sort')).toBeInTheDocument();
+
+            // The audio element's accessible name is built from the same
+            // resolved label, so a screen-reader user never hears the raw
+            // key either.
+            const audioEl = screen.getByLabelText(/Spoken comment on the Q-sort by Priya/);
+            expect(audioEl.tagName.toLowerCase()).toBe('audio');
+        });
+
+        it('falls back to the generic label for an unmapped question key, never the raw key', async () => {
+            const participants = [makeParticipant(92, 'Quinn', [1])];
+            const unmappedKey = 'q_1737849283000'; // a researcher-configured key with no lookup entry
+            const recordings = [
+                makeRecording(902, 92, unmappedKey, 'https://cdn.example.com/rec902.webm'),
+            ];
+
+            mockAudiosHook.mockReturnValue(dataOk(recordings));
+            mockCommentsHook.mockReturnValue(emptyOk<ParticipantCardComment>());
+
+            renderWithProviders(
+                <FactorVoicesPanel slug="demo-study" factorIndex={0} participants={participants} />
+            );
+
+            await waitFor(() => {
+                expect(screen.getByText('Quinn')).toBeInTheDocument();
+            });
+
+            expect(screen.queryByText(unmappedKey)).not.toBeInTheDocument();
+            expect(screen.getByText('Spoken comment')).toBeInTheDocument();
         });
     });
 

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx
@@ -563,6 +563,10 @@ describe('FactorVoicesPanel', () => {
             );
 
             const participants = [makeParticipant(92, 'Quinn', [1])];
+            // gitleaks:allow — a question key minted by QuestionBuilder as
+            // `q_${Date.now()}`, not a credential. Kept realistic on purpose: the
+            // whole point of this case is a key shaped like the ones real studies
+            // produce.
             const unmappedKey = 'question_q_1737849283000';
             const recordings = [
                 makeRecording(902, 92, unmappedKey, 'https://cdn.example.com/rec902.webm'),

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.test.tsx
@@ -1,19 +1,22 @@
 import { renderWithProviders, screen, waitFor } from '@/test-utils/test-utils';
+import i18n from '@/test-utils/i18n-test';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { FactorVoicesPanel } from './FactorVoicesPanel';
 import type { ParticipantLoading } from '@/api/model/participantLoading';
 import type { ParticipantAudioRecording } from '@/api/model/participantAudioRecording';
 import type { ParticipantCardComment } from '@/api/model/participantCardComment';
 
-// Hoisted mocks for both API hooks
-const { mockAudiosHook, mockCommentsHook } = vi.hoisted(() => ({
+// Hoisted mocks for the three API hooks the panel calls
+const { mockAudiosHook, mockCommentsHook, mockStudyHook } = vi.hoisted(() => ({
     mockAudiosHook: vi.fn(),
     mockCommentsHook: vi.fn(),
+    mockStudyHook: vi.fn(),
 }));
 
 vi.mock('@/api/generated', () => ({
     useListAudiosForParticipantsApiAdminStudiesSlugAnalysisAudiosGet: mockAudiosHook,
     useListCommentsForParticipantsApiAdminStudiesSlugAnalysisCommentsGet: mockCommentsHook,
+    useGetStudyApiAdminStudiesSlugGet: mockStudyHook,
 }));
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -85,11 +88,29 @@ function dataOk<T>(data: T[]): {
     return { data, isLoading: false, isSuccess: true, isError: false };
 }
 
+/** The study query resolved with a postsort_config carrying `questions`. */
+function studyWithPostsortQuestions(questions: Record<string, unknown>) {
+    return {
+        data: { slug: 'demo-study', postsort_config: { questions } },
+        isLoading: false,
+        isSuccess: true,
+        isError: false,
+    };
+}
+
+/** The study query still in flight / unavailable. */
+function noStudy() {
+    return { data: undefined, isLoading: false, isSuccess: false, isError: false };
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe('FactorVoicesPanel', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        // Default: no study config available, so recordings fall back to the
+        // generic label. Tests that care override this.
+        mockStudyHook.mockReturnValue(noStudy());
     });
 
     // ── Test 1: empty state when neither audio nor comments are present ───────
@@ -381,29 +402,19 @@ describe('FactorVoicesPanel', () => {
         });
     });
 
-    // ── Question key → human label (Task 2.2) ──────────────────────────────
-    describe('question label lookup (Task 2.2)', () => {
-        it('never renders the raw question key', async () => {
-            const participants = [makeParticipant(90, 'Omar', [1])];
-            const recordings = [
-                makeRecording(900, 90, 'question_q_voice', 'https://cdn.example.com/rec900.webm'),
-            ];
-
-            mockAudiosHook.mockReturnValue(dataOk(recordings));
-            mockCommentsHook.mockReturnValue(emptyOk<ParticipantCardComment>());
-
-            renderWithProviders(
-                <FactorVoicesPanel slug="demo-study" factorIndex={0} participants={participants} />
+    // ── Question key → human label ─────────────────────────────────────────
+    describe('question label lookup', () => {
+        it("labels the recording with the researcher's own configured question label", async () => {
+            // Exactly the demo study's post-sort audio question
+            // (backend/data/example-study.json), uploaded under the
+            // "question_"-prefixed key (backend/seed_demo.py).
+            const configuredLabel = 'Optionally, record a short spoken comment about your sort.';
+            mockStudyHook.mockReturnValue(
+                studyWithPostsortQuestions({
+                    q_voice: { type: 'text_audio', label: { en: configuredLabel } },
+                })
             );
 
-            await waitFor(() => {
-                expect(screen.getByText('Omar')).toBeInTheDocument();
-            });
-
-            expect(screen.queryByText('question_q_voice')).not.toBeInTheDocument();
-        });
-
-        it('labels the recording with its human question label', async () => {
             const participants = [makeParticipant(91, 'Priya', [1])];
             const recordings = [
                 makeRecording(901, 91, 'question_q_voice', 'https://cdn.example.com/rec901.webm'),
@@ -420,18 +431,139 @@ describe('FactorVoicesPanel', () => {
                 expect(screen.getByText('Priya')).toBeInTheDocument();
             });
 
-            expect(screen.getByText('Spoken comment on the Q-sort')).toBeInTheDocument();
+            // Positive: the label the researcher wrote — the same one the
+            // participant saw, and the same one the Post-Sort tab shows for
+            // this very recording.
+            expect(screen.getByText(configuredLabel)).toBeInTheDocument();
+            // Negative: neither the raw key nor the generic stand-in.
+            expect(screen.queryByText('question_q_voice')).not.toBeInTheDocument();
+            expect(screen.queryByText('Spoken comment')).not.toBeInTheDocument();
 
             // The audio element's accessible name is built from the same
-            // resolved label, so a screen-reader user never hears the raw
-            // key either.
-            const audioEl = screen.getByLabelText(/Spoken comment on the Q-sort by Priya/);
+            // resolved label, so a screen-reader user hears it too.
+            const audioEl = screen.getByLabelText(new RegExp(`${configuredLabel} by Priya`));
             expect(audioEl.tagName.toLowerCase()).toBe('audio');
         });
 
-        it('falls back to the generic label for an unmapped question key, never the raw key', async () => {
+        it('gives two audio questions two different labels', async () => {
+            // A study with more than one audio question is the case the
+            // lookup has to get right: both players must be distinguishable.
+            mockStudyHook.mockReturnValue(
+                studyWithPostsortQuestions({
+                    q_1737849283000: {
+                        type: 'text_audio',
+                        label: { en: 'Why did you place the top card there?' },
+                    },
+                    q_1737849299000: {
+                        type: 'text_audio',
+                        label: { en: 'What would you change about this study?' },
+                    },
+                })
+            );
+
+            const participants = [makeParticipant(93, 'Rita', [1])];
+            const recordings = [
+                makeRecording(
+                    903,
+                    93,
+                    'question_q_1737849283000',
+                    'https://cdn.example.com/rec903.webm'
+                ),
+                makeRecording(
+                    904,
+                    93,
+                    'question_q_1737849299000',
+                    'https://cdn.example.com/rec904.webm'
+                ),
+            ];
+
+            mockAudiosHook.mockReturnValue(dataOk(recordings));
+            mockCommentsHook.mockReturnValue(emptyOk<ParticipantCardComment>());
+
+            renderWithProviders(
+                <FactorVoicesPanel slug="demo-study" factorIndex={0} participants={participants} />
+            );
+
+            await waitFor(() => {
+                expect(screen.getByText('Rita')).toBeInTheDocument();
+            });
+
+            expect(screen.getByText('Why did you place the top card there?')).toBeInTheDocument();
+            expect(screen.getByText('What would you change about this study?')).toBeInTheDocument();
+            // Not two identical generic labels, and never the raw keys.
+            expect(screen.queryByText('Spoken comment')).not.toBeInTheDocument();
+            expect(screen.queryByText('question_q_1737849283000')).not.toBeInTheDocument();
+            expect(screen.queryByText('question_q_1737849299000')).not.toBeInTheDocument();
+        });
+
+        it("resolves the label in the admin's active language", async () => {
+            // The researcher browsing the analysis in French must read the
+            // French wording of the question, not the English one.
+            await i18n.changeLanguage('fr');
+            try {
+                mockStudyHook.mockReturnValue(
+                    studyWithPostsortQuestions({
+                        q_voice: {
+                            type: 'text_audio',
+                            label: {
+                                en: 'Optionally, record a short spoken comment about your sort.',
+                                fr: 'Optionnel : enregistrez un bref commentaire audio sur votre tri.',
+                            },
+                        },
+                    })
+                );
+
+                const participants = [makeParticipant(94, 'Sami', [1])];
+                const recordings = [
+                    makeRecording(
+                        905,
+                        94,
+                        'question_q_voice',
+                        'https://cdn.example.com/rec905.webm'
+                    ),
+                ];
+
+                mockAudiosHook.mockReturnValue(dataOk(recordings));
+                mockCommentsHook.mockReturnValue(emptyOk<ParticipantCardComment>());
+
+                renderWithProviders(
+                    <FactorVoicesPanel
+                        slug="demo-study"
+                        factorIndex={0}
+                        participants={participants}
+                    />
+                );
+
+                await waitFor(() => {
+                    expect(screen.getByText('Sami')).toBeInTheDocument();
+                });
+
+                expect(
+                    screen.getByText(
+                        'Optionnel : enregistrez un bref commentaire audio sur votre tri.'
+                    )
+                ).toBeInTheDocument();
+                expect(
+                    screen.queryByText('Optionally, record a short spoken comment about your sort.')
+                ).not.toBeInTheDocument();
+            } finally {
+                await i18n.changeLanguage('en');
+            }
+        });
+
+        it('falls back to the generic label when the question is gone from the config, never the raw key', async () => {
+            // A different question exists in the config, but not the one this
+            // recording references (the researcher deleted it after the
+            // participant answered) — this proves a real lookup that missed,
+            // not an empty-config short-circuit that would pass vacuously.
+            mockStudyHook.mockReturnValue(
+                studyWithPostsortQuestions({
+                    q_other: { type: 'text_audio', label: { en: 'A different question' } },
+                })
+            );
+
             const participants = [makeParticipant(92, 'Quinn', [1])];
-            const unmappedKey = 'q_1737849283000'; // a researcher-configured key with no lookup entry
+            const unmappedKey = 'question_q_1737849283000';
             const recordings = [
                 makeRecording(902, 92, unmappedKey, 'https://cdn.example.com/rec902.webm'),
             ];
@@ -448,6 +580,8 @@ describe('FactorVoicesPanel', () => {
             });
 
             expect(screen.queryByText(unmappedKey)).not.toBeInTheDocument();
+            expect(screen.queryByText('q_1737849283000')).not.toBeInTheDocument();
+            expect(screen.queryByText('A different question')).not.toBeInTheDocument();
             expect(screen.getByText('Spoken comment')).toBeInTheDocument();
         });
     });

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
@@ -98,33 +98,43 @@ function ParticipantMaterialCard({
 
             {recordings.length > 0 && (
                 <div className="space-y-2">
-                    {recordings.map((rec) => (
-                        <div key={rec.id} className="space-y-1">
-                            <p className="text-2xs text-slate-500 font-medium">
-                                {rec.question_key}
-                            </p>
-                            {rec.presigned_url ? (
-                                // biome-ignore lint/a11y/useMediaCaption: research tool — transcripts are not available server-side
-                                <audio
-                                    controls
-                                    src={rec.presigned_url}
-                                    className="w-full h-8"
-                                    aria-label={t(
-                                        'admin.analysis.factor_voices.audio_label',
-                                        'Recording: {{key}} by {{participant}}',
-                                        { key: rec.question_key, participant: label }
-                                    )}
-                                />
-                            ) : (
-                                <p className="text-2xs text-slate-400 italic">
-                                    {t(
-                                        'admin.analysis.factor_voices.url_unavailable',
-                                        'Audio URL not available.'
-                                    )}
+                    {recordings.map((rec) => {
+                        // rec.question_key is an internal, researcher-configured
+                        // identifier (e.g. "q_1737849283000") — never fit for
+                        // display. Map it to a human label, falling back to a
+                        // generic one rather than ever leaking the raw key.
+                        const questionLabel = t(
+                            `admin.analysis.factor_voices.question.${rec.question_key}`,
+                            t('admin.analysis.factor_voices.question_default', 'Spoken comment')
+                        );
+                        return (
+                            <div key={rec.id} className="space-y-1">
+                                <p className="text-2xs text-slate-500 font-medium">
+                                    {questionLabel}
                                 </p>
-                            )}
-                        </div>
-                    ))}
+                                {rec.presigned_url ? (
+                                    // biome-ignore lint/a11y/useMediaCaption: research tool — transcripts are not available server-side
+                                    <audio
+                                        controls
+                                        src={rec.presigned_url}
+                                        className="w-full h-8"
+                                        aria-label={t(
+                                            'admin.analysis.factor_voices.audio_label',
+                                            'Recording: {{key}} by {{participant}}',
+                                            { key: questionLabel, participant: label }
+                                        )}
+                                    />
+                                ) : (
+                                    <p className="text-2xs text-slate-400 italic">
+                                        {t(
+                                            'admin.analysis.factor_voices.url_unavailable',
+                                            'Audio URL not available.'
+                                        )}
+                                    </p>
+                                )}
+                            </div>
+                        );
+                    })}
                 </div>
             )}
 

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
@@ -1,13 +1,19 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Info, Loader2, AlertTriangle, Mic, MessageSquareText } from 'lucide-react';
 import type { ParticipantLoading } from '@/api/model/participantLoading';
 import type { ParticipantCardComment } from '@/api/model/participantCardComment';
 import type { ParticipantAudioRecording } from '@/api/model/participantAudioRecording';
 import {
+    useGetStudyApiAdminStudiesSlugGet,
     useListAudiosForParticipantsApiAdminStudiesSlugAnalysisAudiosGet,
     useListCommentsForParticipantsApiAdminStudiesSlugAnalysisCommentsGet,
 } from '@/api/generated';
+import {
+    buildQuestionsMap,
+    resolveAudioQuestionLabel,
+    type QuestionMapEntry,
+} from '@/components/admin/dashboard/SurveyResponseTable.helpers';
 
 /** |Δloading| threshold above which the chip is visually emphasised. Mirrors spec §5.5. */
 const DELTA_LOADING_HIGHLIGHT = 0.2;
@@ -61,6 +67,10 @@ interface ParticipantMaterialCardProps {
     deltaLoading?: number;
     recordings: ParticipantAudioRecording[];
     comments: ParticipantCardComment[];
+    /** Researcher-authored post-sort questions, keyed by their config id. */
+    questionsMap: Record<string, QuestionMapEntry>;
+    /** Active admin language, used to pick a translation of the question label. */
+    language: string;
     onInsertCommentQuote?: (comment: ParticipantCardComment, participantLabel: string) => void;
 }
 
@@ -69,6 +79,8 @@ function ParticipantMaterialCard({
     deltaLoading,
     recordings,
     comments,
+    questionsMap,
+    language,
     onInsertCommentQuote,
 }: ParticipantMaterialCardProps) {
     const { t } = useTranslation();
@@ -100,11 +112,17 @@ function ParticipantMaterialCard({
                 <div className="space-y-2">
                     {recordings.map((rec) => {
                         // rec.question_key is an internal, researcher-configured
-                        // identifier (e.g. "q_1737849283000") — never fit for
-                        // display. Map it to a human label, falling back to a
-                        // generic one rather than ever leaking the raw key.
-                        const questionLabel = t(
-                            `admin.analysis.factor_voices.question.${rec.question_key}`,
+                        // identifier (e.g. "question_q_1737849283000") — never
+                        // fit for display. Resolve the researcher's own label
+                        // from the study's postsort_config, exactly as the
+                        // participant Post-Sort tab does, so one recording is
+                        // named the same way on both screens. The generic
+                        // fallback applies only when the question config is
+                        // genuinely gone.
+                        const questionLabel = resolveAudioQuestionLabel(
+                            questionsMap,
+                            rec.question_key,
+                            language,
                             t('admin.analysis.factor_voices.question_default', 'Spoken comment')
                         );
                         return (
@@ -195,7 +213,7 @@ export function FactorVoicesPanel({
     onInsertCommentQuote,
     deltaByParticipant,
 }: FactorVoicesPanelProps) {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const [tooltipOpen, setTooltipOpen] = useState(false);
 
     const factorNumber = factorIndex + 1;
@@ -216,6 +234,15 @@ export function FactorVoicesPanel({
         slug,
         { participant_ids: participantIds },
         { query: { enabled: queryEnabled } }
+    );
+
+    // The researcher's own post-sort question labels live on the study, so
+    // the analysis screen can name a recording the way its author wrote it
+    // (and the way the participant read it) instead of showing a raw id.
+    const studyQuery = useGetStudyApiAdminStudiesSlugGet(slug);
+    const postsortQuestionsMap = useMemo(
+        () => buildQuestionsMap(studyQuery.data?.postsort_config ?? {}),
+        [studyQuery.data]
     );
 
     const recordingsByParticipant = groupByParticipant(audiosQuery.data);
@@ -307,6 +334,8 @@ export function FactorVoicesPanel({
                             deltaLoading={deltaByParticipant?.get(p.db_id)}
                             recordings={recordingsByParticipant.get(p.db_id) ?? []}
                             comments={commentsByParticipant.get(p.db_id) ?? []}
+                            questionsMap={postsortQuestionsMap}
+                            language={i18n.language}
                             onInsertCommentQuote={onInsertCommentQuote}
                         />
                     ))}

--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.test.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.test.tsx
@@ -382,12 +382,20 @@ describe('ParticipantDetailContent — post-sort audio question labels', () => {
 
         switchToPostsortTab();
 
-        // Never the raw identifier.
-        expect(screen.queryByText('q_9999999999999')).not.toBeInTheDocument();
         // The answer value itself renders — proves the row actually
         // mounted, not that the whole section silently failed to render.
         expect(screen.getByText('A genuine free-text answer')).toBeInTheDocument();
         // ...labelled with the generic fallback, not the identifier.
         expect(screen.getByText('Response')).toBeInTheDocument();
+        // The raw key does reach this screen, but only in the row's explicit
+        // "Internal ID" line — a deliberate, labelled disclosure. It must
+        // appear exactly there and nowhere else; in particular it must not be
+        // the question's label. (A bare queryByText('q_9999999999999') would
+        // pass whatever happened, because testing-library's default matcher
+        // compares an element's whole text and the ID line reads
+        // "Internal ID: q_9999999999999".)
+        const rawKeyNodes = screen.getAllByText(/q_9999999999999/);
+        expect(rawKeyNodes).toHaveLength(1);
+        expect(rawKeyNodes[0]).toHaveTextContent('Internal ID: q_9999999999999');
     });
 });

--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.test.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.test.tsx
@@ -344,4 +344,50 @@ describe('ParticipantDetailContent — post-sort audio question labels', () => {
         // because nothing rendered at all).
         expect(screen.getByText('Spoken response')).toBeInTheDocument();
     });
+
+    it('falls back to a generic label — never the raw key — for a text-type post-sort question no longer in the config', () => {
+        // Same defect class, reached via a different render path: the
+        // presort/postsort question table (SurveyResponseTable), rendered
+        // two lines above the audio-recordings block on this exact tab, has
+        // the identical "config entry is gone" failure mode for non-audio
+        // answers (SurveyResponseTable.helpers.ts's resolveAnswerLabel).
+        const studyData = buildStudyData(undefined, 1, [1, 1], {
+            questions: {
+                // A different question exists in the config, but not the
+                // one this participant answered — proves a real map lookup
+                // that missed, not an empty-config short-circuit.
+                q_other: {
+                    type: 'text',
+                    label: { en: 'A different question' },
+                    required: false,
+                },
+            },
+        });
+        const participant: DumpParticipant = {
+            ...buildParticipant({ '1': 0 }),
+            postsort: {
+                questions_answers: {
+                    q_9999999999999: 'A genuine free-text answer',
+                },
+            },
+        };
+
+        render(
+            <ParticipantDetailContent
+                participant={participant}
+                studyData={studyData}
+                onToggleDiscard={() => {}}
+            />
+        );
+
+        switchToPostsortTab();
+
+        // Never the raw identifier.
+        expect(screen.queryByText('q_9999999999999')).not.toBeInTheDocument();
+        // The answer value itself renders — proves the row actually
+        // mounted, not that the whole section silently failed to render.
+        expect(screen.getByText('A genuine free-text answer')).toBeInTheDocument();
+        // ...labelled with the generic fallback, not the identifier.
+        expect(screen.getByText('Response')).toBeInTheDocument();
+    });
 });

--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.test.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.test.tsx
@@ -68,7 +68,8 @@ const countSlotsInColumnByScore = (score: number) => {
 const buildStudyData = (
     distributionMode: 'forced' | 'free' | 'flexible' | undefined,
     statementCount: number,
-    capacities: number[]
+    capacities: number[],
+    postsortConfig?: Record<string, unknown>
 ): DumpResponse => {
     const statements = Array.from({ length: statementCount }, (_, i) => ({
         id: i + 1,
@@ -89,6 +90,7 @@ const buildStudyData = (
             state: 'active',
             // distribution_mode is the under-test field — propagated from the page.
             distribution_mode: distributionMode,
+            postsort_config: postsortConfig,
         } as DumpResponse['study'],
         participants: [],
         statement_id_to_index: statements.reduce(
@@ -101,7 +103,10 @@ const buildStudyData = (
     };
 };
 
-const buildParticipant = (placements: Record<string, number>): DumpParticipant => ({
+const buildParticipant = (
+    placements: Record<string, number>,
+    audioRecordings?: Record<string, unknown>
+): DumpParticipant => ({
     id: 'session-1',
     db_id: 1,
     duration_seconds: 600,
@@ -109,7 +114,7 @@ const buildParticipant = (placements: Record<string, number>): DumpParticipant =
     placements,
     presort: {},
     postsort: {},
-    audio_recordings: {},
+    audio_recordings: audioRecordings ?? {},
     language: 'en',
     is_discarded: false,
     discard_reason: null,
@@ -133,6 +138,24 @@ const switchToGridTab = () => {
         fireEvent.mouseDown(gridTab);
         fireEvent.pointerUp(gridTab);
         fireEvent.click(gridTab);
+    });
+};
+
+const switchToPostsortTab = () => {
+    // Same rationale as switchToGridTab: identify by Radix's id suffix and
+    // dispatch the full pointer sequence Radix Tabs requires to switch.
+    const tabs = screen.getAllByRole('tab');
+    const postsortTab = tabs.find((tab) =>
+        (tab.getAttribute('id') || '').endsWith('-trigger-postsort')
+    );
+    if (!postsortTab) {
+        throw new Error('Postsort tab not found');
+    }
+    act(() => {
+        fireEvent.pointerDown(postsortTab, { button: 0 });
+        fireEvent.mouseDown(postsortTab);
+        fireEvent.pointerUp(postsortTab);
+        fireEvent.click(postsortTab);
     });
 };
 
@@ -226,5 +249,99 @@ describe('ParticipantDetailContent — read-only GridSort overflow propagation',
         // the legacy behaviour we want to preserve when distribution_mode
         // is unset.)
         expect(countSlotsInColumnByScore(0)).toBe(2);
+    });
+});
+
+describe('ParticipantDetailContent — post-sort audio question labels', () => {
+    it('resolves a custom post-sort audio question to its researcher-configured label', () => {
+        // The upload path (Step2_Questionnaire.tsx) prefixes the researcher's
+        // own question id with "question_" when saving the recording key.
+        const studyData = buildStudyData(undefined, 1, [1, 1], {
+            questions: {
+                q_1737849283000: {
+                    type: 'text_audio',
+                    label: { en: 'Tell us why you placed the top card here' },
+                    required: false,
+                },
+            },
+        });
+        const participant = buildParticipant(
+            { '1': 0 },
+            {
+                question_q_1737849283000: {
+                    presigned_url: 'https://example.com/audio.webm',
+                    duration_seconds: 12,
+                    file_size_bytes: 2048,
+                },
+            }
+        );
+
+        render(
+            <ParticipantDetailContent
+                participant={participant}
+                studyData={studyData}
+                onToggleDiscard={() => {}}
+            />
+        );
+
+        switchToPostsortTab();
+
+        // Positive: the researcher's own label is shown — proves the real
+        // config was actually consulted, not just that nothing crashed and
+        // the raw-key assertions below passed vacuously.
+        expect(screen.getByText('Tell us why you placed the top card here')).toBeInTheDocument();
+        // Negative: neither the bare config key nor the uploaded (prefixed)
+        // key ever reach the screen.
+        expect(screen.queryByText('q_1737849283000')).not.toBeInTheDocument();
+        expect(screen.queryByText('question_q_1737849283000')).not.toBeInTheDocument();
+    });
+
+    it('falls back to a generic label — never the raw key — for a question no longer in the config', () => {
+        // Simulates a researcher-generated key with no matching lookup entry
+        // (e.g. the question was edited or removed from postsort_config
+        // after the participant answered). This is resolution #3's required
+        // safe-degrade case: an unmapped key must render the generic label,
+        // never the identifier.
+        const studyData = buildStudyData(undefined, 1, [1, 1], {
+            questions: {
+                // A different question exists in the config, but not the one
+                // this participant's recording references — this proves a
+                // real map lookup that missed, not an empty-config
+                // short-circuit that would pass for the wrong reason.
+                q_other: {
+                    type: 'text_audio',
+                    label: { en: 'A different question' },
+                    required: false,
+                },
+            },
+        });
+        const participant = buildParticipant(
+            { '1': 0 },
+            {
+                question_q_9999999999999: {
+                    presigned_url: 'https://example.com/audio.webm',
+                    duration_seconds: 5,
+                    file_size_bytes: 1024,
+                },
+            }
+        );
+
+        render(
+            <ParticipantDetailContent
+                participant={participant}
+                studyData={studyData}
+                onToggleDiscard={() => {}}
+            />
+        );
+
+        switchToPostsortTab();
+
+        // Never the raw identifier, in either form.
+        expect(screen.queryByText('q_9999999999999')).not.toBeInTheDocument();
+        expect(screen.queryByText('question_q_9999999999999')).not.toBeInTheDocument();
+        // The generic, honest fallback label is shown instead — this proves
+        // the row actually rendered (not merely that the raw key is absent
+        // because nothing rendered at all).
+        expect(screen.getByText('Spoken response')).toBeInTheDocument();
     });
 });

--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
@@ -27,6 +27,8 @@ import SortableCard from '@/components/SortableCard';
 import { AudioPlayer } from '@/components/admin/AudioPlayer';
 import { MultiLangFieldIcon } from '@/components/admin/designer/MultiLangFieldIcon';
 import type { InteractionUtils } from '@/types/grid';
+import { buildQuestionsMap } from './SurveyResponseTable.helpers';
+import { getLocalizedText } from '@/utils/localization';
 
 /** Shape of an audio recording entry in the participant answer blob. */
 type AudioEntry = {
@@ -206,6 +208,16 @@ export function ParticipantDetailContent({
 
     const language = participant.language || 'en';
     const studyForSurvey = studyData.study as unknown as StudyRead;
+
+    // Researcher-authored labels for custom post-sort questions (text_audio
+    // type included), keyed by the same id the study designer assigns in
+    // QuestionBuilder (e.g. "q_1737849283000"). Used below to resolve a real
+    // label for audio recordings instead of ever showing that raw,
+    // researcher-generated id.
+    const postsortQuestionsMap = useMemo(
+        () => buildQuestionsMap(studyData.study.postsort_config ?? {}),
+        [studyData.study.postsort_config]
+    );
 
     const detailStatement = detailStatementId ? statementsMap.get(detailStatementId) : null;
     const detailComment = detailStatementId
@@ -587,6 +599,34 @@ export function ParticipantDetailContent({
                                                     label = t(
                                                         'post.extreme.general_comment',
                                                         'General Comment'
+                                                    );
+                                                } else {
+                                                    // Custom post-sort question (text_audio type),
+                                                    // uploaded with a "question_" prefix — see
+                                                    // Step2_Questionnaire.tsx. The participant-
+                                                    // facing label lives in the study's own
+                                                    // postsort_config.questions[key].label (a
+                                                    // MultilangString the researcher wrote in
+                                                    // QuestionBuilder) — resolve it there instead
+                                                    // of ever showing the raw, researcher-generated
+                                                    // id (e.g. "q_1737849283000", see
+                                                    // QuestionBuilder.tsx:964). Falls back to a
+                                                    // generic label only if the question can no
+                                                    // longer be found in the config (e.g. deleted
+                                                    // after the participant answered).
+                                                    const configKey = key.startsWith('question_')
+                                                        ? key.slice('question_'.length)
+                                                        : key;
+                                                    const questionConfig =
+                                                        postsortQuestionsMap[configKey];
+                                                    label = getLocalizedText(
+                                                        questionConfig?.label ||
+                                                            questionConfig?.text,
+                                                        language,
+                                                        t(
+                                                            'admin.participant.survey.question_default',
+                                                            'Spoken response'
+                                                        )
                                                     );
                                                 }
 

--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
@@ -27,8 +27,7 @@ import SortableCard from '@/components/SortableCard';
 import { AudioPlayer } from '@/components/admin/AudioPlayer';
 import { MultiLangFieldIcon } from '@/components/admin/designer/MultiLangFieldIcon';
 import type { InteractionUtils } from '@/types/grid';
-import { buildQuestionsMap } from './SurveyResponseTable.helpers';
-import { getLocalizedText } from '@/utils/localization';
+import { buildQuestionsMap, resolveAudioQuestionLabel } from './SurveyResponseTable.helpers';
 
 /** Shape of an audio recording entry in the participant answer blob. */
 type AudioEntry = {
@@ -574,8 +573,12 @@ export function ParticipantDetailContent({
                                                     AudioEntry
                                                 >
                                             ).map(([key, audio]) => {
-                                                // Resolve label from question_key
-                                                let label = key;
+                                                // Resolve label from question_key.
+                                                // Deliberately left uninitialised: the chain
+                                                // below must assign on every branch, and the
+                                                // compiler now says so. Seeding it with `key`
+                                                // is what leaked the raw identifier before.
+                                                let label: string;
                                                 if (key.startsWith('card_')) {
                                                     const sId = Number(key.replace('card_', ''));
                                                     const stmt = statementsMap.get(sId);
@@ -603,25 +606,16 @@ export function ParticipantDetailContent({
                                                 } else {
                                                     // Custom post-sort question (text_audio type),
                                                     // uploaded with a "question_" prefix — see
-                                                    // Step2_Questionnaire.tsx. The participant-
-                                                    // facing label lives in the study's own
-                                                    // postsort_config.questions[key].label (a
-                                                    // MultilangString the researcher wrote in
-                                                    // QuestionBuilder) — resolve it there instead
-                                                    // of ever showing the raw, researcher-generated
-                                                    // id (e.g. "q_1737849283000", see
-                                                    // QuestionBuilder.tsx:964). Falls back to a
-                                                    // generic label only if the question can no
-                                                    // longer be found in the config (e.g. deleted
-                                                    // after the participant answered).
-                                                    const configKey = key.startsWith('question_')
-                                                        ? key.slice('question_'.length)
-                                                        : key;
-                                                    const questionConfig =
-                                                        postsortQuestionsMap[configKey];
-                                                    label = getLocalizedText(
-                                                        questionConfig?.label ||
-                                                            questionConfig?.text,
+                                                    // Step2_Questionnaire.tsx. resolveAudioQuestionLabel
+                                                    // reads the researcher's own wording out of
+                                                    // postsort_config instead of ever showing the raw,
+                                                    // researcher-generated id (e.g. "q_1737849283000",
+                                                    // see QuestionBuilder.tsx:964); the analysis
+                                                    // Voices panel uses the same helper, so one
+                                                    // recording is named the same way on both screens.
+                                                    label = resolveAudioQuestionLabel(
+                                                        postsortQuestionsMap,
+                                                        key,
                                                         language,
                                                         t(
                                                             'admin.participant.survey.question_default',

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.test.ts
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.test.ts
@@ -49,8 +49,21 @@ describe('resolveAnswerLabel', () => {
         expect(resolveAnswerLabel({}, 'general_comment', 'en', t)).toBe('General Comment');
     });
 
-    it('returns raw key when no match found', () => {
-        expect(resolveAnswerLabel({}, 'unknown_key', 'en', t)).toBe('unknown_key');
+    it('returns a generic fallback — never the raw key — when no match found', () => {
+        const result = resolveAnswerLabel({}, 'unknown_key', 'en', t);
+        expect(result).not.toBe('unknown_key');
+        expect(result).toBe('Response');
+    });
+
+    it('returns a generic fallback — never the raw key — when the matched entry has no label or text', () => {
+        // A config entry exists for this key (e.g. a legacy/malformed
+        // question config), but it carries neither a label nor a text
+        // field. This must degrade the same way as a missing entry, not
+        // leak the key via getLocalizedText's own fallback parameter.
+        const map = { q1: { id: 'q1' } };
+        const result = resolveAnswerLabel(map, 'q1', 'en', t);
+        expect(result).not.toBe('q1');
+        expect(result).toBe('Response');
     });
 });
 

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.test.ts
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
     resolveAnswerLabel,
+    resolveAudioQuestionLabel,
     resolveOptionText,
     buildQuestionsMap,
     classifyAnswerKey,
@@ -64,6 +65,68 @@ describe('resolveAnswerLabel', () => {
         const result = resolveAnswerLabel(map, 'q1', 'en', t);
         expect(result).not.toBe('q1');
         expect(result).toBe('Response');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAudioQuestionLabel
+// ---------------------------------------------------------------------------
+
+describe('resolveAudioQuestionLabel', () => {
+    const GENERIC = 'Spoken comment';
+
+    it('strips the storage "question_" prefix before looking the id up', () => {
+        // Recordings are stored as "question_<id>" while postsort_config is
+        // keyed by the bare id — the prefix must not defeat the lookup.
+        const map = {
+            q_voice: { id: 'q_voice', label: { en: 'Record a short spoken comment.' } },
+        };
+        expect(resolveAudioQuestionLabel(map, 'question_q_voice', 'en', GENERIC)).toBe(
+            'Record a short spoken comment.'
+        );
+    });
+
+    it('resolves an unprefixed key too', () => {
+        const map = { q_voice: { id: 'q_voice', label: { en: 'Record a short comment.' } } };
+        expect(resolveAudioQuestionLabel(map, 'q_voice', 'en', GENERIC)).toBe(
+            'Record a short comment.'
+        );
+    });
+
+    it('returns the requested language, not just English', () => {
+        const map = {
+            q_voice: {
+                id: 'q_voice',
+                label: { en: 'Record a short comment.', fr: 'Enregistrez un bref commentaire.' },
+            },
+        };
+        expect(resolveAudioQuestionLabel(map, 'question_q_voice', 'fr', GENERIC)).toBe(
+            'Enregistrez un bref commentaire.'
+        );
+    });
+
+    it('falls back to `text` when the entry has no `label`', () => {
+        const map = { q_voice: { id: 'q_voice', text: 'Legacy text field' } };
+        expect(resolveAudioQuestionLabel(map, 'question_q_voice', 'en', GENERIC)).toBe(
+            'Legacy text field'
+        );
+    });
+
+    it('returns the generic fallback — never the key — when the question is gone', () => {
+        // A populated map that simply lacks this id: the question was deleted
+        // after the participant answered.
+        const map = { q_other: { id: 'q_other', label: { en: 'A different question' } } };
+        const result = resolveAudioQuestionLabel(map, 'question_q_1737849283000', 'en', GENERIC);
+        expect(result).not.toBe('question_q_1737849283000');
+        expect(result).not.toBe('q_1737849283000');
+        expect(result).toBe(GENERIC);
+    });
+
+    it('returns the generic fallback when the entry carries neither label nor text', () => {
+        const map = { q_voice: { id: 'q_voice' } };
+        const result = resolveAudioQuestionLabel(map, 'question_q_voice', 'en', GENERIC);
+        expect(result).not.toBe('q_voice');
+        expect(result).toBe(GENERIC);
     });
 });
 

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.ts
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.ts
@@ -15,11 +15,18 @@ export function resolveAnswerLabel(
     language: string,
     t: TFunction
 ): string {
+    // Generic, honest fallback for a key that cannot be resolved to a real
+    // question label — e.g. a researcher-generated key (see
+    // QuestionBuilder.tsx) whose config entry no longer exists (the question
+    // was edited or removed after the participant answered). Never fall back
+    // to the raw key itself: that leaks an internal identifier to the
+    // researcher (same defect class as the audio-recording labels above).
+    const genericFallback = t('admin.participant.survey.answer_default', 'Response');
     const q = questionsMap[key];
     if (q) {
         // label/text are typed as string | Record<string,string> | undefined —
         // both are valid inputs for getLocalizedText.
-        return getLocalizedText(q.label || q.text, language, key);
+        return getLocalizedText(q.label || q.text, language, genericFallback);
     }
     if (key === 'email') return t('post.contact.email_label', 'Email Address');
     if (key === 'interview_consent') return t('post.contact.interview_consent', 'Follow-up');
@@ -29,7 +36,7 @@ export function resolveAnswerLabel(
     if (key === 'missing_statement')
         return t('post.extreme.missing_statement', 'Missing Statement');
     if (key === 'general_comment') return t('post.extreme.general_comment', 'General Comment');
-    return key;
+    return genericFallback;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.ts
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.ts
@@ -7,7 +7,10 @@ import type { TFunction } from 'i18next';
 
 /**
  * Returns a human-readable label for a survey answer key.
- * Falls back to the raw key when no match is found.
+ *
+ * Resolution order: the study's own question config, then the small set of
+ * built-in keys, then a generic label. The raw key is never returned — it is
+ * an internal identifier that must not be shown to the researcher.
  */
 export function resolveAnswerLabel(
     questionsMap: Record<string, QuestionMapEntry>,
@@ -37,6 +40,44 @@ export function resolveAnswerLabel(
         return t('post.extreme.missing_statement', 'Missing Statement');
     if (key === 'general_comment') return t('post.extreme.general_comment', 'General Comment');
     return genericFallback;
+}
+
+// ---------------------------------------------------------------------------
+// Audio-recording label resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Prefix the upload path adds to a researcher-configured question id when it
+ * stores an audio recording (see Step2_Questionnaire.tsx / seed_demo.py).
+ */
+const AUDIO_QUESTION_KEY_PREFIX = 'question_';
+
+/**
+ * Returns a human-readable label for a post-sort *audio* recording key.
+ *
+ * The participant-facing wording lives in the study's own
+ * `postsort_config.questions[<id>].label` — a MultilangString the researcher
+ * wrote in QuestionBuilder. Recordings are stored under that id prefixed with
+ * `question_`, so strip the prefix before the lookup. `genericFallback` is
+ * used only when the question can no longer be found (e.g. it was deleted
+ * after the participant answered); the raw, internal id is never returned.
+ *
+ * Shared by the participant Post-Sort tab and the analysis Voices panel so
+ * that one recording is named the same way on both screens.
+ */
+export function resolveAudioQuestionLabel(
+    questionsMap: Record<string, QuestionMapEntry>,
+    key: string,
+    language: string,
+    genericFallback: string
+): string {
+    const configKey = key.startsWith(AUDIO_QUESTION_KEY_PREFIX)
+        ? key.slice(AUDIO_QUESTION_KEY_PREFIX.length)
+        : key;
+    const question = questionsMap[configKey];
+    // label/text are typed as string | Record<string,string> | undefined —
+    // both are valid inputs for getLocalizedText.
+    return getLocalizedText(question?.label || question?.text, language, genericFallback);
 }
 
 // ---------------------------------------------------------------------------
@@ -86,7 +127,7 @@ type ConfigWithQuestionsOrFields = {
  * needing `any`; the index signature keeps the type compatible with
  * `Record<string, any>` consumers (e.g. renderValue in SurveyResponseTable).
  */
-type QuestionMapEntry = {
+export type QuestionMapEntry = {
     label?: string | Record<string, string>;
     text?: string | Record<string, string>;
     options?: unknown[];

--- a/frontend/src/pages/admin/AccountSettingsPage.tsx
+++ b/frontend/src/pages/admin/AccountSettingsPage.tsx
@@ -225,7 +225,7 @@ const AccountSettingsPage = () => {
                                             <p className="text-2xs text-slate-400 italic">
                                                 {t(
                                                     'admin.account.personal.email_locked',
-                                                    'Email changes via the API are coming soon to this page; backend support is live.'
+                                                    "Your email address can't be changed here yet. Contact your administrator to update it."
                                                 )}
                                             </p>
                                         </FormItem>

--- a/frontend/src/pages/admin/AnalysisPage.test.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.test.tsx
@@ -66,6 +66,15 @@ vi.mock('@/api/generated', () => ({
         isError: false,
         error: null,
     }),
+    // FactorVoicesPanel also reads the study to resolve post-sort audio
+    // question labels; no recordings here, so an idle query is enough.
+    useGetStudyApiAdminStudiesSlugGet: () => ({
+        data: undefined,
+        isLoading: false,
+        isSuccess: false,
+        isError: false,
+        error: null,
+    }),
 }));
 
 // Mock useParams only — let useSearchParams work against MemoryRouter so

--- a/frontend/src/pages/admin/ProjectMembersPage.test.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.test.tsx
@@ -43,6 +43,12 @@ vi.mock('@/api/generated', () => ({
                     joined_at: '2024-01-01T00:00:00Z',
                     user: { full_name: 'Grace Hopper', email: 'grace@x.io' },
                 },
+                {
+                    user_id: 13,
+                    role: 'member',
+                    joined_at: '2024-01-01T00:00:00Z',
+                    user: { full_name: null, email: 'nn@example.com' },
+                },
             ],
         },
         isLoading: false,
@@ -105,5 +111,19 @@ describe('ProjectMembersPage role select', () => {
         expect(await screen.findByRole('option', { name: /^member$/i })).toBeInTheDocument();
         expect(screen.getByRole('option', { name: /^viewer$/i })).toBeInTheDocument();
         expect(screen.queryByRole('option', { name: /^owner$/i })).not.toBeInTheDocument();
+    });
+
+    it('falls back to the email when the member has no full name', async () => {
+        renderWithProviders(<ProjectMembersPage />);
+
+        // Scope to the no-name member's row: an unscoped query would still
+        // pass if some other row happened to render matching text.
+        const row = await screen.findByRole('row', { name: /nn@example\.com/i });
+        expect(within(row).queryByText(/no name/i)).not.toBeInTheDocument();
+        // The email must appear exactly once in the cell — as the display
+        // name. A second, identical "email line" underneath it would be a
+        // redundant duplicate rather than a real fix, so assert the count
+        // instead of just presence.
+        expect(within(row).getAllByText('nn@example.com')).toHaveLength(1);
     });
 });

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -210,12 +210,15 @@ export default function ProjectMembersPage() {
                                                     </div>
                                                     <div className="flex flex-col">
                                                         <span className="text-sm font-bold text-slate-900">
-                                                            {member.user.full_name || 'No Name'}
+                                                            {member.user.full_name ||
+                                                                member.user.email}
                                                         </span>
-                                                        <span className="text-xs text-slate-400 font-medium flex items-center gap-1">
-                                                            <Mail className="size-3" />{' '}
-                                                            {member.user.email}
-                                                        </span>
+                                                        {member.user.full_name && (
+                                                            <span className="text-xs text-slate-400 font-medium flex items-center gap-1">
+                                                                <Mail className="size-3" />{' '}
+                                                                {member.user.email}
+                                                            </span>
+                                                        )}
                                                     </div>
                                                 </div>
                                             </TableCell>


### PR DESCRIPTION
## Summary

Phase 2 of the remediation plan in `docs/superpowers/plans/2026-07-26-admin-ux-remediation.md`, following [#323](https://github.com/jvastenaekels/qualis/pull/323). One theme: **strings written for engineers that ended up in front of researchers.**

## Changes

- **An API-status note shipped as product copy** (`Account settings`): *"Email changes via the API are coming soon to this page; backend support is live."* Replaced in all nine admin locales — and in the component's `t()` fallback, which review caught still carrying the banned sentence into the bundle.
- **A raw database key rendered as a label** (`Analysis` → Voices on Factor N): `question_key` printed `question_q_voice` above each audio player. It now resolves the researcher's **own configured question label** from the study's `postsort_config`, falling back to a generic label only when the question has been deleted.
- **"No Name"** as a person's display name (`Team members`) — a bare literal never wired through `t()`. Now the email, shown once rather than twice.
- **The same leak on the participant detail page** — added mid-phase after the Analysis fix's review found it. Two further leak points in `SurveyResponseTable.helpers.ts` were closed in a follow-up round; that helper now has no path returning the raw key.

## Checklist

- [ ] `make ci` passes locally — **frontend is green (183 files / 1534 tests, biome + tsc clean); backend `pytest` fails on a local Postgres credential issue that reproduces identically on `main` with a clean tree.** No backend file is touched.
- [x] Tests cover new/changed behavior — every new assertion pairs a negative with a positive and was observed RED first. Tests load the real locale JSON via `src/test-utils/i18n-test.ts`, so they validate shipped content rather than a stub.
- [x] Translation keys added to all locales — five new keys across all nine admin locales; `i18n-check` and `check-interpolations` clean. Review corrected register (`it` formal *Lei*, `nl` formal *U/uw*), variant (`pt` European, not Brazilian), a Dutch het/de agreement error, and non-canonical domain terms in `fi`/`fr`.
- [x] API client regenerated if backend schemas changed — not applicable.

## Worth knowing

The Analysis fix initially shipped a static lookup table, on the belief that reaching the researcher's real label needed a props signature change. The whole-branch review showed that was wrong — the component already had `slug`, and `StudyRead` carries `postsort_config`. Before the correction the demo labelled the *same audio file* two different ways on two screens; verified on a rebuilt stack that both now agree.

One residual is documented rather than fixed: the Voices panel resolves labels in the **admin's** UI language while the participant page uses the **participant's**, so a multilingual study can still show two legitimate translations of one question. Closing that needs participant language threaded into an aggregate panel — a real scope expansion.

Review also found, and the plan now records for Phase 5, **twelve `t()` calls whose keys are missing from the locale files** — i18next renders the raw dotted key path as UI text, including on the access-denied gate and the clear-all-participants confirm button. The `t('key') || 'Fallback'` guard used at ~17 sites is inert, since `t()` returns the truthy key on a miss.

## Related Issue

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)