### PR TITLE
fix(a11y): pair every label with its control, and name the groups that had none

### DIFF
--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1542,6 +1542,114 @@ git commit -m "fix(a11y): enforce accessible names with a lint gate and clear th
 
 ---
 
+### Task 6.7b: Burn down the label backlog
+
+**The work:** 40 `noLabelWithoutControl` errors held behind 13 dated file-level suppressions that Task 6.7a landed. Each is a `<Label>` with no `htmlFor`, sitting beside a control with no `id` — so the control has no accessible name, and clicking the label does nothing.
+
+Distribution, measured: `QuestionBuilder` 9, `ConcourseDetailPage` 8, `ProcessStepEditor` 4, `IntroductionEditor` 4, `InterfaceEditor` 3, `RecruitmentPage` 2, `ProjectMembersPage` 2, `Step1_Feedback` 2, `ImportStudyDialog` 2, `QSortEditor` 1, `PostSortConfigEditor` 1, `ImportFromConcourseDialog` 1, `BrandingEditor` 1.
+
+> **The standing rule, because the gate cannot tell the difference:** never add a bare `id` without the matching `htmlFor` in the same hunk. Task 6.7a's first gate silenced its checker on any `id`; that hole is closed, but the discipline is what makes the fix real rather than the count going down.
+
+**Expected side effect:** several of the 9 remaining unnamed `<SelectTrigger>` findings resolve for free. Verified in Chromium that `<label for="b1">Role</label><button id="b1" role="combobox">Member</button>` yields the accessible name "Role" — so labelling the field names the trigger.
+
+**Out of scope:** the five `<SelectTrigger>` that already carry `<SelectValue placeholder={t(…)} />` — they have a real translated name and are not in the backlog.
+
+**Files:** the 13 above, plus `frontend/a11y-baseline.json` as counts drop, minus each `biome-ignore-all` line as its file reaches zero.
+
+- [ ] **Step 1: Work file by file, committing per file or per small group**
+
+For each `<Label>` without `htmlFor`: give the control an `id`, point the label at it in the same edit. Prefer the control's existing `name`/field key for the id so it stays stable.
+
+- [ ] **Step 2: Remove that file's suppression as it reaches zero**
+
+The gate re-lints suppressed files, so a stale suppression fails as "baseline still records N". That is the burn-down working — re-run with `--update` and confirm the count dropped by what you fixed, not more.
+
+- [ ] **Step 3: Verify the label actually labels**
+
+```tsx
+it('names the field and lets its label focus it', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<QuestionBuilder {...props} />);
+    const field = screen.getByRole('textbox', { name: /question text/i });
+    await user.click(screen.getByText(/question text/i));
+    expect(field).toHaveFocus();
+});
+```
+
+The focus assertion is what distinguishes a real pairing from an `id` that satisfies a linter.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "fix(a11y): pair every label with its control"
+```
+
+---
+
+### Task 6.7c: Name the 37 controls the gate still records
+
+**The work:** the baseline at `frontend/a11y-baseline.json` records **37** controls with no accessible name after Task 6.7b: `<Button>`, `<TooltipTrigger>`, `<SelectTrigger>` and bare `<button>`. Run `cd frontend && node scripts/check-a11y-names.mjs --list` for the live set — do not work from a copied list, it moves.
+
+The largest single cluster is `InteractiveDataView.columns.tsx` — seven `<TooltipTrigger>` without `asChild`, each rendering a focusable Radix `<button>` whose only content is a `<div>` and an icon, with the descriptive text in `TooltipContent` wired as `aria-describedby` only while open. That is up to **seven unnamed tab stops per participant row** on the Data table.
+
+**Prefer `asChild`** where a `TooltipTrigger` wraps a control that can carry the name itself. Otherwise `aria-label`, through `t()`, in all nine admin locales.
+
+**The standing rule still applies:** never add a bare `id` without the matching `htmlFor` in the same hunk.
+
+- [ ] **Step 1: `node scripts/check-a11y-names.mjs --list`, group by mechanism**
+- [ ] **Step 2: Name them, asserting the computed name** — `getByRole(role, { name })`, never an attribute check
+- [ ] **Step 3: Re-baseline; confirm the drop equals what you fixed**
+- [ ] **Step 4: Commit** — `fix(a11y): name the controls the gate records as anonymous`
+
+---
+
+### Task 6.7d: Contrast and role hygiene
+
+**The work, both measured:**
+
+1. **13 interactive controls at 1.45:1** (`text-slate-300` on white, against a 4.5:1 threshold), recorded in the baseline. Task 3.1 fixed one file; these are the rest — `QuestionBuilder.tsx:209, 273, 303, 811`, `ProcessStepEditor.tsx:80, 124`, `InterfaceEditor.tsx:357`, `QSortEditor.tsx:139, 290`, `BrandingEditor.tsx:313` and siblings. Several are delete buttons.
+2. **`role="button"` + `tabIndex={0}` divs** at `ImageUploadInput.tsx:194`, `ImportFromConcourseDialog.tsx:248`, `StudyStatusControl.tsx:115`, `QSortEditor.tsx:200` — the pattern Task 3.3 replaced with native `<button>` on the dashboard.
+
+`text-slate-500` is 4.6:1 and is the token Task 3.1 settled on.
+
+**If you enable `useSemanticElements` to catch the divs, use line-level suppressions for the dnd-kit exceptions, not file-level ones** — Phase 3 learned that file-scoped suppressions blind the largest files, and Biome 2.5.5 has no unused-suppression rule to force their removal.
+
+- [ ] **Step 1: Fix the contrast; confirm the baseline's low-contrast count drops to 0**
+- [ ] **Step 2: Convert the four divs to native `<button>`, preserving layout** (Task 3.3's `AdminDashboard` conversion is the worked example, including the stretched `::after` for whole-area clicking)
+- [ ] **Step 3: Commit** — `fix(a11y): raise interactive contrast and drop the clickable divs`
+
+---
+
+### Task 6.7f: Translate the hardcoded accessible names
+
+**The work:** 9 accessible names are hardcoded English string literals rather than `t()` calls — including `dialog.tsx:47`'s `<span className="sr-only">Close</span>`, which every dialog in the product renders. A French researcher's screen reader announces them in English.
+
+Independent of 6.7c and 6.7d; touches no file they touch, so it can run in parallel.
+
+- [ ] **Step 1: Find them** — `grep -rn 'sr-only\|aria-label="' frontend/src --include=*.tsx | grep -v "t("`
+- [ ] **Step 2: Route each through `t('key', 'Fallback')`**, fallback matching `en/admin.json` character-for-character, keys in all nine admin locales, register per `frontend/scripts/i18n/glossaries/<code>.yaml` (there is no `fr.yaml`)
+- [ ] **Step 3: `npm run i18n-check && npm run check-interpolations`**
+- [ ] **Step 4: Commit** — `fix(i18n): translate the accessible names that were hardcoded`
+
+---
+
+### Task 6.7e: Extend the axe spec to the admin
+
+**The work:** Task 6.7a wired `Accessibility Smoke` into CI, but the spec itself covers **two public pages**. The admin — where every defect in this remediation lived — is not covered by it at all.
+
+Extend it to the admin surfaces: dashboard, concourse, study design, data, analysis, access, settings. It needs an authenticated session; `frontend/e2e/fixtures/db-setup.ts`'s `loginToAdminUI` injects `admin-auth-storage` into `sessionStorage`, which is how the admin specs already do it.
+
+Run at **375px as well as desktop** — Task 6.7a found a language switcher whose only text is in a `hidden sm:inline` span, so it has no accessible name at all below that breakpoint, and a desktop-only run would never see it.
+
+**This is the check that would have caught most of this remediation on its own.** axe computes the rendered accessible name: it sees through `asChild`, resolves `<SelectValue placeholder>`, honours `display:none`, and computes real contrast ratios rather than matching a banned class string.
+
+- [ ] **Step 1: Add admin routes to the spec with an authenticated fixture**
+- [ ] **Step 2: Enable the name rules and `color-contrast`; run at both widths**
+- [ ] **Step 3: Confirm it fails on a deliberately unnamed control, then passes** — a spec that cannot fail is not a check
+- [ ] **Step 4: Commit** — `test(a11y): run axe against the admin at both breakpoints`
+
+---
+
 ### Task 6.8: Charts mounting at zero size
 
 **The defect:** loading the `Data` screen logs the Recharts warning *"The width(-1) and height(-1) of chart should be greater than 0"* five times — charts are mounting inside collapsed containers. Harmless today, but it is console noise that will mask a real warning later.

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -244,6 +244,26 @@
                 "preview": "Vorschau",
                 "empty": "Nichts für die Vorschau"
             },
+            "icon_picker": {
+                "icons": {
+                    "User": "Person",
+                    "Zap": "Blitz",
+                    "Scale": "Waage",
+                    "MessageSquareText": "Nachricht",
+                    "ClipboardList": "Klemmbrett",
+                    "CheckCircle": "Häkchen",
+                    "Flag": "Flagge",
+                    "Info": "Information",
+                    "HelpCircle": "Hilfe",
+                    "FileText": "Dokument",
+                    "LayoutGrid": "Raster",
+                    "Rocket": "Rakete",
+                    "Target": "Ziel",
+                    "Brain": "Gehirn",
+                    "Lightbulb": "Idee",
+                    "ListChecks": "Checkliste"
+                }
+            },
             "click_to_edit": "Zum Bearbeiten klicken"
         },
         "layout": {
@@ -1420,6 +1440,7 @@
                     "question": "Fragenbezeichnung",
                     "required": "Pflichtfeld",
                     "options": "Optionen",
+                    "option_ordinal": "Option {{number}}",
                     "multiple": "(Mehrfachauswahl erlaubt)",
                     "single": "(Einfachauswahl)",
                     "placeholder": "Geben Sie hier Ihre Frage ein...",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -244,6 +244,26 @@
                 "preview": "Preview",
                 "empty": "Nothing to preview"
             },
+            "icon_picker": {
+                "icons": {
+                    "User": "Person",
+                    "Zap": "Lightning bolt",
+                    "Scale": "Balance",
+                    "MessageSquareText": "Message",
+                    "ClipboardList": "Clipboard",
+                    "CheckCircle": "Checkmark",
+                    "Flag": "Flag",
+                    "Info": "Information",
+                    "HelpCircle": "Help",
+                    "FileText": "Document",
+                    "LayoutGrid": "Grid",
+                    "Rocket": "Rocket",
+                    "Target": "Target",
+                    "Brain": "Brain",
+                    "Lightbulb": "Idea",
+                    "ListChecks": "Checklist"
+                }
+            },
             "click_to_edit": "Click to edit"
         },
         "layout": {
@@ -1422,6 +1442,7 @@
                     "question": "Question label",
                     "required": "Required field",
                     "options": "Options",
+                    "option_ordinal": "Option {{number}}",
                     "multiple": "(Multiple selection allowed)",
                     "single": "(Single selection)",
                     "placeholder": "Enter your question here...",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -244,6 +244,26 @@
                 "preview": "Vista previa",
                 "empty": "Nada que previsualizar"
             },
+            "icon_picker": {
+                "icons": {
+                    "User": "Persona",
+                    "Zap": "Rayo",
+                    "Scale": "Balanza",
+                    "MessageSquareText": "Mensaje",
+                    "ClipboardList": "Portapapeles",
+                    "CheckCircle": "Marca de verificación",
+                    "Flag": "Bandera",
+                    "Info": "Información",
+                    "HelpCircle": "Ayuda",
+                    "FileText": "Documento",
+                    "LayoutGrid": "Cuadrícula",
+                    "Rocket": "Cohete",
+                    "Target": "Objetivo",
+                    "Brain": "Cerebro",
+                    "Lightbulb": "Idea",
+                    "ListChecks": "Lista de verificación"
+                }
+            },
             "click_to_edit": "Haga clic para editar"
         },
         "layout": {
@@ -1420,6 +1440,7 @@
                     "question": "Etiqueta de pregunta",
                     "required": "Campo obligatorio",
                     "options": "Opciones",
+                    "option_ordinal": "Opción {{number}}",
                     "multiple": "(Se permiten múltiples selecciones)",
                     "single": "(Selección única)",
                     "placeholder": "Introduzca su pregunta aquí...",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -156,6 +156,26 @@
                 "preview": "Esikatselu",
                 "empty": "Ei esikatseltavaa sisältöä"
             },
+            "icon_picker": {
+                "icons": {
+                    "User": "Henkilö",
+                    "Zap": "Salama",
+                    "Scale": "Vaaka",
+                    "MessageSquareText": "Viesti",
+                    "ClipboardList": "Muistilista",
+                    "CheckCircle": "Valintamerkki",
+                    "Flag": "Lippu",
+                    "Info": "Info",
+                    "HelpCircle": "Ohje",
+                    "FileText": "Asiakirja",
+                    "LayoutGrid": "Ruudukko",
+                    "Rocket": "Raketti",
+                    "Target": "Tavoite",
+                    "Brain": "Aivot",
+                    "Lightbulb": "Idea",
+                    "ListChecks": "Tarkistuslista"
+                }
+            },
             "click_to_edit": "Napsauta muokataksesi"
         },
         "layout": {
@@ -1331,6 +1351,7 @@
                     "question": "Kysymyksen otsikko",
                     "required": "Pakollinen kenttä",
                     "options": "Vaihtoehdot",
+                    "option_ordinal": "Vaihtoehto {{number}}",
                     "multiple": "(useita valintoja sallittu)",
                     "single": "(yksi valinta)",
                     "placeholder": "Kirjoita kysymyksesi tähän...",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -156,6 +156,26 @@
                 "preview": "Aperçu",
                 "empty": "Rien à prévisualiser"
             },
+            "icon_picker": {
+                "icons": {
+                    "User": "Personne",
+                    "Zap": "Éclair",
+                    "Scale": "Balance",
+                    "MessageSquareText": "Message",
+                    "ClipboardList": "Presse-papiers",
+                    "CheckCircle": "Coche",
+                    "Flag": "Drapeau",
+                    "Info": "Information",
+                    "HelpCircle": "Aide",
+                    "FileText": "Document",
+                    "LayoutGrid": "Grille",
+                    "Rocket": "Fusée",
+                    "Target": "Cible",
+                    "Brain": "Cerveau",
+                    "Lightbulb": "Idée",
+                    "ListChecks": "Liste de contrôle"
+                }
+            },
             "click_to_edit": "Cliquer pour éditer"
         },
         "layout": {
@@ -1369,6 +1389,7 @@
                     "question": "Libellé de la question",
                     "required": "Champ obligatoire",
                     "options": "Options",
+                    "option_ordinal": "Option {{number}}",
                     "multiple": "(choix multiples autorisés)",
                     "single": "(choix unique)",
                     "placeholder": "Entrez votre question ici...",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -244,6 +244,26 @@
                 "preview": "Anteprima",
                 "empty": "Nulla da visualizzare in anteprima"
             },
+            "icon_picker": {
+                "icons": {
+                    "User": "Persona",
+                    "Zap": "Fulmine",
+                    "Scale": "Bilancia",
+                    "MessageSquareText": "Messaggio",
+                    "ClipboardList": "Appunti",
+                    "CheckCircle": "Segno di spunta",
+                    "Flag": "Bandiera",
+                    "Info": "Informazioni",
+                    "HelpCircle": "Aiuto",
+                    "FileText": "Documento",
+                    "LayoutGrid": "Griglia",
+                    "Rocket": "Razzo",
+                    "Target": "Obiettivo",
+                    "Brain": "Cervello",
+                    "Lightbulb": "Idea",
+                    "ListChecks": "Lista di controllo"
+                }
+            },
             "click_to_edit": "Clicchi per modificare"
         },
         "layout": {
@@ -1420,6 +1440,7 @@
                     "question": "Etichetta domanda",
                     "required": "Campo obbligatorio",
                     "options": "Opzioni",
+                    "option_ordinal": "Opzione {{number}}",
                     "multiple": "(Selezione multipla consentita)",
                     "single": "(Selezione singola)",
                     "placeholder": "Inserisca qui la sua domanda...",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -244,6 +244,26 @@
                 "preview": "Voorbeeld",
                 "empty": "Niets te bekijken"
             },
+            "icon_picker": {
+                "icons": {
+                    "User": "Persoon",
+                    "Zap": "Bliksem",
+                    "Scale": "Balans",
+                    "MessageSquareText": "Bericht",
+                    "ClipboardList": "Klembord",
+                    "CheckCircle": "Vinkje",
+                    "Flag": "Vlag",
+                    "Info": "Informatie",
+                    "HelpCircle": "Help",
+                    "FileText": "Document",
+                    "LayoutGrid": "Raster",
+                    "Rocket": "Raket",
+                    "Target": "Doel",
+                    "Brain": "Brein",
+                    "Lightbulb": "Idee",
+                    "ListChecks": "Checklist"
+                }
+            },
             "click_to_edit": "Klik om te bewerken"
         },
         "layout": {
@@ -1420,6 +1440,7 @@
                     "question": "Vraaglabel",
                     "required": "Verplicht veld",
                     "options": "Opties",
+                    "option_ordinal": "Optie {{number}}",
                     "multiple": "(Meerdere keuzes mogelijk)",
                     "single": "(Enkelvoudige keuze)",
                     "placeholder": "Voer uw vraag in...",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -244,6 +244,26 @@
         "preview": "Podgląd",
         "empty": "Brak treści do podglądu"
       },
+      "icon_picker": {
+        "icons": {
+          "User": "Osoba",
+          "Zap": "Błyskawica",
+          "Scale": "Waga",
+          "MessageSquareText": "Wiadomość",
+          "ClipboardList": "Schowek",
+          "CheckCircle": "Znacznik wyboru",
+          "Flag": "Flaga",
+          "Info": "Informacja",
+          "HelpCircle": "Pomoc",
+          "FileText": "Dokument",
+          "LayoutGrid": "Siatka",
+          "Rocket": "Rakieta",
+          "Target": "Cel",
+          "Brain": "Mózg",
+          "Lightbulb": "Pomysł",
+          "ListChecks": "Lista kontrolna"
+        }
+      },
       "click_to_edit": "Kliknij, aby edytować"
     },
     "layout": {
@@ -1420,6 +1440,7 @@
           "question": "Etykieta pytania",
           "required": "Pole wymagane",
           "options": "Opcje",
+          "option_ordinal": "Opcja {{number}}",
           "multiple": "(Dozwolony wielokrotny wybór)",
           "single": "(Pojedynczy wybór)",
           "placeholder": "Wpisz tutaj swoje pytanie...",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -244,6 +244,26 @@
                 "preview": "Pré-visualizar",
                 "empty": "Nada para pré-visualizar"
             },
+            "icon_picker": {
+                "icons": {
+                    "User": "Pessoa",
+                    "Zap": "Raio",
+                    "Scale": "Balança",
+                    "MessageSquareText": "Mensagem",
+                    "ClipboardList": "Prancheta",
+                    "CheckCircle": "Marca de verificação",
+                    "Flag": "Bandeira",
+                    "Info": "Informação",
+                    "HelpCircle": "Ajuda",
+                    "FileText": "Documento",
+                    "LayoutGrid": "Grade",
+                    "Rocket": "Foguete",
+                    "Target": "Alvo",
+                    "Brain": "Cérebro",
+                    "Lightbulb": "Ideia",
+                    "ListChecks": "Lista de verificação"
+                }
+            },
             "click_to_edit": "Clique para editar"
         },
         "layout": {
@@ -1420,6 +1440,7 @@
                     "question": "Etiqueta da pergunta",
                     "required": "Campo obrigatório",
                     "options": "Opções",
+                    "option_ordinal": "Opção {{number}}",
                     "multiple": "(Seleção múltipla permitida)",
                     "single": "(Seleção única)",
                     "placeholder": "Introduza aqui a sua pergunta...",

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -108,9 +108,6 @@
             "Label#8d66a2a9af": 1,
             "Label#b6d369de71": 1
         },
-        "src/components/admin/designer/QSortEditor.tsx": {
-            "Label#357faf6410": 1
-        },
         "src/components/admin/designer/QuestionBuilder.tsx": {
             "Label#55a33a00e6": 1,
             "Label#5bbd85ed1f": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -57,7 +57,7 @@
         },
         "src/pages/admin/ProjectMembersPage.tsx": {
             "Button#d8507040f1": 1,
-            "SelectTrigger#872cdad358": 2
+            "SelectTrigger#872cdad358": 1
         }
     },
     "lowContrastControls": {
@@ -132,10 +132,6 @@
             "Label#dd23d8021a": 1,
             "Label#e4d9b72f77": 1,
             "Label#efa4e00bc8": 1
-        },
-        "src/pages/admin/ProjectMembersPage.tsx": {
-            "Label#302a87c2cf": 1,
-            "Label#9eade0b790": 1
         },
         "src/pages/admin/RecruitmentPage.tsx": {
             "Label#5e73029fe1": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -91,12 +91,6 @@
         }
     },
     "suppressedLabelErrors": {
-        "src/components/admin/designer/IntroductionEditor.tsx": {
-            "Label#02e66bf1f6": 1,
-            "Label#2081ca5d80": 1,
-            "Label#7ab5d8c56c": 1,
-            "Label#e4bc2d1838": 1
-        },
         "src/components/admin/designer/QuestionBuilder.tsx": {
             "Label#55a33a00e6": 1,
             "Label#5bbd85ed1f": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -132,10 +132,6 @@
             "Label#dd23d8021a": 1,
             "Label#e4d9b72f77": 1,
             "Label#efa4e00bc8": 1
-        },
-        "src/pages/admin/RecruitmentPage.tsx": {
-            "Label#5e73029fe1": 1,
-            "Label#9e6b67bc74": 1
         }
     }
 }

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -91,9 +91,6 @@
         }
     },
     "suppressedLabelErrors": {
-        "src/components/admin/designer/ImportFromConcourseDialog.tsx": {
-            "Label#2851b69212": 1
-        },
         "src/components/admin/designer/InterfaceEditor.tsx": {
             "Label#82b1d76fc7": 1,
             "Label#941606f737": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -119,10 +119,6 @@
             "Label#eb3e025ad6": 1,
             "Label#ff10c47a50": 1
         },
-        "src/components/admin/ImportStudyDialog.tsx": {
-            "Label#27fb62ced8": 1,
-            "Label#8ef1b3adb6": 1
-        },
         "src/components/postsort/Step1_Feedback.tsx": {
             "Label#202c7721b8": 1,
             "Label#8eaf4a8179": 1

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -52,7 +52,7 @@
             "Button#1dd7a5d308": 1,
             "Button#81017c5def": 1,
             "Button#a1f3efb8f5": 1,
-            "SelectTrigger#872cdad358": 4,
+            "SelectTrigger#872cdad358": 3,
             "SelectTrigger#bb89cca4e9": 1
         },
         "src/pages/admin/ProjectMembersPage.tsx": {
@@ -101,16 +101,6 @@
             "Label#b70312b797": 1,
             "Label#eb3e025ad6": 1,
             "Label#ff10c47a50": 1
-        },
-        "src/pages/admin/ConcourseDetailPage.tsx": {
-            "Label#03f1e6a441": 1,
-            "Label#0612b2c469": 1,
-            "Label#5015a98ae6": 1,
-            "Label#b8819b4553": 1,
-            "Label#bac85b7720": 1,
-            "Label#dd23d8021a": 1,
-            "Label#e4d9b72f77": 1,
-            "Label#efa4e00bc8": 1
         }
     }
 }

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -42,8 +42,7 @@
         },
         "src/components/admin/designer/QuestionBuilder.tsx": {
             "Button#81017c5def": 2,
-            "Button#83b5f464b1": 1,
-            "SelectTrigger#872cdad358": 2
+            "Button#83b5f464b1": 1
         },
         "src/pages/admin/AccountSettingsPage.tsx": {
             "button#3ddd1d5369": 1
@@ -90,17 +89,5 @@
             "button#543c37a641": 1
         }
     },
-    "suppressedLabelErrors": {
-        "src/components/admin/designer/QuestionBuilder.tsx": {
-            "Label#55a33a00e6": 1,
-            "Label#5bbd85ed1f": 1,
-            "Label#929f555fc8": 1,
-            "Label#98da6c948b": 1,
-            "Label#b1230a6e26": 1,
-            "Label#b24dbd75d7": 1,
-            "Label#b70312b797": 1,
-            "Label#eb3e025ad6": 1,
-            "Label#ff10c47a50": 1
-        }
-    }
+    "suppressedLabelErrors": {}
 }

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -102,9 +102,6 @@
             "Label#7ab5d8c56c": 1,
             "Label#e4bc2d1838": 1
         },
-        "src/components/admin/designer/PostSortConfigEditor.tsx": {
-            "Label#13a6b7e74a": 1
-        },
         "src/components/admin/designer/ProcessStepEditor.tsx": {
             "Label#0af60f23ef": 1,
             "Label#0c96a77f87": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -91,11 +91,6 @@
         }
     },
     "suppressedLabelErrors": {
-        "src/components/admin/designer/InterfaceEditor.tsx": {
-            "Label#82b1d76fc7": 1,
-            "Label#941606f737": 1,
-            "Label#fe9364a7a7": 1
-        },
         "src/components/admin/designer/IntroductionEditor.tsx": {
             "Label#02e66bf1f6": 1,
             "Label#2081ca5d80": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -97,12 +97,6 @@
             "Label#7ab5d8c56c": 1,
             "Label#e4bc2d1838": 1
         },
-        "src/components/admin/designer/ProcessStepEditor.tsx": {
-            "Label#0af60f23ef": 1,
-            "Label#0c96a77f87": 1,
-            "Label#8d66a2a9af": 1,
-            "Label#b6d369de71": 1
-        },
         "src/components/admin/designer/QuestionBuilder.tsx": {
             "Label#55a33a00e6": 1,
             "Label#5bbd85ed1f": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -91,9 +91,6 @@
         }
     },
     "suppressedLabelErrors": {
-        "src/components/admin/designer/BrandingEditor.tsx": {
-            "Label#fc7744f7ff": 1
-        },
         "src/components/admin/designer/ImportFromConcourseDialog.tsx": {
             "Label#2851b69212": 1
         },

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -119,10 +119,6 @@
             "Label#eb3e025ad6": 1,
             "Label#ff10c47a50": 1
         },
-        "src/components/postsort/Step1_Feedback.tsx": {
-            "Label#202c7721b8": 1,
-            "Label#8eaf4a8179": 1
-        },
         "src/pages/admin/ConcourseDetailPage.tsx": {
             "Label#03f1e6a441": 1,
             "Label#0612b2c469": 1,

--- a/frontend/src/components/admin/ImportStudyDialog.test.tsx
+++ b/frontend/src/components/admin/ImportStudyDialog.test.tsx
@@ -1,0 +1,55 @@
+import { renderWithProviders, screen, fireEvent } from '@/test-utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ImportStudyDialog } from './ImportStudyDialog';
+
+const validateStudyImport = vi.fn();
+vi.mock('@/api/admin', () => ({
+    AdminService: {
+        validateStudyImport: (...args: unknown[]) => validateStudyImport(...args),
+        importStudyConfig: vi.fn(),
+    },
+}));
+
+describe('ImportStudyDialog — validation errors/warnings headings (Task 6.7b)', () => {
+    it('renders the errors and warnings sections as real headings, not dangling form labels', async () => {
+        validateStudyImport.mockResolvedValue({
+            data: {
+                valid: false,
+                errors: ['Missing study title'],
+                warnings: ['Grid capacity does not match statement count'],
+                summary: {
+                    title: '',
+                    languages: [],
+                    statement_count: 0,
+                    grid_range: '',
+                    has_presort: false,
+                    has_postsort: false,
+                },
+            },
+        });
+
+        const user = userEvent.setup();
+        renderWithProviders(
+            <ImportStudyDialog open onOpenChange={vi.fn()} projectSlug="demo-project" />
+        );
+
+        await user.click(screen.getByRole('tab', { name: /paste json/i }));
+        fireEvent.change(screen.getByLabelText(/paste json configuration/i), {
+            target: { value: '{"version":"1.0","study":{}}' },
+        });
+        await user.click(screen.getByRole('button', { name: /validate & continue/i }));
+
+        // A <Label> with no htmlFor target used to sit here, announced as a
+        // dangling form label pointing at nothing. Now it is a real heading:
+        // getByRole computes that structurally, not from an attribute.
+        expect(
+            await screen.findByRole('heading', { name: /errors:/i, level: 4 })
+        ).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /warnings:/i, level: 4 })).toBeInTheDocument();
+        expect(screen.getByText('Missing study title')).toBeInTheDocument();
+        expect(
+            screen.getByText('Grid capacity does not match statement count')
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/ImportStudyDialog.tsx
+++ b/frontend/src/components/admin/ImportStudyDialog.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -286,9 +285,11 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
                         {/* Errors */}
                         {validation.errors.length > 0 && (
                             <div className="space-y-2">
-                                <Label className="text-red-600 font-semibold">
+                                {/* Heads a static error list, not a form control — a real
+                                    heading element, not the form-field <Label>. */}
+                                <h4 className="text-sm font-semibold text-red-600">
                                     {t('admin.import.errors', 'Errors')}:
-                                </Label>
+                                </h4>
                                 <ul className="text-sm space-y-1">
                                     {validation.errors.map((error, i) => (
                                         <li key={i} className="text-red-600 flex items-start gap-2">
@@ -303,9 +304,11 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
                         {/* Warnings */}
                         {validation.warnings.length > 0 && (
                             <div className="space-y-2">
-                                <Label className="text-amber-600 font-semibold">
+                                {/* Heads a static warning list, not a form control — a real
+                                    heading element, not the form-field <Label>. */}
+                                <h4 className="text-sm font-semibold text-amber-600">
                                     {t('admin.import.warnings', 'Warnings')}:
-                                </Label>
+                                </h4>
                                 <ul className="text-sm space-y-1">
                                     {validation.warnings.map((warning, i) => (
                                         <li

--- a/frontend/src/components/admin/designer/BrandingEditor.test.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.test.tsx
@@ -1,0 +1,32 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { renderWithStore } from '@/test-utils/renderWithStore';
+import BrandingEditor from './BrandingEditor';
+
+describe('BrandingEditor — partner name accessible name (Task 6.7b)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: convenient partial mock
+    const mockDraft: any = {
+        slug: 'test-study',
+        state: 'draft',
+        branding: {
+            logo_url: null,
+            accent_color: null,
+            partners: [{ id: 'partner-1', name: 'Acme University', logo_url: null }],
+        },
+    };
+
+    const renderEditor = () =>
+        renderWithStore(<BrandingEditor />, {
+            initialState: { draft: mockDraft, activeLocale: 'en' },
+        });
+
+    it('names the partner name field and lets its label focus it', async () => {
+        const user = userEvent.setup();
+        renderEditor();
+
+        const field = screen.getByRole('textbox', { name: /institution name/i });
+        await user.click(screen.getByText('Institution name'));
+        expect(field).toHaveFocus();
+    });
+});

--- a/frontend/src/components/admin/designer/BrandingEditor.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 
 import { Label } from '@/components/ui/label';
@@ -261,13 +260,17 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                             </div>
                                             <div className="flex-1 space-y-3">
                                                 <div className="grid gap-1.5">
-                                                    <Label className="text-2xs font-black text-slate-400">
+                                                    <Label
+                                                        htmlFor={`partner-name-${partner.id ?? index}`}
+                                                        className="text-2xs font-black text-slate-400"
+                                                    >
                                                         {t(
                                                             'admin.design.theme.partners.name_placeholder',
                                                             'Name'
                                                         )}
                                                     </Label>
                                                     <Input
+                                                        id={`partner-name-${partner.id ?? index}`}
                                                         name="partnerName"
                                                         value={partner.name}
                                                         onChange={(e) => {

--- a/frontend/src/components/admin/designer/IconPicker.tsx
+++ b/frontend/src/components/admin/designer/IconPicker.tsx
@@ -16,6 +16,7 @@ import {
     Lightbulb,
     ListChecks,
 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 
 const ICONS = {
@@ -39,32 +40,77 @@ const ICONS = {
 
 type IconName = keyof typeof ICONS;
 
+/**
+ * Fallback text for each icon's translated name — `name` from `ICONS` is a
+ * raw lucide component identifier (`MessageSquareText`, `ListChecks`) and is
+ * not fit to announce to a screen-reader user, so every button is named via
+ * `t()` instead of `title={name}`.
+ */
+const ICON_NAME_FALLBACKS: Record<IconName, string> = {
+    User: 'Person',
+    Zap: 'Lightning bolt',
+    Scale: 'Balance',
+    MessageSquareText: 'Message',
+    ClipboardList: 'Clipboard',
+    CheckCircle: 'Checkmark',
+    Flag: 'Flag',
+    Info: 'Information',
+    HelpCircle: 'Help',
+    FileText: 'Document',
+    LayoutGrid: 'Grid',
+    Rocket: 'Rocket',
+    Target: 'Target',
+    Brain: 'Brain',
+    Lightbulb: 'Idea',
+    ListChecks: 'Checklist',
+};
+
 interface IconPickerProps {
     selectedIcon: string;
     onChange: (icon: IconName) => void;
     disabled?: boolean;
+    /**
+     * Id of the visible heading that names this picker as a group — the
+     * caller supplies its own heading text (e.g. "Icon") and points it here
+     * via `aria-labelledby`, same pattern as the other 6.7b group fixes.
+     */
+    ariaLabelledBy?: string;
 }
 
-export function IconPicker({ selectedIcon, onChange, disabled }: IconPickerProps) {
+export function IconPicker({ selectedIcon, onChange, disabled, ariaLabelledBy }: IconPickerProps) {
+    const { t } = useTranslation();
+
     return (
-        <div className={cn('grid grid-cols-4 gap-2', disabled && 'opacity-50 pointer-events-none')}>
-            {Object.entries(ICONS).map(([name, Icon]) => (
-                <button
-                    key={name}
-                    type="button"
-                    disabled={disabled}
-                    onClick={() => onChange(name as IconName)}
-                    className={cn(
-                        'flex aspect-square items-center justify-center rounded-lg border p-2 transition-all hover:bg-accent hover:text-accent-foreground',
-                        selectedIcon === name
-                            ? 'border-primary bg-primary/10 text-primary'
-                            : 'border-muted bg-background text-muted-foreground'
-                    )}
-                    title={name}
-                >
-                    <Icon size={20} strokeWidth={selectedIcon === name ? 2.5 : 2} />
-                </button>
-            ))}
+        <div
+            role="group"
+            aria-labelledby={ariaLabelledBy}
+            className={cn('grid grid-cols-4 gap-2', disabled && 'opacity-50 pointer-events-none')}
+        >
+            {Object.entries(ICONS).map(([name, Icon]) => {
+                const iconName = name as IconName;
+                const label = t(
+                    `admin.components.icon_picker.icons.${iconName}`,
+                    ICON_NAME_FALLBACKS[iconName]
+                );
+                return (
+                    <button
+                        key={name}
+                        type="button"
+                        disabled={disabled}
+                        onClick={() => onChange(iconName)}
+                        className={cn(
+                            'flex aspect-square items-center justify-center rounded-lg border p-2 transition-all hover:bg-accent hover:text-accent-foreground',
+                            selectedIcon === name
+                                ? 'border-primary bg-primary/10 text-primary'
+                                : 'border-muted bg-background text-muted-foreground'
+                        )}
+                        title={label}
+                        aria-label={label}
+                    >
+                        <Icon size={20} strokeWidth={selectedIcon === name ? 2.5 : 2} />
+                    </button>
+                );
+            })}
         </div>
     );
 }

--- a/frontend/src/components/admin/designer/ImportFromConcourseDialog.test.tsx
+++ b/frontend/src/components/admin/designer/ImportFromConcourseDialog.test.tsx
@@ -1,0 +1,49 @@
+import { renderWithProviders, screen } from '@/test-utils/test-utils';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ImportFromConcourseDialog } from './ImportFromConcourseDialog';
+
+vi.mock('@/api/generated', () => ({
+    useListConcoursesApiAdminConcoursesGet: () => ({
+        data: { items: [{ id: 1, title: 'Demo concourse' }] },
+    }),
+    useGetConcourseApiAdminConcoursesConcourseIdGet: () => ({
+        data: {
+            id: 1,
+            items: [
+                {
+                    id: 101,
+                    status: 'accepted',
+                    translations: [{ language_code: 'en', text: 'A statement' }],
+                },
+            ],
+        },
+        isLoading: false,
+    }),
+    useImportFromConcourseApiAdminStudiesSlugImportConcoursePost: () => ({
+        mutateAsync: vi.fn(),
+        isPending: false,
+    }),
+}));
+
+describe('ImportFromConcourseDialog — code prefix accessible name (Task 6.7b)', () => {
+    const renderDialog = () =>
+        renderWithProviders(
+            <ImportFromConcourseDialog
+                open
+                onOpenChange={vi.fn()}
+                studySlug="demo-study"
+                activeLocale="en"
+                onImported={vi.fn()}
+            />
+        );
+
+    it('names the code prefix field and lets its label focus it', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        const field = screen.getByRole('textbox', { name: /code prefix/i });
+        await user.click(screen.getByText('Code prefix'));
+        expect(field).toHaveFocus();
+    });
+});

--- a/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
+++ b/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Library, Loader2, Upload } from 'lucide-react';
@@ -174,10 +173,14 @@ export function ImportFromConcourseDialog({
                     {/* Options */}
                     <div className="flex flex-col sm:flex-row sm:items-end gap-3">
                         <div className="space-y-1">
-                            <Label className="text-2xs font-black text-slate-500">
+                            <Label
+                                htmlFor="concourse-import-code-prefix"
+                                className="text-2xs font-black text-slate-500"
+                            >
                                 {t('admin.concourse_import.code_prefix', 'Code prefix')}
                             </Label>
                             <Input
+                                id="concourse-import-code-prefix"
                                 value={codePrefix}
                                 onChange={(e) => setCodePrefix(e.target.value)}
                                 placeholder={t(

--- a/frontend/src/components/admin/designer/InterfaceEditor.test.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.test.tsx
@@ -1,4 +1,5 @@
 import { screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
 import InterfaceEditor from './InterfaceEditor';
 import { renderWithStore } from '@/test-utils/renderWithStore';
@@ -93,5 +94,42 @@ describe('InterfaceEditor', () => {
         // biome-ignore lint/suspicious/noExplicitAny: access internal structure
         const enTranslation = currentDraft.translations.find((t: any) => t.language_code === 'en');
         expect(enTranslation.ui_labels['welcome.start']).toBeUndefined();
+    });
+
+    describe('accessible names (Task 6.7b)', () => {
+        it('names the "Next step button" field and lets its label focus it', async () => {
+            const user = userEvent.setup();
+            renderEditor();
+
+            const field = screen.getByRole('textbox', { name: /next step button/i });
+            await user.click(screen.getByText('Next step button'));
+            expect(field).toHaveFocus();
+        });
+
+        it('names the terminology fields distinctly per stance and per group', () => {
+            renderEditor();
+
+            // "Agree"/"Most agree" are unique across the two term groups —
+            // getByRole computes the real accessible name, so this only
+            // passes if each group's htmlFor/id pairing resolved to the
+            // right sibling Input rather than colliding across groups.
+            expect(screen.getByRole('textbox', { name: /^agree$/i })).toBeInTheDocument();
+            expect(screen.getByRole('textbox', { name: /^most agree$/i })).toBeInTheDocument();
+            expect(screen.getByRole('textbox', { name: /^disagree$/i })).toBeInTheDocument();
+            expect(screen.getByRole('textbox', { name: /^most disagree$/i })).toBeInTheDocument();
+        });
+
+        it('names the "What we ask"/"Why it matters" step-help fields for every visible step', () => {
+            renderEditor();
+
+            // Every step in the Step Guidance card renders its own What/Why
+            // pair with a per-step id (`step-help-${step.id}-${field}`) — if
+            // any two steps collided on id, some of these would resolve to
+            // the wrong control or fail to resolve at all.
+            const whatFields = screen.getAllByRole('textbox', { name: /^what we ask$/i });
+            const whyFields = screen.getAllByRole('textbox', { name: /^why it matters$/i });
+            expect(whatFields.length).toBeGreaterThanOrEqual(2);
+            expect(whatFields).toHaveLength(whyFields.length);
+        });
     });
 });

--- a/frontend/src/components/admin/designer/InterfaceEditor.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { isPresortEnabled, isRoughSortEnabled } from '@/utils/studyConfig';
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
@@ -170,7 +169,10 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                 <div key={inputKey} className="space-y-2.5">
                                     <div className="flex items-center justify-between">
                                         <div className="flex items-center gap-2">
-                                            <Label className="text-2xs font-black text-slate-500">
+                                            <Label
+                                                htmlFor={`interface-nav-${inputKey}`}
+                                                className="text-2xs font-black text-slate-500"
+                                            >
                                                 {t(`admin.design.interface.nav.${tipKey}`)}
                                             </Label>
                                             <TooltipProvider>
@@ -202,6 +204,7 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                         )}
                                     </div>
                                     <Input
+                                        id={`interface-nav-${inputKey}`}
                                         name={inputKey}
                                         value={getLabel(inputKey)}
                                         onChange={(e) => updateLabel(inputKey, e.target.value)}
@@ -285,12 +288,16 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                             const inputKey = `${group.keyPrefix}.${suffix}`;
                                             return (
                                                 <div key={inputKey} className="space-y-2.5">
-                                                    <Label className="text-2xs font-black text-slate-400">
+                                                    <Label
+                                                        htmlFor={`interface-term-${inputKey}`}
+                                                        className="text-2xs font-black text-slate-400"
+                                                    >
                                                         {t(
                                                             `admin.design.interface.terms.${termKey}`
                                                         )}
                                                     </Label>
                                                     <Input
+                                                        id={`interface-term-${inputKey}`}
                                                         name={inputKey}
                                                         value={getLabel(inputKey)}
                                                         onChange={(e) =>
@@ -453,10 +460,14 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-8 pl-6 border-l-2 border-slate-100">
                                     {(['what', 'why'] as const).map((field) => (
                                         <div key={field} className="space-y-2.5">
-                                            <Label className="text-2xs font-black text-slate-400">
+                                            <Label
+                                                htmlFor={`step-help-${step.id}-${field}`}
+                                                className="text-2xs font-black text-slate-400"
+                                            >
                                                 {t(`study.help.${field}`)}
                                             </Label>
                                             <Input
+                                                id={`step-help-${step.id}-${field}`}
                                                 value={
                                                     stepHelp[field] ||
                                                     tStudy(`study.help.step_${step.id}.${field}`)

--- a/frontend/src/components/admin/designer/IntroductionEditor.test.tsx
+++ b/frontend/src/components/admin/designer/IntroductionEditor.test.tsx
@@ -66,3 +66,89 @@ describe('IntroductionEditor — Wave B progressive disclosure', () => {
         expect(screen.getByDisplayValue('Informed consent')).toBeInTheDocument();
     });
 });
+
+describe('IntroductionEditor — field accessible names (Task 6.7b)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: convenient partial mock
+    const mockDraft: any = {
+        slug: 'test-study',
+        state: 'draft',
+        default_language: 'en',
+        translations: [
+            {
+                language_code: 'en',
+                title: 'Test Study',
+                subtitle: '',
+                objective: '',
+                instructions: '',
+                consent_title: 'Informed consent',
+                consent_description: 'Consent body',
+                process_steps: [
+                    {
+                        id: 'step-1',
+                        title: 'Welcome',
+                        description: 'A short description that should preview',
+                        icon: 'Hand',
+                    },
+                ],
+            },
+        ],
+    };
+
+    const renderEditor = () =>
+        renderWithStore(<IntroductionEditor />, {
+            initialState: { draft: mockDraft, activeLocale: 'en' },
+        });
+
+    it('names the "Default Language" select and lets its label open it', async () => {
+        const user = userEvent.setup();
+        renderEditor();
+
+        // The trigger's own content is the selected language's code ("EN");
+        // pairing the Label overrides that with the field's purpose.
+        const trigger = screen.getByRole('combobox', { name: /default language/i });
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+        await user.click(screen.getByText('Default Language'));
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('names the "Study objective" markdown field and lets its label focus it', async () => {
+        const user = userEvent.setup();
+        renderEditor();
+
+        // MarkdownEditor's id lives on a <textarea> it renders internally
+        // (a separate component/file); the pairing is still a real DOM
+        // htmlFor/id match once rendered, which this focus assertion proves.
+        const field = screen.getByRole('textbox', { name: /study objective/i });
+        await user.click(screen.getByText('Study objective'));
+        expect(field).toHaveFocus();
+    });
+
+    it('names the "Study steps overview" (task overview) markdown field', async () => {
+        const user = userEvent.setup();
+        renderEditor();
+
+        const processTrigger = screen.getByRole('button', {
+            name: /Study steps overview|Aperçu des étapes de l'étude/i,
+        });
+        await user.click(processTrigger);
+
+        const field = await screen.findByRole('textbox', { name: /^introduction$/i });
+        await user.click(screen.getByText('Introduction'));
+        expect(field).toHaveFocus();
+    });
+
+    it('names the "Legal text / agreement" (consent description) markdown field', async () => {
+        const user = userEvent.setup();
+        renderEditor();
+
+        const consentTrigger = screen.getByRole('button', {
+            name: /Consent form|Formulaire de consentement/i,
+        });
+        await user.click(consentTrigger);
+
+        const field = await screen.findByRole('textbox', { name: /legal text \/ agreement/i });
+        await user.click(screen.getByText('Legal text / agreement'));
+        expect(field).toHaveFocus();
+    });
+});

--- a/frontend/src/components/admin/designer/IntroductionEditor.tsx
+++ b/frontend/src/components/admin/designer/IntroductionEditor.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -88,7 +87,10 @@ const IntroductionEditor = ({ readOnly }: { readOnly?: boolean }) => {
                 <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
                     <CardContent className="pt-6 space-y-6">
                         <div className="grid gap-2.5">
-                            <Label className="text-2xs font-black text-slate-500">
+                            <Label
+                                htmlFor="default-language-select"
+                                className="text-2xs font-black text-slate-500"
+                            >
                                 {t('admin.design.intro.fields.default_lang')}
                             </Label>
                             <Select
@@ -104,7 +106,10 @@ const IntroductionEditor = ({ readOnly }: { readOnly?: boolean }) => {
                                 }
                                 disabled={readOnly}
                             >
-                                <SelectTrigger className="w-full h-11 rounded-xl font-medium">
+                                <SelectTrigger
+                                    id="default-language-select"
+                                    className="w-full h-11 rounded-xl font-medium"
+                                >
                                     <SelectValue
                                         placeholder={t('admin.design.toolbar.select_lang')}
                                     />
@@ -223,7 +228,10 @@ const IntroductionEditor = ({ readOnly }: { readOnly?: boolean }) => {
                                 />
                             </div>
                             <div className="flex items-center gap-2 mb-2">
-                                <Label className="text-2xs font-black text-slate-500">
+                                <Label
+                                    htmlFor="objective"
+                                    className="text-2xs font-black text-slate-500"
+                                >
                                     {t('admin.design.intro.fields.objective')}
                                 </Label>
                                 <MultiLangFieldIcon
@@ -270,7 +278,10 @@ const IntroductionEditor = ({ readOnly }: { readOnly?: boolean }) => {
                             <div className="space-y-4">
                                 <div className="flex items-center justify-between">
                                     <div className="flex items-center gap-2">
-                                        <Label className="text-2xs font-black text-slate-500">
+                                        <Label
+                                            htmlFor="instructions"
+                                            className="text-2xs font-black text-slate-500"
+                                        >
                                             {t('admin.design.intro.fields.task_overview')}
                                         </Label>
                                         <MultiLangFieldIcon
@@ -398,7 +409,10 @@ const IntroductionEditor = ({ readOnly }: { readOnly?: boolean }) => {
                                 />
                             </div>
                             <div className="flex items-center gap-2 mb-2">
-                                <Label className="text-2xs font-black text-slate-500">
+                                <Label
+                                    htmlFor="consent-description"
+                                    className="text-2xs font-black text-slate-500"
+                                >
                                     {t('admin.design.intro.fields.legal_text')}
                                 </Label>
                                 <MultiLangFieldIcon

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.test.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.test.tsx
@@ -246,6 +246,24 @@ describe('PostSortConfigEditor - Extreme Columns Prompts', () => {
         expect(screen.getByText(/Prompt for statements \(\+\)/)).toBeInTheDocument();
         expect(screen.queryByText(/Prompt for statements \(-\)/)).not.toBeInTheDocument();
     });
+
+    it('names the "Add column" select and lets its label open it (Task 6.7b)', async () => {
+        const user = userEvent.setup();
+        renderEditor();
+
+        // The trigger's own content is the placeholder ("Select..."); pairing the
+        // Label overrides that with the field's purpose, per accname's label
+        // priority over content.
+        const trigger = screen.getByRole('combobox', { name: /add column/i });
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+        // Clicking the label dispatches a real click at the paired control — a
+        // Radix Select combobox opens (and moves focus into its listbox) exactly
+        // as it would from a direct click on the trigger, which is only possible
+        // because htmlFor/id actually resolve to this element.
+        await user.click(screen.getByText('Add column:'));
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
 });
 
 describe('PostSortConfigEditor - accessible names (Task 3.6)', () => {

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useStudyDesigner } from '@/store/useStudyDesigner';
 import { usePlatformConfigStore } from '@/store/usePlatformConfigStore';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -217,14 +216,20 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
 
                             {unselectedScores.length > 0 && !readOnly && !structureLocked && (
                                 <div className="flex items-center gap-3 pt-6 border-t border-slate-100">
-                                    <Label className="text-2xs font-black text-slate-500">
+                                    <Label
+                                        htmlFor="postsort-extreme-score-select"
+                                        className="text-2xs font-black text-slate-500"
+                                    >
                                         {t('admin.design.postsort.extreme.add_label')}
                                     </Label>
                                     <Select
                                         value={selectedScore?.toString() || ''}
                                         onValueChange={(val) => setSelectedScore(Number(val))}
                                     >
-                                        <SelectTrigger className="w-32 h-10 rounded-xl border-slate-200 bg-white font-bold">
+                                        <SelectTrigger
+                                            id="postsort-extreme-score-select"
+                                            className="w-32 h-10 rounded-xl border-slate-200 bg-white font-bold"
+                                        >
                                             <SelectValue
                                                 placeholder={t(
                                                     'admin.design.postsort.extreme.select_placeholder'

--- a/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
@@ -203,3 +203,46 @@ describe('ProcessStepEditor — inconsistent feature flags banner', () => {
         expect(items).toHaveLength(2);
     });
 });
+
+describe('ProcessStepEditor — step field accessible names (Task 6.7b)', () => {
+    const expandTheOneStep = async (user: ReturnType<typeof userEvent.setup>) => {
+        const draft = buildDraft([otherStep]);
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+        await user.click(screen.getByRole('button', { name: /toggle/i }));
+    };
+
+    it('names the "Step title" field and lets its label focus it', async () => {
+        const user = userEvent.setup();
+        await expandTheOneStep(user);
+
+        const field = await screen.findByRole('textbox', { name: /^step title$/i });
+        await user.click(screen.getByText('Step title'));
+        expect(field).toHaveFocus();
+    });
+
+    it('names the "Short description" and "Color" fields', async () => {
+        const user = userEvent.setup();
+        await expandTheOneStep(user);
+
+        expect(
+            await screen.findByRole('textbox', { name: /^short description$/i })
+        ).toBeInTheDocument();
+        // The color swatch <input type="color"> has no ARIA role in jsdom, so
+        // getByLabelText (which also resolves via htmlFor/id) stands in for
+        // getByRole here — same as the datetime-local case elsewhere in 6.7b.
+        expect(screen.getByLabelText('Color')).toBeInTheDocument();
+    });
+
+    it('renders "Icon" as plain text heading a group of individually-named icon buttons', async () => {
+        const user = userEvent.setup();
+        await expandTheOneStep(user);
+
+        const heading = await screen.findByText('Icon');
+        expect(heading.tagName).not.toBe('LABEL');
+        // Each icon button in the picker already carries its own name (title=)
+        // — this fix didn't touch that, only stopped mislabelling the group.
+        expect(screen.getByRole('button', { name: 'User' })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
@@ -235,14 +235,22 @@ describe('ProcessStepEditor — step field accessible names (Task 6.7b)', () => 
         expect(screen.getByLabelText('Color')).toBeInTheDocument();
     });
 
-    it('renders "Icon" as plain text heading a group of individually-named icon buttons', async () => {
+    it('renders "Icon" as plain text heading a real, named group of icon buttons (Task 6.7b fix round 1)', async () => {
         const user = userEvent.setup();
         await expandTheOneStep(user);
 
         const heading = await screen.findByText('Icon');
         expect(heading.tagName).not.toBe('LABEL');
-        // Each icon button in the picker already carries its own name (title=)
-        // — this fix didn't touch that, only stopped mislabelling the group.
-        expect(screen.getByRole('button', { name: 'User' })).toBeInTheDocument();
+
+        // IconPicker's root carries role="group" aria-labelledby={heading.id} —
+        // getByRole computes the group's real accessible name from that
+        // association, not from the heading merely sitting nearby in the DOM.
+        expect(screen.getByRole('group', { name: 'Icon' })).toBeInTheDocument();
+
+        // Each button is named via a translated word ("Person"), not the raw
+        // lucide identifier ("User") the component key uses internally —
+        // getByRole with the identifier would now fail to resolve.
+        expect(screen.getByRole('button', { name: 'Person' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'User' })).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import type React from 'react';
 import { useEffect, useMemo } from 'react';
 import {
@@ -138,10 +137,14 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                 <div className="grid gap-6 sm:grid-cols-2">
                                     <div className="space-y-6">
                                         <div className="grid gap-2">
-                                            <Label className="text-2xs font-black text-slate-500">
+                                            <Label
+                                                htmlFor={`step-title-${id}`}
+                                                className="text-2xs font-black text-slate-500"
+                                            >
                                                 {t('admin.design.intro.process_steps.fields.title')}
                                             </Label>
                                             <Input
+                                                id={`step-title-${id}`}
                                                 value={step.title}
                                                 className="h-11 rounded-xl border-slate-200 bg-slate-50/50 focus:bg-white transition-all font-medium"
                                                 onChange={(e) =>
@@ -155,12 +158,16 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                         </div>
 
                                         <div className="grid gap-2">
-                                            <Label className="text-2xs font-black text-slate-500">
+                                            <Label
+                                                htmlFor={`step-description-${id}`}
+                                                className="text-2xs font-black text-slate-500"
+                                            >
                                                 {t(
                                                     'admin.design.intro.process_steps.fields.description'
                                                 )}
                                             </Label>
                                             <Textarea
+                                                id={`step-description-${id}`}
                                                 value={step.description}
                                                 onChange={(e) =>
                                                     onUpdate({
@@ -179,9 +186,12 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
 
                                     <div className="space-y-6">
                                         <div className="grid gap-2">
-                                            <Label className="text-2xs font-black text-slate-500">
+                                            {/* Heads a grid of 16 individually-named icon buttons
+                                                (each has its own title), not one control — a real
+                                                heading element, not the form-field <Label>. */}
+                                            <p className="text-2xs font-black text-slate-500">
                                                 {t('admin.design.intro.process_steps.fields.icon')}
-                                            </Label>
+                                            </p>
                                             <IconPicker
                                                 selectedIcon={step.icon}
                                                 onChange={(icon) => onUpdate({ ...step, icon })}
@@ -190,7 +200,10 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                         </div>
 
                                         <div className="grid gap-2">
-                                            <Label className="text-2xs font-black text-slate-500">
+                                            <Label
+                                                htmlFor={`step-color-${id}`}
+                                                className="text-2xs font-black text-slate-500"
+                                            >
                                                 {t(
                                                     'admin.design.intro.process_steps.fields.color',
                                                     'Color'
@@ -199,6 +212,7 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                             <div className="flex items-center gap-3">
                                                 <div className="relative group/color">
                                                     <Input
+                                                        id={`step-color-${id}`}
                                                         type="color"
                                                         value={step.color || '#3b82f6'}
                                                         onChange={(e) =>

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -187,15 +187,21 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                     <div className="space-y-6">
                                         <div className="grid gap-2">
                                             {/* Heads a grid of 16 individually-named icon buttons
-                                                (each has its own title), not one control — a real
-                                                heading element, not the form-field <Label>. */}
-                                            <p className="text-2xs font-black text-slate-500">
+                                                via aria-labelledby on IconPicker's own group
+                                                wrapper, not htmlFor — a real heading element
+                                                naming a group, not the form-field <Label>
+                                                pointing at one control. */}
+                                            <p
+                                                id={`step-icon-heading-${id}`}
+                                                className="text-2xs font-black text-slate-500"
+                                            >
                                                 {t('admin.design.intro.process_steps.fields.icon')}
                                             </p>
                                             <IconPicker
                                                 selectedIcon={step.icon}
                                                 onChange={(icon) => onUpdate({ ...step, icon })}
                                                 disabled={readOnly}
+                                                ariaLabelledBy={`step-icon-heading-${id}`}
                                             />
                                         </div>
 

--- a/frontend/src/components/admin/designer/QSortEditor.test.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.test.tsx
@@ -311,4 +311,18 @@ describe('QSortEditor', () => {
             expect(screen.getByTestId('grid-column-4-slots').children).toHaveLength(1);
         });
     });
+
+    describe('Distribution mode group name (Task 6.7b)', () => {
+        it('names the distribution-mode radiogroup via aria-labelledby', () => {
+            renderEditor({ activeSubStep: 'grid' });
+
+            // "Distribution mode" headed a group of three radios with no
+            // association at all before this fix — getByRole computes the real
+            // accessible name of the `radiogroup`, so this only passes because
+            // aria-labelledby now resolves to the heading text.
+            expect(
+                screen.getByRole('radiogroup', { name: /distribution mode/i })
+            ).toBeInTheDocument();
+        });
+    });
 });

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { useState, useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useStudyDesigner } from '@/store/useStudyDesigner';
@@ -1340,12 +1339,19 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                             <div className="mb-8 px-4 py-4 sm:px-6 bg-white border border-slate-200 rounded-2xl shadow-sm">
                                 <div className="flex items-start gap-3 mb-3">
                                     <div className="flex-1">
-                                        <Label className="text-xs font-black uppercase tracking-wide text-slate-500">
+                                        {/* Names the radiogroup below via aria-labelledby, not htmlFor —
+                                            this heads a group of three radios, not one control, so a
+                                            <Label>/htmlFor pairing would misleadingly imply it selects
+                                            a specific option. */}
+                                        <p
+                                            id="distribution-mode-heading"
+                                            className="leading-none text-xs font-black uppercase tracking-wide text-slate-500"
+                                        >
                                             {t(
                                                 'admin.study_design.distribution_mode.title',
                                                 'Distribution mode'
                                             )}
-                                        </Label>
+                                        </p>
                                         <p className="mt-1 text-xs text-slate-500 leading-relaxed">
                                             {t(
                                                 'admin.study_design.distribution_mode.helper',
@@ -1355,6 +1361,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                     </div>
                                 </div>
                                 <RadioGroup
+                                    aria-labelledby="distribution-mode-heading"
                                     value={draft.distribution_mode ?? 'forced'}
                                     onValueChange={(value) => {
                                         if (

--- a/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
@@ -103,3 +103,152 @@ describe('QuestionBuilder - presort-toggle accessible name (Task 3.6 closing swe
         expect(screen.getAllByRole('switch')).toHaveLength(1);
     });
 });
+
+/**
+ * Task 6.7b: the nine `noLabelWithoutControl` findings measured in this file
+ * by task 6.7a. Seven are real Label/control pairings (each control given a
+ * stable id derived from the question's own `id`); two ("Rating scale" and
+ * "Options") headed a group of several fields rather than one control and
+ * became plain text instead of a fake htmlFor pairing.
+ */
+describe('QuestionBuilder — question field accessible names (Task 6.7b)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: weak typing for test utility
+    const renderBuilder = (initialStateOverrides: any = {}) => {
+        const mergedDraft = {
+            slug: 'test',
+            state: 'draft',
+            postsort_config: { questions: {} },
+            ...(initialStateOverrides.draft || {}),
+        };
+
+        return renderWithStore(<QuestionBuilder type="post" />, {
+            initialState: {
+                ...initialStateOverrides,
+                draft: mergedDraft,
+                activeLocale: 'en',
+            },
+        });
+    };
+
+    const expandSecondQuestion = async (user: ReturnType<typeof userEvent.setup>) => {
+        const secondItemText = await screen.findByText('Second question');
+        const secondItem = secondItemText.closest('[data-testid="question-item"]');
+        if (!secondItem) throw new Error('question item not found');
+        const trigger = within(secondItem as HTMLElement).getByTestId('question-accordion-trigger');
+        await user.click(trigger);
+        return within(secondItem as HTMLElement);
+    };
+
+    it('names the "Question label" field and lets its label focus it', async () => {
+        const user = userEvent.setup();
+        renderBuilder({
+            draft: {
+                postsort_config: {
+                    questions: {
+                        q1: { type: 'text', label: 'First question', required: false },
+                    },
+                },
+            },
+        });
+
+        const trigger = await screen.findByTestId('question-accordion-trigger');
+        await user.click(trigger);
+
+        const field = screen.getByRole('textbox', { name: /question label/i });
+        await user.click(screen.getByText('Question label'));
+        expect(field).toHaveFocus();
+    });
+
+    it('names the visibility-condition "depends on"/"operator"/"value" fields', async () => {
+        const user = userEvent.setup();
+        renderBuilder({
+            draft: {
+                postsort_config: {
+                    questions: {
+                        q1: { type: 'text', label: 'First question', required: false },
+                        q2: {
+                            type: 'text',
+                            label: 'Second question',
+                            required: false,
+                            visibility_condition: {
+                                depends_on: 'q1',
+                                operator: 'equals',
+                                value: 'x',
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        const scope = await expandSecondQuestion(user);
+
+        // getByRole computes the real accessible name — a trigger named only
+        // by its selected value ("First question"/"Equals") would still
+        // satisfy a naive text query, so this is what actually distinguishes
+        // "has a name" from "has the RIGHT name".
+        expect(
+            scope.getByRole('combobox', { name: /show this question only if/i })
+        ).toBeInTheDocument();
+        expect(scope.getByRole('combobox', { name: /^operator$/i })).toBeInTheDocument();
+        expect(scope.getByRole('textbox', { name: /comparison value/i })).toBeInTheDocument();
+    });
+
+    it('names the rating-scale fields and renders "Rating scale" as a real heading', async () => {
+        const user = userEvent.setup();
+        renderBuilder({
+            draft: {
+                postsort_config: {
+                    questions: {
+                        q1: {
+                            type: 'rating',
+                            label: 'Satisfaction',
+                            required: false,
+                            scale_points: 5,
+                        },
+                    },
+                },
+            },
+        });
+
+        const trigger = await screen.findByTestId('question-accordion-trigger');
+        await user.click(trigger);
+
+        // "Rating scale" used to be a <Label> with no htmlFor at all, heading
+        // the scale-points select and the Left/Right fields below it. Scoped
+        // to <p>: the "add a rating field" button in the palette above is
+        // also named "Rating scale" and is not part of this fix.
+        const heading = screen.getByText('Rating scale', { selector: 'p' });
+        expect(heading.tagName).not.toBe('LABEL');
+
+        expect(screen.getByRole('combobox', { name: /number of points/i })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /left endpoint label/i })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /right endpoint label/i })).toBeInTheDocument();
+    });
+
+    it('renders "Options" as a real heading over the option list, not a dangling label', async () => {
+        const user = userEvent.setup();
+        renderBuilder({
+            draft: {
+                postsort_config: {
+                    questions: {
+                        q1: {
+                            type: 'select',
+                            label: 'Pick one',
+                            required: false,
+                            options: ['Alpha', 'Beta'],
+                        },
+                    },
+                },
+            },
+        });
+
+        const trigger = await screen.findByTestId('question-accordion-trigger');
+        await user.click(trigger);
+
+        const heading = screen.getByText('Options');
+        expect(heading.tagName).not.toBe('LABEL');
+        expect(screen.getByDisplayValue('Alpha')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Beta')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
@@ -221,12 +221,17 @@ describe('QuestionBuilder — question field accessible names (Task 6.7b)', () =
         const heading = screen.getByText('Rating scale', { selector: 'p' });
         expect(heading.tagName).not.toBe('LABEL');
 
+        // The wrapper div now carries role="group" aria-labelledby={heading.id}
+        // — getByRole resolves the group's real accessible name from that
+        // association, not from the heading merely sitting nearby.
+        expect(screen.getByRole('group', { name: 'Rating scale' })).toBeInTheDocument();
+
         expect(screen.getByRole('combobox', { name: /number of points/i })).toBeInTheDocument();
         expect(screen.getByRole('textbox', { name: /left endpoint label/i })).toBeInTheDocument();
         expect(screen.getByRole('textbox', { name: /right endpoint label/i })).toBeInTheDocument();
     });
 
-    it('renders "Options" as a real heading over the option list, not a dangling label', async () => {
+    it('renders "Options" as a real, named heading over individually-named option fields (fix round 1)', async () => {
         const user = userEvent.setup();
         renderBuilder({
             draft: {
@@ -248,7 +253,16 @@ describe('QuestionBuilder — question field accessible names (Task 6.7b)', () =
 
         const heading = screen.getByText('Options');
         expect(heading.tagName).not.toBe('LABEL');
-        expect(screen.getByDisplayValue('Alpha')).toBeInTheDocument();
-        expect(screen.getByDisplayValue('Beta')).toBeInTheDocument();
+        expect(screen.getByRole('group', { name: 'Options' })).toBeInTheDocument();
+
+        // The group name alone doesn't say WHICH option a given input is — a
+        // screen-reader user editing the second option used to hear only
+        // "edit text, Beta", indistinguishable from any other textbox on the
+        // page. Each Input now carries its own ordinal aria-label, so
+        // getByRole resolves it directly rather than falling back to
+        // getByDisplayValue (which only proves the value rendered, not that
+        // the field announces anything).
+        expect(screen.getByRole('textbox', { name: 'Option 1' })).toHaveValue('Alpha');
+        expect(screen.getByRole('textbox', { name: 'Option 2' })).toHaveValue('Beta');
     });
 });

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import {
     DndContext,
     closestCenter,
@@ -316,7 +315,10 @@ const QuestionItem = (props: QuestionItemProps) => {
                             <AccordionContent className="pt-6 pb-2 space-y-6">
                                 <div className="grid gap-2.5">
                                     <div className="flex items-center gap-2">
-                                        <Label className="text-2xs font-black text-slate-500">
+                                        <Label
+                                            htmlFor={`question-label-${id}`}
+                                            className="text-2xs font-black text-slate-500"
+                                        >
                                             {t('admin.design.questions.labels.question')}
                                         </Label>
                                         <MultiLangFieldIcon
@@ -329,6 +331,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                         />
                                     </div>
                                     <Input
+                                        id={`question-label-${id}`}
                                         value={label}
                                         readOnly={readOnly}
                                         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -411,7 +414,10 @@ const QuestionItem = (props: QuestionItemProps) => {
                                         {question.visibility_condition && (
                                             <div className="grid gap-4 p-4 bg-slate-50/50 rounded-xl border border-slate-100">
                                                 <div className="space-y-2">
-                                                    <Label className="text-2xs font-bold text-slate-500">
+                                                    <Label
+                                                        htmlFor={`depends-on-${id}`}
+                                                        className="text-2xs font-bold text-slate-500"
+                                                    >
                                                         {t(
                                                             'admin.design.questions.logic.depends_on'
                                                         )}
@@ -433,7 +439,10 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                             })
                                                         }
                                                     >
-                                                        <SelectTrigger className="bg-white rounded-lg h-9 text-xs">
+                                                        <SelectTrigger
+                                                            id={`depends-on-${id}`}
+                                                            className="bg-white rounded-lg h-9 text-xs"
+                                                        >
                                                             <SelectValue
                                                                 placeholder={t(
                                                                     'admin.design.questions.logic.select_placeholder'
@@ -463,7 +472,10 @@ const QuestionItem = (props: QuestionItemProps) => {
 
                                                 <div className="grid grid-cols-2 gap-4">
                                                     <div className="space-y-2">
-                                                        <Label className="text-2xs font-bold text-slate-500">
+                                                        <Label
+                                                            htmlFor={`operator-${id}`}
+                                                            className="text-2xs font-bold text-slate-500"
+                                                        >
                                                             {t(
                                                                 'admin.design.questions.logic.operator'
                                                             )}
@@ -493,7 +505,10 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                                 })
                                                             }
                                                         >
-                                                            <SelectTrigger className="bg-white rounded-lg h-9 text-xs">
+                                                            <SelectTrigger
+                                                                id={`operator-${id}`}
+                                                                className="bg-white rounded-lg h-9 text-xs"
+                                                            >
                                                                 <SelectValue />
                                                             </SelectTrigger>
                                                             <SelectContent>
@@ -515,12 +530,16 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                     </div>
 
                                                     <div className="space-y-2">
-                                                        <Label className="text-2xs font-bold text-slate-500">
+                                                        <Label
+                                                            htmlFor={`condition-value-${id}`}
+                                                            className="text-2xs font-bold text-slate-500"
+                                                        >
                                                             {t(
                                                                 'admin.design.questions.logic.value'
                                                             )}
                                                         </Label>
                                                         <Input
+                                                            id={`condition-value-${id}`}
                                                             value={
                                                                 (question.visibility_condition
                                                                     .value as string) || ''
@@ -549,12 +568,19 @@ const QuestionItem = (props: QuestionItemProps) => {
 
                                 {question.type === 'rating' && (
                                     <div className="space-y-4 pt-4 border-t border-slate-100">
-                                        <Label className="text-2xs font-black text-slate-500">
+                                        {/* Heads the scale-points select and the Left/Right
+                                            fields below (each already correctly labelled),
+                                            not one control — a real heading element, not
+                                            the form-field <Label>. */}
+                                        <p className="text-2xs font-black text-slate-500">
                                             {t('admin.design.questions.labels.scale')}
-                                        </Label>
+                                        </p>
                                         <div className="grid gap-4">
                                             <div className="space-y-2">
-                                                <Label className="text-2xs font-bold text-slate-500">
+                                                <Label
+                                                    htmlFor={`scale-points-${id}`}
+                                                    className="text-2xs font-bold text-slate-500"
+                                                >
                                                     {t(
                                                         'admin.design.questions.labels.scale_points'
                                                     )}
@@ -569,7 +595,10 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                     }
                                                     disabled={readOnly}
                                                 >
-                                                    <SelectTrigger className="bg-white rounded-lg h-9 text-xs">
+                                                    <SelectTrigger
+                                                        id={`scale-points-${id}`}
+                                                        className="bg-white rounded-lg h-9 text-xs"
+                                                    >
                                                         <SelectValue />
                                                     </SelectTrigger>
                                                     <SelectContent>
@@ -584,7 +613,10 @@ const QuestionItem = (props: QuestionItemProps) => {
                                             <div className="grid grid-cols-2 gap-4">
                                                 <div className="space-y-2">
                                                     <div className="flex items-center gap-2">
-                                                        <Label className="text-2xs font-bold text-slate-500">
+                                                        <Label
+                                                            htmlFor={`scale-left-${id}`}
+                                                            className="text-2xs font-bold text-slate-500"
+                                                        >
                                                             {t(
                                                                 'admin.design.questions.labels.scale_left'
                                                             )}
@@ -607,6 +639,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                         />
                                                     </div>
                                                     <Input
+                                                        id={`scale-left-${id}`}
                                                         readOnly={readOnly}
                                                         value={
                                                             (typeof question.scale_labels?.left ===
@@ -655,7 +688,10 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                 </div>
                                                 <div className="space-y-2">
                                                     <div className="flex items-center gap-2">
-                                                        <Label className="text-2xs font-bold text-slate-500">
+                                                        <Label
+                                                            htmlFor={`scale-right-${id}`}
+                                                            className="text-2xs font-bold text-slate-500"
+                                                        >
                                                             {t(
                                                                 'admin.design.questions.labels.scale_right'
                                                             )}
@@ -678,6 +714,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                         />
                                                     </div>
                                                     <Input
+                                                        id={`scale-right-${id}`}
                                                         readOnly={readOnly}
                                                         value={
                                                             (typeof question.scale_labels?.right ===
@@ -733,13 +770,17 @@ const QuestionItem = (props: QuestionItemProps) => {
                                     question.type === 'radio' ||
                                     question.type === 'checkbox') && (
                                     <div className="space-y-4 pt-4 border-t border-slate-100">
-                                        <Label className="text-2xs font-black text-slate-500">
+                                        {/* Heads the list of option Inputs below (each item
+                                            in the map is its own field, none individually
+                                            named), not one control — a real heading element,
+                                            not the form-field <Label>. */}
+                                        <p className="text-2xs font-black text-slate-500">
                                             {t('admin.design.questions.labels.options')}
                                             {question.type === 'checkbox' &&
                                                 ` (${t('admin.design.questions.labels.multiple')})`}
                                             {question.type === 'radio' &&
                                                 ` (${t('admin.design.questions.labels.single')})`}
-                                        </Label>
+                                        </p>
                                         <div className="space-y-3">
                                             {(question.options || []).map((opt, idx) => (
                                                 <div

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -569,13 +569,23 @@ const QuestionItem = (props: QuestionItemProps) => {
                                 {question.type === 'rating' && (
                                     <div className="space-y-4 pt-4 border-t border-slate-100">
                                         {/* Heads the scale-points select and the Left/Right
-                                            fields below (each already correctly labelled),
-                                            not one control — a real heading element, not
-                                            the form-field <Label>. */}
-                                        <p className="text-2xs font-black text-slate-500">
+                                            fields below via aria-labelledby on the group
+                                            wrapper, not htmlFor — each field already has its
+                                            own correct Label/htmlFor, so this only supplies
+                                            the group's name, same pattern as the Options
+                                            group below and QSortEditor's distribution-mode
+                                            radiogroup. */}
+                                        <p
+                                            id={`scale-heading-${id}`}
+                                            className="text-2xs font-black text-slate-500"
+                                        >
                                             {t('admin.design.questions.labels.scale')}
                                         </p>
-                                        <div className="grid gap-4">
+                                        <div
+                                            role="group"
+                                            aria-labelledby={`scale-heading-${id}`}
+                                            className="grid gap-4"
+                                        >
                                             <div className="space-y-2">
                                                 <Label
                                                     htmlFor={`scale-points-${id}`}
@@ -770,18 +780,28 @@ const QuestionItem = (props: QuestionItemProps) => {
                                     question.type === 'radio' ||
                                     question.type === 'checkbox') && (
                                     <div className="space-y-4 pt-4 border-t border-slate-100">
-                                        {/* Heads the list of option Inputs below (each item
-                                            in the map is its own field, none individually
-                                            named), not one control — a real heading element,
-                                            not the form-field <Label>. */}
-                                        <p className="text-2xs font-black text-slate-500">
+                                        {/* Heads the list of option Inputs below via
+                                            aria-labelledby on the group wrapper, not htmlFor —
+                                            a real heading element naming a group, not the
+                                            form-field <Label> pointing at one control. The
+                                            group name alone doesn't say WHICH option a given
+                                            input is, so each Input also gets its own ordinal
+                                            aria-label below. */}
+                                        <p
+                                            id={`options-heading-${id}`}
+                                            className="text-2xs font-black text-slate-500"
+                                        >
                                             {t('admin.design.questions.labels.options')}
                                             {question.type === 'checkbox' &&
                                                 ` (${t('admin.design.questions.labels.multiple')})`}
                                             {question.type === 'radio' &&
                                                 ` (${t('admin.design.questions.labels.single')})`}
                                         </p>
-                                        <div className="space-y-3">
+                                        <div
+                                            role="group"
+                                            aria-labelledby={`options-heading-${id}`}
+                                            className="space-y-3"
+                                        >
                                             {(question.options || []).map((opt, idx) => (
                                                 <div
                                                     key={idx}
@@ -790,6 +810,11 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                     <div className="size-1.5 rounded-full bg-slate-300 group-hover/opt:bg-indigo-400 transition-colors" />
                                                     <div className="flex-1 flex items-center gap-2">
                                                         <Input
+                                                            aria-label={t(
+                                                                'admin.design.questions.labels.option_ordinal',
+                                                                'Option {{number}}',
+                                                                { number: idx + 1 }
+                                                            )}
                                                             className={cn(
                                                                 'h-10 text-sm font-medium rounded-xl border-slate-200 focus:border-indigo-500 transition-all bg-white',
                                                                 readOnly &&

--- a/frontend/src/components/postsort/Step1_Feedback.tsx
+++ b/frontend/src/components/postsort/Step1_Feedback.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import type React from 'react';
 import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -358,7 +357,10 @@ export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
                             </blockquote>
 
                             <div className="relative space-y-3">
-                                <Label className="block text-sm font-semibold text-slate-700">
+                                <Label
+                                    htmlFor={`comment-${card.statementId}`}
+                                    className="block text-sm font-semibold text-slate-700"
+                                >
                                     {getPrompt(
                                         isPositive
                                             ? ['extreme_positive', 'extreme']
@@ -591,7 +593,10 @@ export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
                 <>
                     <hr className="border-slate-200" />
                     <div className="space-y-4">
-                        <Label className="text-xl font-bold text-slate-800 block">
+                        <Label
+                            htmlFor="missing-statements"
+                            className="text-xl font-bold text-slate-800 block"
+                        >
                             {getPrompt(
                                 'missing_statements_label',
                                 'admin.study.postsort.missing.desc',

--- a/frontend/src/pages/PostSortPage.test.tsx
+++ b/frontend/src/pages/PostSortPage.test.tsx
@@ -262,4 +262,62 @@ describe('PostSortPage', () => {
         expect(screen.getByText('Spread the word')).toBeInTheDocument();
         expect(screen.getByText('Copy link')).toBeInTheDocument();
     });
+
+    describe('Step 1 label accessible names (Task 6.7b)', () => {
+        beforeEach(async () => {
+            // A prior test in this file (`Shows share links…`) permanently
+            // overrides this module-level mock's return value — restore the
+            // Step-1 default explicitly rather than depending on file order.
+            const { useSubmitStudy } = await import('../hooks/useSubmitStudy');
+            vi.mocked(useSubmitStudy).mockReturnValue({
+                submit: vi.fn(),
+                isLoading: false,
+                isSuccess: false,
+                error: null,
+                confirmationCode: null,
+            });
+        });
+
+        it('names the "missing statements" textarea and lets its label focus it', async () => {
+            const user = userEvent.setup();
+
+            renderWithProviders(
+                <Routes>
+                    <Route path="/study/:slug/post-sort" element={<PostSortPage />} />
+                </Routes>,
+                { initialEntries: ['/study/demo/post-sort'] }
+            );
+
+            const field = await screen.findByRole('textbox', {
+                name: /are there any ideas or perspectives/i,
+            });
+            await user.click(screen.getByText(/are there any ideas or perspectives/i));
+            expect(field).toHaveFocus();
+        });
+
+        it('names each extreme-card comment textarea and lets its label focus it', async () => {
+            const user = userEvent.setup();
+
+            renderWithProviders(
+                <Routes>
+                    <Route path="/study/:slug/post-sort" element={<PostSortPage />} />
+                </Routes>,
+                { initialEntries: ['/study/demo/post-sort'] }
+            );
+
+            // Two extreme cards (statements 1 and 2, per the base config's
+            // grid_config/qsort) each carry their own "Why" prompt label — a
+            // per-card `id={comment-${statementId}}` so the pairing must
+            // survive the .map() rather than collide on a single id.
+            const fields = await screen.findAllByRole('textbox', { name: /why/i });
+            expect(fields).toHaveLength(2);
+
+            const labels = screen.getAllByText(/why/i);
+            await user.click(labels[0]);
+            expect(fields[0]).toHaveFocus();
+
+            await user.click(labels[1]);
+            expect(fields[1]).toHaveFocus();
+        });
+    });
 });

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import ConcourseDetailPage from './ConcourseDetailPage';
 import type { ConcourseDetailPageApi } from '@/hooks/admin/useConcourseDetailPage';
@@ -350,5 +351,69 @@ describe('ConcourseDetailPage tag-picker checkboxes (a11y, Task 3.6)', () => {
 
         expect(screen.getByRole('checkbox', { name: /vision/i })).toBeInTheDocument();
         expect(screen.getByRole('checkbox', { name: /risk/i })).toBeInTheDocument();
+    });
+});
+
+describe('ConcourseDetailPage — Add Item / Bulk Import label accessible names (Task 6.7b)', () => {
+    it('names the "Code" field in the Add Item dialog and lets its label focus it', async () => {
+        const user = userEvent.setup();
+        const concourse = concourseWith(0, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            addItemOpen: true,
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        const field = screen.getByRole('textbox', { name: /^code$/i });
+        await user.click(screen.getByText('Code'));
+        expect(field).toHaveFocus();
+    });
+
+    it('names the "Statement text" and "Source" fields in the Add Item dialog', () => {
+        const concourse = concourseWith(0, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            addItemOpen: true,
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expect(screen.getByRole('textbox', { name: /^statement text$/i })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /^source \(optional\)$/i })).toBeInTheDocument();
+    });
+
+    it('names the "Code prefix" and "Statements" fields in the Bulk Import dialog', () => {
+        const concourse = concourseWith(0, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            importOpen: true,
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expect(screen.getByRole('textbox', { name: /^code prefix$/i })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /^statements$/i })).toBeInTheDocument();
+    });
+
+    it('renders the tag-picker group heading as plain text, not a dangling label', () => {
+        const concourse = concourseWith(0, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            addItemOpen: true,
+            tags: [{ id: 1, name: 'Vision', color: '#6366f1', project_id: 1 }],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        // "Tags(0/1)" used to be a <Label> with no htmlFor target at all,
+        // sitting above a group of individually-labelled checkboxes — a
+        // dangling form label announced as pointing nowhere. Scoped to the
+        // dialog: the page's filter toolbar has its own unrelated "Tags"
+        // text outside it.
+        const dialog = screen.getByRole('dialog');
+        const heading = within(dialog).getByText(/^Tags/);
+        expect(heading.tagName).not.toBe('LABEL');
+        expect(within(dialog).getByRole('checkbox', { name: /vision/i })).toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -396,7 +396,7 @@ describe('ConcourseDetailPage — Add Item / Bulk Import label accessible names 
         expect(screen.getByRole('textbox', { name: /^statements$/i })).toBeInTheDocument();
     });
 
-    it('renders the tag-picker group heading as plain text, not a dangling label', () => {
+    it('renders the tag-picker group heading as plain text naming a real group (fix round 1)', () => {
         const concourse = concourseWith(0, 0, 0);
         mockUseConcourseDetailPage.mockReturnValue({
             ...baseApi(concourse),
@@ -414,6 +414,11 @@ describe('ConcourseDetailPage — Add Item / Bulk Import label accessible names 
         const dialog = screen.getByRole('dialog');
         const heading = within(dialog).getByText(/^Tags/);
         expect(heading.tagName).not.toBe('LABEL');
+
+        // The wrapper div now carries role="group" aria-labelledby={heading.id}
+        // — getByRole resolves the group's real accessible name from that
+        // association, not from the heading merely sitting nearby.
+        expect(within(dialog).getByRole('group', { name: /^Tags/ })).toBeInTheDocument();
         expect(within(dialog).getByRole('checkbox', { name: /vision/i })).toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -1774,15 +1774,22 @@ function TagCheckboxGroup({
     return (
         <div className="space-y-1">
             {/* Heads a group of individually-labelled checkboxes (each tag
-                already has its own Label/htmlFor below), not one control —
-                a real heading element, not the form-field <Label>. */}
-            <p className="text-2xs font-black text-slate-500">
+                already has its own Label/htmlFor below) via aria-labelledby
+                on the group wrapper, not htmlFor — a real heading element
+                naming a group, not the form-field <Label> pointing at one
+                control. Static id: TagCheckboxGroup is called from a single
+                site in this file, so only one instance is ever mounted. */}
+            <p id="tag-checkbox-group-heading" className="text-2xs font-black text-slate-500">
                 {label}
                 <span className="text-slate-400 font-normal ml-1">
                     ({selectedIds.length}/{tags.length})
                 </span>
             </p>
-            <div className="flex flex-wrap gap-2">
+            <div
+                role="group"
+                aria-labelledby="tag-checkbox-group-heading"
+                className="flex flex-wrap gap-2"
+            >
                 {tags.map((tag) => (
                     <div key={tag.id} className="flex items-center gap-1.5 cursor-pointer">
                         <Checkbox

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 /*
  * Qualis - Open-source platform for conducting Q-methodology research
  * Copyright (C) 2025 Julien Vastenekels
@@ -1199,10 +1198,14 @@ export default function ConcourseDetailPage() {
                     </DialogHeader>
                     <div className="space-y-3 py-2">
                         <div className="space-y-1">
-                            <Label className="text-2xs font-black text-slate-500">
+                            <Label
+                                htmlFor="add-item-code"
+                                className="text-2xs font-black text-slate-500"
+                            >
                                 {t('admin.concourse.field_code', 'Code')}
                             </Label>
                             <Input
+                                id="add-item-code"
                                 value={newCode}
                                 onChange={(e) => setNewCode(e.target.value)}
                                 placeholder="C1"
@@ -1212,14 +1215,20 @@ export default function ConcourseDetailPage() {
                         </div>
                         {!activeLocale && (
                             <div className="space-y-1">
-                                <Label className="text-2xs font-black text-slate-500">
+                                <Label
+                                    htmlFor="add-item-language"
+                                    className="text-2xs font-black text-slate-500"
+                                >
                                     {t('admin.concourse.field_language', 'Language')}
                                 </Label>
                                 <Select
                                     value={newItemLocale}
                                     onValueChange={(val) => setNewItemLocale(val)}
                                 >
-                                    <SelectTrigger className="h-10 rounded-xl">
+                                    <SelectTrigger
+                                        id="add-item-language"
+                                        className="h-10 rounded-xl"
+                                    >
                                         <SelectValue
                                             placeholder={t(
                                                 'admin.concourse.select_language',
@@ -1249,12 +1258,16 @@ export default function ConcourseDetailPage() {
                             </div>
                         )}
                         <div className="space-y-1">
-                            <Label className="text-2xs font-black text-slate-500">
+                            <Label
+                                htmlFor="add-item-text"
+                                className="text-2xs font-black text-slate-500"
+                            >
                                 {t('admin.concourse.field_text', 'Statement text')}{' '}
                                 {(activeLocale || newItemLocale) &&
                                     `(${langDisplayName(activeLocale || newItemLocale)})`}
                             </Label>
                             <Textarea
+                                id="add-item-text"
                                 value={newText}
                                 onChange={(e) => setNewText(e.target.value)}
                                 placeholder={t(
@@ -1265,13 +1278,17 @@ export default function ConcourseDetailPage() {
                             />
                         </div>
                         <div className="space-y-1">
-                            <Label className="text-2xs font-black text-slate-500">
+                            <Label
+                                htmlFor="add-item-source"
+                                className="text-2xs font-black text-slate-500"
+                            >
                                 {t('admin.concourse.field_source', 'Source')}
                                 <span className="text-slate-400 font-normal ml-1">
                                     ({t('common.optional', 'optional')})
                                 </span>
                             </Label>
                             <Input
+                                id="add-item-source"
                                 value={newSource}
                                 onChange={(e) => setNewSource(e.target.value)}
                                 placeholder={t(
@@ -1427,24 +1444,34 @@ export default function ConcourseDetailPage() {
                     </DialogHeader>
                     <div className="space-y-3 py-2">
                         <div className="space-y-1">
-                            <Label className="text-2xs font-black text-slate-500">
+                            <Label
+                                htmlFor="import-code-prefix"
+                                className="text-2xs font-black text-slate-500"
+                            >
                                 {t('admin.concourse.import_prefix', 'Code prefix')}
                             </Label>
                             <Input
+                                id="import-code-prefix"
                                 value={importPrefix}
                                 onChange={(e) => setImportPrefix(e.target.value)}
                                 className="h-10 rounded-xl w-32"
                             />
                         </div>
                         <div className="space-y-1">
-                            <Label className="text-2xs font-black text-slate-500">
+                            <Label
+                                htmlFor="import-language"
+                                className="text-2xs font-black text-slate-500"
+                            >
                                 {t('admin.concourse.import_language', 'Language')}
                             </Label>
                             <Select
                                 value={importLocale || activeLocale}
                                 onValueChange={(val) => setImportLocale(val)}
                             >
-                                <SelectTrigger className="h-10 rounded-xl w-48">
+                                <SelectTrigger
+                                    id="import-language"
+                                    className="h-10 rounded-xl w-48"
+                                >
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent className="rounded-xl max-h-60">
@@ -1463,7 +1490,10 @@ export default function ConcourseDetailPage() {
                         </div>
                         <div className="space-y-1">
                             <div className="flex items-center justify-between gap-2">
-                                <Label className="text-2xs font-black text-slate-500">
+                                <Label
+                                    htmlFor="import-statements"
+                                    className="text-2xs font-black text-slate-500"
+                                >
                                     {t('admin.concourse.import_statements', 'Statements')}
                                     {(importLocale || activeLocale) &&
                                         ` (${langDisplayName(importLocale || activeLocale)})`}
@@ -1495,6 +1525,7 @@ export default function ConcourseDetailPage() {
                                 </div>
                             </div>
                             <Textarea
+                                id="import-statements"
                                 value={importText}
                                 onChange={(e) => setImportText(e.target.value)}
                                 placeholder={t(
@@ -1742,12 +1773,15 @@ function TagCheckboxGroup({
 }) {
     return (
         <div className="space-y-1">
-            <Label className="text-2xs font-black text-slate-500">
+            {/* Heads a group of individually-labelled checkboxes (each tag
+                already has its own Label/htmlFor below), not one control —
+                a real heading element, not the form-field <Label>. */}
+            <p className="text-2xs font-black text-slate-500">
                 {label}
                 <span className="text-slate-400 font-normal ml-1">
                     ({selectedIds.length}/{tags.length})
                 </span>
-            </Label>
+            </p>
             <div className="flex flex-wrap gap-2">
                 {tags.map((tag) => (
                     <div key={tag.id} className="flex items-center gap-1.5 cursor-pointer">

--- a/frontend/src/pages/admin/ProjectMembersPage.test.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.test.tsx
@@ -127,3 +127,41 @@ describe('ProjectMembersPage role select', () => {
         expect(within(row).getAllByText('nn@example.com')).toHaveLength(1);
     });
 });
+
+describe('ProjectMembersPage invite modal accessible names (Task 6.7b)', () => {
+    beforeEach(() => {
+        removeMember.mockReset().mockResolvedValue({});
+        useAuthStore.setState({
+            user: { id: 12, email: 'grace@x.io', is_superuser: false },
+            isAuthenticated: true,
+        });
+    });
+
+    it('names the email field and lets its label focus it', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<ProjectMembersPage />);
+
+        await user.click(await screen.findByRole('button', { name: /invite collaborator/i }));
+
+        const emailField = screen.getByRole('textbox', { name: /collaborator email/i });
+        await user.click(screen.getByText('Collaborator email'));
+        expect(emailField).toHaveFocus();
+    });
+
+    it('names the role select and lets its label open it', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<ProjectMembersPage />);
+
+        await user.click(await screen.findByRole('button', { name: /invite collaborator/i }));
+
+        // The trigger's own content is the selected role's value ("Member");
+        // pairing the Label overrides that with the field's purpose, per
+        // accname's label priority over content — the same mechanism the a11y
+        // gate's brief verified in Chromium.
+        const roleTrigger = screen.getByRole('combobox', { name: /assigned role/i });
+        expect(roleTrigger).toHaveAttribute('aria-expanded', 'false');
+
+        await user.click(screen.getByText('Assigned role'));
+        expect(roleTrigger).toHaveAttribute('aria-expanded', 'true');
+    });
+});

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import { Users, Trash2, UserPlus, Shield, Mail, Check, Copy, Loader2 } from 'lucide-react';
 import { useLoaderData } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -503,10 +502,14 @@ function InviteMemberModal({ slug, isOwner }: { slug: string; isOwner: boolean }
                     {!inviteUrl ? (
                         <form onSubmit={handleInvite} className="space-y-4 pt-4">
                             <div className="space-y-2">
-                                <Label className="text-2xs font-black text-slate-700">
+                                <Label
+                                    htmlFor="invite-email"
+                                    className="text-2xs font-black text-slate-700"
+                                >
                                     {t('admin.projects.settings.team.invite_modal.email_label')}
                                 </Label>
                                 <Input
+                                    id="invite-email"
                                     type="email"
                                     value={email}
                                     onChange={(e) => setEmail(e.target.value)}
@@ -516,14 +519,20 @@ function InviteMemberModal({ slug, isOwner }: { slug: string; isOwner: boolean }
                                 />
                             </div>
                             <div className="space-y-2">
-                                <Label className="text-2xs font-black text-slate-700">
+                                <Label
+                                    htmlFor="invite-role"
+                                    className="text-2xs font-black text-slate-700"
+                                >
                                     {t('admin.projects.settings.team.invite_modal.role_label')}
                                 </Label>
                                 <Select
                                     value={role}
                                     onValueChange={(val) => setRole(val as ProjectRole)}
                                 >
-                                    <SelectTrigger className="h-11 rounded-xl bg-slate-50 border-slate-200">
+                                    <SelectTrigger
+                                        id="invite-role"
+                                        className="h-11 rounded-xl bg-slate-50 border-slate-200"
+                                    >
                                         <SelectValue />
                                     </SelectTrigger>
                                     <SelectContent className="rounded-xl border-slate-200 bg-white shadow-2xl">

--- a/frontend/src/pages/admin/RecruitmentPage.test.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.test.tsx
@@ -13,6 +13,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders, screen } from '@/test-utils/test-utils';
@@ -121,5 +122,41 @@ describe('RecruitmentPage — access rule switches (a11y)', () => {
         const windowSwitch = screen.getByRole('switch', { name: /limit collection window/i });
         expect(windowSwitch).toBeInTheDocument();
         expect(windowSwitch).toHaveAttribute('aria-labelledby', 'window-toggle-label');
+    });
+});
+
+describe('RecruitmentPage — group headings are real text, not dangling labels (Task 6.7b)', () => {
+    // "Full URL" and "Collection window" head a read-only URL readout and a
+    // pair of already-individually-labelled date fields, respectively —
+    // neither is a single control a <Label htmlFor> could truthfully point
+    // at. They were <Label> elements with no `for` target at all (a dangling
+    // form label announced as pointing nowhere); the fix drops the <Label>
+    // component for plain text, which this test confirms structurally.
+
+    it('renders "Full URL" as plain text next to the read-only URL readout', () => {
+        mockUseRecruitmentPage.mockReturnValue(baseApi());
+        renderWithProviders(<RecruitmentPage />);
+
+        const heading = screen.getByText('Full URL');
+        expect(heading.tagName).not.toBe('LABEL');
+        expect(screen.getByText('https://example.com/study/demo-study')).toBeInTheDocument();
+    });
+
+    it('renders "Collection window" as plain text, and still lets "Opens at" focus its input', async () => {
+        const user = userEvent.setup();
+        mockUseRecruitmentPage.mockReturnValue(baseApi({ showWindowPickers: true }));
+        renderWithProviders(<RecruitmentPage />);
+
+        const heading = screen.getByText('Collection window');
+        expect(heading.tagName).not.toBe('LABEL');
+
+        // The two date fields beneath the heading already carry their own
+        // Label/htmlFor and are untouched by this fix — confirm the edit
+        // above them didn't collateral-damage that real pairing. (A
+        // `datetime-local` input has no ARIA role, so getByLabelText —
+        // which also resolves via htmlFor/id — stands in for getByRole here.)
+        const opensAt = screen.getByLabelText('Opens at');
+        await user.click(screen.getByText('Opens at'));
+        expect(opensAt).toHaveFocus();
     });
 });

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noLabelWithoutControl: pre-existing backlog measured 2026-07-27 by task 6.7a; remove this line when the file's labels get htmlFor (task 6.7b).
 import {
     QrCode,
     Plus,
@@ -172,9 +171,11 @@ const RecruitmentPage = () => {
                 <CardContent className="p-6 space-y-5">
                     {/* Full URL display */}
                     <div className="space-y-1.5">
-                        <Label className="text-2xs font-black text-slate-500">
+                        {/* Heads a read-only URL readout, not an editable control — a
+                            real heading element, not the form-field <Label>. */}
+                        <p className="text-2xs font-black text-slate-500">
                             {t('admin.recruitment.study_url.full_url_label', 'Full URL')}
-                        </Label>
+                        </p>
                         <div className="flex items-center gap-2">
                             <div className="flex-1 bg-slate-50 border border-slate-100 rounded-xl px-4 py-2.5 font-mono text-sm text-slate-700 truncate">
                                 {studyUrl}
@@ -490,12 +491,15 @@ const RecruitmentPage = () => {
                             </div>
                             {showWindowPickers && (
                                 <>
-                                    <Label className="text-2xs font-black text-slate-400 uppercase tracking-wider">
+                                    {/* Heads the "Opens at"/"Closes at" pair below, both of
+                                        which already carry their own Label/htmlFor — a real
+                                        heading element, not the form-field <Label>. */}
+                                    <p className="text-2xs font-black text-slate-400 uppercase tracking-wider">
                                         {t(
                                             'admin.recruitment.access_rules.collection_window',
                                             'Collection window'
                                         )}
-                                    </Label>
+                                    </p>
                                     <div className="grid gap-4 sm:grid-cols-2">
                                         <div className="space-y-2">
                                             <Label


### PR DESCRIPTION
## Summary

Task 6.7b — the first burn-down against the gate landed in [#326](https://github.com/jvastenaekels/qualis/pull/326). **Stacked on it; merge that first.**

40 `noLabelWithoutControl` errors were held behind 13 dated file-level suppressions as a deliberate burn-down list. Each was a `<Label>` with no `htmlFor` beside a control with no `id`: no accessible name, and clicking the label did nothing.

**Result: 40 → 0.** All 13 suppressions removed. Unnamed controls 41 → 37, because four `<SelectTrigger>` gained a name for free — labelling the field names the trigger.

## Changes

Thirteen commits, one per file, so each file's pairings can be checked against one commit: `QuestionBuilder` 9, `ConcourseDetailPage` 8, `ProcessStepEditor` 4, `IntroductionEditor` 4, `InterfaceEditor` 3, `RecruitmentPage` 2, `ProjectMembersPage` 2, `Step1_Feedback` 2, `ImportStudyDialog` 2, `QSortEditor` 1, `PostSortConfigEditor` 1, `ImportFromConcourseDialog` 1, `BrandingEditor` 1.

Ids derive from stable data (`step.id`, `q.id`, `partner.id`, translation-key-shaped field names) rather than render index, so they survive reorder and re-render.

## Nine of the forty were not field labels

They were group headings mis-marked as `<Label>`: a `RadioGroup`, an icon picker, a tag-checkbox list, an options list, error and warning lists, a URL readout, a date-field pair. Inventing a `htmlFor` pointing at one arbitrary member is exactly what the standing rule forbids, so these were converted instead — to headings, to plain text, or to `role="group"` + `aria-labelledby`.

## The finding worth reading

One of those conversions turned a lint error into a **silent accessibility gap**, and it is the subtlest failure mode this remediation has produced.

`QuestionBuilder`'s "Options" heading became a bare `<p>` above a `.map()` of `<Input>`s carrying no `id`, no `aria-label` and no `placeholder`. A researcher on a screen reader editing a multiple-choice question heard *"edit text, Alpha"* — no field name, no ordinal. Not a regression, since the old `<Label>` named nothing either. But `noLabelWithoutControl` had been the last automated marker on those lines, and the gate does not track `<Input>` — so after the commit, **nothing recorded them**. A fix that improves the metric by removing the instrument that measured it.

Now fixed properly: all four groups carry `role="group"` + `aria-labelledby` on wrapper divs that already existed, each Options input announces `Option N`, and the icon picker no longer announces raw component identifiers (`MessageSquareText`, `Zap`) — 16 translated icon names across all nine locales.

## Checklist

- [ ] `make ci` passes locally — **frontend green (189 files / 1624 tests, biome + tsc clean, gate clean); backend `pytest` fails on a local Postgres credential issue reproducing identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — one focus-moves test per file (`click the label → `toHaveFocus()``), which is what distinguishes a real pairing from an `id` that satisfies a linter. The three files without it have no single-control pairing and assert the computed group/combobox name instead.
- [x] Translation keys added to all locales — `option_ordinal` and 16 icon names in all nine admin locales, register per the repo's glossaries.
- [x] API client regenerated if backend schemas changed — not applicable.

## How the burn-down was verified

Review reconstructed `a11y-baseline.json` at all fourteen commits and diffed per-fingerprint: `40 → 39 → 38 → 37 → 36 → 34 → 32 → 30 → 28 → 25 → 21 → 17 → 9 → 0`. Every drop is a `Label#<fingerprint>: 1 → 0` in exactly the file that commit touched; no key ever increased, none fell by more than that commit's fixes. Pairings were mutation-tested across three mechanisms — deliberate mis-pairings each broke a test.

The gate output is unchanged by the final round (37 unnamed / 13 low-contrast / 0 label errors, baseline untouched, no suppression added) because the checker tracks neither `<Input>` nor `role="group"`. Verified as a real improvement outside the gate's visibility rather than a suppressed regression.

## What remains

Recorded in the plan as 6.7c (name the 37 the gate still records — worst is seven `TooltipTrigger`s per participant row on the Data table), 6.7d (13 controls at 1.45:1 contrast, plus four `role="button"` divs), 6.7f (nine hardcoded English accessible names, including the close button every dialog renders), and 6.7e (extend the axe spec to the admin, at 375px as well as desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)