### PR TITLE
fix(a11y): phase 3 of the UX audit remediation — keyboard and screen-reader usability

### DIFF
--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -569,7 +569,9 @@ git commit -m "fix(participants): stop rendering raw question keys on the detail
 
 ### Task 3.1: Row actions are invisible but tabbable
 
-**The defect:** each concourse row carries four 32×32 buttons (History, Comments, Edit, Delete). Three sit at `opacity: 0`, revealed by `group-hover` only — no `group-focus-within`. Across 36 statements that is ~108 tab stops on invisible targets, and the actions are undiscoverable on touch. "Edit" is permanently at `opacity-50` on `text-slate-400`, roughly 1.4:1 against white.
+**The defect:** each concourse row carries four 32×32 buttons (History, Comments, Edit, Delete). Three sit at `opacity: 0`, revealed by `group-hover` only, and are undiscoverable on touch, where there is no hover at all. "Edit" is permanently visible but at `text-slate-300` — **1.49:1** against white, against a 4.5:1 AA threshold; the mobile variant of the same control is 2.56:1.
+
+> **Audit correction.** The original finding claimed ~108 invisible tab stops and "no visible focus anywhere". That was wrong: the pre-fix source already carried `focus-visible:opacity-100` on all three hover-only buttons, so keyboard focus did reveal the focused button. The measurement behind the claim read resting opacity and never exercised focus. What this task adds is that the whole cluster reveals together on focus, matching hover — an improvement, not a rescue. The contrast defect is the real accessibility failure here, and it was worse than first described.
 
 **Files:**
 - Test: `frontend/src/pages/admin/ConcourseDetailPage.test.tsx`
@@ -720,7 +722,12 @@ git commit -m "fix(a11y): make dashboard study cards keyboard-operable"
 
 ### Task 3.4: Unlabelled switches
 
-**The defect:** both switches in `Access → Access rules` return an empty accessible name. A screen reader announces "switch" with no indication of what it toggles.
+**The defect — retracted.** The original finding claimed both switches in `Access → Access rules` returned an empty accessible name. That was wrong, on two counts:
+
+- `<button>` is a **labelable element** (WHATWG HTML §4.10.2, which lists it first), so the existing `<Label htmlFor="password-toggle">` / `<Switch id="password-toggle">` pairing names them legitimately. The claim in this task's original text that "`htmlFor`/`<label>` association does not apply to buttons" is simply false.
+- The measurement behind it read the absent `aria-label` **attribute** and mistook it for the computed accessible **name**. Verified two ways: live Chromium, and the project's own happy-dom test environment (which implements `HTMLButtonElement.labels`), both resolve the names pre-fix.
+
+What shipped is therefore **hardening, not a bug fix**: an explicit `aria-labelledby` so the name no longer depends on a single `id`/`htmlFor` pairing that a future edit could silently break. Keep it, but do not cite this task as having fixed a silent control.
 
 **Files:**
 - Modify: `frontend/src/pages/admin/RecruitmentPage.tsx:376-390`, `:465-…`
@@ -808,6 +815,49 @@ Expected: PASS.
 git add frontend/src/pages/LoginPage.tsx frontend/src/pages/LoginPage.test.tsx \
         frontend/src/components/admin/AdminDashboard.tsx frontend/public/locales/en/admin.json
 git commit -m "fix(a11y): repair heading hierarchy and login form affordances"
+```
+
+---
+
+### Task 3.6: Controls that genuinely have no accessible name
+
+**The defect:** found while retracting Task 3.4. Six controls have **no `id`, no `htmlFor`, and no `aria-label`** anywhere near them — unlike the Access switches, these are real, unambiguous accessible-name gaps, confirmed by reading each one:
+
+- `frontend/src/components/admin/designer/PostSortConfigEditor.tsx:386`, `:446`, `:512`
+- `frontend/src/components/admin/designer/QuestionBuilder.tsx:380`
+- `frontend/src/pages/admin/ConcourseDetailPage.tsx:655`, `:696`
+
+A screen-reader user hears "switch" or "checkbox" with nothing to identify it.
+
+**Do not blanket-fix every switch in the codebase.** Task 3.4's retraction exists precisely because a control that looks unlabelled in source may be correctly labelled through `<label for>`. `QuestionBuilder.tsx:346` (`req-${id}`) is one such false positive — it has a matching pair. Verify each candidate's computed accessible name before changing it.
+
+**Files:**
+- Modify: the six sites above
+- Test: the corresponding test files
+
+- [ ] **Step 1: Confirm each one is genuinely unnamed**
+
+```tsx
+it('names every settings toggle', () => {
+    renderWithProviders(<PostSortConfigEditor {...props} />);
+    // getByRole computes the real accessible name — an unnamed control will not match.
+    expect(screen.getByRole('switch', { name: /allow audio/i })).toBeInTheDocument();
+});
+```
+
+Run it first: it must fail because the name does not resolve, not because the element is absent.
+
+- [ ] **Step 2: Add the label association**
+
+Prefer a visible `<Label htmlFor>` pointing at an `id` on the control — that names it *and* gives a click target. Use `aria-label` only where no visible text exists to point at.
+
+- [ ] **Step 3: Confirm the tests pass, and that no control gained a name that differs from its visible text**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/admin/designer frontend/src/pages/admin/ConcourseDetailPage.tsx
+git commit -m "fix(a11y): name the designer and concourse controls that had none"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1505,7 +1505,44 @@ git commit -m "fix(access): unfreeze the clear-date buttons under React Compiler
 
 ---
 
-### Task 6.7: Charts mounting at zero size
+### Task 6.7: A lint gate for accessible names
+
+**Why:** Phase 3's whole-branch review called this *"the highest-leverage follow-up in the whole remediation"*. Biome's a11y rules are clearly enabled (the repo carries `biome-ignore lint/a11y/*` comments), but **nothing enforces that an interactive control has an accessible name**. That is why the class kept regrowing: Phase 3 named 12 controls by hand, and a sweep immediately found ~76 more.
+
+Without a gate, every later phase re-introduces the defect at whatever rate new controls are written. With one, the 22 icon-only buttons below would have been caught mechanically, on the commit that created them.
+
+**Files:**
+- Modify: `frontend/biome.json` (or the equivalent lint config)
+- Modify: whatever the rule then flags
+
+- [ ] **Step 1: Turn the rule on and count the damage**
+
+Enable Biome's `a11y/useButtonType`, `a11y/useAriaPropsForRole`, and above all the rules covering accessible names on interactive elements. Run `npm run lint` and record the count — the review's own enumeration put it at ~76 unnamed controls out of ~465.
+
+- [ ] **Step 2: Fix by cluster, highest impact first**
+
+The review enumerated these; verify each before changing it (Task 3.4's retraction exists because a control that *looks* unnamed in source may be correctly named by `<label for>`):
+
+1. **`InteractiveDataView.columns.tsx:504, 516, 531, 636, 652, 664, 676`** — seven `<TooltipTrigger>` without `asChild`. Radix renders each as a real focusable `<button>` containing only a `<div>` and an icon; the descriptive text lives in `TooltipContent`, wired as `aria-describedby` only while open. That is **up to seven unnamed tab stops per participant row** on the Data table — the single largest instance of this defect in the product.
+2. **22 icon-only `<Button>`s**, several destructive: delete a survey question (`QuestionBuilder.tsx:300`), delete a choice option (`:808`), delete a process step (`ProcessStepEditor.tsx:121`), delete a methodology tip (`InterfaceEditor.tsx:346`), delete a tag (`ConcourseDetailPage.tsx:1648`), remove a partner (`BrandingEditor.tsx:304`), save/cancel inline statement edit (`QSortEditor.tsx:179, 187`), copy TOTP secret (`AccountSettingsPage.tsx:338`), copy invite link (`ProjectMembersPage.tsx:572`), play/pause participant audio (`AudioPlayer.tsx:106`), table paging (`InteractiveDataView.tsx:932, 944`), and the six accent-colour swatches at `BrandingEditor.tsx:135`, which currently announce identically to each other.
+3. **`StudyDesignPage.tsx:188`** — the designer's language switcher. Its only text sits in a `<span className="hidden sm:inline">`, so **below the `sm` breakpoint it has no accessible name at all**.
+4. **~40 `<Input>`/`<Textarea>`** with a visually adjacent `<Label>` carrying no `htmlFor` — systemic across `ConcourseDetailPage` (11), `QuestionBuilder` (5), `QSortEditor` (3), `InterfaceEditor` (4), `ProcessStepEditor` (4), `BrandingEditor` (2), the memo module, and `ProjectMembersPage.tsx:508` (the invite form's only field).
+5. **`ImportFromConcourseDialog.tsx:262`** — the one unnamed `<Checkbox>` left in the admin.
+
+- [ ] **Step 3: Also ban `text-slate-300` on interactive elements**
+
+Task 3.1 fixed the contrast on one file. `text-slate-300` (1.45:1 on white) still sits on interactive controls in `QuestionBuilder.tsx:209, 273, 303, 811`, `ProcessStepEditor.tsx:80, 124`, `InterfaceEditor.tsx:357`, `QSortEditor.tsx:139, 290`, `BrandingEditor.tsx:313` — several of them delete buttons.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/biome.json frontend/src
+git commit -m "fix(a11y): enforce accessible names with a lint gate and clear the backlog"
+```
+
+---
+
+### Task 6.8: Charts mounting at zero size
 
 **The defect:** loading the `Data` screen logs the Recharts warning *"The width(-1) and height(-1) of chart should be greater than 0"* five times — charts are mounting inside collapsed containers. Harmless today, but it is console noise that will mask a real warning later.
 

--- a/frontend/e2e/pages/AdminPage.ts
+++ b/frontend/e2e/pages/AdminPage.ts
@@ -10,7 +10,7 @@ export class AdminPage extends BasePage {
         await this.page.goto('/login');
         await this.page.getByLabel(/email/i).fill(email);
         await this.page.getByLabel(/password/i).fill(password);
-        await this.page.getByRole('button', { name: /continue/i }).click();
+        await this.page.getByRole('button', { name: /sign in/i }).click();
         await expect(this.page).toHaveURL(/\/(admin|app\/)/);
     }
 

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1547,6 +1547,7 @@
                     "locked_paused": "Diese Studie ist pausiert. Wechseln Sie in den Entwurfsmodus, um zu bearbeiten.",
                     "locked_closed": "Diese Studie ist geschlossen. Das Design ist archiviert.",
                     "view_read_only": "Nur lesend anzeigen",
+                    "locked_dialog_desc": "Die Bearbeitung ist gesperrt, solange sich die Studie in diesem Status befindet. Schließen Sie diesen Hinweis, um die Konfiguration zu lesen, ohne sie zu ändern.",
                     "mismatch_title": "Rasterkapazität stimmt nicht überein",
                     "mismatch_desc": "Sie haben {{statements}} Aussagen, aber das Raster hat nur Positionen für {{slots}} Elemente. Bitte passen Sie die unten stehenden Spalten entsprechend an.",
                     "unlock_hint": "Gehen Sie zum Daten-Explorer, um Sitzungen zu löschen und die Struktur freizuschalten"

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -3,7 +3,7 @@
         "login": {
             "email_label": "E-Mail-Adresse",
             "password_label": "Passwort",
-            "submit": "Weiter",
+            "submit": "Anmelden",
             "cta": "Anmelden",
             "forgot_password": "Vergessen?",
             "loading": "Authentifizierung läuft...",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1545,6 +1545,7 @@
                     "locked_active": "Diese Studie ist aktiv. Wechseln Sie in den Entwurfsmodus, um zu bearbeiten.",
                     "locked_paused": "Diese Studie ist pausiert. Wechseln Sie in den Entwurfsmodus, um zu bearbeiten.",
                     "locked_closed": "Diese Studie ist geschlossen. Das Design ist archiviert.",
+                    "view_read_only": "Nur lesend anzeigen",
                     "mismatch_title": "Rasterkapazität stimmt nicht überein",
                     "mismatch_desc": "Sie haben {{statements}} Aussagen, aber das Raster hat nur Positionen für {{slots}} Elemente. Bitte passen Sie die unten stehenden Spalten entsprechend an.",
                     "unlock_hint": "Gehen Sie zum Daten-Explorer, um Sitzungen zu löschen und die Struktur freizuschalten"

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -420,6 +420,7 @@
             "field_language": "Sprache",
             "import_language": "Sprache",
             "select_all": "Alle auswählen",
+            "select_item": "{{code}} auswählen",
             "bulk_selected": "{{count}} ausgewählt",
             "bulk_set_status": "Status setzen:",
             "bulk_clear": "Auswahl aufheben",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1549,6 +1549,7 @@
                     "locked_paused": "This study is paused. Switch to draft mode to edit.",
                     "locked_closed": "This study is closed. The design is archived.",
                     "view_read_only": "View read-only",
+                    "locked_dialog_desc": "Editing is locked while the study is in this state. Close this notice to read the configuration without changing it.",
                     "mismatch_title": "Grid capacity mismatch",
                     "mismatch_desc": "You have {{statements}} statements but the grid only has slots for {{slots}} items. Please adjust the columns below to match.",
                     "unlock_hint": "Go to data explorer to purge sessions and unlock structure"

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1547,6 +1547,7 @@
                     "locked_active": "This study is active. Switch to draft mode to edit.",
                     "locked_paused": "This study is paused. Switch to draft mode to edit.",
                     "locked_closed": "This study is closed. The design is archived.",
+                    "view_read_only": "View read-only",
                     "mismatch_title": "Grid capacity mismatch",
                     "mismatch_desc": "You have {{statements}} statements but the grid only has slots for {{slots}} items. Please adjust the columns below to match.",
                     "unlock_hint": "Go to data explorer to purge sessions and unlock structure"

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -420,6 +420,7 @@
             "field_language": "Language",
             "import_language": "Language",
             "select_all": "Select all",
+            "select_item": "Select {{code}}",
             "bulk_selected": "{{count}} selected",
             "bulk_set_status": "Set status:",
             "bulk_clear": "Clear",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -3,7 +3,7 @@
         "login": {
             "email_label": "Email address",
             "password_label": "Password",
-            "submit": "Continue",
+            "submit": "Sign in",
             "cta": "Sign in",
             "forgot_password": "Forgot?",
             "loading": "Authenticating...",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1545,6 +1545,7 @@
                     "locked_active": "Este estudio está activo. Cambie al modo borrador para editar.",
                     "locked_paused": "Este estudio está pausado. Cambie al modo borrador para editar.",
                     "locked_closed": "Este estudio está cerrado. El diseño está archivado.",
+                    "view_read_only": "Ver en modo solo lectura",
                     "mismatch_title": "Discrepancia en la capacidad de la cuadrícula",
                     "mismatch_desc": "Tiene {{statements}} enunciados pero la cuadrícula solo tiene posiciones para {{slots}} elementos. Por favor, ajuste las columnas a continuación para que coincidan.",
                     "unlock_hint": "Vaya al explorador de datos para eliminar sesiones y desbloquear la estructura"

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -3,7 +3,7 @@
         "login": {
             "email_label": "Dirección de correo electrónico",
             "password_label": "Contraseña",
-            "submit": "Continuar",
+            "submit": "Iniciar sesión",
             "cta": "Iniciar sesión",
             "forgot_password": "¿Olvidó?",
             "loading": "Autenticando...",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -420,6 +420,7 @@
             "field_language": "Idioma",
             "import_language": "Idioma",
             "select_all": "Seleccionar todo",
+            "select_item": "Seleccionar {{code}}",
             "bulk_selected": "{{count}} seleccionados",
             "bulk_set_status": "Establecer estado:",
             "bulk_clear": "Limpiar",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1547,6 +1547,7 @@
                     "locked_paused": "Este estudio está pausado. Cambie al modo borrador para editar.",
                     "locked_closed": "Este estudio está cerrado. El diseño está archivado.",
                     "view_read_only": "Ver en modo solo lectura",
+                    "locked_dialog_desc": "La edición está bloqueada mientras el estudio esté en este estado. Cierre este aviso para leer la configuración sin modificarla.",
                     "mismatch_title": "Discrepancia en la capacidad de la cuadrícula",
                     "mismatch_desc": "Tiene {{statements}} enunciados pero la cuadrícula solo tiene posiciones para {{slots}} elementos. Por favor, ajuste las columnas a continuación para que coincidan.",
                     "unlock_hint": "Vaya al explorador de datos para eliminar sesiones y desbloquear la estructura"

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1458,6 +1458,7 @@
                     "locked_paused": "Tämä tutkimus on tauolla. Vaihda luonnostilaan muokataksesi.",
                     "locked_closed": "Tämä tutkimus on suljettu. Suunnittelu on arkistoitu.",
                     "view_read_only": "Katso vain luku -tilassa",
+                    "locked_dialog_desc": "Muokkaus on lukittu, kun tutkimus on tässä tilassa. Sulje tämä ilmoitus, niin voit lukea asetukset muuttamatta niitä.",
                     "mismatch_title": "Ruudukon kapasiteetti ei täsmää",
                     "mismatch_desc": "Sinulla on {{statements}} väitettä, mutta ruudukossa on vain {{slots}} paikkaa. Säädä sarakkeita alla.",
                     "unlock_hint": "Siirry Data-selaimeen tyhjentääksesi vastaukset ja avataksesi rakenteen muokkauksen"

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -3,7 +3,7 @@
         "login": {
             "email_label": "Sähköpostiosoite",
             "password_label": "Salasana",
-            "submit": "Jatka",
+            "submit": "Kirjaudu sisään",
             "cta": "Kirjaudu sisään",
             "forgot_password": "Unohditko?",
             "loading": "Tunnistaudutaan...",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1456,6 +1456,7 @@
                     "locked_active": "Tämä tutkimus on aktiivinen. Vaihda luonnostilaan muokataksesi.",
                     "locked_paused": "Tämä tutkimus on tauolla. Vaihda luonnostilaan muokataksesi.",
                     "locked_closed": "Tämä tutkimus on suljettu. Suunnittelu on arkistoitu.",
+                    "view_read_only": "Katso vain luku -tilassa",
                     "mismatch_title": "Ruudukon kapasiteetti ei täsmää",
                     "mismatch_desc": "Sinulla on {{statements}} väitettä, mutta ruudukossa on vain {{slots}} paikkaa. Säädä sarakkeita alla.",
                     "unlock_hint": "Siirry Data-selaimeen tyhjentääksesi vastaukset ja avataksesi rakenteen muokkauksen"

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -332,6 +332,7 @@
             "field_language": "Kieli",
             "import_language": "Kieli",
             "select_all": "Valitse kaikki",
+            "select_item": "Valitse {{code}}",
             "bulk_selected": "{{count}} valittu",
             "bulk_set_status": "Aseta tila:",
             "bulk_clear": "Tyhjennä",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -332,6 +332,7 @@
             "field_language": "Langue",
             "import_language": "Langue",
             "select_all": "Tout sélectionner",
+            "select_item": "Sélectionner {{code}}",
             "bulk_selected": "{{count}} sélectionné(s)",
             "bulk_set_status": "Définir le statut :",
             "bulk_clear": "Effacer",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1496,6 +1496,7 @@
                     "locked_paused": "Cette étude est en pause. Pour la modifier, passez-la en brouillon.",
                     "locked_closed": "Cette étude est clôturée. La conception est archivée.",
                     "view_read_only": "Voir en lecture seule",
+                    "locked_dialog_desc": "La modification est verrouillée tant que l'étude est dans cet état. Fermez ce message pour consulter la configuration sans la modifier.",
                     "mismatch_title": "Capacité de grille incorrecte",
                     "mismatch_desc": "Vous avez {{statements}} énoncés mais la grille n'a que {{slots}} emplacements. Veuillez ajuster les colonnes ci-dessous.",
                     "unlock_hint": "Aller dans l'explorateur de données pour purger les sessions et débloquer la structure"

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -3,7 +3,7 @@
         "login": {
             "email_label": "Adresse e-mail",
             "password_label": "Mot de passe",
-            "submit": "Continuer",
+            "submit": "Se connecter",
             "cta": "Se connecter",
             "forgot_password": "Oublié ?",
             "loading": "Authentification...",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1494,6 +1494,7 @@
                     "locked_active": "Cette étude est active. Pour la modifier, passez-la en brouillon.",
                     "locked_paused": "Cette étude est en pause. Pour la modifier, passez-la en brouillon.",
                     "locked_closed": "Cette étude est clôturée. La conception est archivée.",
+                    "view_read_only": "Voir en lecture seule",
                     "mismatch_title": "Capacité de grille incorrecte",
                     "mismatch_desc": "Vous avez {{statements}} énoncés mais la grille n'a que {{slots}} emplacements. Veuillez ajuster les colonnes ci-dessous.",
                     "unlock_hint": "Aller dans l'explorateur de données pour purger les sessions et débloquer la structure"

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -3,7 +3,7 @@
         "login": {
             "email_label": "Indirizzo e-mail",
             "password_label": "Password",
-            "submit": "Continua",
+            "submit": "Accedi",
             "cta": "Accedi",
             "forgot_password": "Dimenticata?",
             "loading": "Autenticazione in corso...",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -420,6 +420,7 @@
             "field_language": "Lingua",
             "import_language": "Lingua",
             "select_all": "Seleziona tutto",
+            "select_item": "Seleziona {{code}}",
             "bulk_selected": "{{count}} selezionate",
             "bulk_set_status": "Imposta stato:",
             "bulk_clear": "Cancella",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1547,6 +1547,7 @@
                     "locked_paused": "Questo studio è in pausa. Passi alla modalità bozza per modificare.",
                     "locked_closed": "Questo studio è chiuso. La progettazione è archiviata.",
                     "view_read_only": "Visualizza in sola lettura",
+                    "locked_dialog_desc": "La modifica è bloccata finché lo studio si trova in questo stato. Chiuda questo avviso per leggere la configurazione senza modificarla.",
                     "mismatch_title": "Capacità della griglia non corrispondente",
                     "mismatch_desc": "Ha {{statements}} affermazioni ma la griglia ha posizioni solo per {{slots}} voci. Regoli le colonne qui sotto per corrispondere.",
                     "unlock_hint": "Vada all'esploratore dati per eliminare le sessioni e sbloccare la struttura"

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1545,7 +1545,7 @@
                     "locked_active": "Questo studio è attivo. Passi alla modalità bozza per modificare.",
                     "locked_paused": "Questo studio è in pausa. Passi alla modalità bozza per modificare.",
                     "locked_closed": "Questo studio è chiuso. La progettazione è archiviata.",
-                    "view_read_only": "Visualizzi in sola lettura",
+                    "view_read_only": "Visualizza in sola lettura",
                     "mismatch_title": "Capacità della griglia non corrispondente",
                     "mismatch_desc": "Ha {{statements}} affermazioni ma la griglia ha posizioni solo per {{slots}} voci. Regoli le colonne qui sotto per corrispondere.",
                     "unlock_hint": "Vada all'esploratore dati per eliminare le sessioni e sbloccare la struttura"

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1545,6 +1545,7 @@
                     "locked_active": "Questo studio è attivo. Passi alla modalità bozza per modificare.",
                     "locked_paused": "Questo studio è in pausa. Passi alla modalità bozza per modificare.",
                     "locked_closed": "Questo studio è chiuso. La progettazione è archiviata.",
+                    "view_read_only": "Visualizzi in sola lettura",
                     "mismatch_title": "Capacità della griglia non corrispondente",
                     "mismatch_desc": "Ha {{statements}} affermazioni ma la griglia ha posizioni solo per {{slots}} voci. Regoli le colonne qui sotto per corrispondere.",
                     "unlock_hint": "Vada all'esploratore dati per eliminare le sessioni e sbloccare la struttura"

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1545,7 +1545,7 @@
                     "locked_active": "Dit onderzoek is actief. Schakel over naar conceptmodus om te bewerken.",
                     "locked_paused": "Dit onderzoek is gepauzeerd. Schakel over naar conceptmodus om te bewerken.",
                     "locked_closed": "Dit onderzoek is gesloten. Het ontwerp is gearchiveerd.",
-                    "view_read_only": "Bekijk alleen-lezen",
+                    "view_read_only": "Bekijken (alleen-lezen)",
                     "mismatch_title": "Rastercapaciteit komt niet overeen",
                     "mismatch_desc": "U heeft {{statements}} stellingen, maar het raster heeft slechts posities voor {{slots}} items. Pas de kolommen hieronder aan.",
                     "unlock_hint": "Ga naar de data-verkenner om sessies te wissen en de structuur te ontgrendelen"

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -420,6 +420,7 @@
             "field_language": "Taal",
             "import_language": "Taal",
             "select_all": "Alles selecteren",
+            "select_item": "{{code}} selecteren",
             "bulk_selected": "{{count}} geselecteerd",
             "bulk_set_status": "Status instellen:",
             "bulk_clear": "Wissen",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -3,7 +3,7 @@
         "login": {
             "email_label": "E-mailadres",
             "password_label": "Wachtwoord",
-            "submit": "Doorgaan",
+            "submit": "Aanmelden",
             "cta": "Aanmelden",
             "forgot_password": "Vergeten?",
             "loading": "Authenticeren...",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1547,6 +1547,7 @@
                     "locked_paused": "Dit onderzoek is gepauzeerd. Schakel over naar conceptmodus om te bewerken.",
                     "locked_closed": "Dit onderzoek is gesloten. Het ontwerp is gearchiveerd.",
                     "view_read_only": "Bekijken (alleen-lezen)",
+                    "locked_dialog_desc": "Bewerken is geblokkeerd zolang het onderzoek in deze status is. Sluit deze melding om de configuratie te lezen zonder deze te wijzigen.",
                     "mismatch_title": "Rastercapaciteit komt niet overeen",
                     "mismatch_desc": "U heeft {{statements}} stellingen, maar het raster heeft slechts posities voor {{slots}} items. Pas de kolommen hieronder aan.",
                     "unlock_hint": "Ga naar de data-verkenner om sessies te wissen en de structuur te ontgrendelen"

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1545,6 +1545,7 @@
                     "locked_active": "Dit onderzoek is actief. Schakel over naar conceptmodus om te bewerken.",
                     "locked_paused": "Dit onderzoek is gepauzeerd. Schakel over naar conceptmodus om te bewerken.",
                     "locked_closed": "Dit onderzoek is gesloten. Het ontwerp is gearchiveerd.",
+                    "view_read_only": "Bekijk alleen-lezen",
                     "mismatch_title": "Rastercapaciteit komt niet overeen",
                     "mismatch_desc": "U heeft {{statements}} stellingen, maar het raster heeft slechts posities voor {{slots}} items. Pas de kolommen hieronder aan.",
                     "unlock_hint": "Ga naar de data-verkenner om sessies te wissen en de structuur te ontgrendelen"

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1547,6 +1547,7 @@
           "locked_paused": "To badanie jest wstrzymane. Przełącz na tryb szkicu, aby edytować.",
           "locked_closed": "To badanie jest zamknięte. Projekt jest zarchiwizowany.",
           "view_read_only": "Podgląd tylko do odczytu",
+          "locked_dialog_desc": "Edycja jest zablokowana, gdy badanie jest w tym stanie. Zamknij to powiadomienie, aby przeczytać konfigurację bez wprowadzania zmian.",
           "mismatch_title": "Niezgodność pojemności siatki",
           "mismatch_desc": "Masz {{statements}} stwierdzeń, ale siatka ma tylko miejsca dla {{slots}} elementów. Dostosuj kolumny poniżej.",
           "unlock_hint": "Przejdź do eksploratora danych, aby wyczyścić sesje i odblokować strukturę"

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1545,6 +1545,7 @@
           "locked_active": "To badanie jest aktywne. Przełącz na tryb szkicu, aby edytować.",
           "locked_paused": "To badanie jest wstrzymane. Przełącz na tryb szkicu, aby edytować.",
           "locked_closed": "To badanie jest zamknięte. Projekt jest zarchiwizowany.",
+          "view_read_only": "Podgląd tylko do odczytu",
           "mismatch_title": "Niezgodność pojemności siatki",
           "mismatch_desc": "Masz {{statements}} stwierdzeń, ale siatka ma tylko miejsca dla {{slots}} elementów. Dostosuj kolumny poniżej.",
           "unlock_hint": "Przejdź do eksploratora danych, aby wyczyścić sesje i odblokować strukturę"

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -420,6 +420,7 @@
       "field_language": "Język",
       "import_language": "Język",
       "select_all": "Zaznacz wszystko",
+      "select_item": "Zaznacz {{code}}",
       "bulk_selected": "Zaznaczono {{count}}",
       "bulk_set_status": "Ustaw status:",
       "bulk_clear": "Wyczyść",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -3,7 +3,7 @@
     "login": {
       "email_label": "Adres e-mail",
       "password_label": "Hasło",
-      "submit": "Kontynuuj",
+      "submit": "Zaloguj się",
       "cta": "Zaloguj się",
       "forgot_password": "Nie pamiętasz?",
       "loading": "Uwierzytelnianie...",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -420,6 +420,7 @@
             "field_language": "Idioma",
             "import_language": "Idioma",
             "select_all": "Selecionar tudo",
+            "select_item": "Selecionar {{code}}",
             "bulk_selected": "{{count}} selecionados",
             "bulk_set_status": "Definir estado:",
             "bulk_clear": "Limpar",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -3,7 +3,7 @@
         "login": {
             "email_label": "Endereço de email",
             "password_label": "Palavra-passe",
-            "submit": "Continuar",
+            "submit": "Iniciar sessão",
             "cta": "Iniciar sessão",
             "forgot_password": "Esqueceu?",
             "loading": "A autenticar...",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1545,6 +1545,7 @@
                     "locked_active": "Este estudo está ativo. Mude para modo de rascunho para editar.",
                     "locked_paused": "Este estudo está pausado. Mude para modo de rascunho para editar.",
                     "locked_closed": "Este estudo está fechado. O desenho está arquivado.",
+                    "view_read_only": "Ver em modo só de leitura",
                     "mismatch_title": "Capacidade da grelha incorreta",
                     "mismatch_desc": "Tem {{statements}} afirmações mas a grelha só tem posições para {{slots}} itens. Ajuste as colunas abaixo para corrigir.",
                     "unlock_hint": "Aceda ao explorador de dados para eliminar sessões e desbloquear a estrutura"

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1545,7 +1545,7 @@
                     "locked_active": "Este estudo está ativo. Mude para modo de rascunho para editar.",
                     "locked_paused": "Este estudo está pausado. Mude para modo de rascunho para editar.",
                     "locked_closed": "Este estudo está fechado. O desenho está arquivado.",
-                    "view_read_only": "Ver em modo só de leitura",
+                    "view_read_only": "Ver em modo de leitura apenas",
                     "mismatch_title": "Capacidade da grelha incorreta",
                     "mismatch_desc": "Tem {{statements}} afirmações mas a grelha só tem posições para {{slots}} itens. Ajuste as colunas abaixo para corrigir.",
                     "unlock_hint": "Aceda ao explorador de dados para eliminar sessões e desbloquear a estrutura"

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1547,6 +1547,7 @@
                     "locked_paused": "Este estudo está pausado. Mude para modo de rascunho para editar.",
                     "locked_closed": "Este estudo está fechado. O desenho está arquivado.",
                     "view_read_only": "Ver em modo de leitura apenas",
+                    "locked_dialog_desc": "A edição está bloqueada enquanto o estudo estiver neste estado. Feche este aviso para ler a configuração sem a alterar.",
                     "mismatch_title": "Capacidade da grelha incorreta",
                     "mismatch_desc": "Tem {{statements}} afirmações mas a grelha só tem posições para {{slots}} itens. Ajuste as colunas abaixo para corrigir.",
                     "unlock_hint": "Aceda ao explorador de dados para eliminar sessões e desbloquear a estrutura"

--- a/frontend/src/components/admin/AdminDashboard.test.tsx
+++ b/frontend/src/components/admin/AdminDashboard.test.tsx
@@ -1,5 +1,7 @@
 import { renderWithProviders, screen } from '@/test-utils/test-utils';
+import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { Routes, Route } from 'react-router-dom';
 import { AdminDashboard } from './AdminDashboard';
 
 // Hoisted mocks for generated API hooks
@@ -187,5 +189,93 @@ describe('AdminDashboard', () => {
         expect(screen.getByText('Needs attention')).toBeInTheDocument();
         // Alert message includes study name and days
         expect(screen.getByText(/My Study.*closing in 3 days/)).toBeInTheDocument();
+    });
+
+    describe('keyboard-operable cards', () => {
+        // Real navigation (Routes/Route), not a mocked `useNavigate` — same
+        // pattern as AdminDashboard.onboarding.test.tsx. Proves the whole
+        // chain: focusable -> Enter -> onClick -> navigate -> route change,
+        // not just that some callback fired.
+        function renderDashboardWithRoutes() {
+            return renderWithProviders(
+                <Routes>
+                    <Route path="/app/:projectSlug/dashboard" element={<AdminDashboard />} />
+                    <Route
+                        path="/app/:projectSlug/studies/:slug"
+                        element={<div data-testid="study-detail" />}
+                    />
+                    <Route
+                        path="/app/:projectSlug/concourses"
+                        element={<div data-testid="concourse-page" />}
+                    />
+                </Routes>,
+                { initialEntries: ['/app/test-project/dashboard'] }
+            );
+        }
+
+        it('exposes the single-study card as a real, keyboard-operable button', async () => {
+            const user = userEvent.setup();
+            setupDefaultHooks({ studies: [makeStudy({ state: 'active' })] });
+
+            renderDashboardWithRoutes();
+
+            const card = screen.getByRole('button', { name: /my study/i });
+            // Positive: it is a genuine <button>, not a div faking the role.
+            expect(card.tagName).toBe('BUTTON');
+            // Negative: no hand-rolled role attribute needed — the tag itself
+            // carries the semantics.
+            expect(card).not.toHaveAttribute('role');
+            // Negative: nothing has navigated yet.
+            expect(screen.queryByTestId('study-detail')).not.toBeInTheDocument();
+
+            card.focus();
+            await user.keyboard('{Enter}');
+
+            // Positive: Enter on the focused card actually navigated.
+            expect(await screen.findByTestId('study-detail')).toBeInTheDocument();
+        });
+
+        it('exposes multi-study rows as real buttons, not ARIA-only divs', async () => {
+            const user = userEvent.setup();
+            const study1 = makeStudy({ id: 1, slug: 'study-1', state: 'active' });
+            const study2 = makeStudy({
+                id: 2,
+                slug: 'study-2',
+                state: 'draft',
+                translations: [
+                    { language_code: 'en', title: 'Second Study', pre_instruction: 'Hi' },
+                ],
+            });
+            setupDefaultHooks({ studies: [study1, study2] });
+
+            renderDashboardWithRoutes();
+
+            const row = screen.getByRole('button', { name: /second study/i });
+            expect(row.tagName).toBe('BUTTON');
+            expect(row).not.toHaveAttribute('role');
+            expect(screen.queryByTestId('study-detail')).not.toBeInTheDocument();
+
+            row.focus();
+            await user.keyboard('{Enter}');
+
+            expect(await screen.findByTestId('study-detail')).toBeInTheDocument();
+        });
+
+        it('exposes the concourse card as a real button, not an ARIA-only div', async () => {
+            const user = userEvent.setup();
+            setupDefaultHooks({ studies: [makeStudy({ state: 'active' })] });
+
+            renderDashboardWithRoutes();
+
+            const card = screen.getByRole('button', { name: /concourse/i });
+            expect(card.tagName).toBe('BUTTON');
+            expect(card).not.toHaveAttribute('role');
+            expect(screen.queryByTestId('concourse-page')).not.toBeInTheDocument();
+
+            card.focus();
+            await user.keyboard('{Enter}');
+
+            expect(await screen.findByTestId('concourse-page')).toBeInTheDocument();
+        });
     });
 });

--- a/frontend/src/components/admin/AdminDashboard.test.tsx
+++ b/frontend/src/components/admin/AdminDashboard.test.tsx
@@ -189,6 +189,58 @@ describe('AdminDashboard', () => {
         ).not.toBeInTheDocument();
     });
 
+    // ── Headings must survive the accessibility tree (review finding 2) ──
+    // WAI-ARIA §5.2.7 gives `button` presentational children: Chrome and
+    // Firefox prune heading descendants of a button from the accessibility
+    // tree. `dom-testing-library`'s role engine does not implement that rule,
+    // so `getByRole('heading', …)` alone cannot tell a real heading from one
+    // a screen reader will never hear. These tests assert the structure the
+    // rule turns on — the heading must not sit inside the card button — and
+    // pair it with the card staying operable.
+    it('keeps the card headings outside the card button, so AT can hear them', () => {
+        setupDefaultHooks({ studies: [makeStudy({ state: 'active' })] });
+
+        renderWithProviders(<AdminDashboard />);
+
+        const concourseHeading = screen.getByRole('heading', { level: 2, name: 'Concourse' });
+        const studyHeading = screen.getByRole('heading', { level: 3, name: 'My Study' });
+
+        // Negative: neither heading is pruned by an ancestor button role.
+        expect(concourseHeading.closest('button')).toBeNull();
+        expect(studyHeading.closest('button')).toBeNull();
+
+        // Positive: each card is still a real button, and now takes its
+        // accessible name from the heading it labels rather than from the
+        // whole card blurb.
+        expect(screen.getByRole('button', { name: 'Concourse' }).tagName).toBe('BUTTON');
+        expect(screen.getByRole('button', { name: 'My Study' }).tagName).toBe('BUTTON');
+    });
+
+    it('keeps multi-study row headings outside the row button', () => {
+        setupDefaultHooks({
+            studies: [
+                makeStudy({ id: 1, slug: 'study-1', state: 'active' }),
+                makeStudy({
+                    id: 2,
+                    slug: 'study-2',
+                    state: 'draft',
+                    translations: [
+                        { language_code: 'en', title: 'Second Study', pre_instruction: 'Hi' },
+                    ],
+                }),
+            ],
+        });
+
+        renderWithProviders(<AdminDashboard />);
+
+        const rowHeading = screen.getByRole('heading', { level: 3, name: 'Second Study' });
+
+        // Negative: not pruned by an ancestor button role.
+        expect(rowHeading.closest('button')).toBeNull();
+        // Positive: the row is still operable and named by its heading.
+        expect(screen.getByRole('button', { name: 'Second Study' }).tagName).toBe('BUTTON');
+    });
+
     it('shows alert when active study is near deadline', () => {
         const now = new Date();
         const threeDaysFromNow = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);

--- a/frontend/src/components/admin/AdminDashboard.test.tsx
+++ b/frontend/src/components/admin/AdminDashboard.test.tsx
@@ -172,6 +172,23 @@ describe('AdminDashboard', () => {
         expect(screen.getByText('Second Study')).toBeInTheDocument();
     });
 
+    it('keeps the Concourse heading level with Studies, with no skipped level', () => {
+        const study = makeStudy({ state: 'active' });
+        setupDefaultHooks({ studies: [study] });
+
+        renderWithProviders(<AdminDashboard />);
+
+        // Positive: Concourse sits at the same level as the Studies heading.
+        expect(screen.getByRole('heading', { level: 2, name: 'Concourse' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: 'Studies' })).toBeInTheDocument();
+
+        // Negative: it is no longer demoted to level 3, which skipped a level
+        // under the page's level-1 heading and preceded its level-2 sibling.
+        expect(
+            screen.queryByRole('heading', { level: 3, name: 'Concourse' })
+        ).not.toBeInTheDocument();
+    });
+
     it('shows alert when active study is near deadline', () => {
         const now = new Date();
         const threeDaysFromNow = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -386,9 +386,9 @@ function ConcourseCard({
                 <div className="flex items-center gap-3">
                     <Library className="h-5 w-5 text-indigo-500 shrink-0" />
                     <div className="flex-1 min-w-0">
-                        <h3 className="text-sm font-semibold truncate group-hover:text-indigo-600 transition-colors">
+                        <h2 className="text-sm font-semibold truncate group-hover:text-indigo-600 transition-colors">
                             {t('admin.concourse.title', 'Concourse')}
-                        </h3>
+                        </h2>
                         <p className="text-xs text-muted-foreground mt-0.5">
                             {concourse
                                 ? t('admin.dashboard.concourse_n_items', {

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -377,17 +377,10 @@ function ConcourseCard({
     const itemCount = concourse?.item_count ?? 0;
 
     return (
-        <Card
-            className="group cursor-pointer hover:border-foreground/20 transition-colors"
+        <button
+            type="button"
             onClick={onOpen}
-            onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    onOpen();
-                }
-            }}
-            tabIndex={0}
-            role="button"
+            className="group w-full block text-left rounded-xl border bg-card text-card-foreground shadow cursor-pointer outline-none ring-offset-background transition-colors hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
         >
             <CardContent className="py-3 px-4">
                 <div className="flex items-center gap-3">
@@ -411,7 +404,7 @@ function ConcourseCard({
                     <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
                 </div>
             </CardContent>
-        </Card>
+        </button>
     );
 }
 
@@ -509,9 +502,10 @@ function SingleStudyCard({
                 )}
             </div>
 
-            <Card
-                className="group cursor-pointer hover:border-foreground/20 transition-colors"
+            <button
+                type="button"
                 onClick={() => navigate(studyBase)}
+                className="group w-full block text-left rounded-xl border bg-card text-card-foreground shadow cursor-pointer outline-none ring-offset-background transition-colors hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
             >
                 <CardContent className="py-4 px-5">
                     <div className="flex items-start justify-between gap-3">
@@ -570,7 +564,7 @@ function SingleStudyCard({
                         click away via the study sidebar after opening the
                         card. */}
                 </CardContent>
-            </Card>
+            </button>
         </div>
     );
 }
@@ -715,17 +709,10 @@ function StudyRow({
     const participants = study.participant_count ?? 0;
 
     return (
-        <Card
-            className="group hover:border-foreground/20 transition-colors cursor-pointer"
+        <button
+            type="button"
             onClick={onOpen}
-            onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    onOpen();
-                }
-            }}
-            tabIndex={0}
-            role="button"
+            className="group w-full block text-left rounded-xl border bg-card text-card-foreground shadow cursor-pointer outline-none ring-offset-background transition-colors hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
         >
             <CardContent className="py-3 px-4">
                 <div className="flex items-center gap-3">
@@ -781,6 +768,6 @@ function StudyRow({
                     <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
                 </div>
             </CardContent>
-        </Card>
+        </button>
     );
 }

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -32,6 +32,29 @@ import type { ConcourseRead } from '@/api/model/concourseRead';
 
 type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
+/*
+ * Card-as-button shape, shared by the concourse card and the two study cards.
+ *
+ * The whole card used to *be* the `<button>`, with the title heading nested
+ * inside it. WAI-ARIA §5.2.7 gives `button` presentational children, so Chrome
+ * and Firefox prune `<h2>`/`<h3>` descendants of a button from the
+ * accessibility tree: the heading a screen reader saw was nothing at all. (The
+ * role engine in `dom-testing-library` does not implement that rule, which is
+ * why the DOM-level heading assertions kept passing.)
+ *
+ * So the heading now wraps the button and the button stretches over the card
+ * with an `::after` overlay — the standard card pattern. Three consequences,
+ * all wanted: the heading is real in the accessibility tree; the button's
+ * accessible name is the title alone instead of the whole card blurb; and the
+ * card stays clickable edge to edge. The focus ring moves to the card shell via
+ * `has-[:focus-visible]` so it still tracks keyboard focus only, not mouse.
+ */
+const CARD_SHELL =
+    'group relative rounded-xl border bg-card text-card-foreground shadow ring-offset-background transition-colors hover:border-foreground/20 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-indigo-500 has-[:focus-visible]:ring-offset-2';
+
+const CARD_TITLE_BUTTON =
+    'block max-w-full truncate text-left cursor-pointer outline-none transition-colors group-hover:text-indigo-600 after:absolute after:inset-0 after:rounded-xl';
+
 function getStateColor(state: string | undefined): string {
     switch (state) {
         case 'active':
@@ -377,17 +400,15 @@ function ConcourseCard({
     const itemCount = concourse?.item_count ?? 0;
 
     return (
-        <button
-            type="button"
-            onClick={onOpen}
-            className="group w-full block text-left rounded-xl border bg-card text-card-foreground shadow cursor-pointer outline-none ring-offset-background transition-colors hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
-        >
+        <div className={CARD_SHELL}>
             <CardContent className="py-3 px-4">
                 <div className="flex items-center gap-3">
                     <Library className="h-5 w-5 text-indigo-500 shrink-0" />
                     <div className="flex-1 min-w-0">
-                        <h2 className="text-sm font-semibold truncate group-hover:text-indigo-600 transition-colors">
-                            {t('admin.concourse.title', 'Concourse')}
+                        <h2 className="text-sm font-semibold min-w-0">
+                            <button type="button" onClick={onOpen} className={CARD_TITLE_BUTTON}>
+                                {t('admin.concourse.title', 'Concourse')}
+                            </button>
                         </h2>
                         <p className="text-xs text-muted-foreground mt-0.5">
                             {concourse
@@ -404,7 +425,7 @@ function ConcourseCard({
                     <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
                 </div>
             </CardContent>
-        </button>
+        </div>
     );
 }
 
@@ -502,18 +523,20 @@ function SingleStudyCard({
                 )}
             </div>
 
-            <button
-                type="button"
-                onClick={() => navigate(studyBase)}
-                className="group w-full block text-left rounded-xl border bg-card text-card-foreground shadow cursor-pointer outline-none ring-offset-background transition-colors hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
-            >
+            <div className={CARD_SHELL}>
                 <CardContent className="py-4 px-5">
                     <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0 flex-1">
                             <div className="flex items-center gap-2">
                                 <div className="shrink-0">{getStateIcon(study.state)}</div>
-                                <h3 className="text-base font-semibold truncate group-hover:text-indigo-600 transition-colors">
-                                    {title}
+                                <h3 className="text-base font-semibold min-w-0">
+                                    <button
+                                        type="button"
+                                        onClick={() => navigate(studyBase)}
+                                        className={CARD_TITLE_BUTTON}
+                                    >
+                                        {title}
+                                    </button>
                                 </h3>
                                 <Badge
                                     variant="outline"
@@ -564,7 +587,7 @@ function SingleStudyCard({
                         click away via the study sidebar after opening the
                         card. */}
                 </CardContent>
-            </button>
+            </div>
         </div>
     );
 }
@@ -709,11 +732,7 @@ function StudyRow({
     const participants = study.participant_count ?? 0;
 
     return (
-        <button
-            type="button"
-            onClick={onOpen}
-            className="group w-full block text-left rounded-xl border bg-card text-card-foreground shadow cursor-pointer outline-none ring-offset-background transition-colors hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
-        >
+        <div className={CARD_SHELL}>
             <CardContent className="py-3 px-4">
                 <div className="flex items-center gap-3">
                     {/* State indicator */}
@@ -722,8 +741,14 @@ function StudyRow({
                     {/* Main content */}
                     <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
-                            <h3 className="text-sm font-semibold truncate group-hover:text-indigo-600 transition-colors">
-                                {title}
+                            <h3 className="text-sm font-semibold min-w-0">
+                                <button
+                                    type="button"
+                                    onClick={onOpen}
+                                    className={CARD_TITLE_BUTTON}
+                                >
+                                    {title}
+                                </button>
                             </h3>
                             <Badge
                                 variant="outline"
@@ -768,6 +793,6 @@ function StudyRow({
                     <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
                 </div>
             </CardContent>
-        </button>
+        </div>
     );
 }

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.test.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.test.tsx
@@ -247,3 +247,47 @@ describe('PostSortConfigEditor - Extreme Columns Prompts', () => {
         expect(screen.queryByText(/Prompt for statements \(-\)/)).not.toBeInTheDocument();
     });
 });
+
+describe('PostSortConfigEditor - accessible names (Task 3.6)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: weak typing
+    const renderEditor = (initialStateOverrides: any = {}) => {
+        const mergedDraft = {
+            slug: 'test',
+            state: 'draft',
+            postsort_config: {},
+            ...(initialStateOverrides.draft || {}),
+        };
+
+        return renderWithStore(<PostSortConfigEditor />, {
+            initialState: {
+                ...initialStateOverrides,
+                draft: mergedDraft,
+                activeLocale: 'en',
+            },
+        });
+    };
+
+    // These three switches sit next to a CardTitle/CardDescription pair with
+    // no `id`/`htmlFor`/`aria-label` anywhere — getByRole computes the real
+    // accessible name, so an unnamed switch fails to resolve even though
+    // three switches exist on the page (this isn't a missing-element check).
+    it('names the "Allow random comments" switch', () => {
+        renderEditor();
+
+        expect(screen.getByRole('switch', { name: /allow random comments/i })).toBeInTheDocument();
+    });
+
+    it('names the "Ask about missing statements" switch', () => {
+        renderEditor();
+
+        expect(
+            screen.getByRole('switch', { name: /ask about missing statements/i })
+        ).toBeInTheDocument();
+    });
+
+    it('names the "Audio Recording" switch', () => {
+        renderEditor();
+
+        expect(screen.getByRole('switch', { name: /audio recording/i })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.test.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.test.tsx
@@ -291,3 +291,72 @@ describe('PostSortConfigEditor - accessible names (Task 3.6)', () => {
         expect(screen.getByRole('switch', { name: /audio recording/i })).toBeInTheDocument();
     });
 });
+
+// Follow-up sweep (coordinator request): the email/contact section on the
+// same Post-sort page carries three more switches with the identical defect
+// — a sibling `Label` with no `htmlFor` and a `Switch` with no `id`. Found
+// while verifying the six controls above; folded into this task rather than
+// split into a follow-up, since it's the same file, same defect, same fix.
+describe('PostSortConfigEditor - accessible names (Task 3.6 follow-up: email section)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: weak typing
+    const renderEditor = (initialStateOverrides: any = {}) => {
+        const mergedDraft = {
+            slug: 'test',
+            state: 'draft',
+            postsort_config: {},
+            ...(initialStateOverrides.draft || {}),
+        };
+
+        return renderWithStore(<PostSortConfigEditor />, {
+            initialState: {
+                ...initialStateOverrides,
+                draft: mergedDraft,
+                activeLocale: 'en',
+            },
+        });
+    };
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing user utilities mock
+    const switchToStep2 = async (user: any) => {
+        await user.click(screen.getByText('Step 2: questions'));
+        await screen.findByText('Participant follow-up');
+    };
+
+    it('names the "Participant follow-up" (email collection) switch', async () => {
+        const user = userEvent.setup();
+        renderEditor({ draft: { postsort_config: {}, grid_config: [] } });
+        await switchToStep2(user);
+
+        expect(screen.getByRole('switch', { name: /participant follow-up/i })).toBeInTheDocument();
+    });
+
+    it('names the "Offer follow-up" (interview consent) switch', async () => {
+        const user = userEvent.setup();
+        renderEditor({
+            draft: {
+                postsort_config: { email_collection_enabled: true },
+                grid_config: [],
+            },
+        });
+        await switchToStep2(user);
+
+        expect(screen.getByRole('switch', { name: /^offer follow-up$/i })).toBeInTheDocument();
+    });
+
+    it('names the "Offer to subscribe..." (newsletter consent) switch', async () => {
+        const user = userEvent.setup();
+        renderEditor({
+            draft: {
+                postsort_config: { email_collection_enabled: true },
+                grid_config: [],
+            },
+        });
+        await switchToStep2(user);
+
+        expect(
+            screen.getByRole('switch', {
+                name: /offer to subscribe to a mailing list about study outcomes/i,
+            })
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -376,14 +376,18 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                         <CardHeader className={allowRandomComments ? 'pb-4' : ''}>
                             <div className="flex items-center justify-between">
                                 <div className="space-y-1">
-                                    <CardTitle className="text-base font-black text-slate-900 tracking-tight">
+                                    <Label
+                                        htmlFor="random-comments-toggle"
+                                        className="block text-base font-black text-slate-900 tracking-tight"
+                                    >
                                         {t('admin.design.postsort.random_comments.title')}
-                                    </CardTitle>
+                                    </Label>
                                     <CardDescription className="text-sm font-medium text-slate-500 leading-relaxed">
                                         {t('admin.design.postsort.random_comments.desc')}
                                     </CardDescription>
                                 </div>
                                 <Switch
+                                    id="random-comments-toggle"
                                     data-testid="allow-random-comments-toggle"
                                     checked={allowRandomComments}
                                     onCheckedChange={(checked: boolean) => {
@@ -436,14 +440,18 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                         <CardHeader className="pb-4">
                             <div className="flex items-center justify-between">
                                 <div className="space-y-1">
-                                    <CardTitle className="text-base font-black text-slate-900 tracking-tight">
+                                    <Label
+                                        htmlFor="missing-statements-toggle"
+                                        className="block text-base font-black text-slate-900 tracking-tight"
+                                    >
                                         {t('admin.design.postsort.missing.title')}
-                                    </CardTitle>
+                                    </Label>
                                     <CardDescription className="text-sm font-medium text-slate-500 leading-relaxed">
                                         {t('admin.design.postsort.missing.desc')}
                                     </CardDescription>
                                 </div>
                                 <Switch
+                                    id="missing-statements-toggle"
                                     data-testid="allow-missing-statements-toggle"
                                     checked={allowMissingStatements}
                                     onCheckedChange={(checked: boolean) => {
@@ -499,17 +507,21 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                         <CardHeader>
                             <div className="flex items-center justify-between">
                                 <div className="space-y-1">
-                                    <CardTitle className="text-lg font-black text-slate-800 flex items-center gap-2">
+                                    <Label
+                                        htmlFor="audio-recording-toggle"
+                                        className="text-lg font-black text-slate-800 flex items-center gap-2"
+                                    >
                                         <Mic className="w-5 h-5 text-indigo-600" />
                                         {t('admin.design.postsort.audio.title') ||
                                             'Audio Recording'}
-                                    </CardTitle>
+                                    </Label>
                                     <CardDescription className="text-sm font-medium text-slate-500 leading-relaxed">
                                         {t('admin.design.postsort.audio.desc') ||
                                             'Allow participants to record audio responses instead of text'}
                                     </CardDescription>
                                 </div>
                                 <Switch
+                                    id="audio-recording-toggle"
                                     data-testid="audio-recording-toggle"
                                     checked={config?.audio?.enabled || false}
                                     onCheckedChange={(checked: boolean) => {

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -378,7 +378,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                 <div className="space-y-1">
                                     <Label
                                         htmlFor="random-comments-toggle"
-                                        className="block text-base font-black text-slate-900 tracking-tight"
+                                        className="block cursor-pointer text-base font-black text-slate-900 tracking-tight"
                                     >
                                         {t('admin.design.postsort.random_comments.title')}
                                     </Label>
@@ -442,7 +442,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                 <div className="space-y-1">
                                     <Label
                                         htmlFor="missing-statements-toggle"
-                                        className="block text-base font-black text-slate-900 tracking-tight"
+                                        className="block cursor-pointer text-base font-black text-slate-900 tracking-tight"
                                     >
                                         {t('admin.design.postsort.missing.title')}
                                     </Label>
@@ -509,7 +509,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                 <div className="space-y-1">
                                     <Label
                                         htmlFor="audio-recording-toggle"
-                                        className="text-lg font-black text-slate-800 flex items-center gap-2"
+                                        className="flex cursor-pointer items-center gap-2 text-lg font-black text-slate-800"
                                     >
                                         <Mic className="w-5 h-5 text-indigo-600" />
                                         {t('admin.design.postsort.audio.title') ||

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -647,7 +647,10 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                     {/* Email/Contact Section */}
                     <div className="flex items-center justify-between rounded-2xl border border-indigo-100 bg-indigo-50/50 p-6 mt-6 shadow-sm group hover:border-indigo-200 hover:shadow-md transition-all">
                         <div className="space-y-1.5 text-indigo-900">
-                            <Label className="text-base font-bold flex items-center gap-3 tracking-tight">
+                            <Label
+                                htmlFor="email-collection-toggle"
+                                className="flex cursor-pointer items-center gap-3 text-base font-bold tracking-tight"
+                            >
                                 {t('admin.design.postsort.email.title')}
                                 <Badge
                                     variant="outline"
@@ -661,6 +664,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                             </p>
                         </div>
                         <Switch
+                            id="email-collection-toggle"
                             data-testid="email-collection-toggle"
                             checked={config?.email_collection_enabled || false}
                             onCheckedChange={(checked: boolean) => {
@@ -679,10 +683,14 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                         <div className="ml-8 mt-4 space-y-4 border-l-2 border-indigo-100 pl-8 animate-in slide-in-from-left-4 duration-500">
                             <div className="rounded-2xl border border-amber-200 bg-amber-50/50 p-6 shadow-sm">
                                 <div className="flex items-center justify-between group/item mb-2">
-                                    <Label className="text-sm font-bold text-amber-900 group-hover/item:text-amber-950 transition-colors tracking-tight">
+                                    <Label
+                                        htmlFor="interview-consent-toggle"
+                                        className="cursor-pointer text-sm font-bold text-amber-900 transition-colors group-hover/item:text-amber-950"
+                                    >
                                         {t('admin.design.postsort.email.interview')}
                                     </Label>
                                     <Switch
+                                        id="interview-consent-toggle"
                                         data-testid="interview-consent-toggle"
                                         checked={config?.interview_consent_enabled ?? true}
                                         onCheckedChange={(checked: boolean) => {
@@ -706,7 +714,10 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
 
                             <div className="flex items-center justify-between group/item py-4 px-6 bg-white rounded-2xl border border-slate-100 shadow-sm">
                                 <div className="space-y-1">
-                                    <Label className="text-sm font-bold text-slate-800 group-hover/item:text-indigo-600 transition-all tracking-tight">
+                                    <Label
+                                        htmlFor="newsletter-consent-toggle"
+                                        className="cursor-pointer text-sm font-bold text-slate-800 transition-all group-hover/item:text-indigo-600"
+                                    >
                                         {t('admin.design.postsort.email.results')}
                                     </Label>
                                     <p className="text-xs font-medium text-slate-500">
@@ -714,6 +725,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                     </p>
                                 </div>
                                 <Switch
+                                    id="newsletter-consent-toggle"
                                     data-testid="newsletter-consent-toggle"
                                     checked={config?.newsletter_consent_enabled ?? true}
                                     onCheckedChange={(checked: boolean) => {

--- a/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
@@ -61,3 +61,45 @@ describe('QuestionBuilder - conditional logic switch accessible name (Task 3.6)'
         expect(scope.getByRole('switch', { name: /visibility logic/i })).toBeInTheDocument();
     });
 });
+
+/**
+ * Accessible-name regression test for the "Enable pre-sort survey" switch
+ * (coordinator-requested closing sweep). Same defect class as the rest of
+ * Task 3.6, on the `type === 'pre'` branch (Pre-sort tab) rather than the
+ * Post-sort page: a sibling `Label` with no `htmlFor`, a `Switch` with no
+ * `id`/`aria-label`.
+ */
+describe('QuestionBuilder - presort-toggle accessible name (Task 3.6 closing sweep)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: weak typing for test utility
+    const renderPresortBuilder = (initialStateOverrides: any = {}) => {
+        const mergedDraft = {
+            slug: 'test',
+            state: 'draft',
+            presort_config: {},
+            ...(initialStateOverrides.draft || {}),
+        };
+
+        return renderWithStore(<QuestionBuilder type="pre" />, {
+            initialState: {
+                ...initialStateOverrides,
+                draft: mergedDraft,
+                activeLocale: 'en',
+            },
+        });
+    };
+
+    it('names the "Enable pre-sort survey" switch', () => {
+        renderPresortBuilder();
+
+        // getByRole computes the real accessible name — an unnamed switch
+        // will not match even though it's on screen (the positive baseline
+        // below proves that).
+        expect(screen.getByRole('switch', { name: /enable pre-sort survey/i })).toBeInTheDocument();
+    });
+
+    it('renders exactly one switch on this tab (positive baseline)', () => {
+        renderPresortBuilder();
+
+        expect(screen.getAllByRole('switch')).toHaveLength(1);
+    });
+});

--- a/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Accessible-name regression test for QuestionBuilder's "Visibility logic"
+ * conditional switch (Task 3.6). `QuestionBuilder.tsx:346` (`req-${id}`) is a
+ * known false positive — it already has a matching `id`/`htmlFor` pair — and
+ * is deliberately left untouched by this task.
+ */
+
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import QuestionBuilder from './QuestionBuilder';
+import { renderWithStore } from '@/test-utils/renderWithStore';
+
+describe('QuestionBuilder - conditional logic switch accessible name (Task 3.6)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: weak typing for test utility
+    const renderBuilder = (initialStateOverrides: any = {}) => {
+        const mergedDraft = {
+            slug: 'test',
+            state: 'draft',
+            postsort_config: {
+                questions: {
+                    q1: { type: 'text', label: 'First question', required: false },
+                    q2: { type: 'text', label: 'Second question', required: false },
+                },
+            },
+            ...(initialStateOverrides.draft || {}),
+        };
+
+        return renderWithStore(<QuestionBuilder type="post" />, {
+            initialState: {
+                ...initialStateOverrides,
+                draft: mergedDraft,
+                activeLocale: 'en',
+            },
+        });
+    };
+
+    it('names the conditional-logic switch on a question that has a prior question to depend on', async () => {
+        const user = userEvent.setup();
+        renderBuilder();
+
+        // q2 is the second question — it has q1 as an available "depends on"
+        // target, so its accordion content renders the visibility-logic switch.
+        const secondItemText = await screen.findByText('Second question');
+        const secondItem = secondItemText.closest('[data-testid="question-item"]');
+        if (!secondItem) throw new Error('question item not found');
+
+        const trigger = within(secondItem as HTMLElement).getByTestId('question-accordion-trigger');
+        await user.click(trigger);
+
+        const scope = within(secondItem as HTMLElement);
+        // getByRole computes the real accessible name — an unnamed switch
+        // will not match, even though the "Required" switch in the same
+        // item (req-${id}, a known-good pairing) is right next to it.
+        expect(scope.getByRole('switch', { name: /visibility logic/i })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -372,12 +372,16 @@ const QuestionItem = (props: QuestionItemProps) => {
                                         <div className="flex items-center justify-between">
                                             <div className="flex items-center gap-2">
                                                 <GitBranch className="h-3.5 w-3.5 text-indigo-500" />
-                                                <Label className="text-2xs font-black text-slate-500">
+                                                <Label
+                                                    htmlFor={`visibility-toggle-${id}`}
+                                                    className="text-2xs font-black text-slate-500"
+                                                >
                                                     {t('admin.design.questions.logic.title')}
                                                 </Label>
                                             </div>
                                             {!readOnly && (
                                                 <Switch
+                                                    id={`visibility-toggle-${id}`}
                                                     checked={!!question.visibility_condition}
                                                     onCheckedChange={(checked) => {
                                                         if (checked) {

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -374,7 +374,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                 <GitBranch className="h-3.5 w-3.5 text-indigo-500" />
                                                 <Label
                                                     htmlFor={`visibility-toggle-${id}`}
-                                                    className="text-2xs font-black text-slate-500"
+                                                    className="cursor-pointer text-2xs font-black text-slate-500"
                                                 >
                                                     {t('admin.design.questions.logic.title')}
                                                 </Label>

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -1049,7 +1049,10 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                 <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
                     <CardContent className="p-6 flex items-center justify-between">
                         <div className="space-y-1">
-                            <Label className="text-base font-bold text-slate-900 tracking-tight">
+                            <Label
+                                htmlFor="presort-toggle"
+                                className="cursor-pointer text-base font-bold text-slate-900 tracking-tight"
+                            >
                                 {t('admin.design.questions.enable_presort')}
                             </Label>
                             <p className="text-sm font-medium text-slate-500">
@@ -1057,6 +1060,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                             </p>
                         </div>
                         <Switch
+                            id="presort-toggle"
                             data-testid="presort-toggle"
                             checked={!!isPresortEnabled}
                             onCheckedChange={handlePresortToggle}

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -31,11 +31,11 @@ describe('LoginPage', () => {
         renderWithProviders(<LoginPage />);
 
         const emailInput = screen.getByPlaceholderText(/name@example\.com/i);
-        const passwordInput = screen.getAllByPlaceholderText(/.+/)[1];
+        const passwordInput = screen.getByLabelText('Password');
         fireEvent.change(emailInput, { target: { value: 'a@b.io' } });
-        fireEvent.change(passwordInput as HTMLElement, { target: { value: 'pw12345678' } });
+        fireEvent.change(passwordInput, { target: { value: 'pw12345678' } });
 
-        fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+        fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 
         await waitFor(() => {
             expect(screen.getByText(/code from your authenticator app/i)).toBeInTheDocument();
@@ -43,5 +43,42 @@ describe('LoginPage', () => {
         expect(screen.getByRole('button', { name: /verify/i })).toBeInTheDocument();
         // No email-only 'Resend' link
         expect(screen.queryByText(/resend code|resend available/i)).not.toBeInTheDocument();
+    });
+
+    it('exposes the visible title as the page heading, not a hidden duplicate', () => {
+        renderWithProviders(<LoginPage />);
+
+        const headings = screen.getAllByRole('heading', { level: 1 });
+
+        // Positive: exactly one level-1 heading, carrying the visible title's
+        // own styling (it IS the visible card title, not a wrapper around it).
+        expect(headings).toHaveLength(1);
+        expect(headings[0]).toHaveTextContent('Sign in');
+        expect(headings[0]).toHaveClass('font-black');
+
+        // Negative: it is not the old visually-hidden duplicate that sat
+        // alongside a separate, unlabelled visible title.
+        expect(headings[0]).not.toHaveClass('sr-only');
+    });
+
+    it('labels the submit button with the action it performs', () => {
+        renderWithProviders(<LoginPage />);
+
+        // Positive: the primary action names what it does.
+        expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+
+        // Negative: the old generic "Continue" label is gone.
+        expect(screen.queryByRole('button', { name: /^continue$/i })).not.toBeInTheDocument();
+    });
+
+    it('does not disguise the empty password field as already filled', () => {
+        renderWithProviders(<LoginPage />);
+
+        const passwordInput = screen.getByLabelText('Password') as HTMLInputElement;
+
+        // Negative: no bullet placeholder mimicking existing content.
+        expect(passwordInput).not.toHaveAttribute('placeholder', '••••••••');
+        // Positive: the empty field genuinely looks empty.
+        expect(passwordInput.placeholder).toBe('');
     });
 });

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -8,7 +8,7 @@ import { customInstance } from '@/api/mutator';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
 import { toast } from 'sonner';
 import { Loader2, Lock, AtSign, ArrowRight, ShieldCheck, Info, ArrowLeft } from 'lucide-react';
 import { motion } from 'framer-motion';
@@ -163,7 +163,6 @@ const LoginPage = () => {
 
     return (
         <div className="flex-1 w-full flex items-center justify-center bg-[#fafafa] p-4">
-            <h1 className="sr-only">{t('auth.login.card_title')}</h1>
             {/* Background decorative elements */}
             <div className="absolute inset-0 overflow-hidden pointer-events-none">
                 <div className="absolute -top-[10%] -left-[10%] w-[40%] h-[40%] bg-indigo-500/5 blur-[120px] rounded-full" />
@@ -186,9 +185,9 @@ const LoginPage = () => {
                     {stage === 'credentials' && (
                         <form onSubmit={handleLogin}>
                             <CardHeader className="pb-4">
-                                <CardTitle className="text-xl font-black">
+                                <h1 className="font-semibold leading-none tracking-tight text-xl font-black">
                                     {t('auth.login.card_title')}
-                                </CardTitle>
+                                </h1>
                             </CardHeader>
                             {resetSuccess && (
                                 <div className="px-6 pb-2">
@@ -275,7 +274,6 @@ const LoginPage = () => {
                                         <Input
                                             id="password"
                                             type="password"
-                                            placeholder={t('auth.register.placeholder_password')}
                                             className="pl-10 h-11 bg-white border-slate-300 text-slate-900 placeholder:text-slate-600 focus:bg-white transition-all shadow-sm"
                                             value={password}
                                             onChange={(e) => setPassword(e.target.value)}
@@ -298,7 +296,7 @@ const LoginPage = () => {
                                         </>
                                     ) : (
                                         <>
-                                            {t('auth.login.submit')}
+                                            {t('auth.login.submit', 'Sign in')}
                                             <ArrowRight className="ml-2 h-4 w-4" />
                                         </>
                                     )}
@@ -310,9 +308,9 @@ const LoginPage = () => {
                     {stage === 'two_factor' && (
                         <form onSubmit={handleOtpSubmit}>
                             <CardHeader className="pb-4">
-                                <CardTitle className="text-xl font-black">
+                                <h1 className="font-semibold leading-none tracking-tight text-xl font-black">
                                     {t('auth.login.two_factor_title', 'Two-factor authentication')}
-                                </CardTitle>
+                                </h1>
                             </CardHeader>
                             <CardContent className="space-y-4">
                                 <p className="text-sm text-slate-700">

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -196,3 +196,66 @@ describe('ConcourseDetailPage curation panel', () => {
         expect(panelScope.getByText(/25 accepted/i)).toBeInTheDocument();
     });
 });
+
+/**
+ * jsdom/happy-dom never lays out Tailwind classes, so `:focus-within` and the
+ * cascade order that decides whether `sm:opacity-0` or `focus-visible:opacity-100`
+ * wins in a real browser cannot be observed here (verified separately by tabbing
+ * through the real app — see task-3.1-report.md). What CAN be asserted from the
+ * DOM: the hover-reveal classes are paired with an equivalent focus-within
+ * reveal on the desktop row-action group, the controls stay real, focusable
+ * tab stops (not pulled from the tab order as a shortcut), and the always-on
+ * Edit button no longer ships the near-invisible resting token.
+ */
+describe('ConcourseDetailPage row actions', () => {
+    function renderEditableRow() {
+        const concourse = concourseWith(1, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            // baseApi hardcodes filteredItems to [] (the curation-panel test
+            // above only needs concourse.items) — the row list renders from
+            // filteredItems, so it must be wired up here for any row to exist.
+            filteredItems: concourse.items ?? [],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        // Two copies of each action button exist in the DOM (a `sm:hidden`
+        // mobile row and a `hidden sm:flex` desktop row) sharing the same
+        // aria-labels — data-row-actions scopes queries to the desktop group
+        // that actually carries the hover/focus-reveal classes under test.
+        const group = document.querySelector('[data-row-actions]');
+        if (!group) throw new Error('desktop row actions group not found');
+        return within(group as HTMLElement);
+    }
+
+    it('reveals hover-only row actions on keyboard focus, not only on mouse hover', () => {
+        const actions = renderEditableRow();
+
+        for (const name of ['History', 'Comments', 'Delete']) {
+            const button = actions.getByRole('button', { name });
+            // Positive: the group-hover reveal now has a group-focus-within
+            // counterpart, so a keyboard user focusing anywhere in the row
+            // reveals the same controls a mouse hover would.
+            expect(button).toHaveClass('sm:group-hover:opacity-100');
+            expect(button).toHaveClass('sm:group-focus-within:opacity-100');
+            // Negative: still starts hidden at rest (this isn't a shortcut
+            // that makes every action permanently visible, which would defeat
+            // the decluttered-row design) and still carries a real tab stop
+            // (constraint: never pull it from the tab order to "fix" this).
+            expect(button).toHaveClass('sm:opacity-0');
+            expect(button.tabIndex).not.toBe(-1);
+            expect(button).not.toHaveAttribute('disabled');
+        }
+    });
+
+    it('raises the resting Edit button above the near-invisible token it shipped with', () => {
+        const actions = renderEditableRow();
+        const edit = actions.getByRole('button', { name: 'Edit' });
+
+        // Positive: slate-500 clears 4.5:1 against a white row background.
+        expect(edit).toHaveClass('text-slate-500');
+        // Negative: not the ~1.4:1 token this button used to carry at rest.
+        expect(edit).not.toHaveClass('text-slate-300');
+    });
+});

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -301,3 +301,54 @@ describe('ConcourseDetailPage selection checkboxes (a11y, Task 3.6)', () => {
         }
     });
 });
+
+/**
+ * Accessible-name regression test for the tag-picker checkboxes (Task 3.6,
+ * coordinator-requested closing sweep). Found by the reviewer, not in the
+ * original brief: two call sites render a Checkbox next to a `<Badge>` with
+ * the tag's name, with no `id`/`htmlFor`/`aria-label` anywhere — the inline
+ * tag list on an item being edited (~line 930), and the shared
+ * `TagCheckboxGroup` used by the "Add Item" dialog (~line 1747).
+ */
+describe('ConcourseDetailPage tag-picker checkboxes (a11y, Task 3.6)', () => {
+    const tags = [
+        { id: 1, name: 'Vision', color: '#6366f1', project_id: 1 },
+        { id: 2, name: 'Risk', color: '#ef4444', project_id: 1 },
+    ];
+
+    it('names each tag checkbox in the "Add Item" dialog tag picker (TagCheckboxGroup)', () => {
+        const concourse = concourseWith(1, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            addItemOpen: true,
+            tags,
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        // getByRole computes the real accessible name — the tag name sits in
+        // a <Badge> (a plain styled <div>) beside the checkbox, not a
+        // <label htmlFor>, so an unfixed checkbox fails to resolve by name
+        // even though the tag name is visible right next to it.
+        expect(screen.getByRole('checkbox', { name: /vision/i })).toBeInTheDocument();
+        expect(screen.getByRole('checkbox', { name: /risk/i })).toBeInTheDocument();
+    });
+
+    it('names each tag checkbox in the inline item-edit tag picker', () => {
+        const concourse = concourseWith(1, 0, 0);
+        const item = concourse.items?.[0];
+        if (!item) throw new Error('expected at least one item');
+
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            filteredItems: concourse.items ?? [],
+            editingItem: item.id,
+            tags,
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expect(screen.getByRole('checkbox', { name: /vision/i })).toBeInTheDocument();
+        expect(screen.getByRole('checkbox', { name: /risk/i })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -259,3 +259,45 @@ describe('ConcourseDetailPage row actions', () => {
         expect(edit).not.toHaveClass('text-slate-300');
     });
 });
+
+/**
+ * Accessible-name regression test for the item-selection checkboxes
+ * (Task 3.6). Both the "select all" checkbox and each per-row checkbox had
+ * no `id`/`htmlFor`/`aria-label` anywhere near them.
+ */
+describe('ConcourseDetailPage selection checkboxes (a11y, Task 3.6)', () => {
+    function renderEditableRow(itemCount = 1) {
+        const concourse = concourseWith(itemCount, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            filteredItems: concourse.items ?? [],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+        return concourse;
+    }
+
+    it('names the "select all" checkbox', () => {
+        renderEditableRow();
+
+        // getByRole computes the real accessible name — the visible "Select
+        // all" text sits in a plain <span>, not a <label htmlFor>, so an
+        // unfixed checkbox fails to resolve here even though it's on screen.
+        expect(screen.getByRole('checkbox', { name: /select all/i })).toBeInTheDocument();
+    });
+
+    it('names each row checkbox with the specific item it selects', () => {
+        const concourse = renderEditableRow(2);
+        const codes = (concourse.items ?? []).map((item) => item.code);
+        expect(codes).toHaveLength(2);
+
+        // Each row checkbox has no adjacent visible text at all (the item
+        // code is a separate badge elsewhere in the row) — the name must
+        // come from an aria-label distinct per row, not a single fallback.
+        for (const code of codes) {
+            expect(
+                screen.getByRole('checkbox', { name: new RegExp(code, 'i') })
+            ).toBeInTheDocument();
+        }
+    });
+});

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -928,6 +928,7 @@ export default function ConcourseDetailPage() {
                                                                     className="flex items-center gap-1.5 cursor-pointer"
                                                                 >
                                                                     <Checkbox
+                                                                        id={`edit-item-tag-${tag.id}`}
                                                                         checked={editTagIds.includes(
                                                                             tag.id
                                                                         )}
@@ -948,21 +949,26 @@ export default function ConcourseDetailPage() {
                                                                             );
                                                                         }}
                                                                     />
-                                                                    <Badge
-                                                                        variant="outline"
-                                                                        className="text-2xs h-5 cursor-pointer"
-                                                                        style={
-                                                                            tag.color
-                                                                                ? {
-                                                                                      borderColor:
-                                                                                          tag.color,
-                                                                                      color: tag.color,
-                                                                                  }
-                                                                                : undefined
-                                                                        }
+                                                                    <Label
+                                                                        htmlFor={`edit-item-tag-${tag.id}`}
+                                                                        className="cursor-pointer"
                                                                     >
-                                                                        {tag.name}
-                                                                    </Badge>
+                                                                        <Badge
+                                                                            variant="outline"
+                                                                            className="text-2xs h-5 cursor-pointer"
+                                                                            style={
+                                                                                tag.color
+                                                                                    ? {
+                                                                                          borderColor:
+                                                                                              tag.color,
+                                                                                          color: tag.color,
+                                                                                      }
+                                                                                    : undefined
+                                                                            }
+                                                                        >
+                                                                            {tag.name}
+                                                                        </Badge>
+                                                                    </Label>
                                                                 </div>
                                                             ))}
                                                         </div>
@@ -1745,6 +1751,7 @@ function TagCheckboxGroup({
                 {tags.map((tag) => (
                     <div key={tag.id} className="flex items-center gap-1.5 cursor-pointer">
                         <Checkbox
+                            id={`tag-checkbox-group-${tag.id}`}
                             checked={selectedIds.includes(tag.id)}
                             onCheckedChange={(checked) => {
                                 onChange(
@@ -1754,15 +1761,19 @@ function TagCheckboxGroup({
                                 );
                             }}
                         />
-                        <Badge
-                            variant="outline"
-                            className="text-2xs h-5 cursor-pointer"
-                            style={
-                                tag.color ? { borderColor: tag.color, color: tag.color } : undefined
-                            }
-                        >
-                            {tag.name}
-                        </Badge>
+                        <Label htmlFor={`tag-checkbox-group-${tag.id}`} className="cursor-pointer">
+                            <Badge
+                                variant="outline"
+                                className="text-2xs h-5 cursor-pointer"
+                                style={
+                                    tag.color
+                                        ? { borderColor: tag.color, color: tag.color }
+                                        : undefined
+                                }
+                            >
+                                {tag.name}
+                            </Badge>
+                        </Label>
                     </div>
                 ))}
             </div>

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -653,6 +653,7 @@ export default function ConcourseDetailPage() {
                             {canEdit && filteredItems.length > 0 && (
                                 <div className="flex items-center gap-2 px-4 py-2 bg-slate-50/80 border-b border-slate-100">
                                     <Checkbox
+                                        id="concourse-select-all"
                                         checked={
                                             filteredItems.length > 0 &&
                                             filteredItems.every((item) =>
@@ -661,9 +662,12 @@ export default function ConcourseDetailPage() {
                                         }
                                         onCheckedChange={toggleSelectAll}
                                     />
-                                    <span className="text-2xs font-bold text-slate-500">
+                                    <Label
+                                        htmlFor="concourse-select-all"
+                                        className="text-2xs font-bold text-slate-500 cursor-pointer"
+                                    >
                                         {t('admin.concourse.select_all', 'Select all')}
-                                    </span>
+                                    </Label>
                                 </div>
                             )}
                             {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: row rendering — many cooperating visual states (selection, edit mode, status, missing translation, mobile/desktop layouts, hover-only actions). Same shell-suppression precedent as the page-level biome-ignore on line 78 (CLAUDE.md). */}
@@ -694,6 +698,11 @@ export default function ConcourseDetailPage() {
                                             {canEdit && (
                                                 <div className="flex-shrink-0 sm:pt-0.5">
                                                     <Checkbox
+                                                        aria-label={t(
+                                                            'admin.concourse.select_item',
+                                                            'Select {{code}}',
+                                                            { code: item.code }
+                                                        )}
                                                         checked={selectedItems.has(item.id)}
                                                         onCheckedChange={() =>
                                                             toggleSelectItem(item.id)

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -852,7 +852,7 @@ export default function ConcourseDetailPage() {
                                                                     'common.edit',
                                                                     'Edit'
                                                                 )}
-                                                                className="size-8 p-0 text-slate-400 hover:text-slate-700"
+                                                                className="size-8 p-0 text-slate-500 hover:text-slate-700"
                                                                 onClick={() => startEdit(item)}
                                                             >
                                                                 <Pencil className="size-3.5" />
@@ -1070,7 +1070,10 @@ export default function ConcourseDetailPage() {
 
                                         {/* Actions (desktop only — mobile shown in top row) */}
                                         {canEdit && (
-                                            <div className="hidden sm:flex items-center gap-1 flex-shrink-0">
+                                            <div
+                                                className="hidden sm:flex items-center gap-1 flex-shrink-0"
+                                                data-row-actions
+                                            >
                                                 {isEditing ? (
                                                     <>
                                                         <Button
@@ -1109,7 +1112,7 @@ export default function ConcourseDetailPage() {
                                                                 'admin.concourse.history',
                                                                 'History'
                                                             )}
-                                                            className="size-8 p-0 text-slate-400 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                                                            className="size-8 p-0 text-slate-400 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
                                                             onClick={() =>
                                                                 openSheet(item, 'history')
                                                             }
@@ -1123,7 +1126,7 @@ export default function ConcourseDetailPage() {
                                                                 'admin.concourse.comments',
                                                                 'Comments'
                                                             )}
-                                                            className="relative size-8 p-0 text-slate-400 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                                                            className="relative size-8 p-0 text-slate-400 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
                                                             onClick={() =>
                                                                 openSheet(item, 'comments')
                                                             }
@@ -1139,7 +1142,7 @@ export default function ConcourseDetailPage() {
                                                             variant="ghost"
                                                             size="sm"
                                                             aria-label={t('common.edit', 'Edit')}
-                                                            className="size-8 p-0 text-slate-300 hover:text-slate-700 transition-colors"
+                                                            className="size-8 p-0 text-slate-500 hover:text-slate-700 transition-colors"
                                                             onClick={() => startEdit(item)}
                                                         >
                                                             <Pencil className="size-3.5" />
@@ -1151,7 +1154,7 @@ export default function ConcourseDetailPage() {
                                                                 'common.delete',
                                                                 'Delete'
                                                             )}
-                                                            className="size-8 p-0 text-slate-400 hover:text-red-500 hover:bg-red-50 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                                                            className="size-8 p-0 text-slate-400 hover:text-red-500 hover:bg-red-50 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
                                                             onClick={() =>
                                                                 setDeleteConfirmId(item.id)
                                                             }

--- a/frontend/src/pages/admin/RecruitmentPage.test.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.test.tsx
@@ -1,0 +1,125 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Accessibility regression test for RecruitmentPage's "Access rules" switches.
+ *
+ * The page's own JSX is what's under test — bypass useRecruitmentPage entirely
+ * (same approach as ConcourseDetailPage.test.tsx) so the test controls the
+ * study/form fixtures directly, with no query/router/API plumbing to fake out.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, screen } from '@/test-utils/test-utils';
+import RecruitmentPage from './RecruitmentPage';
+import type {
+    AccessRulesValues,
+    RecruitmentPageApi,
+    SlugFormValues,
+} from '@/hooks/admin/useRecruitmentPage';
+import type { StudyRead } from '@/api/model';
+
+const { mockUseRecruitmentPage } = vi.hoisted(() => ({
+    mockUseRecruitmentPage: vi.fn(),
+}));
+
+vi.mock('@/hooks/admin/useRecruitmentPage', () => ({
+    useRecruitmentPage: mockUseRecruitmentPage,
+}));
+
+const mockStudy: StudyRead = {
+    id: 1,
+    slug: 'demo-study',
+    state: 'draft',
+    requires_password: false,
+    start_date: null,
+    end_date: null,
+} as unknown as StudyRead;
+
+/** Real react-hook-form instances — the page reads .register/.watch/.getValues/.setValue directly. */
+function useTestForms() {
+    const slugForm = useForm<SlugFormValues>({ defaultValues: { slug: 'demo-study' } });
+    const accessForm = useForm<AccessRulesValues>({
+        defaultValues: { passwordEnabled: false, accessPassword: '', startDate: '', endDate: '' },
+    });
+    return { slugForm, accessForm };
+}
+
+function baseApi(overrides: Partial<RecruitmentPageApi> = {}): RecruitmentPageApi {
+    const { result } = renderHook(() => useTestForms());
+    return {
+        slug: 'demo-study',
+        navigate: vi.fn(),
+        study: mockStudy,
+        links: [],
+        isSlugLocked: false,
+        isArchived: false,
+        studyUrl: 'https://example.com/study/demo-study',
+        slugForm: result.current.slugForm,
+        accessForm: result.current.accessForm,
+        passwordEnabled: false,
+        showWindowPickers: false,
+        setShowWindowPickers: vi.fn(),
+        onSlugSubmit: vi.fn(),
+        onAccessRulesSubmit: vi.fn(),
+        isCreateModalOpen: false,
+        setIsCreateModalOpen: vi.fn(),
+        handleCreateModalOpenChange: vi.fn(),
+        newLinkType: 'public',
+        setNewLinkType: vi.fn(),
+        newLinkCount: 1,
+        setNewLinkCount: vi.fn(),
+        newLinkName: '',
+        setNewLinkName: vi.fn(),
+        isCreatingLink: false,
+        isRevokingLink: false,
+        handleCreate: vi.fn(),
+        handleRevoke: vi.fn(),
+        copyToClipboard: vi.fn(),
+        getFullUrl: vi.fn((token: string) => `https://example.com/study/demo-study?token=${token}`),
+        ...overrides,
+    };
+}
+
+describe('RecruitmentPage — access rule switches (a11y)', () => {
+    it('renders exactly two access-rule switches', () => {
+        // Positive baseline: proves the assertions below fail (if they do)
+        // because of the accessible NAME wiring, not because the switches
+        // are missing from the DOM.
+        mockUseRecruitmentPage.mockReturnValue(baseApi());
+        renderWithProviders(<RecruitmentPage />);
+
+        expect(screen.getAllByRole('switch')).toHaveLength(2);
+    });
+
+    it('gives the password switch an accessible name explicitly wired to its visible label', () => {
+        mockUseRecruitmentPage.mockReturnValue(baseApi());
+        renderWithProviders(<RecruitmentPage />);
+
+        const passwordSwitch = screen.getByRole('switch', { name: /require a password/i });
+        expect(passwordSwitch).toBeInTheDocument();
+        // Discriminator: the sibling `<label htmlFor>` already resolves a
+        // name above via HTML's implicit label-for-button association (this
+        // holds in both jsdom and real Chromium — verified live, see
+        // task-3.4-report.md), so the `getByRole(..., { name })` query above
+        // passes even on the unfixed source and can't prove this fix. An
+        // explicit aria-labelledby is what makes the name resolution robust
+        // instead of dependent on that implicit, non-native-widget fallback
+        // — and its presence is what actually fails pre-fix.
+        expect(passwordSwitch).toHaveAttribute('aria-labelledby', 'password-toggle-label');
+    });
+
+    it('gives the collection-window switch an accessible name explicitly wired to its visible label', () => {
+        mockUseRecruitmentPage.mockReturnValue(baseApi());
+        renderWithProviders(<RecruitmentPage />);
+
+        const windowSwitch = screen.getByRole('switch', { name: /limit collection window/i });
+        expect(windowSwitch).toBeInTheDocument();
+        expect(windowSwitch).toHaveAttribute('aria-labelledby', 'window-toggle-label');
+    });
+});

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -358,6 +358,7 @@ const RecruitmentPage = () => {
                             <div className="flex items-center justify-between gap-4 p-4 bg-slate-50/50 rounded-xl border border-slate-100">
                                 <div className="space-y-0.5">
                                     <Label
+                                        id="password-toggle-label"
                                         htmlFor="password-toggle"
                                         className="text-sm font-bold text-slate-700"
                                     >
@@ -375,6 +376,7 @@ const RecruitmentPage = () => {
                                 </div>
                                 <Switch
                                     id="password-toggle"
+                                    aria-labelledby="password-toggle-label"
                                     checked={passwordEnabled}
                                     onCheckedChange={(checked) => {
                                         accessForm.setValue('passwordEnabled', checked, {
@@ -447,6 +449,7 @@ const RecruitmentPage = () => {
                             <div className="flex items-start justify-between gap-4">
                                 <div className="space-y-0.5">
                                     <Label
+                                        id="window-toggle-label"
                                         htmlFor="window-toggle"
                                         className="text-sm font-black text-slate-700"
                                     >
@@ -464,6 +467,7 @@ const RecruitmentPage = () => {
                                 </div>
                                 <Switch
                                     id="window-toggle"
+                                    aria-labelledby="window-toggle-label"
                                     checked={showWindowPickers}
                                     onCheckedChange={(checked) => {
                                         setShowWindowPickers(checked);

--- a/frontend/src/pages/admin/StudyDesignPage.test.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithProviders, screen, waitFor, fireEvent } from '@/test-utils/test-utils';
+import { renderWithProviders, screen, waitFor, within, fireEvent } from '@/test-utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
@@ -235,6 +235,80 @@ describe('StudyDesignPage Feature Tests', () => {
         const titleField = screen.getByLabelText(/study title/i);
         expect(titleField).toBeInTheDocument();
         expect(titleField).toBeDisabled();
+    });
+
+    // ── Dismissal must not strand the researcher (review finding 1) ──
+    // `handleSwitchToDraft` used to be called from exactly one place: inside
+    // the lock dialog. A researcher who took the "View read-only" escape to
+    // inspect an active study, then decided to edit it, had every field
+    // disabled and no control anywhere on the page to unlock them — recovery
+    // required a page reload or a detour to the study overview.
+    it('keeps an unlock affordance on the page after the lock dialog is dismissed', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.get('*/api/admin/studies/test-study-designer', () => {
+                return HttpResponse.json({ ...mockStudy, state: 'active' });
+            })
+        );
+
+        renderPage();
+
+        const dialog = await screen.findByRole('dialog');
+        // Before dismissal the dialog owns the unlock action.
+        expect(within(dialog).getByRole('button', { name: /draft mode/i })).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /view read-only/i }));
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+
+        // Positive: the unlock action survives dismissal, outside any dialog.
+        const unlock = screen.getByRole('button', { name: /draft mode/i });
+        expect(unlock).toBeEnabled();
+        expect(unlock.closest('[role="dialog"]')).toBeNull();
+        // ...and the notice that explains *why* the fields are inert stays on
+        // screen with it, so the affordance is not an unexplained button.
+        expect(screen.getByTestId('design-lock-banner')).toHaveTextContent(/this study is active/i);
+
+        // Negative: dismissing the dialog does not silently unlock the design.
+        expect(screen.getByLabelText(/study title/i)).toBeDisabled();
+    });
+
+    // ── The lock dialog describes itself (review findings 5 and 6) ──
+    it('gives the lock dialog a description in every locked state', async () => {
+        // The paused state used to render no DialogDescription at all, so
+        // Radix warned and the dialog shipped with no accessible description.
+        server.use(
+            http.get('*/api/admin/studies/test-study-designer', () => {
+                return HttpResponse.json({ ...mockStudy, state: 'paused' });
+            })
+        );
+
+        renderPage();
+
+        const dialog = await screen.findByRole('dialog');
+        expect(dialog).toHaveAccessibleDescription(/read the configuration without changing it/i);
+        // Negative: it is not left undescribed, as the paused branch was.
+        expect(dialog).not.toHaveAccessibleDescription('');
+    });
+
+    it('describes the lock dialog, not the consequence of one of its buttons', async () => {
+        server.use(
+            http.get('*/api/admin/studies/test-study-designer', () => {
+                return HttpResponse.json({ ...mockStudy, state: 'active' });
+            })
+        );
+
+        renderPage();
+
+        const dialog = await screen.findByRole('dialog');
+        // Negative: the Draft-Mode *confirm* copy is no longer the dialog's
+        // description. Announced before "View read-only", it invited a
+        // screen-reader user to attribute "stops data collection" to the
+        // wrong button.
+        expect(dialog).not.toHaveAccessibleDescription(/stop data collection/i);
+        // Positive: the description now describes the dialog.
+        expect(dialog).toHaveAccessibleDescription(/read the configuration without changing it/i);
     });
 
     it('uses an amber lock icon on the lock notice instead of the green globe', async () => {

--- a/frontend/src/pages/admin/StudyDesignPage.test.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.test.tsx
@@ -1,4 +1,5 @@
 import { renderWithProviders, screen, waitFor, fireEvent } from '@/test-utils/test-utils';
+import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test-utils/server';
@@ -169,6 +170,85 @@ describe('StudyDesignPage Feature Tests', () => {
         // Wait for the overlay to render (status badge appears)
         await screen.findByTestId('study-status');
         expect(screen.queryByRole('button', { name: /Draft Mode/i })).not.toBeInTheDocument();
+        // Even without a "Draft Mode" affordance, the paused notice must still
+        // be a real, accessible, dismissible dialog — not a trap.
+        const dialog = await screen.findByRole('dialog');
+        expect(dialog).toHaveAccessibleName(/paused/i);
+        expect(screen.getByRole('button', { name: /view read-only/i })).toBeInTheDocument();
+    });
+
+    // ── Lock notice is a real dialog, not a trap (Phase 3 task 3.2) ─
+    it('exposes the lock notice as an accessible dialog, not an orphan heading', async () => {
+        server.use(
+            http.get('*/api/admin/studies/test-study-designer', () => {
+                return HttpResponse.json({ ...mockStudy, state: 'active' });
+            })
+        );
+
+        renderPage();
+
+        const dialog = await screen.findByRole('dialog');
+        expect(dialog).toHaveAccessibleName(/active/i);
+        // The old implementation rendered the message as an orphan <h3> with
+        // no dialog semantics at all; that heading must be gone now that the
+        // message lives inside a properly labelled dialog.
+        expect(
+            screen.queryByRole('heading', { level: 3, name: /active/i })
+        ).not.toBeInTheDocument();
+    });
+
+    it('dismisses the lock dialog on Escape', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.get('*/api/admin/studies/test-study-designer', () => {
+                return HttpResponse.json({ ...mockStudy, state: 'active' });
+            })
+        );
+
+        renderPage();
+
+        await screen.findByRole('dialog');
+        await user.keyboard('{Escape}');
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('can be dismissed via "View read-only", leaving the configuration visible but inert', async () => {
+        const user = userEvent.setup();
+        server.use(
+            http.get('*/api/admin/studies/test-study-designer', () => {
+                return HttpResponse.json({ ...mockStudy, state: 'active' });
+            })
+        );
+
+        renderPage();
+
+        await screen.findByRole('dialog');
+        await user.click(screen.getByRole('button', { name: /view read-only/i }));
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+        // The configuration underneath must be legible but not editable: the
+        // field is present (readable) and disabled (not a silently-dropped-edit trap).
+        const titleField = screen.getByLabelText(/study title/i);
+        expect(titleField).toBeInTheDocument();
+        expect(titleField).toBeDisabled();
+    });
+
+    it('uses an amber lock icon on the lock notice instead of the green globe', async () => {
+        server.use(
+            http.get('*/api/admin/studies/test-study-designer', () => {
+                return HttpResponse.json({ ...mockStudy, state: 'active' });
+            })
+        );
+
+        renderPage();
+        const dialog = await screen.findByRole('dialog');
+
+        expect(dialog.querySelector('svg.lucide-lock.text-amber-600')).toBeInTheDocument();
+        expect(dialog.querySelector('svg.lucide-globe')).not.toBeInTheDocument();
     });
 
     // ── Rough-sort toggle (Phase 3 task 17) ───────────────────────

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -75,6 +75,11 @@ const StudyDesignPage = () => {
     const { t, i18n } = useTranslation();
     const [activateDialogOpen, setActivateDialogOpen] = useState(false);
     const [memoOpen, setMemoOpen] = useState(false);
+    // The design-lock notice (study active/paused/closed) must be a real,
+    // dismissible dialog — not a hand-rolled overlay a researcher can't
+    // escape without acting on it. Dismissal leaves the configuration
+    // legible but inert: every editor already receives readOnly={isFullyReadOnly}.
+    const [isLockNoticeDismissed, setIsLockNoticeDismissed] = useState(false);
     const api = useStudyDesignPage();
     const original = useStudyDesigner((s) => s.original);
     const { user: currentUser } = useAuthStore();
@@ -409,54 +414,79 @@ const StudyDesignPage = () => {
 
             {/* Main Content */}
             <div className="flex flex-1 overflow-hidden relative max-w-full min-w-0">
-                {/* Read-only Overlay - For non-draft studies */}
-                {api.isFullyReadOnly && (
-                    <div className="absolute inset-0 z-50 bg-white/60 backdrop-blur-md flex items-start justify-center p-4 sm:p-8 pt-24">
-                        <div className="bg-white border-none shadow-2xl rounded-3xl p-6 sm:p-10 max-w-sm sm:max-w-lg text-center pointer-events-auto animate-in zoom-in duration-500">
-                            <div
+                {/*
+                 * Design Lock Notice - For non-draft studies.
+                 * A real Radix Dialog rather than a hand-rolled overlay: role="dialog",
+                 * aria-modal, focus trapping, Escape-to-close and a labelled close
+                 * button all come for free. Two ways out: dismiss to a read-only view
+                 * (every editor below already receives readOnly={isFullyReadOnly}, so
+                 * the underlying fields stay legible but inert), or the deliberate
+                 * "Draft Mode" action (active studies only) — its side effect
+                 * (suspending data collection) is unchanged.
+                 */}
+                <Dialog
+                    open={api.isFullyReadOnly && !isLockNoticeDismissed}
+                    onOpenChange={(open) => {
+                        if (!open) setIsLockNoticeDismissed(true);
+                    }}
+                >
+                    <DialogContent className="max-w-sm sm:max-w-lg rounded-3xl p-6 sm:p-10 text-center">
+                        <div
+                            className={cn(
+                                'w-20 h-20 rounded-2xl flex items-center justify-center mx-auto mb-2 shadow-inner border',
+                                draft.state === 'closed'
+                                    ? 'bg-rose-50 border-rose-100'
+                                    : 'bg-amber-50 border-amber-100'
+                            )}
+                        >
+                            <Lock
                                 className={cn(
-                                    'w-20 h-20 rounded-2xl flex items-center justify-center mx-auto mb-8 shadow-inner border',
-                                    draft.state === 'active'
-                                        ? 'bg-emerald-50 border-emerald-100 text-emerald-600'
-                                        : draft.state === 'paused'
-                                          ? 'bg-amber-50 border-amber-100 text-amber-600'
-                                          : 'bg-rose-50 border-rose-100 text-rose-600'
+                                    'h-10 w-10',
+                                    draft.state === 'closed' ? 'text-rose-600' : 'text-amber-600'
                                 )}
-                            >
-                                {draft.state === 'active' ? (
-                                    <Globe className="h-10 w-10" />
-                                ) : (
-                                    <Lock className="h-10 w-10" />
-                                )}
-                            </div>
-                            <h3 className="text-2xl font-bold text-slate-800 tracking-normal mb-8">
+                            />
+                        </div>
+                        <DialogHeader className="items-center text-center sm:text-center gap-1.5">
+                            <DialogTitle className="text-2xl font-bold text-slate-800 tracking-normal">
                                 {draft.state === 'active'
                                     ? t('admin.design.qsort.grid.locked_active')
                                     : draft.state === 'paused'
                                       ? t('admin.design.qsort.grid.locked_paused')
                                       : t('admin.design.qsort.grid.locked_closed')}
-                            </h3>
+                            </DialogTitle>
                             {draft.state === 'active' && (
-                                <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                                    <Button
-                                        variant="default"
-                                        disabled={api.isSwitchingToDraft}
-                                        className="h-11 px-6 rounded-xl font-bold shadow-lg shadow-amber-200 bg-amber-500 hover:bg-amber-600 text-white"
-                                        onClick={api.handleSwitchToDraft}
-                                    >
-                                        {api.isSwitchingToDraft && (
-                                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                                        )}
-                                        {t(
-                                            'admin.study_status.state.switch_to_draft',
-                                            'Draft Mode'
-                                        )}
-                                    </Button>
-                                </div>
+                                <DialogDescription>
+                                    {t(
+                                        'admin.study_status.dialog.draft.desc',
+                                        'This will stop data collection but allow you to modify the study design. Existing data is preserved.'
+                                    )}
+                                </DialogDescription>
+                            )}
+                        </DialogHeader>
+                        <div className="flex flex-col sm:flex-row gap-3 justify-center mt-6">
+                            <Button
+                                variant="outline"
+                                className="h-11 px-6 rounded-xl font-bold"
+                                onClick={() => setIsLockNoticeDismissed(true)}
+                            >
+                                {t('admin.design.qsort.grid.view_read_only', 'View read-only')}
+                            </Button>
+                            {draft.state === 'active' && (
+                                <Button
+                                    variant="default"
+                                    disabled={api.isSwitchingToDraft}
+                                    className="h-11 px-6 rounded-xl font-bold shadow-lg shadow-amber-200 bg-amber-500 hover:bg-amber-600 text-white"
+                                    onClick={api.handleSwitchToDraft}
+                                >
+                                    {api.isSwitchingToDraft && (
+                                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                    )}
+                                    {t('admin.study_status.state.switch_to_draft', 'Draft Mode')}
+                                </Button>
                             )}
                         </div>
-                    </div>
-                )}
+                    </DialogContent>
+                </Dialog>
                 {/* Left Pane: Editor */}
                 <div className="flex-1 overflow-y-auto overflow-x-hidden bg-muted/30 p-4 sm:p-6 min-w-0">
                     {(() => {

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -136,6 +136,16 @@ const StudyDesignPage = () => {
 
     if (!draft) return <div>{t('common.errors.study_not_found.title')}</div>;
 
+    // Shared by the lock dialog and the persistent lock banner below it, so the
+    // researcher reads the same sentence whether the notice is still up or has
+    // been dismissed.
+    const lockNoticeTitle =
+        draft.state === 'active'
+            ? t('admin.design.qsort.grid.locked_active')
+            : draft.state === 'paused'
+              ? t('admin.design.qsort.grid.locked_paused')
+              : t('admin.design.qsort.grid.locked_closed');
+
     return (
         <div
             className="flex flex-col h-full animate-in fade-in duration-500 overflow-hidden max-w-full"
@@ -448,20 +458,25 @@ const StudyDesignPage = () => {
                         </div>
                         <DialogHeader className="items-center text-center sm:text-center gap-1.5">
                             <DialogTitle className="text-2xl font-bold text-slate-800 tracking-normal">
-                                {draft.state === 'active'
-                                    ? t('admin.design.qsort.grid.locked_active')
-                                    : draft.state === 'paused'
-                                      ? t('admin.design.qsort.grid.locked_paused')
-                                      : t('admin.design.qsort.grid.locked_closed')}
+                                {lockNoticeTitle}
                             </DialogTitle>
-                            {draft.state === 'active' && (
-                                <DialogDescription>
-                                    {t(
-                                        'admin.study_status.dialog.draft.desc',
-                                        'This will stop data collection but allow you to modify the study design. Existing data is preserved.'
-                                    )}
-                                </DialogDescription>
-                            )}
+                            {/*
+                             * Unconditional, and its own copy. Gating it on
+                             * `state === 'active'` left the paused and closed
+                             * dialogs with no accessible description at all;
+                             * and the string it borrowed —
+                             * `study_status.dialog.draft.desc` — was written for
+                             * the Draft-Mode *confirm* dialog, so as the
+                             * aria-describedby of a two-button dialog it
+                             * announced "this will stop data collection" just
+                             * before "View read-only".
+                             */}
+                            <DialogDescription>
+                                {t(
+                                    'admin.design.qsort.grid.locked_dialog_desc',
+                                    'Editing is locked while the study is in this state. Close this notice to read the configuration without changing it.'
+                                )}
+                            </DialogDescription>
                         </DialogHeader>
                         <div className="flex flex-col sm:flex-row gap-3 justify-center mt-6">
                             <Button
@@ -489,6 +504,56 @@ const StudyDesignPage = () => {
                 </Dialog>
                 {/* Left Pane: Editor */}
                 <div className="flex-1 overflow-y-auto overflow-x-hidden bg-muted/30 p-4 sm:p-6 min-w-0">
+                    {/*
+                     * Persistent lock banner — the unlock affordance has to
+                     * survive dismissal of the dialog above. `handleSwitchToDraft`
+                     * used to be reachable from exactly one place: inside that
+                     * dialog. A researcher who took the "View read-only" escape
+                     * to inspect an active study, then decided to edit it, found
+                     * every field disabled and no control anywhere on the page
+                     * to unlock them — recovery meant a page reload or a detour
+                     * to the study overview's status control, neither signposted.
+                     *
+                     * A banner rather than turning the toolbar status badge into
+                     * a control: the badge is `hidden md:flex`, so it would leave
+                     * narrow viewports with no escape at all, and it carries
+                     * role="status" — making it a button too would muddle both
+                     * semantics. The banner also keeps the *reason* the fields
+                     * are inert on screen, not just the way out.
+                     */}
+                    {api.isFullyReadOnly && isLockNoticeDismissed && (
+                        <div className="max-w-full lg:max-w-5xl mx-auto mb-4">
+                            <div
+                                data-testid="design-lock-banner"
+                                className="flex flex-wrap items-center gap-x-3 gap-y-2 px-3 py-2 rounded-md text-sm bg-amber-50 border border-amber-200 text-amber-900"
+                            >
+                                <Lock
+                                    className="h-4 w-4 flex-shrink-0 text-amber-700"
+                                    aria-hidden="true"
+                                />
+                                <span className="flex-1 min-w-0 font-medium">
+                                    {lockNoticeTitle}
+                                </span>
+                                {draft.state === 'active' && (
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        disabled={api.isSwitchingToDraft}
+                                        className="h-8 shrink-0 rounded-lg font-bold bg-white border-amber-300 text-amber-900 hover:bg-amber-100 hover:text-amber-900"
+                                        onClick={api.handleSwitchToDraft}
+                                    >
+                                        {api.isSwitchingToDraft && (
+                                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                        )}
+                                        {t(
+                                            'admin.study_status.state.switch_to_draft',
+                                            'Draft Mode'
+                                        )}
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+                    )}
                     {(() => {
                         // Banner: chrome locale ≠ language being edited.
                         // Researchers are editing one language while reading the


### PR DESCRIPTION
## Summary

Phase 3 of the remediation plan in `docs/superpowers/plans/2026-07-26-admin-ux-remediation.md`. **Stacked on [#324](https://github.com/jvastenaekels/qualis/pull/324) — merge that first.**

This phase set out to fix five accessibility defects. **Two of them did not exist.** Establishing that turned up twelve that did, none of which were in the original audit.

## Changes

**Confirmed and fixed:**

- **The design-lock overlay was a trap.** A plain `<div>` with no `role="dialog"`, no focus trap, no close button; Escape did nothing; its only action suspends live data collection. A researcher could not *read* their own study configuration while it was collecting. Now a Radix `Dialog` with a **"View read-only"** escape — verified to land on a genuinely non-editable page by tracing `readOnly`/`disabled` through all seven step editors, including the dnd-kit drag handles.
- **Dashboard cards were unreachable by keyboard** — `<div onClick>` beside a real `<button>` on the same screen. Now native buttons, with whole-card clicking preserved.
- **Heading hierarchy and the login form.** The visible "Sign in" was a `div` while the real `h1` was hidden; the submit button read "Continue"; the password placeholder mimicked a filled field; the dashboard outline skipped a level.
- **Contrast.** The concourse row Edit button was `text-slate-300` — **1.49:1** on white against a 4.5:1 threshold, plus a mobile variant at 2.56:1.
- **Twelve controls with no accessible name at all** (Task 3.6) — no `id`, no `htmlFor`, no `aria-label` — swept across `PostSortConfigEditor`, `QuestionBuilder` and `ConcourseDetailPage`.

**Retracted, and recorded as such in the plan:**

- The claim that concourse row actions produced ~108 invisible tab stops. A per-button `focus-visible:opacity-100` was already present. What shipped is additive: the whole cluster now reveals together, matching hover.
- The claim that the Access switches had no accessible name. `<button>` is a *labelable* element (WHATWG HTML §4.10.2), so `<Label htmlFor>` named them all along. What shipped is hardening, not a fix.

Both retractions came from implementers and reviewers checking the claim rather than obeying the brief.

## Checklist

- [ ] `make ci` passes locally — **frontend green (185 files / 1568 tests, biome + tsc clean); backend `pytest` fails on a local Postgres credential issue that reproduces identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — every assertion pairs a negative with a positive and was observed RED first, with RED reading "the accessible name does not resolve" rather than "the element is absent".
- [x] Translation keys added to all locales — new keys in all nine admin locales, register per the repo's own `frontend/scripts/i18n/glossaries/<code>.yaml`.
- [x] API client regenerated if backend schemas changed — not applicable.

## Two things the whole-branch review caught that no per-task review could

1. **The read-only escape stranded the researcher.** `handleSwitchToDraft` was called from exactly one place — inside the dialog — so dismissing it left the designer disabled with no unlock control on the page. Fixed with a persistent banner.
2. **Task 3.3 broke Task 3.5.** Putting card titles inside a `<button>` means WAI-ARIA §5.2.7 prunes them from the accessibility tree, so the heading promotion delivered nothing — and the test passed because `dom-testing-library` does not implement that rule. Fixed properly: headings moved outside the button, whole-card click preserved via a stretched `::after`.

## Known scope

The class is **eradicated in three files, not in the admin.** The review's own sweep found ~76 controls still unnamed — worst of all seven `TooltipTrigger`s per participant row on the Data table. That backlog, the surviving `text-slate-300` on interactive controls in eight files, and a **lint gate** to stop the class regrowing are all recorded as Task 6.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)