### PR TITLE
ci(a11y): gate accessible names, and run the axe spec that was never wired up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,11 @@ jobs:
         run: npm install -g jscpd && npm run lint:duplication
       - name: Dead Code (Knip)
         run: npm run lint:deadcode
+      - name: Accessible names & contrast (baseline ratchet)
+        # Biome's a11y rules only see intrinsic elements, so `<Button>` and
+        # `<TooltipTrigger>` escape every one of them. This gate holds the
+        # measured backlog (task 6.7a) and fails on any increase.
+        run: npm run lint:a11y
       - name: Security SCA (NPM Audit)
         # xlsx CVEs are accepted: SheetJS Community has no fix and Qualis only
         # WRITES XLSX (analysisXlsxExport.ts), never parses untrusted input.

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ check:
 	cd frontend && npm run type-check
 	cd frontend && npm run i18n-check
 	cd frontend && npm run check-interpolations
+	cd frontend && npm run lint:a11y
 
 test:
 	cd backend && uv run pytest tests/

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -44,7 +44,21 @@
             },
             "a11y": {
                 "recommended": true,
-                "useSemanticElements": "off"
+                "useSemanticElements": "off",
+                "noLabelWithoutControl": {
+                    "level": "error",
+                    "options": {
+                        "labelComponents": ["Label"],
+                        "inputComponents": [
+                            "Input",
+                            "Textarea",
+                            "Checkbox",
+                            "Switch",
+                            "RadioGroupItem",
+                            "SelectTrigger"
+                        ]
+                    }
+                }
             }
         }
     },

--- a/frontend/e2e/accessibility/public-pages.spec.ts
+++ b/frontend/e2e/accessibility/public-pages.spec.ts
@@ -1,7 +1,11 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test, type Page } from '@playwright/test';
 
-const PUBLIC_PAGE_RULES = [
+/**
+ * Structure and contrast. `color-contrast` computes real ratios, which is what the
+ * static gate (`npm run lint:a11y`) cannot do — it only bans one literal class.
+ */
+const STRUCTURE_RULES = [
     'color-contrast',
     'heading-order',
     'landmark-no-duplicate-main',
@@ -9,6 +13,33 @@ const PUBLIC_PAGE_RULES = [
     'page-has-heading-one',
     'region',
 ];
+
+/**
+ * Accessible names, computed from the rendered DOM.
+ *
+ * This is the half of the accessible-name problem no static checker reaches: axe sees
+ * through Radix `asChild`, resolves `<SelectValue>` to the text actually rendered,
+ * honours the `title` fallback, and respects `display:none` — so a name that only
+ * exists above the `sm` breakpoint fails here and nowhere else.
+ *
+ * Admin pages are not covered yet: they still carry the backlog measured by task 6.7a
+ * (see scripts/a11y-baseline.json). Extending these rules to the admin is task 6.7e,
+ * once 6.7b–d have cleared it.
+ */
+const NAME_RULES = [
+    'aria-command-name',
+    'aria-input-field-name',
+    'aria-toggle-field-name',
+    'button-name',
+    'image-alt',
+    'input-button-name',
+    'input-image-alt',
+    'label',
+    'link-name',
+    'select-name',
+];
+
+const PUBLIC_PAGE_RULES = [...STRUCTURE_RULES, ...NAME_RULES];
 
 async function expectNoPublicPageA11yViolations(page: Page) {
     const results = await new AxeBuilder({ page }).withRules(PUBLIC_PAGE_RULES).analyze();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
         "e2e:headed": "playwright test --headed",
         "e2e:debug": "playwright test --debug",
         "e2e:report": "playwright show-report",
-        "test:e2e:admin": "playwright test --project='Admin E2E' --project='Admin Config Tests' --project='Integration Tests'",
+        "test:e2e:admin": "playwright test --project='Admin E2E' --project='Admin Config Tests' --project='Integration Tests' --project='Accessibility Smoke'",
         "test:e2e:study": "playwright test --project='Study E2E' --project='Study Mobile'",
         "i18n-check": "python3 scripts/check_i18n.py",
         "check-interpolations": "python3 scripts/i18n/check_interpolations.py",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
         "check-interpolations": "python3 scripts/i18n/check_interpolations.py",
         "lint:duplication": "jscpd --config ../.jscpd.json",
         "lint:deadcode": "knip",
+        "lint:a11y": "node scripts/check-a11y-names.mjs",
         "lint:architecture": "depcruise src --include-only \"^src\" --config .dependency-cruiser.cjs",
         "visualize:deps": "madge --image graph.svg src",
         "check:api": "orval && biome check --fix src/api/generated.ts src/api/model && git diff --exit-code src/api/generated.ts src/api/model",

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,27 +1,161 @@
 {
     "unnamedControls": {
-        "src/components/admin/dashboard/InteractiveDataView.columns.tsx": 7,
-        "src/components/admin/dashboard/InteractiveDataView.tsx": 3,
-        "src/components/admin/designer/BrandingEditor.tsx": 4,
-        "src/components/admin/designer/ImageUploadInput.tsx": 1,
-        "src/components/admin/designer/InterfaceEditor.tsx": 2,
-        "src/components/admin/designer/IntroductionEditor.tsx": 1,
-        "src/components/admin/designer/PostSortConfigEditor.tsx": 2,
-        "src/components/admin/designer/ProcessStepEditor.tsx": 1,
-        "src/components/admin/designer/QSortEditor.tsx": 3,
-        "src/components/admin/designer/QuestionBuilder.tsx": 6,
-        "src/pages/admin/AccountSettingsPage.tsx": 1,
-        "src/pages/admin/ConcourseDetailPage.tsx": 9,
-        "src/pages/admin/ProjectMembersPage.tsx": 2
+        "src/components/admin/AudioPlayer.tsx": {
+            "Button#9eaa609dff": 1
+        },
+        "src/components/admin/dashboard/InteractiveDataView.columns.tsx": {
+            "TooltipTrigger#07b7bb5f30": 1,
+            "TooltipTrigger#64528336d1": 1,
+            "TooltipTrigger#66bd021c8d": 1,
+            "TooltipTrigger#991c394724": 1,
+            "TooltipTrigger#d1a4ff6af5": 1,
+            "TooltipTrigger#ef4eaf74a9": 1,
+            "TooltipTrigger#f738eb0490": 1
+        },
+        "src/components/admin/dashboard/InteractiveDataView.tsx": {
+            "Button#0bacf4658c": 1,
+            "Button#e38e166000": 1,
+            "Button#f08923f571": 1
+        },
+        "src/components/admin/designer/BrandingEditor.tsx": {
+            "button#aa40493fca": 1,
+            "button#acb2a0d0e8": 1,
+            "TooltipTrigger#ee8b70d151": 3
+        },
+        "src/components/admin/designer/ImageUploadInput.tsx": {
+            "button#c142fb7ba6": 1
+        },
+        "src/components/admin/designer/InterfaceEditor.tsx": {
+            "Button#5a9712977a": 1,
+            "TooltipTrigger#ee8b70d151": 1
+        },
+        "src/components/admin/designer/PostSortConfigEditor.tsx": {
+            "button#c142fb7ba6": 1
+        },
+        "src/components/admin/designer/ProcessStepEditor.tsx": {
+            "Button#81017c5def": 1
+        },
+        "src/components/admin/designer/QSortEditor.tsx": {
+            "Button#afbf633168": 1,
+            "Button#b1a1a82138": 1,
+            "Button#e81d9b56d8": 1
+        },
+        "src/components/admin/designer/QuestionBuilder.tsx": {
+            "Button#81017c5def": 2,
+            "Button#83b5f464b1": 1,
+            "SelectTrigger#872cdad358": 2
+        },
+        "src/pages/admin/AccountSettingsPage.tsx": {
+            "button#3ddd1d5369": 1
+        },
+        "src/pages/admin/ConcourseDetailPage.tsx": {
+            "Button#1dd7a5d308": 1,
+            "Button#81017c5def": 1,
+            "Button#a1f3efb8f5": 1,
+            "SelectTrigger#872cdad358": 4,
+            "SelectTrigger#bb89cca4e9": 1
+        },
+        "src/pages/admin/ProjectMembersPage.tsx": {
+            "Button#d8507040f1": 1,
+            "SelectTrigger#872cdad358": 2
+        }
     },
     "lowContrastControls": {
-        "src/components/admin/analysis/AnalysisHistoryPanel.tsx": 1,
-        "src/components/admin/dashboard/InteractiveDataView.columns.tsx": 4,
-        "src/components/admin/designer/BrandingEditor.tsx": 1,
-        "src/components/admin/designer/InterfaceEditor.tsx": 1,
-        "src/components/admin/designer/ProcessStepEditor.tsx": 1,
-        "src/components/admin/designer/QSortEditor.tsx": 1,
-        "src/components/admin/designer/QuestionBuilder.tsx": 3,
-        "src/layouts/StudyLayout.tsx": 1
+        "src/components/admin/analysis/AnalysisHistoryPanel.tsx": {
+            "button#74bf5e335c": 1
+        },
+        "src/components/admin/dashboard/InteractiveDataView.columns.tsx": {
+            "Button#2af1b92949": 1,
+            "Button#51bc640990": 1,
+            "Button#7d4243c19a": 1,
+            "Button#ff3d58c3b9": 1
+        },
+        "src/components/admin/designer/BrandingEditor.tsx": {
+            "button#acb2a0d0e8": 1
+        },
+        "src/components/admin/designer/InterfaceEditor.tsx": {
+            "Button#5a9712977a": 1
+        },
+        "src/components/admin/designer/ProcessStepEditor.tsx": {
+            "Button#81017c5def": 1
+        },
+        "src/components/admin/designer/QSortEditor.tsx": {
+            "Button#cfd0f92c60": 1
+        },
+        "src/components/admin/designer/QuestionBuilder.tsx": {
+            "Button#81017c5def": 2,
+            "DropdownMenuTrigger#f0edeb0f8a": 1
+        },
+        "src/layouts/StudyLayout.tsx": {
+            "button#543c37a641": 1
+        }
+    },
+    "suppressedLabelErrors": {
+        "src/components/admin/designer/BrandingEditor.tsx": {
+            "Label#fc7744f7ff": 1
+        },
+        "src/components/admin/designer/ImportFromConcourseDialog.tsx": {
+            "Label#2851b69212": 1
+        },
+        "src/components/admin/designer/InterfaceEditor.tsx": {
+            "Label#82b1d76fc7": 1,
+            "Label#941606f737": 1,
+            "Label#fe9364a7a7": 1
+        },
+        "src/components/admin/designer/IntroductionEditor.tsx": {
+            "Label#02e66bf1f6": 1,
+            "Label#2081ca5d80": 1,
+            "Label#7ab5d8c56c": 1,
+            "Label#e4bc2d1838": 1
+        },
+        "src/components/admin/designer/PostSortConfigEditor.tsx": {
+            "Label#13a6b7e74a": 1
+        },
+        "src/components/admin/designer/ProcessStepEditor.tsx": {
+            "Label#0af60f23ef": 1,
+            "Label#0c96a77f87": 1,
+            "Label#8d66a2a9af": 1,
+            "Label#b6d369de71": 1
+        },
+        "src/components/admin/designer/QSortEditor.tsx": {
+            "Label#357faf6410": 1
+        },
+        "src/components/admin/designer/QuestionBuilder.tsx": {
+            "Label#55a33a00e6": 1,
+            "Label#5bbd85ed1f": 1,
+            "Label#929f555fc8": 1,
+            "Label#98da6c948b": 1,
+            "Label#b1230a6e26": 1,
+            "Label#b24dbd75d7": 1,
+            "Label#b70312b797": 1,
+            "Label#eb3e025ad6": 1,
+            "Label#ff10c47a50": 1
+        },
+        "src/components/admin/ImportStudyDialog.tsx": {
+            "Label#27fb62ced8": 1,
+            "Label#8ef1b3adb6": 1
+        },
+        "src/components/postsort/Step1_Feedback.tsx": {
+            "Label#202c7721b8": 1,
+            "Label#8eaf4a8179": 1
+        },
+        "src/pages/admin/ConcourseDetailPage.tsx": {
+            "Label#03f1e6a441": 1,
+            "Label#0612b2c469": 1,
+            "Label#5015a98ae6": 1,
+            "Label#b8819b4553": 1,
+            "Label#bac85b7720": 1,
+            "Label#dd23d8021a": 1,
+            "Label#e4d9b72f77": 1,
+            "Label#efa4e00bc8": 1
+        },
+        "src/pages/admin/ProjectMembersPage.tsx": {
+            "Label#302a87c2cf": 1,
+            "Label#9eade0b790": 1
+        },
+        "src/pages/admin/RecruitmentPage.tsx": {
+            "Label#5e73029fe1": 1,
+            "Label#9e6b67bc74": 1
+        }
     }
 }

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,0 +1,27 @@
+{
+    "unnamedControls": {
+        "src/components/admin/dashboard/InteractiveDataView.columns.tsx": 7,
+        "src/components/admin/dashboard/InteractiveDataView.tsx": 3,
+        "src/components/admin/designer/BrandingEditor.tsx": 4,
+        "src/components/admin/designer/ImageUploadInput.tsx": 1,
+        "src/components/admin/designer/InterfaceEditor.tsx": 2,
+        "src/components/admin/designer/IntroductionEditor.tsx": 1,
+        "src/components/admin/designer/PostSortConfigEditor.tsx": 2,
+        "src/components/admin/designer/ProcessStepEditor.tsx": 1,
+        "src/components/admin/designer/QSortEditor.tsx": 3,
+        "src/components/admin/designer/QuestionBuilder.tsx": 6,
+        "src/pages/admin/AccountSettingsPage.tsx": 1,
+        "src/pages/admin/ConcourseDetailPage.tsx": 9,
+        "src/pages/admin/ProjectMembersPage.tsx": 2
+    },
+    "lowContrastControls": {
+        "src/components/admin/analysis/AnalysisHistoryPanel.tsx": 1,
+        "src/components/admin/dashboard/InteractiveDataView.columns.tsx": 4,
+        "src/components/admin/designer/BrandingEditor.tsx": 1,
+        "src/components/admin/designer/InterfaceEditor.tsx": 1,
+        "src/components/admin/designer/ProcessStepEditor.tsx": 1,
+        "src/components/admin/designer/QSortEditor.tsx": 1,
+        "src/components/admin/designer/QuestionBuilder.tsx": 3,
+        "src/layouts/StudyLayout.tsx": 1
+    }
+}

--- a/frontend/scripts/check-a11y-names.mjs
+++ b/frontend/scripts/check-a11y-names.mjs
@@ -1,31 +1,38 @@
 #!/usr/bin/env node
 /**
- * check-a11y-names — a regression gate for two accessibility defects that Biome
- * cannot express.
+ * check-a11y-names — a regression gate for the accessibility defects that Biome
+ * cannot express, plus a guard on the Biome configuration that expresses the rest.
  *
  * Why this exists (task 6.7a, 2026-07-27):
  *
- *   1. Biome's a11y rules only reason about *intrinsic* JSX elements. `useButtonType`
- *      fires on `<button>`, never on `<Button>`; nothing at all fires on
- *      `<TooltipTrigger>`. Qualis writes almost every control as a component, so
- *      37 of Biome's 39 a11y rules were already on at `error` and the codebase was
- *      green while ~49 interactive controls had no accessible name.
- *   2. No linter knows that `text-slate-300` is 1.45:1 on white. Contrast on
- *      interactive controls is invisible to static analysis unless someone names
- *      the class.
+ *   1. Biome 2.5.5 has no accessible-name rule at all — not even for intrinsic
+ *      `<button>` — and only three of its 39 a11y rules accept any component
+ *      mapping. Qualis writes almost every control as a component, so `<Button>`
+ *      and `<TooltipTrigger>` escape the entire rule set. No configuration covers
+ *      this; it needs its own checker.
+ *   2. No linter knows that `text-slate-300` is 1.45:1 on white.
+ *   3. `biome-ignore-all` suppressions are prose: nothing fails when the backlog
+ *      they cover is cleared, and while they stand the rule is off for the whole
+ *      file. This checker re-lints those files with the suppressions stripped, so
+ *      they are never blind and the suppressions become self-removing.
+ *   4. A `//` comment in biome.json makes Biome discard the entire config with no
+ *      diagnostic naming the file and lint on defaults. This checker parses the
+ *      config as strict JSON and asserts the rule that matters is still armed.
  *
- * Mechanism: parse every non-test .tsx with the TypeScript compiler API, count the
- * two defects per file, and compare against a committed baseline. Any increase, or
- * any occurrence in a file that is not in the baseline, fails. A decrease also fails,
- * with instructions to re-baseline — that is what makes the number ratchet down and
- * stay honest.
+ * Findings are keyed by a structural fingerprint (tag + attribute names + descendant
+ * tags), not by a per-file count, so a fix and a fresh regression in the same file
+ * cannot cancel each other out, and not by line number, so unrelated edits above a
+ * control do not spuriously fail.
  *
- *   npm run lint:a11y            check against the baseline
+ *   npm run lint:a11y             check against the baseline
  *   npm run lint:a11y -- --update rewrite the baseline from the current tree
  *   npm run lint:a11y -- --list   print every finding with file:line
  */
 
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
@@ -34,11 +41,19 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const FRONTEND_DIR = path.resolve(SCRIPT_DIR, '..');
 const SRC_DIR = path.join(FRONTEND_DIR, 'src');
 const BASELINE_PATH = path.join(SCRIPT_DIR, 'a11y-baseline.json');
+const BIOME_CONFIG_PATH = path.join(FRONTEND_DIR, 'biome.json');
+const BIOME_BIN = path.join(FRONTEND_DIR, 'node_modules', '.bin', 'biome');
+
+const LABEL_RULE = 'lint/a11y/noLabelWithoutControl';
+const SUPPRESSION_MARKER = `biome-ignore-all ${LABEL_RULE}`;
 
 /**
- * Components and intrinsic elements that render a focusable control which the
+ * Components and intrinsic elements that render a focusable control the
  * accessible-name computation applies to. Radix `*Trigger` components render a real
  * `<button>` unless `asChild` hands rendering to their child.
+ *
+ * Known limitation: this is a hand-maintained allowlist. An aliased import
+ * (`import { Button as Btn }`) or a new local wrapper is invisible to it.
  */
 const NAME_BEARING = new Set([
     'a',
@@ -66,17 +81,9 @@ const CONTRAST_BEARING = new Set([...NAME_BEARING, 'Input', 'Textarea', 'Checkbo
 /** 1.45:1 against white — fails WCAG 1.4.3 (4.5:1) and 1.4.11 (3:1) outright. */
 const LOW_CONTRAST_CLASS = 'text-slate-300';
 
-function collectSourceFiles(dir, acc = []) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        const full = path.join(dir, entry.name);
-        if (entry.isDirectory()) {
-            collectSourceFiles(full, acc);
-        } else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.')) {
-            acc.push(full);
-        }
-    }
-    return acc;
-}
+/* -------------------------------------------------------------------------- */
+/* AST helpers                                                                 */
+/* -------------------------------------------------------------------------- */
 
 function openingElementOf(node) {
     return ts.isJsxElement(node) ? node.openingElement : node;
@@ -99,91 +106,250 @@ function attributesOf(node, sourceFile) {
     return { map, hasSpread };
 }
 
-/** Matches a `t(...)` call or any quoted string of two or more characters. */
-const LOOKS_LIKE_TEXT = /\bt\s*\(|['"`][^'"`]{2,}['"`]/;
+function jsxChildrenOf(node) {
+    return ts.isJsxElement(node) ? node.children : [];
+}
+
+/** `t('key', 'Fallback')`, `i18n.t(…)` — anything whose callee is named `t`. */
+function isTranslationCall(node) {
+    if (!ts.isCallExpression(node)) return false;
+    const callee = node.expression;
+    if (ts.isIdentifier(callee)) return callee.text === 't';
+    if (ts.isPropertyAccessExpression(callee)) return callee.name.text === 't';
+    return false;
+}
+
+function isTextLiteral(node) {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+        return node.text.trim().length > 0;
+    }
+    if (ts.isTemplateExpression(node)) {
+        return (
+            node.head.text.trim().length > 0 ||
+            node.templateSpans.some((span) => span.literal.text.trim().length > 0)
+        );
+    }
+    return false;
+}
 
 /**
- * Walk an element's rendered subtree looking for anything that would contribute to
- * its accessible name: literal JSX text, a translated string, or a visually hidden
- * `sr-only` label. Also reports whether any child is a dynamic expression whose text
- * content cannot be decided statically.
+ * Does this attribute carry user-visible text? `placeholder={t('…')}` on a
+ * `<SelectValue>` renders inside its trigger and names it; `className="h-4 w-4"`
+ * does not name anything.
+ */
+function attributeYieldsText(attribute) {
+    const initializer = attribute?.initializer;
+    if (!initializer) return false;
+    if (ts.isStringLiteral(initializer)) return initializer.text.trim().length > 0;
+    if (ts.isJsxExpression(initializer) && initializer.expression) {
+        let text = false;
+        const walk = (node) => {
+            if (text) return;
+            if (isTranslationCall(node) || isTextLiteral(node)) {
+                text = true;
+                return;
+            }
+            node.forEachChild(walk);
+        };
+        walk(initializer.expression);
+        return text;
+    }
+    return false;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Accessible-name inspection                                                  */
+/* -------------------------------------------------------------------------- */
+
+/** Expression forms that render nothing at all. */
+const RENDERS_NOTHING = new Set([
+    ts.SyntaxKind.NullKeyword,
+    ts.SyntaxKind.TrueKeyword,
+    ts.SyntaxKind.FalseKeyword,
+    ts.SyntaxKind.NumericLiteral,
+]);
+
+/**
+ * Props an icon component may carry. A self-closing element limited to these renders
+ * a glyph and contributes no text; anything else may render words, so it is treated
+ * as opaque rather than assumed silent.
+ */
+const ICON_ONLY_PROPS = new Set([
+    'className',
+    'size',
+    'strokeWidth',
+    'style',
+    'key',
+    'color',
+    'fill',
+    'aria-hidden',
+]);
+
+function isIconElement(node, sourceFile) {
+    if (!ts.isJsxSelfClosingElement(node)) return false;
+    const { map, hasSpread } = attributesOf(node, sourceFile);
+    if (hasSpread) return false;
+    return [...map.keys()].every((name) => ICON_ONLY_PROPS.has(name));
+}
+
+/**
+ * Walk an element's rendered subtree for anything that contributes to its accessible
+ * name. JSX *attributes* are never treated as text unless they are one of the
+ * naming attributes below — that is what stops `className="h-4 w-4"` from making
+ * `{cond ? <Trash2 className="h-4 w-4"/> : null}` look like a named control.
  */
 function inspectChildren(node, sourceFile) {
-    const found = { literalText: false, translatedText: false, srOnly: false, dynamic: false };
+    const found = { literalText: false, translatedText: false, namedChild: false, dynamic: false };
 
-    const visitJsxNode = (jsxNode) => {
-        const { map } = attributesOf(jsxNode, sourceFile);
+    const visitElement = (element) => {
+        const { map } = attributesOf(element, sourceFile);
         const className = map.get('className');
         if (className && /sr-only/.test(className.getText(sourceFile))) {
-            found.srOnly = true;
+            found.namedChild = true;
         }
-        // An `<img alt="…">` inside a link or button names the control.
-        if (map.has('alt') || map.has('aria-label')) {
-            found.srOnly = true;
-        }
-        if (ts.isJsxElement(jsxNode)) {
-            visitChildren(jsxNode);
-        }
+        // `<img alt="…">` names its link; `aria-label` on a child is exposed when the
+        // child is the only content; `<SelectValue placeholder={t(…)}>` renders inside
+        // its trigger.
+        if (map.has('alt') || map.has('aria-label')) found.namedChild = true;
+        if (attributeYieldsText(map.get('placeholder'))) found.namedChild = true;
+        visitChildren(element);
     };
 
-    const visitExpression = (expression) => {
+    /**
+     * Walks an expression's *value* positions, never its JSX attributes and never a
+     * condition. `{busy ? <Trash2 className="h-4 w-4"/> : null}` renders an icon or
+     * nothing — that is decidable, and it is decidably nameless. `{label}` is not:
+     * an identifier may hold a string, so it sets `opaque` and the control is left
+     * alone.
+     */
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: a dispatch over JSX/conditional/logical/literal expression forms; splitting it would hide the shape of the grammar it walks
+    const visitExpression = (expression, sub) => {
         if (ts.isJsxElement(expression) || ts.isJsxSelfClosingElement(expression)) {
-            visitJsxNode(expression);
+            visitElement(expression);
+            if (!isIconElement(expression, sourceFile)) sub.opaque = true;
             return;
         }
-        expression.forEachChild(visitExpression);
-    };
-
-    const visitJsxExpressionChild = (child) => {
-        const expression = child.expression;
-        if (!expression) return;
-        if (LOOKS_LIKE_TEXT.test(expression.getText(sourceFile))) {
-            found.translatedText = true;
-        } else {
-            found.dynamic = true;
+        if (isTranslationCall(expression) || isTextLiteral(expression)) {
+            sub.text = true;
+            return;
         }
-        visitExpression(expression);
+        if (ts.isParenthesizedExpression(expression)) {
+            visitExpression(expression.expression, sub);
+            return;
+        }
+        if (ts.isConditionalExpression(expression)) {
+            visitExpression(expression.whenTrue, sub);
+            visitExpression(expression.whenFalse, sub);
+            return;
+        }
+        if (ts.isBinaryExpression(expression)) {
+            // `cond && <Icon/>` renders only the right-hand side.
+            const kind = expression.operatorToken.kind;
+            if (kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+                visitExpression(expression.right, sub);
+                return;
+            }
+            visitExpression(expression.left, sub);
+            visitExpression(expression.right, sub);
+            return;
+        }
+        if (RENDERS_NOTHING.has(expression.kind)) return;
+        // Identifier, call, property access, template with holes…: could be text.
+        sub.opaque = true;
     };
 
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: three JSX child kinds, each with its own naming rule; the branching IS the specification
     function visitChildren(parent) {
-        for (const child of parent.children ?? []) {
-            if (ts.isJsxText(child) && child.getText(sourceFile).trim()) {
-                found.literalText = true;
+        for (const child of jsxChildrenOf(parent)) {
+            if (ts.isJsxText(child)) {
+                if (child.getText(sourceFile).trim()) found.literalText = true;
             } else if (ts.isJsxExpression(child)) {
-                visitJsxExpressionChild(child);
+                if (!child.expression) continue;
+                const sub = { text: false, opaque: false };
+                visitExpression(child.expression, sub);
+                if (sub.text) found.translatedText = true;
+                else if (sub.opaque) found.dynamic = true;
             } else if (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child)) {
-                visitJsxNode(child);
+                visitElement(child);
             }
         }
     }
 
-    if (ts.isJsxElement(node)) {
-        visitChildren(node);
-    }
+    visitChildren(node);
     return found;
 }
 
 /**
- * A control counts as unnamed when nothing in the accessible-name computation can
- * reach it: no `aria-label`/`aria-labelledby`, no `title` fallback, no `sr-only`
- * text, no literal or translated child text, and rendering is not delegated with
- * `asChild`. Elements whose only children are dynamic expressions, that spread
- * unknown props, or that carry an `id` (so an external `<Label htmlFor>` may name
- * them — Biome's `noLabelWithoutControl` guards that side) are treated as named:
- * the checker never guesses, so its count is a floor, not a ceiling.
+ * Every `htmlFor`/`for` target declared by a label-ish element in this file, keyed by
+ * the *source text* of the value so `htmlFor={fieldId}` matches `id={fieldId}`.
+ *
+ * This is what stops the gate certifying its own defeat: task 6.7b's mechanism is
+ * "add an id", so an `id` may only silence a finding when a label actually points at
+ * it.
  */
-function isUnnamed(node, sourceFile) {
+function collectLabelTargets(sourceFile) {
+    const targets = new Set();
+    const visit = (node) => {
+        if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+            const tag = tagNameOf(node, sourceFile);
+            if (/(^|\.)([Ll]abel)$/.test(tag)) {
+                const { map } = attributesOf(node, sourceFile);
+                const target = map.get('htmlFor') ?? map.get('for');
+                const initializer = target?.initializer;
+                if (initializer) {
+                    targets.add(
+                        initializer
+                            .getText(sourceFile)
+                            .replace(/^["'{]|["'}]$/g, '')
+                            .trim()
+                    );
+                }
+            }
+        }
+        node.forEachChild(visit);
+    };
+    visit(sourceFile);
+    return targets;
+}
+
+/**
+ * A control counts as unnamed when nothing in the accessible-name computation can
+ * reach it. Escape hatches, each deliberate and each documented:
+ *
+ *   asChild        rendering is delegated; the child is judged instead
+ *   aria-label*    an explicit name
+ *   title          accname's last-resort fallback (weak, but conformant)
+ *   id             ONLY when a label in the same file points at it
+ *   {...props}     the name may arrive from the caller; undecidable
+ *   dynamic child  the name is computed at runtime; undecidable
+ *
+ * The checker never guesses, so its count is a floor, not a ceiling.
+ */
+function isUnnamed(node, sourceFile, labelTargets) {
     const { map, hasSpread } = attributesOf(node, sourceFile);
     if (map.has('asChild')) return false;
     if (map.has('aria-label') || map.has('aria-labelledby')) return false;
     if (map.has('title')) return false;
-    if (map.has('id')) return false;
     if (hasSpread) return false;
+
+    const id = map.get('id');
+    if (id?.initializer) {
+        const key = id.initializer
+            .getText(sourceFile)
+            .replace(/^["'{]|["'}]$/g, '')
+            .trim();
+        if (labelTargets.has(key)) return false;
+    }
+
     const children = inspectChildren(node, sourceFile);
-    if (children.literalText || children.translatedText || children.srOnly) return false;
+    if (children.literalText || children.translatedText || children.namedChild) return false;
     if (children.dynamic) return false;
     return true;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Contrast inspection                                                         */
+/* -------------------------------------------------------------------------- */
 
 function classNameIsLowContrast(node, sourceFile) {
     const { map } = attributesOf(node, sourceFile);
@@ -220,97 +386,405 @@ function hasLowContrastClass(node, sourceFile) {
     return found;
 }
 
-function scan() {
+/* -------------------------------------------------------------------------- */
+/* Fingerprinting                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A structural identity that survives reformatting and line moves but changes when
+ * the control itself changes. Adding `aria-label` to a control retires its old
+ * fingerprint AND a new unnamed control introduces an unknown one, so a fix and a
+ * regression in the same file are both reported instead of cancelling out.
+ */
+export function fingerprintOf(node, sourceFile) {
+    const { map, hasSpread } = attributesOf(node, sourceFile);
+    const attributeNames = [...map.keys()].sort();
+    if (hasSpread) attributeNames.push('...');
+
+    const descendants = [];
+    // Translation keys are the strongest discriminator available: they survive
+    // restyling and rewording, and they are what makes two `<Label className="…">`
+    // elements in the same file distinguishable at all.
+    const translationKeys = [];
+    const visit = (child) => {
+        if (
+            descendants.length < 12 &&
+            (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child))
+        ) {
+            descendants.push(tagNameOf(child, sourceFile));
+        }
+        if (translationKeys.length < 4 && isTranslationCall(child)) {
+            const [first] = child.arguments;
+            // Keys are often template literals (`admin.design.interface.nav.${tipKey}`),
+            // so take the raw source rather than only plain string literals.
+            if (first) translationKeys.push(first.getText(sourceFile));
+        }
+        child.forEachChild(visit);
+    };
+    node.forEachChild(visit);
+
+    const material = [
+        tagNameOf(node, sourceFile),
+        attributeNames.join(','),
+        descendants.join('>'),
+        translationKeys.join(','),
+    ].join('|');
+    return crypto.createHash('sha1').update(material).digest('hex').slice(0, 10);
+}
+
+function keyOf(finding) {
+    return `${finding.tag}#${finding.fingerprint}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Source analysis                                                             */
+/* -------------------------------------------------------------------------- */
+
+/** Exported for scripts/check-a11y-names.test.mjs. */
+export function analyzeSource(fileName, sourceText) {
+    const sourceFile = ts.createSourceFile(
+        fileName,
+        sourceText,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TSX
+    );
+    const labelTargets = collectLabelTargets(sourceFile);
     const unnamed = [];
     const lowContrast = [];
 
-    for (const filePath of collectSourceFiles(SRC_DIR)) {
-        const relative = path.relative(FRONTEND_DIR, filePath).split(path.sep).join('/');
-        const sourceFile = ts.createSourceFile(
-            filePath,
-            fs.readFileSync(filePath, 'utf8'),
-            ts.ScriptTarget.Latest,
-            true,
-            ts.ScriptKind.TSX
-        );
-
-        // `insideCountedControl` stops a wrapper/child pair such as
-        // `<DropdownMenuTrigger asChild><Button …>` counting the same visual control twice.
-        const visit = (node, insideCountedControl) => {
-            let counted = insideCountedControl;
-            if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
-                const tag = tagNameOf(node, sourceFile);
-                const line =
-                    sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
-                if (NAME_BEARING.has(tag) && isUnnamed(node, sourceFile)) {
-                    unnamed.push({ file: relative, line, tag });
-                }
-                if (
-                    !insideCountedControl &&
-                    CONTRAST_BEARING.has(tag) &&
-                    hasLowContrastClass(node, sourceFile)
-                ) {
-                    lowContrast.push({ file: relative, line, tag });
-                    counted = true;
-                }
+    // `insideCountedControl` stops a wrapper/child pair such as
+    // `<DropdownMenuTrigger asChild><Button …>` counting the same visual control twice.
+    const visit = (node, insideCountedControl) => {
+        let counted = insideCountedControl;
+        if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+            const tag = tagNameOf(node, sourceFile);
+            const line =
+                sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+            if (NAME_BEARING.has(tag) && isUnnamed(node, sourceFile, labelTargets)) {
+                unnamed.push({ line, tag, fingerprint: fingerprintOf(node, sourceFile) });
             }
-            node.forEachChild((child) => visit(child, counted));
-        };
-        visit(sourceFile, false);
-    }
+            if (
+                !insideCountedControl &&
+                CONTRAST_BEARING.has(tag) &&
+                hasLowContrastClass(node, sourceFile)
+            ) {
+                lowContrast.push({ line, tag, fingerprint: fingerprintOf(node, sourceFile) });
+                counted = true;
+            }
+        }
+        node.forEachChild((child) => visit(child, counted));
+    };
+    visit(sourceFile, false);
 
     return { unnamed, lowContrast };
 }
 
-function countByFile(findings) {
-    const counts = {};
-    for (const finding of findings) {
-        counts[finding.file] = (counts[finding.file] ?? 0) + 1;
+function collectSourceFiles(dir, acc = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) collectSourceFiles(full, acc);
+        else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.')) acc.push(full);
     }
-    return Object.fromEntries(Object.entries(counts).sort(([a], [b]) => a.localeCompare(b)));
+    return acc;
+}
+
+function relativeToFrontend(filePath) {
+    return path.relative(FRONTEND_DIR, filePath).split(path.sep).join('/');
+}
+
+function scanTree() {
+    const unnamed = [];
+    const lowContrast = [];
+    for (const filePath of collectSourceFiles(SRC_DIR)) {
+        const file = relativeToFrontend(filePath);
+        const result = analyzeSource(filePath, fs.readFileSync(filePath, 'utf8'));
+        for (const finding of result.unnamed) unnamed.push({ file, ...finding });
+        for (const finding of result.lowContrast) lowContrast.push({ file, ...finding });
+    }
+    return { unnamed, lowContrast };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Biome config guard + suppressed-file re-lint                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A `//` comment in biome.json makes Biome 2.5.5 discard the whole config silently
+ * and lint on defaults. Parse it strictly and assert the rule is still armed the way
+ * this gate assumes.
+ */
+function readBiomeConfig() {
+    const raw = fs.readFileSync(BIOME_CONFIG_PATH, 'utf8');
+    let config;
+    try {
+        config = JSON.parse(raw);
+    } catch (error) {
+        throw new Error(
+            `${relativeToFrontend(BIOME_CONFIG_PATH)} is not strict JSON (${error.message}).\n` +
+                'Biome 2.5.5 discards a malformed config with no diagnostic naming the file and\n' +
+                'lints on its defaults instead — comments are NOT supported here.'
+        );
+    }
+    const rule = config?.linter?.rules?.a11y?.noLabelWithoutControl;
+    if (rule?.level !== 'error') {
+        throw new Error(
+            `${relativeToFrontend(BIOME_CONFIG_PATH)}: a11y.noLabelWithoutControl must be "error".`
+        );
+    }
+    if (!rule?.options?.labelComponents?.includes('Label')) {
+        throw new Error(
+            `${relativeToFrontend(BIOME_CONFIG_PATH)}: ` +
+                'a11y.noLabelWithoutControl needs options.labelComponents to include "Label" — ' +
+                'without it the rule matches nothing in this codebase.'
+        );
+    }
+    return config;
+}
+
+function suppressedFiles() {
+    return collectSourceFiles(SRC_DIR).filter((filePath) =>
+        fs.readFileSync(filePath, 'utf8').includes(SUPPRESSION_MARKER)
+    );
+}
+
+/**
+ * Re-lint the files that carry a `biome-ignore-all` for the label rule, with the
+ * suppression removed. Without this the rule is simply off in the four largest admin
+ * files, and nothing fails when the backlog they cover is finally cleared.
+ *
+ * The suppression line is blanked rather than deleted so Biome's line numbers stay
+ * aligned with the real file and each diagnostic can be fingerprinted.
+ */
+function lintSuppressedFiles(biomeConfig) {
+    const files = suppressedFiles();
+    if (files.length === 0) return { findings: [], stale: [] };
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qualis-a11y-'));
+    try {
+        fs.writeFileSync(
+            path.join(tempDir, 'biome.json'),
+            JSON.stringify({
+                $schema: biomeConfig.$schema,
+                vcs: { enabled: false },
+                formatter: { enabled: false },
+                assist: { enabled: false },
+                linter: {
+                    enabled: true,
+                    rules: {
+                        preset: 'none',
+                        a11y: {
+                            preset: 'none',
+                            // Copied verbatim so this pass can never drift from the real rule.
+                            noLabelWithoutControl:
+                                biomeConfig.linter.rules.a11y.noLabelWithoutControl,
+                        },
+                    },
+                },
+            })
+        );
+
+        const originalOf = new Map();
+        for (const filePath of files) {
+            const relative = relativeToFrontend(filePath);
+            const destination = path.join(tempDir, relative);
+            fs.mkdirSync(path.dirname(destination), { recursive: true });
+            const stripped = fs
+                .readFileSync(filePath, 'utf8')
+                .split('\n')
+                .map((line) => (line.includes(SUPPRESSION_MARKER) ? '' : line))
+                .join('\n');
+            fs.writeFileSync(destination, stripped);
+            originalOf.set(destination, relative);
+        }
+
+        // The JSON reporter omits diagnostic spans, so positions come from the default
+        // reporter's `path:line:col <category>` header, which Biome writes to stderr.
+        const args = [
+            'lint',
+            `--config-path=${tempDir}`,
+            '--colors=off',
+            '--max-diagnostics=1000',
+            tempDir,
+        ];
+        const options = { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], cwd: tempDir };
+        let output = '';
+        try {
+            output = execFileSync(BIOME_BIN, args, options);
+        } catch (error) {
+            // Biome exits 1 when it emits errors; that is the expected path here.
+            output = `${error.stdout ?? ''}\n${error.stderr ?? ''}`;
+            if (!output.trim()) throw error;
+        }
+
+        const header = new RegExp(`^(\\S+):(\\d+):\\d+ ${LABEL_RULE} `, 'gm');
+        const findings = [];
+        const seen = new Set();
+        const astCache = new Map();
+        for (const match of output.matchAll(header)) {
+            const absolute = path.resolve(tempDir, match[1]);
+            const relative = originalOf.get(absolute);
+            if (!relative) continue;
+            const line = Number(match[2]);
+            // stdout and stderr both carry the report; count each diagnostic once.
+            const dedupe = `${relative}:${line}`;
+            if (seen.has(dedupe)) continue;
+            seen.add(dedupe);
+            findings.push({ file: relative, line, ...labelIdentity(relative, line, astCache) });
+        }
+
+        // A suppression that no longer suppresses anything is dead weight that also keeps
+        // the rule off for the whole file. Make clearing the backlog delete its own licence.
+        const stale = files
+            .map(relativeToFrontend)
+            .filter((relative) => !findings.some((finding) => finding.file === relative));
+        return { findings, stale };
+    } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
+/** Fingerprint the `<Label>` Biome flagged, so the label backlog is keyed like the rest. */
+function labelIdentity(relative, line, astCache) {
+    if (line === 0) return { tag: 'Label', fingerprint: 'unlocated' };
+    if (!astCache.has(relative)) {
+        const absolute = path.join(FRONTEND_DIR, relative);
+        astCache.set(
+            relative,
+            ts.createSourceFile(
+                absolute,
+                fs.readFileSync(absolute, 'utf8'),
+                ts.ScriptTarget.Latest,
+                true,
+                ts.ScriptKind.TSX
+            )
+        );
+    }
+    const sourceFile = astCache.get(relative);
+    let identity = null;
+    const visit = (node) => {
+        if (identity) return;
+        if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+            const start =
+                sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+            if (start === line && /(^|\.)([Ll]abel)$/.test(tagNameOf(node, sourceFile))) {
+                identity = {
+                    tag: tagNameOf(node, sourceFile),
+                    fingerprint: fingerprintOf(node, sourceFile),
+                };
+                return;
+            }
+        }
+        node.forEachChild(visit);
+    };
+    visit(sourceFile);
+    return identity ?? { tag: 'Label', fingerprint: `line${line}` };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Baseline comparison                                                         */
+/* -------------------------------------------------------------------------- */
+
+function tallyByFile(findings) {
+    const byFile = {};
+    for (const finding of findings) {
+        byFile[finding.file] ??= {};
+        const bucket = byFile[finding.file];
+        const key = keyOf(finding);
+        bucket[key] = (bucket[key] ?? 0) + 1;
+    }
+    return Object.fromEntries(
+        Object.entries(byFile)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([file, bucket]) => [
+                file,
+                Object.fromEntries(Object.entries(bucket).sort(([a], [b]) => a.localeCompare(b))),
+            ])
+    );
 }
 
 function compare(label, actual, baseline) {
-    const problems = [];
-    for (const [file, count] of Object.entries(actual)) {
-        const allowed = baseline[file] ?? 0;
-        if (count > allowed) {
-            problems.push(`  ${file}: ${count} ${label} (baseline allows ${allowed})`);
+    const regressions = [];
+    const improvements = [];
+    const files = new Set([...Object.keys(actual), ...Object.keys(baseline)]);
+    for (const file of [...files].sort()) {
+        const now = actual[file] ?? {};
+        const then = baseline[file] ?? {};
+        for (const key of new Set([...Object.keys(now), ...Object.keys(then)])) {
+            const count = now[key] ?? 0;
+            const allowed = then[key] ?? 0;
+            if (count > allowed) {
+                regressions.push(
+                    `  ${file}  ${key}: ${count} ${label} (baseline allows ${allowed})`
+                );
+            } else if (count < allowed) {
+                improvements.push(
+                    `  ${file}  ${key}: ${count} ${label} (baseline still records ${allowed})`
+                );
+            }
         }
     }
-    const improved = [];
-    for (const [file, allowed] of Object.entries(baseline)) {
-        const count = actual[file] ?? 0;
-        if (count < allowed) {
-            improved.push(`  ${file}: ${count} ${label} (baseline still records ${allowed})`);
-        }
-    }
-    return { problems, improved };
+    return { regressions, improvements };
+}
+
+function totalOf(tally) {
+    return Object.values(tally).reduce(
+        (sum, bucket) => sum + Object.values(bucket).reduce((a, b) => a + b, 0),
+        0
+    );
+}
+
+/* -------------------------------------------------------------------------- */
+/* CLI                                                                         */
+/* -------------------------------------------------------------------------- */
+
+function reportStale(stale) {
+    console.error('These files no longer have any label errors, so their suppression is dead');
+    console.error(`weight — and while it stands, ${LABEL_RULE} is off for the whole file:\n`);
+    for (const file of stale) console.error(`  ${file}`);
+    console.error(`\nDelete the \`// ${SUPPRESSION_MARKER}\` line from each of them.`);
 }
 
 function main() {
     const args = process.argv.slice(2);
-    const { unnamed, lowContrast } = scan();
+    const biomeConfig = readBiomeConfig();
+    const { unnamed, lowContrast } = scanTree();
+    const { findings: suppressedLabels, stale } = lintSuppressedFiles(biomeConfig);
+
     const actual = {
-        unnamedControls: countByFile(unnamed),
-        lowContrastControls: countByFile(lowContrast),
+        unnamedControls: tallyByFile(unnamed),
+        lowContrastControls: tallyByFile(lowContrast),
+        suppressedLabelErrors: tallyByFile(suppressedLabels),
     };
 
     if (args.includes('--list')) {
-        for (const finding of [...unnamed].sort((a, b) => a.file.localeCompare(b.file))) {
-            console.log(`unnamed-control    ${finding.file}:${finding.line} <${finding.tag}>`);
-        }
-        for (const finding of [...lowContrast].sort((a, b) => a.file.localeCompare(b.file))) {
-            console.log(`low-contrast       ${finding.file}:${finding.line} <${finding.tag}>`);
+        const rows = [
+            ...unnamed.map((f) => ['unnamed-control  ', f]),
+            ...lowContrast.map((f) => ['low-contrast     ', f]),
+            ...suppressedLabels.map((f) => ['suppressed-label ', f]),
+        ];
+        for (const [kind, finding] of rows.sort((a, b) =>
+            `${a[0]}${a[1].file}`.localeCompare(`${b[0]}${b[1].file}`)
+        )) {
+            console.log(
+                `${kind} ${finding.file}:${finding.line} <${finding.tag}> ${keyOf(finding)}`
+            );
         }
     }
 
     if (args.includes('--update')) {
+        if (stale.length > 0) reportStale(stale);
         fs.writeFileSync(BASELINE_PATH, `${JSON.stringify(actual, null, 4)}\n`);
         console.log(
-            `a11y baseline written: ${unnamed.length} unnamed controls, ${lowContrast.length} low-contrast controls.`
+            `a11y baseline written: ${unnamed.length} unnamed, ${lowContrast.length} low-contrast, ` +
+                `${suppressedLabels.length} label errors behind suppressions.`
         );
         return;
+    }
+
+    if (stale.length > 0) {
+        reportStale(stale);
+        process.exit(1);
     }
 
     if (!fs.existsSync(BASELINE_PATH)) {
@@ -319,42 +793,56 @@ function main() {
     }
     const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
 
-    const names = compare(
-        'unnamed controls',
-        actual.unnamedControls,
-        baseline.unnamedControls ?? {}
-    );
-    const contrast = compare(
-        'low-contrast controls',
-        actual.lowContrastControls,
-        baseline.lowContrastControls ?? {}
-    );
-
-    const regressions = [...names.problems, ...contrast.problems];
-    const improvements = [...names.improved, ...contrast.improved];
+    const checks = [
+        compare('unnamed controls', actual.unnamedControls, baseline.unnamedControls ?? {}),
+        compare(
+            'low-contrast controls',
+            actual.lowContrastControls,
+            baseline.lowContrastControls ?? {}
+        ),
+        compare(
+            'label errors behind a biome-ignore-all',
+            actual.suppressedLabelErrors,
+            baseline.suppressedLabelErrors ?? {}
+        ),
+    ];
+    const regressions = checks.flatMap((check) => check.regressions);
+    const improvements = checks.flatMap((check) => check.improvements);
 
     if (regressions.length > 0) {
-        console.error('Accessibility regression — new controls without an accessible name,');
-        console.error('or new interactive controls using a 1.45:1 text colour:\n');
+        console.error('Accessibility regression:\n');
         console.error(regressions.join('\n'));
         console.error(
-            '\nGive every control a name (visible text, aria-label, or a sr-only span) and'
+            '\nGive every control a name (visible text, aria-label, or an sr-only span),' +
+                '\npair every <Label> with htmlFor, and use text-slate-400 or darker on controls.' +
+                '\nRun `npm run lint:a11y -- --list` to see each finding.'
         );
-        console.error('use text-slate-400 or darker on interactive controls.');
-        console.error('Run `npm run lint:a11y -- --list` to see each finding.');
         process.exit(1);
     }
 
     if (improvements.length > 0) {
-        console.error('The a11y baseline is stale — these files improved:\n');
+        console.error('The a11y baseline is stale — these findings are gone:\n');
         console.error(improvements.join('\n'));
-        console.error('\nLock the improvement in with: npm run lint:a11y -- --update');
+        console.error(
+            '\nIf a file now has zero label errors, delete its `// biome-ignore-all` line too.' +
+                '\nThen lock the improvement in with: npm run lint:a11y -- --update'
+        );
         process.exit(1);
     }
 
     console.log(
-        `a11y names OK — ${unnamed.length} unnamed controls and ${lowContrast.length} low-contrast controls, matching the baseline.`
+        `a11y OK — ${totalOf(actual.unnamedControls)} unnamed controls, ` +
+            `${totalOf(actual.lowContrastControls)} low-contrast controls, ` +
+            `${totalOf(actual.suppressedLabelErrors)} label errors behind suppressions ` +
+            'in 0 unsuppressed files, all matching the baseline.'
     );
 }
 
-main();
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}

--- a/frontend/scripts/check-a11y-names.mjs
+++ b/frontend/scripts/check-a11y-names.mjs
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+/**
+ * check-a11y-names — a regression gate for two accessibility defects that Biome
+ * cannot express.
+ *
+ * Why this exists (task 6.7a, 2026-07-27):
+ *
+ *   1. Biome's a11y rules only reason about *intrinsic* JSX elements. `useButtonType`
+ *      fires on `<button>`, never on `<Button>`; nothing at all fires on
+ *      `<TooltipTrigger>`. Qualis writes almost every control as a component, so
+ *      37 of Biome's 39 a11y rules were already on at `error` and the codebase was
+ *      green while ~49 interactive controls had no accessible name.
+ *   2. No linter knows that `text-slate-300` is 1.45:1 on white. Contrast on
+ *      interactive controls is invisible to static analysis unless someone names
+ *      the class.
+ *
+ * Mechanism: parse every non-test .tsx with the TypeScript compiler API, count the
+ * two defects per file, and compare against a committed baseline. Any increase, or
+ * any occurrence in a file that is not in the baseline, fails. A decrease also fails,
+ * with instructions to re-baseline — that is what makes the number ratchet down and
+ * stay honest.
+ *
+ *   npm run lint:a11y            check against the baseline
+ *   npm run lint:a11y -- --update rewrite the baseline from the current tree
+ *   npm run lint:a11y -- --list   print every finding with file:line
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_DIR = path.resolve(SCRIPT_DIR, '..');
+const SRC_DIR = path.join(FRONTEND_DIR, 'src');
+const BASELINE_PATH = path.join(SCRIPT_DIR, 'a11y-baseline.json');
+
+/**
+ * Components and intrinsic elements that render a focusable control which the
+ * accessible-name computation applies to. Radix `*Trigger` components render a real
+ * `<button>` unless `asChild` hands rendering to their child.
+ */
+const NAME_BEARING = new Set([
+    'a',
+    'button',
+    'AccordionTrigger',
+    'AlertDialogTrigger',
+    'Button',
+    'DialogTrigger',
+    'DropdownMenuTrigger',
+    'PopoverTrigger',
+    'SelectTrigger',
+    'SheetTrigger',
+    'TabsTrigger',
+    'Toggle',
+    'TooltipTrigger',
+]);
+
+// Deliberately absent from NAME_BEARING: `SidebarTrigger`, which renders its own
+// `<span className="sr-only">` label inside src/components/ui/sidebar.tsx, so every
+// call site is named without saying so.
+
+/** Every element above, plus the controls that can carry a contrast-bearing class. */
+const CONTRAST_BEARING = new Set([...NAME_BEARING, 'Input', 'Textarea', 'Checkbox', 'Switch']);
+
+/** 1.45:1 against white — fails WCAG 1.4.3 (4.5:1) and 1.4.11 (3:1) outright. */
+const LOW_CONTRAST_CLASS = 'text-slate-300';
+
+function collectSourceFiles(dir, acc = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            collectSourceFiles(full, acc);
+        } else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.')) {
+            acc.push(full);
+        }
+    }
+    return acc;
+}
+
+function openingElementOf(node) {
+    return ts.isJsxElement(node) ? node.openingElement : node;
+}
+
+function tagNameOf(node, sourceFile) {
+    return openingElementOf(node).tagName.getText(sourceFile);
+}
+
+function attributesOf(node, sourceFile) {
+    const map = new Map();
+    let hasSpread = false;
+    for (const attribute of openingElementOf(node).attributes.properties) {
+        if (ts.isJsxSpreadAttribute(attribute)) {
+            hasSpread = true;
+            continue;
+        }
+        map.set(attribute.name.getText(sourceFile), attribute);
+    }
+    return { map, hasSpread };
+}
+
+/** Matches a `t(...)` call or any quoted string of two or more characters. */
+const LOOKS_LIKE_TEXT = /\bt\s*\(|['"`][^'"`]{2,}['"`]/;
+
+/**
+ * Walk an element's rendered subtree looking for anything that would contribute to
+ * its accessible name: literal JSX text, a translated string, or a visually hidden
+ * `sr-only` label. Also reports whether any child is a dynamic expression whose text
+ * content cannot be decided statically.
+ */
+function inspectChildren(node, sourceFile) {
+    const found = { literalText: false, translatedText: false, srOnly: false, dynamic: false };
+
+    const visitJsxNode = (jsxNode) => {
+        const { map } = attributesOf(jsxNode, sourceFile);
+        const className = map.get('className');
+        if (className && /sr-only/.test(className.getText(sourceFile))) {
+            found.srOnly = true;
+        }
+        // An `<img alt="…">` inside a link or button names the control.
+        if (map.has('alt') || map.has('aria-label')) {
+            found.srOnly = true;
+        }
+        if (ts.isJsxElement(jsxNode)) {
+            visitChildren(jsxNode);
+        }
+    };
+
+    const visitExpression = (expression) => {
+        if (ts.isJsxElement(expression) || ts.isJsxSelfClosingElement(expression)) {
+            visitJsxNode(expression);
+            return;
+        }
+        expression.forEachChild(visitExpression);
+    };
+
+    const visitJsxExpressionChild = (child) => {
+        const expression = child.expression;
+        if (!expression) return;
+        if (LOOKS_LIKE_TEXT.test(expression.getText(sourceFile))) {
+            found.translatedText = true;
+        } else {
+            found.dynamic = true;
+        }
+        visitExpression(expression);
+    };
+
+    function visitChildren(parent) {
+        for (const child of parent.children ?? []) {
+            if (ts.isJsxText(child) && child.getText(sourceFile).trim()) {
+                found.literalText = true;
+            } else if (ts.isJsxExpression(child)) {
+                visitJsxExpressionChild(child);
+            } else if (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child)) {
+                visitJsxNode(child);
+            }
+        }
+    }
+
+    if (ts.isJsxElement(node)) {
+        visitChildren(node);
+    }
+    return found;
+}
+
+/**
+ * A control counts as unnamed when nothing in the accessible-name computation can
+ * reach it: no `aria-label`/`aria-labelledby`, no `title` fallback, no `sr-only`
+ * text, no literal or translated child text, and rendering is not delegated with
+ * `asChild`. Elements whose only children are dynamic expressions, that spread
+ * unknown props, or that carry an `id` (so an external `<Label htmlFor>` may name
+ * them — Biome's `noLabelWithoutControl` guards that side) are treated as named:
+ * the checker never guesses, so its count is a floor, not a ceiling.
+ */
+function isUnnamed(node, sourceFile) {
+    const { map, hasSpread } = attributesOf(node, sourceFile);
+    if (map.has('asChild')) return false;
+    if (map.has('aria-label') || map.has('aria-labelledby')) return false;
+    if (map.has('title')) return false;
+    if (map.has('id')) return false;
+    if (hasSpread) return false;
+    const children = inspectChildren(node, sourceFile);
+    if (children.literalText || children.translatedText || children.srOnly) return false;
+    if (children.dynamic) return false;
+    return true;
+}
+
+function classNameIsLowContrast(node, sourceFile) {
+    const { map } = attributesOf(node, sourceFile);
+    const className = map.get('className');
+    if (!className) return false;
+    // Only the base state matters: `hover:text-slate-300` is not the resting colour.
+    return className
+        .getText(sourceFile)
+        .split(/[\s'"`]+/)
+        .some(
+            (token) => token === LOW_CONTRAST_CLASS || token.startsWith(`${LOW_CONTRAST_CLASS}/`)
+        );
+}
+
+/**
+ * The colour may sit on the control itself or on the icon it wraps — both render the
+ * control's resting foreground at 1.45:1. One finding per control either way.
+ */
+function hasLowContrastClass(node, sourceFile) {
+    if (classNameIsLowContrast(node, sourceFile)) return true;
+    let found = false;
+    const visit = (child) => {
+        if (found) return;
+        if (
+            (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child)) &&
+            classNameIsLowContrast(child, sourceFile)
+        ) {
+            found = true;
+            return;
+        }
+        child.forEachChild(visit);
+    };
+    node.forEachChild(visit);
+    return found;
+}
+
+function scan() {
+    const unnamed = [];
+    const lowContrast = [];
+
+    for (const filePath of collectSourceFiles(SRC_DIR)) {
+        const relative = path.relative(FRONTEND_DIR, filePath).split(path.sep).join('/');
+        const sourceFile = ts.createSourceFile(
+            filePath,
+            fs.readFileSync(filePath, 'utf8'),
+            ts.ScriptTarget.Latest,
+            true,
+            ts.ScriptKind.TSX
+        );
+
+        // `insideCountedControl` stops a wrapper/child pair such as
+        // `<DropdownMenuTrigger asChild><Button …>` counting the same visual control twice.
+        const visit = (node, insideCountedControl) => {
+            let counted = insideCountedControl;
+            if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+                const tag = tagNameOf(node, sourceFile);
+                const line =
+                    sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+                if (NAME_BEARING.has(tag) && isUnnamed(node, sourceFile)) {
+                    unnamed.push({ file: relative, line, tag });
+                }
+                if (
+                    !insideCountedControl &&
+                    CONTRAST_BEARING.has(tag) &&
+                    hasLowContrastClass(node, sourceFile)
+                ) {
+                    lowContrast.push({ file: relative, line, tag });
+                    counted = true;
+                }
+            }
+            node.forEachChild((child) => visit(child, counted));
+        };
+        visit(sourceFile, false);
+    }
+
+    return { unnamed, lowContrast };
+}
+
+function countByFile(findings) {
+    const counts = {};
+    for (const finding of findings) {
+        counts[finding.file] = (counts[finding.file] ?? 0) + 1;
+    }
+    return Object.fromEntries(Object.entries(counts).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function compare(label, actual, baseline) {
+    const problems = [];
+    for (const [file, count] of Object.entries(actual)) {
+        const allowed = baseline[file] ?? 0;
+        if (count > allowed) {
+            problems.push(`  ${file}: ${count} ${label} (baseline allows ${allowed})`);
+        }
+    }
+    const improved = [];
+    for (const [file, allowed] of Object.entries(baseline)) {
+        const count = actual[file] ?? 0;
+        if (count < allowed) {
+            improved.push(`  ${file}: ${count} ${label} (baseline still records ${allowed})`);
+        }
+    }
+    return { problems, improved };
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    const { unnamed, lowContrast } = scan();
+    const actual = {
+        unnamedControls: countByFile(unnamed),
+        lowContrastControls: countByFile(lowContrast),
+    };
+
+    if (args.includes('--list')) {
+        for (const finding of [...unnamed].sort((a, b) => a.file.localeCompare(b.file))) {
+            console.log(`unnamed-control    ${finding.file}:${finding.line} <${finding.tag}>`);
+        }
+        for (const finding of [...lowContrast].sort((a, b) => a.file.localeCompare(b.file))) {
+            console.log(`low-contrast       ${finding.file}:${finding.line} <${finding.tag}>`);
+        }
+    }
+
+    if (args.includes('--update')) {
+        fs.writeFileSync(BASELINE_PATH, `${JSON.stringify(actual, null, 4)}\n`);
+        console.log(
+            `a11y baseline written: ${unnamed.length} unnamed controls, ${lowContrast.length} low-contrast controls.`
+        );
+        return;
+    }
+
+    if (!fs.existsSync(BASELINE_PATH)) {
+        console.error(`Missing baseline ${BASELINE_PATH}. Run: npm run lint:a11y -- --update`);
+        process.exit(1);
+    }
+    const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+
+    const names = compare(
+        'unnamed controls',
+        actual.unnamedControls,
+        baseline.unnamedControls ?? {}
+    );
+    const contrast = compare(
+        'low-contrast controls',
+        actual.lowContrastControls,
+        baseline.lowContrastControls ?? {}
+    );
+
+    const regressions = [...names.problems, ...contrast.problems];
+    const improvements = [...names.improved, ...contrast.improved];
+
+    if (regressions.length > 0) {
+        console.error('Accessibility regression — new controls without an accessible name,');
+        console.error('or new interactive controls using a 1.45:1 text colour:\n');
+        console.error(regressions.join('\n'));
+        console.error(
+            '\nGive every control a name (visible text, aria-label, or a sr-only span) and'
+        );
+        console.error('use text-slate-400 or darker on interactive controls.');
+        console.error('Run `npm run lint:a11y -- --list` to see each finding.');
+        process.exit(1);
+    }
+
+    if (improvements.length > 0) {
+        console.error('The a11y baseline is stale — these files improved:\n');
+        console.error(improvements.join('\n'));
+        console.error('\nLock the improvement in with: npm run lint:a11y -- --update');
+        process.exit(1);
+    }
+
+    console.log(
+        `a11y names OK — ${unnamed.length} unnamed controls and ${lowContrast.length} low-contrast controls, matching the baseline.`
+    );
+}
+
+main();

--- a/frontend/scripts/check-a11y-names.test.mjs
+++ b/frontend/scripts/check-a11y-names.test.mjs
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeSource } from './check-a11y-names.mjs';
+
+/** Names of the controls the checker considers unnamed, for readable assertions. */
+function unnamedTags(source) {
+    return analyzeSource('probe.tsx', source).unnamed.map((finding) => finding.tag);
+}
+
+function lowContrastTags(source) {
+    return analyzeSource('probe.tsx', source).lowContrast.map((finding) => finding.tag);
+}
+
+const wrap = (jsx) => `export const Probe = () => (\n${jsx}\n);\n`;
+
+describe('analyzeSource — controls that ARE named', () => {
+    it.each([
+        ['visible text', '<Button onClick={go}>Delete</Button>'],
+        ['a translated child', "<Button onClick={go}>{t('a.b', 'Delete')}</Button>"],
+        ['aria-label', '<Button aria-label="Delete"><Trash2 /></Button>'],
+        ['aria-labelledby', '<Button aria-labelledby="x"><Trash2 /></Button>'],
+        ['an sr-only span', '<Button><Trash2 /><span className="sr-only">Delete</span></Button>'],
+        ['an img alt', '<a href="/x"><img src="/l.png" alt="Partner" /></a>'],
+        ['a title fallback', '<Button title="Delete"><Trash2 /></Button>'],
+        ['asChild delegation', '<TooltipTrigger asChild><Button>Go</Button></TooltipTrigger>'],
+    ])('accepts a control named by %s', (_label, jsx) => {
+        expect(unnamedTags(wrap(jsx))).toEqual([]);
+    });
+
+    it('accepts a SelectTrigger whose SelectValue carries a translated placeholder', () => {
+        const source = wrap(`<SelectTrigger>
+            <SelectValue placeholder={t('admin.design.toolbar.select_lang')} />
+        </SelectTrigger>`);
+        expect(unnamedTags(source)).toEqual([]);
+    });
+});
+
+describe('analyzeSource — controls that are NOT named', () => {
+    it.each([
+        ['an icon-only Button', '<Button onClick={go}><Trash2 /></Button>', 'Button'],
+        ['an icon-only button', '<button type="button"><X /></button>', 'button'],
+        [
+            'a bare TooltipTrigger',
+            '<TooltipTrigger><div><Mail /></div></TooltipTrigger>',
+            'TooltipTrigger',
+        ],
+        [
+            'a SelectTrigger with a bare SelectValue',
+            '<SelectTrigger><SelectValue /></SelectTrigger>',
+            'SelectTrigger',
+        ],
+    ])('flags %s', (_label, jsx, tag) => {
+        expect(unnamedTags(wrap(jsx))).toEqual([tag]);
+    });
+
+    it('is not fooled by a className that merely looks like a string', () => {
+        // Regression guard: a `LOOKS_LIKE_TEXT` regex over the expression source treated
+        // "h-4 w-4" as an accessible name, which passes almost every icon button in React.
+        const source = wrap('<Button>{isBusy ? <Trash2 className="h-4 w-4" /> : null}</Button>');
+        expect(unnamedTags(source)).toEqual(['Button']);
+    });
+});
+
+describe('analyzeSource — the id escape hatch', () => {
+    it('does NOT accept a bare id, because task 6.7b adds ids for a living', () => {
+        expect(unnamedTags(wrap('<Button id="delete-thing"><Trash2 /></Button>'))).toEqual([
+            'Button',
+        ]);
+    });
+
+    it('accepts an id a Label in the same file points at', () => {
+        const source = `export const Probe = () => (
+            <div>
+                <Label htmlFor="role-select">Role</Label>
+                <SelectTrigger id="role-select"><SelectValue /></SelectTrigger>
+            </div>
+        );`;
+        expect(unnamedTags(source)).toEqual([]);
+    });
+
+    it('matches an expression id against an expression htmlFor', () => {
+        const source = `export const Probe = () => (
+            <div>
+                <Label htmlFor={fieldId}>Role</Label>
+                <SelectTrigger id={fieldId}><SelectValue /></SelectTrigger>
+            </div>
+        );`;
+        expect(unnamedTags(source)).toEqual([]);
+    });
+
+    it('does not accept an id that no label points at', () => {
+        const source = `export const Probe = () => (
+            <div>
+                <Label htmlFor="other-field">Role</Label>
+                <SelectTrigger id="role-select"><SelectValue /></SelectTrigger>
+            </div>
+        );`;
+        expect(unnamedTags(source)).toEqual(['SelectTrigger']);
+    });
+});
+
+describe('analyzeSource — the remaining escape hatches', () => {
+    it('treats {...props} as possibly named by the caller', () => {
+        expect(unnamedTags(wrap('<Button {...props}><Trash2 /></Button>'))).toEqual([]);
+    });
+
+    it('treats a dynamic child as undecidable rather than unnamed', () => {
+        expect(unnamedTags(wrap('<Button>{label}</Button>'))).toEqual([]);
+    });
+});
+
+describe('analyzeSource — fingerprints', () => {
+    it('distinguishes two structurally different controls in one file', () => {
+        const source = `export const Probe = () => (
+            <div>
+                <Button onClick={a}><Trash2 /></Button>
+                <Button onClick={a}><Pencil /></Button>
+            </div>
+        );`;
+        const fingerprints = analyzeSource('probe.tsx', source).unnamed.map((f) => f.fingerprint);
+        expect(new Set(fingerprints).size).toBe(2);
+    });
+
+    it('survives a line move, so unrelated edits above a control do not churn the baseline', () => {
+        const jsx = '<Button onClick={a}><Trash2 /></Button>';
+        const first = analyzeSource('probe.tsx', wrap(jsx)).unnamed[0];
+        const second = analyzeSource('probe.tsx', `// a new import\n${wrap(jsx)}`).unnamed[0];
+        expect(second.fingerprint).toBe(first.fingerprint);
+        expect(second.line).not.toBe(first.line);
+    });
+
+    it('changes when the control is given a name, so a fix cannot mask a regression', () => {
+        const before = analyzeSource('probe.tsx', wrap('<Button a={1}><Trash2 /></Button>'))
+            .unnamed[0];
+        const after = analyzeSource(
+            'probe.tsx',
+            wrap('<Button a={1} data-x="1"><Trash2 /></Button>')
+        ).unnamed[0];
+        expect(after.fingerprint).not.toBe(before.fingerprint);
+    });
+});
+
+describe('analyzeSource — contrast', () => {
+    it('flags the resting colour on the control', () => {
+        expect(lowContrastTags(wrap('<Button className="text-slate-300">Go</Button>'))).toEqual([
+            'Button',
+        ]);
+    });
+
+    it('flags the resting colour on the icon the control wraps', () => {
+        expect(
+            lowContrastTags(
+                wrap('<Button aria-label="Delete"><Trash2 className="text-slate-300" /></Button>')
+            )
+        ).toEqual(['Button']);
+    });
+
+    it('ignores a hover-only variant', () => {
+        expect(
+            lowContrastTags(wrap('<Button className="hover:text-slate-300">Go</Button>'))
+        ).toEqual([]);
+    });
+
+    it('counts a wrapper and its asChild target once', () => {
+        const source = wrap(`<DropdownMenuTrigger asChild>
+            <Button className="text-slate-300" aria-label="More"><MoreHorizontal /></Button>
+        </DropdownMenuTrigger>`);
+        expect(lowContrastTags(source)).toEqual(['DropdownMenuTrigger']);
+    });
+});

--- a/frontend/src/components/admin/ImportStudyDialog.tsx
+++ b/frontend/src/components/admin/ImportStudyDialog.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';

--- a/frontend/src/components/admin/designer/BrandingEditor.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 
 import { Label } from '@/components/ui/label';

--- a/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
+++ b/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Library, Loader2, Upload } from 'lucide-react';

--- a/frontend/src/components/admin/designer/InterfaceEditor.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { isPresortEnabled, isRoughSortEnabled } from '@/utils/studyConfig';
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';

--- a/frontend/src/components/admin/designer/IntroductionEditor.tsx
+++ b/frontend/src/components/admin/designer/IntroductionEditor.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 import { usePlatformConfigStore } from '@/store/usePlatformConfigStore';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import type React from 'react';
 import { useEffect, useMemo } from 'react';
 import {

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useState, useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useStudyDesigner } from '@/store/useStudyDesigner';

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import {
     DndContext,
     closestCenter,

--- a/frontend/src/components/postsort/Step1_Feedback.tsx
+++ b/frontend/src/components/postsort/Step1_Feedback.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import type React from 'react';
 import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: DropdownMenuLabel wraps Radix DropdownMenuPrimitive.Label, a menu group label, not a form label — the rule matches on the `.Label` member name only.
 import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { Check, ChevronRight, Circle } from 'lucide-react';

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: DropdownMenuLabel wraps Radix DropdownMenuPrimitive.Label, a menu group label, not a form label — the rule matches on the `.Label` member name only.
 import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { Check, ChevronRight, Circle } from 'lucide-react';
@@ -141,6 +140,7 @@ const DropdownMenuLabel = React.forwardRef<
         inset?: boolean;
     }
 >(({ className, inset, ...props }, ref) => (
+    // biome-ignore lint/a11y/noLabelWithoutControl: DropdownMenuPrimitive.Label is a menu group label, not a form label — the rule matches the trailing .Label member name.
     <DropdownMenuPrimitive.Label
         ref={ref}
         className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: FormLabel forwards children via props spread; the htmlFor is set from useFormField.
 import * as React from 'react';
 import type * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: FormLabel forwards children via props spread; the htmlFor is set from useFormField.
 import * as React from 'react';
 import type * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';
@@ -87,6 +86,7 @@ const FormLabel = React.forwardRef<
     const { error, formItemId } = useFormField();
 
     return (
+        // biome-ignore lint/a11y/noLabelWithoutControl: FormLabel sets htmlFor from useFormField; its children arrive through {...props}, which the rule cannot see.
         <Label
             ref={ref}
             className={cn(error && 'text-destructive', className)}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: SelectLabel wraps Radix SelectPrimitive.Label, a listbox group label, not a form label — the rule matches on the `.Label` member name only.
 import * as React from 'react';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';
@@ -95,6 +94,7 @@ const SelectLabel = React.forwardRef<
     React.ElementRef<typeof SelectPrimitive.Label>,
     React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({ className, ...props }, ref) => (
+    // biome-ignore lint/a11y/noLabelWithoutControl: SelectPrimitive.Label is a listbox group label, not a form label — the rule matches the trailing .Label member name.
     <SelectPrimitive.Label
         ref={ref}
         className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: SelectLabel wraps Radix SelectPrimitive.Label, a listbox group label, not a form label — the rule matches on the `.Label` member name only.
 import * as React from 'react';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 /*
  * Qualis - Open-source platform for conducting Q-methodology research
  * Copyright (C) 2025 Julien Vastenekels

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { Users, Trash2, UserPlus, Shield, Mail, Check, Copy, Loader2 } from 'lucide-react';
 import { useLoaderData } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import {
     QrCode,
     Plus,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         globals: true,
         environment: 'happy-dom',
         setupFiles: ['./src/setupStorage.ts', './src/setupTests.ts'],
-        include: ['src/**/*.test.{ts,tsx}'],
+        include: ['src/**/*.test.{ts,tsx}', 'scripts/**/*.test.mjs'],
         css: true,
         coverage: {
             provider: 'v8',


### PR DESCRIPTION
## Summary

Task 6.7 of the remediation plan, **pulled forward** ahead of phases 4–6 so later work cannot reintroduce the class it would otherwise write. **Stacked on [#325](https://github.com/jvastenaekels/qualis/pull/325) — merge that first.**

Three phases of accessibility work each fixed a defect class by hand in one or two files, and each time a sweep found the class surviving everywhere else. This lands the enforcement, and measures the real backlog so the correction work can be scoped from output rather than estimate.

## The premise was wrong, and that is the finding

We assumed no a11y lint rules were enabled. In fact **37 of Biome's 39 a11y rules were already at `error`, and the repo was green.**

The class survived for a structural reason: Biome's a11y rules only inspect **intrinsic JSX**. Nothing fires on `<Button>` or `<TooltipTrigger>`, which are React components — and Biome 2.5.5 has **no button-name rule at all**, not even for a native `<button>`. Only 3 of its 39 rules accept any component mapping, and there is no `settings.components` equivalent. No configuration would have covered this. Verified three ways: the schema, an empirical probe, and toggling `labelComponents` (0 violations → 43).

## The cheaper answer was already in the repo

`Accessibility Smoke` — an axe-core Playwright project — existed and was wired into **no CI job**, while `ci.yml` already stands up PostgreSQL and Playwright for the admin E2E run. axe computes the *rendered* accessible name: it sees through `asChild`, resolves `<SelectValue placeholder>`, and honours `display:none` at 375px. It covers most of this class — including a false negative the custom checker documents about itself — while correctly passing five controls the checker flagged wrongly.

It is now wired into `test:e2e:admin` with ten name rules, and mutation-tested: stripping a button's visible text produces a real `button-name` violation.

## Changes

- **Layer 1** — `noLabelWithoutControl` at `error` with `labelComponents: ["Label"]`, which is what makes it see this codebase at all. 13 dated file-level burn-down suppressions, plus 3 line-level permanent ones for genuine Radix `.Label` false positives.
- **Layer 2** — `frontend/scripts/check-a11y-names.mjs` + `a11y-baseline.json`: a TypeScript-compiler baseline ratchet keyed on structural fingerprints, wired into `make check` and CI. It covers what axe cannot: pages no test visits, and "named but useless".
- **A config guard** — a `//` comment in `biome.json` makes Biome discard the whole config and run on defaults. That is now caught explicitly.
- **27 parser tests**, including a regression test for each escape hatch found in review.

## The measured backlog

**41** controls with no accessible name (16 `<Button>`, 11 `<TooltipTrigger>`, 9 `<SelectTrigger>`, 5 `<button>`), **13** interactive controls at 1.45:1 contrast, **40** label errors held behind enforced, self-removing suppressions. The earlier human sweep proved accurate — 74 suspicious of 433, against its own estimate of ~76 of ~465, with the seven `TooltipTrigger`s and ~40 labels matching to the unit.

## Review found seven ways to defeat the gate; all are closed

The first version could be defeated, and one way was pointed straight at the next task: **`id=` silenced the checker, while task 6.7b consists of adding `id` attributes.** Executed literally it would have driven the count from 42 toward zero without creating a single accessible name, and certified the backlog cleared. The baseline also keyed on `{file: count}`, so a fix and a regression in the same file cancelled out silently.

Each defeat was reproduced in-tree by the reviewer, then **re-run after the fix** rather than re-read: an `id` with no matching `htmlFor`, the cancel-out scenario, the exact `LOOKS_LIKE_TEXT` snippet, a suppressed file mutated in both directions, a `//` in `biome.json`, and a full local stack stood up to mutation-test axe.

## Checklist

- [ ] `make ci` passes locally — **frontend green (186 files / 1595 tests, biome + tsc + knip + depcruise clean, `Accessibility Smoke` 2 passed); backend `pytest` fails on a local Postgres credential issue that reproduces identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — 27 parser cases including a regression test per escape hatch.
- [x] Translation keys added to all locales — no user-facing strings changed.
- [x] API client regenerated if backend schemas changed — not applicable.

## What comes next

The correction backlog is split into reviewable tasks, in reviewer-endorsed order: labels + `htmlFor` (40) → name the 41 controls → contrast and role hygiene → translate 9 hardcoded names → extend axe to admin pages. With one standing rule, because the gate cannot tell the difference: **never add a bare `id` without the matching `htmlFor` in the same hunk.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)