### PR TITLE
fix(a11y): name the 37 controls that announced only their role

### DIFF
--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1633,6 +1633,26 @@ Independent of 6.7c and 6.7d; touches no file they touch, so it can run in paral
 
 ---
 
+### Task 6.7g: The Data table's status chips should not be buttons at all
+
+**The defect, and why no automated check will find it.** Task 6.7c named the seven per-row indicator `TooltipTrigger`s in `InteractiveDataView.columns.tsx` — a strict improvement over seven anonymous tab stops. But naming them was the wrong end state: **they are pure status indicators, and activating them does nothing.** Seven focusable buttons × 25 rows is up to **175 phantom tab stops per page**, each announcing a fact the researcher cannot act on.
+
+Critically, **Task 6.7e will not catch this** — a named button is axe-clean — and the static gate counts them as fixed. This is a defect that only a human reading the tab order will find, which is why it is written down here rather than left to a check.
+
+**Why `asChild` is not the fix** (established in 6.7c, worth not relearning): Radix injects no `tabIndex` under `asChild` — `grep tabIndex node_modules/@radix-ui/react-tooltip/dist/index.mjs` returns nothing. Wrapping a bare `<div>` in `asChild` removes the tab stop *and* the accessible name, and the gate exempts `asChild` unconditionally (`check-a11y-names.mjs:330`), so the counter would read zero while keyboard users lost access entirely.
+
+**The end state:** `<span role="img" aria-label={…}>` inside the `<td>`, with the Radix tooltip dropped or reduced to `title` for mouse users. Zero tab stops; the fact still read during table navigation, under the column header that names it. Do **not** move the text to `aria-describedby` on the `<tr>` — row descriptions are announced inconsistently across screen readers and divorce the fact from the column that gives it meaning.
+
+**Files:** `frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx` (7 sites), and `ParticipantCell` at `:147`, whose OS/browser-icon tooltip uses `asChild` over a nameless `<div>` and is therefore **unreachable by keyboard at all** today.
+
+- [ ] **Step 1: Confirm the current tab order** — count focusable elements in one participant row before the change
+- [ ] **Step 2: Convert the seven to `role="img"` with their existing names**
+- [ ] **Step 3: Assert the count of focusable controls per row drops to what a user can actually act on**
+- [ ] **Step 4: Handle `ParticipantCell` — it needs the name it never had, whichever shape you choose**
+- [ ] **Step 5: Commit** — `fix(a11y): make the Data table's status chips indicators, not buttons`
+
+---
+
 ### Task 6.7e: Extend the axe spec to the admin
 
 **The work:** Task 6.7a wired `Accessibility Smoke` into CI, but the spec itself covers **two public pages**. The admin — where every defect in this remediation lived — is not covered by it at all.

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1848,7 +1848,8 @@
                 "has_audio": "Hat Audioaufnahmen",
                 "email_provided": "E-Mail-Adresse angegeben",
                 "newsletter_consent": "Möchte Ergebnisse",
-                "interview_consent": "Nimmt Folgekontakt an"
+                "interview_consent": "Nimmt Folgekontakt an",
+                "recruitment_link": "Rekrutierungslink"
             },
             "toast": {
                 "discarded": "Teilnehmer verworfen",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -264,11 +264,7 @@
                     "ListChecks": "Checkliste"
                 }
             },
-            "click_to_edit": "Zum Bearbeiten klicken",
-            "audio_player": {
-                "play": "Audio abspielen",
-                "pause": "Audio pausieren"
-            }
+            "click_to_edit": "Zum Bearbeiten klicken"
         },
         "layout": {
             "title": "Admin",
@@ -2316,6 +2312,13 @@
                 "success": "E-Mail aktualisiert.",
                 "title": "Benutzer-E-Mail festlegen"
             }
+        },
+        "audio": {
+            "download": "Audio herunterladen",
+            "recording": "Audioaufnahme",
+            "play": "Audio abspielen",
+            "pause": "Audio pausieren",
+            "seek": "Wiedergabeposition"
         }
     }
 }

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -475,7 +475,15 @@
             "import_csv_hint": "CSV/TSV benötigt Spalten: code, language, text.",
             "import_csv_no_match": "Keine Zeilen entsprechen der gewählten Sprache ({{lang}}).",
             "import_csv_skipped": "{{count}} Zeile(n) in anderen Sprachen übersprungen: {{langs}}.",
-            "import_csv_more_errors": "{{count}} weitere Probleme"
+            "import_csv_more_errors": "{{count}} weitere Probleme",
+            "filters": {
+                "status": "Nach Status filtern",
+                "tag": "Nach Tag filtern"
+            },
+            "status_for": "Status für {{code}}",
+            "create_tag": "Tag erstellen",
+            "delete_tag": "{{tag}} löschen",
+            "cancel_delete_tag": "Löschen von {{tag}} abbrechen"
         },
         "concourse_import": {
             "title": "Aus Aussagenpool importieren",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1484,7 +1484,10 @@
                 "actions": {
                     "add_option": "Option hinzufügen",
                     "copy_from": "Aus Sprache importieren",
-                    "copy_success": "Importiert"
+                    "copy_success": "Importiert",
+                    "copy_from_aria": "{{label}} aus einer anderen Sprache importieren",
+                    "delete": "{{label}} löschen",
+                    "remove_option": "{{option}} entfernen"
                 },
                 "logic": {
                     "title": "Sichtbarkeitslogik",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1914,7 +1914,9 @@
                 "contract_cta": "Studienübersicht öffnen"
             },
             "pagination": {
-                "showing": "{{from}}–{{to}} von {{total}} angezeigt"
+                "showing": "{{from}}–{{to}} von {{total}} angezeigt",
+                "previous": "Vorherige Seite",
+                "next": "Nächste Seite"
             }
         },
         "team": {

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1646,7 +1646,8 @@
                         "next": "Zum nächsten Schritt wechseln",
                         "submit": "Ergebnisse am Ende einreichen",
                         "confirm": "Allgemeine Bestätigungsschaltfläche"
-                    }
+                    },
+                    "info_label": "Über {{label}}"
                 },
                 "terms": {
                     "title": "Sortierbegriffe",
@@ -1664,7 +1665,9 @@
                     "desc": "Fügen Sie schwebende Hinweise hinzu oder ändern Sie diese, um Teilnehmern während der Rastersortierungsphase zu helfen.",
                     "placeholder": "Methodologie-Hinweis eingeben...",
                     "add": "Hinweis hinzufügen",
-                    "reset": "Auf Standard zurücksetzen"
+                    "reset": "Auf Standard zurücksetzen",
+                    "remove": "{{tip}} entfernen",
+                    "unnamed": "Tipp {{number}}"
                 },
                 "help": {
                     "title": "Schrittführung (Was/Warum)",
@@ -2147,8 +2150,11 @@
                         "success": "Einladungslink erstellt!",
                         "error": "Einladung konnte nicht erstellt werden.",
                         "send": "Einladung erstellen und senden",
-                        "copy_success": "Link in die Zwischenablage kopiert!"
-                    }
+                        "copy_success": "Link in die Zwischenablage kopiert!",
+                        "copy_link": "Link kopieren",
+                        "copied": "Kopiert"
+                    },
+                    "role_for": "Rolle für {{name}}"
                 }
             }
         },

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1535,7 +1535,9 @@
                     "imported": "{{count}} Aussagen erfolgreich importiert",
                     "reset_codes": "Codes zurücksetzen",
                     "confirm_reset_codes": "Sind Sie sicher, dass Sie alle Aussagecodes neu sequenzieren möchten (s1, s2, s3...)?",
-                    "codes_reset": "Aussagecodes neu sequenziert"
+                    "codes_reset": "Aussagecodes neu sequenziert",
+                    "save_item": "{{code}} speichern",
+                    "cancel_edit": "Bearbeitung von {{code}} abbrechen"
                 },
                 "settings": {
                     "title": "Forschungseinstellungen",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -264,7 +264,11 @@
                     "ListChecks": "Checkliste"
                 }
             },
-            "click_to_edit": "Zum Bearbeiten klicken"
+            "click_to_edit": "Zum Bearbeiten klicken",
+            "audio_player": {
+                "play": "Audio abspielen",
+                "pause": "Audio pausieren"
+            }
         },
         "layout": {
             "title": "Admin",

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -314,7 +314,8 @@
                 "disabled_success": "Zwei-Faktor-Authentifizierung deaktiviert",
                 "secret_copied": "Secret kopiert",
                 "invalid_token": "Ungültiger Bestätigungscode",
-                "disable_error": "2FA konnte nicht deaktiviert werden"
+                "disable_error": "2FA konnte nicht deaktiviert werden",
+                "copy_secret": "Secret kopieren"
             },
             "password": {
                 "title": "Passwortverwaltung",
@@ -1392,6 +1393,9 @@
                         "rough_disabled": "Der Schritt 'Erste Eindrücke' (Grobsortierung) ist in dieser Liste enthalten, aber die Studie hat die Grobsortierung deaktiviert. Teilnehmer werden ihn nicht sehen.",
                         "presort_disabled": "Der Schritt 'Kennenlernen' (Vorsortierungsumfrage) ist in dieser Liste enthalten, aber die Studie hat die Vorsortierungsumfrage deaktiviert. Teilnehmer werden ihn nicht sehen.",
                         "remove_action": "Entfernen"
+                    },
+                    "actions": {
+                        "delete": "{{title}} löschen"
                     }
                 },
                 "consent_title": "Einwilligungserklärung",
@@ -1588,7 +1592,8 @@
                     "prompt_placeholder": "Warum haben Sie diese Aussage hier platziert?",
                     "add": "Hinzufügen",
                     "add_defaults": "Standard-Extreme hinzufügen",
-                    "select_placeholder": "Auswählen..."
+                    "select_placeholder": "Auswählen...",
+                    "remove": "{{score}} entfernen"
                 },
                 "random_comments": {
                     "title": "Zufällige Kommentare erlauben",
@@ -1673,7 +1678,9 @@
                     "title": "Akzentfarbe",
                     "desc": "Diese Farbe wird für Schaltflächen, Links und Hervorhebungen in der gesamten Studie verwendet.",
                     "pick": "Farbe wählen",
-                    "reset": "Auf Standard zurücksetzen"
+                    "reset": "Auf Standard zurücksetzen",
+                    "info_label": "Über die Akzentfarbe",
+                    "swatch": "Akzentfarbe auf {{color}} setzen"
                 },
                 "logo": {
                     "title": "Studienlogo",
@@ -1682,7 +1689,9 @@
                     "hint": "Empfohlene Größe: 200x50px. Unterstützt PNG, SVG, JPG.",
                     "preview": "Logovorschau",
                     "help_title": "Wo erscheint dieses Logo?",
-                    "help_desc": "Das Logo wird oben auf jeder Studieninhalt-Seite (Navigationsleiste) und auf der Willkommensseite angezeigt. Es stärkt die visuelle Identität Ihres Projekts."
+                    "help_desc": "Das Logo wird oben auf jeder Studieninhalt-Seite (Navigationsleiste) und auf der Willkommensseite angezeigt. Es stärkt die visuelle Identität Ihres Projekts.",
+                    "info_label": "Über das Studienlogo",
+                    "remove": "Logo entfernen"
                 },
                 "partners": {
                     "title": "Institutionelle Partner",
@@ -1694,7 +1703,11 @@
                     "url_label": "Website (optional)",
                     "url_placeholder": "Https://...",
                     "help_title": "Anzeige der Logos",
-                    "help_desc": "Partnerlogos werden auf der Einstiegsseite sowie im Studienheader neben dem Hauptlogo angezeigt."
+                    "help_desc": "Partnerlogos werden auf der Einstiegsseite sowie im Studienheader neben dem Hauptlogo angezeigt.",
+                    "info_label": "Über institutionelle Partner",
+                    "remove_logo": "Logo für {{name}} entfernen",
+                    "remove": "{{name}} entfernen",
+                    "unnamed": "Partner {{number}}"
                 },
                 "upload": {
                     "upload": "Hochladen",
@@ -1704,7 +1717,8 @@
                     "conversion_error": "Bild konnte nicht verarbeitet werden.",
                     "processing": "Bild wird verarbeitet...",
                     "drag_drop": "Ziehen & ablegen oder klicken zum Hochladen",
-                    "max": "Max"
+                    "max": "Max",
+                    "remove_default": "Bild entfernen"
                 }
             },
             "activate_dialog": {

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1850,7 +1850,8 @@
                 "has_audio": "Has audio responses",
                 "email_provided": "Email provided",
                 "newsletter_consent": "Wants results",
-                "interview_consent": "Accepts follow-up"
+                "interview_consent": "Accepts follow-up",
+                "recruitment_link": "Recruitment link"
             },
             "toast": {
                 "discarded": "Participant discarded",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1537,7 +1537,9 @@
                     "imported": "Successfully imported {{count}} statements",
                     "reset_codes": "Reset codes",
                     "confirm_reset_codes": "Are you sure you want to re-sequence all statement codes (s1, s2, s3...)?",
-                    "codes_reset": "Statement codes re-sequenced"
+                    "codes_reset": "Statement codes re-sequenced",
+                    "save_item": "Save {{code}}",
+                    "cancel_edit": "Cancel editing {{code}}"
                 },
                 "settings": {
                     "title": "Research settings",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -314,7 +314,8 @@
                 "disabled_success": "Two-factor authentication disabled",
                 "secret_copied": "Secret copied",
                 "invalid_token": "Invalid verification code",
-                "disable_error": "Failed to disable 2FA"
+                "disable_error": "Failed to disable 2FA",
+                "copy_secret": "Copy secret"
             },
             "password": {
                 "title": "Password management",
@@ -1394,6 +1395,9 @@
                         "rough_disabled": "The 'First impressions' (rough sort) step is in this list but the study has rough sort disabled. Participants will not see it.",
                         "presort_disabled": "The 'Let's meet' (pre-sort survey) step is in this list but the study has the pre-sort survey disabled. Participants will not see it.",
                         "remove_action": "Remove"
+                    },
+                    "actions": {
+                        "delete": "Delete {{title}}"
                     }
                 },
                 "consent_title": "Consent form",
@@ -1590,7 +1594,8 @@
                     "prompt_placeholder": "Why did you place this statement here?",
                     "add": "Add",
                     "add_defaults": "Add default extremes",
-                    "select_placeholder": "Select..."
+                    "select_placeholder": "Select...",
+                    "remove": "Remove {{score}}"
                 },
                 "random_comments": {
                     "title": "Allow random comments",
@@ -1675,7 +1680,9 @@
                     "title": "Accent color",
                     "desc": "This color will be used for buttons, links, and highlights throughout the study.",
                     "pick": "Pick a color",
-                    "reset": "Reset to default"
+                    "reset": "Reset to default",
+                    "info_label": "About accent color",
+                    "swatch": "Set accent color to {{color}}"
                 },
                 "logo": {
                     "title": "Study logo",
@@ -1684,7 +1691,9 @@
                     "hint": "Recommended size: 200x50px. Supports PNG, SVG, JPG.",
                     "preview": "Logo preview",
                     "help_title": "Where does this logo appear?",
-                    "help_desc": "The logo is displayed at the top of every study page (navigation bar) and on the welcome page. It reinforces your project's visual identity."
+                    "help_desc": "The logo is displayed at the top of every study page (navigation bar) and on the welcome page. It reinforces your project's visual identity.",
+                    "info_label": "About the study logo",
+                    "remove": "Remove logo"
                 },
                 "partners": {
                     "title": "Institutional partners",
@@ -1696,7 +1705,11 @@
                     "url_label": "Website (optional)",
                     "url_placeholder": "Https://...",
                     "help_title": "Display of logos",
-                    "help_desc": "Partner logos are displayed on the landing page as well as in the study header, next to the main logo."
+                    "help_desc": "Partner logos are displayed on the landing page as well as in the study header, next to the main logo.",
+                    "info_label": "About institutional partners",
+                    "remove_logo": "Remove logo for {{name}}",
+                    "remove": "Remove {{name}}",
+                    "unnamed": "Partner {{number}}"
                 },
                 "upload": {
                     "upload": "Upload",
@@ -1706,7 +1719,8 @@
                     "conversion_error": "Failed to process image.",
                     "processing": "Processing image...",
                     "drag_drop": "Drag & drop or click to upload",
-                    "max": "Max"
+                    "max": "Max",
+                    "remove_default": "Remove image"
                 }
             },
             "activate_dialog": {

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -264,7 +264,11 @@
                     "ListChecks": "Checklist"
                 }
             },
-            "click_to_edit": "Click to edit"
+            "click_to_edit": "Click to edit",
+            "audio_player": {
+                "play": "Play audio",
+                "pause": "Pause audio"
+            }
         },
         "layout": {
             "title": "Admin",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1486,7 +1486,10 @@
                 "actions": {
                     "add_option": "Add option",
                     "copy_from": "Import from language",
-                    "copy_success": "Imported"
+                    "copy_success": "Imported",
+                    "copy_from_aria": "Import {{label}} from another language",
+                    "delete": "Delete {{label}}",
+                    "remove_option": "Remove {{option}}"
                 },
                 "logic": {
                     "title": "Visibility logic",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -475,7 +475,15 @@
             "import_csv_hint": "CSV/TSV needs columns: code, language, text.",
             "import_csv_no_match": "No rows match the selected language ({{lang}}).",
             "import_csv_skipped": "Skipped {{count}} row(s) in other languages: {{langs}}.",
-            "import_csv_more_errors": "{{count}} more issues"
+            "import_csv_more_errors": "{{count}} more issues",
+            "filters": {
+                "status": "Filter by status",
+                "tag": "Filter by tag"
+            },
+            "status_for": "Status for {{code}}",
+            "create_tag": "Create tag",
+            "delete_tag": "Delete {{tag}}",
+            "cancel_delete_tag": "Cancel deleting {{tag}}"
         },
         "concourse_import": {
             "title": "Import from Concourse",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -264,11 +264,7 @@
                     "ListChecks": "Checklist"
                 }
             },
-            "click_to_edit": "Click to edit",
-            "audio_player": {
-                "play": "Play audio",
-                "pause": "Pause audio"
-            }
+            "click_to_edit": "Click to edit"
         },
         "layout": {
             "title": "Admin",
@@ -2318,6 +2314,13 @@
                 "promote_title": "Grant superuser access?",
                 "promote_body": "Grant {{email}} full superuser privileges over the platform."
             }
+        },
+        "audio": {
+            "download": "Download audio",
+            "recording": "Audio recording",
+            "play": "Play audio",
+            "pause": "Pause audio",
+            "seek": "Seek audio position"
         }
     }
 }

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1648,7 +1648,8 @@
                         "next": "Move to the next step",
                         "submit": "Submit results at the end",
                         "confirm": "Generic validation button"
-                    }
+                    },
+                    "info_label": "About {{label}}"
                 },
                 "terms": {
                     "title": "Sorting terminology",
@@ -1666,7 +1667,9 @@
                     "desc": "Add or modify floating hints to help participants during the grid sort phase.",
                     "placeholder": "Enter a methodology tip...",
                     "add": "Add tip",
-                    "reset": "Reset to defaults"
+                    "reset": "Reset to defaults",
+                    "remove": "Remove {{tip}}",
+                    "unnamed": "Tip {{number}}"
                 },
                 "help": {
                     "title": "Step guidance (what/why)",
@@ -2149,8 +2152,11 @@
                         "success": "Invitation link generated!",
                         "error": "Failed to create invitation.",
                         "send": "Create & send invitation",
-                        "copy_success": "Link copied to clipboard!"
-                    }
+                        "copy_success": "Link copied to clipboard!",
+                        "copy_link": "Copy link",
+                        "copied": "Copied"
+                    },
+                    "role_for": "Role for {{name}}"
                 }
             }
         },

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1916,7 +1916,9 @@
                 "contract_cta": "Open study overview"
             },
             "pagination": {
-                "showing": "Showing {{from}}–{{to}} of {{total}}"
+                "showing": "Showing {{from}}–{{to}} of {{total}}",
+                "previous": "Previous page",
+                "next": "Next page"
             }
         },
         "team": {

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -264,11 +264,7 @@
                     "ListChecks": "Lista de verificación"
                 }
             },
-            "click_to_edit": "Haga clic para editar",
-            "audio_player": {
-                "play": "Reproducir audio",
-                "pause": "Pausar audio"
-            }
+            "click_to_edit": "Haga clic para editar"
         },
         "layout": {
             "title": "Administración",
@@ -2316,6 +2312,13 @@
                 "success": "Correo electrónico actualizado.",
                 "title": "Establecer el correo electrónico del usuario"
             }
+        },
+        "audio": {
+            "download": "Descargar audio",
+            "recording": "Grabación de audio",
+            "play": "Reproducir audio",
+            "pause": "Pausar audio",
+            "seek": "Posición de reproducción"
         }
     }
 }

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1914,7 +1914,9 @@
                 "contract_cta": "Abrir resumen del estudio"
             },
             "pagination": {
-                "showing": "Mostrando {{from}}–{{to}} de {{total}}"
+                "showing": "Mostrando {{from}}–{{to}} de {{total}}",
+                "previous": "Página anterior",
+                "next": "Página siguiente"
             }
         },
         "team": {

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -475,7 +475,15 @@
             "import_csv_hint": "El CSV/TSV necesita columnas: code, language, text.",
             "import_csv_no_match": "Ninguna fila coincide con el idioma seleccionado ({{lang}}).",
             "import_csv_skipped": "Se omitieron {{count}} fila(s) en otros idiomas: {{langs}}.",
-            "import_csv_more_errors": "{{count}} problema(s) más"
+            "import_csv_more_errors": "{{count}} problema(s) más",
+            "filters": {
+                "status": "Filtrar por estado",
+                "tag": "Filtrar por etiqueta"
+            },
+            "status_for": "Estado de {{code}}",
+            "create_tag": "Crear etiqueta",
+            "delete_tag": "Eliminar {{tag}}",
+            "cancel_delete_tag": "Cancelar eliminación de {{tag}}"
         },
         "concourse_import": {
             "title": "Importar desde el concurso",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -264,7 +264,11 @@
                     "ListChecks": "Lista de verificación"
                 }
             },
-            "click_to_edit": "Haga clic para editar"
+            "click_to_edit": "Haga clic para editar",
+            "audio_player": {
+                "play": "Reproducir audio",
+                "pause": "Pausar audio"
+            }
         },
         "layout": {
             "title": "Administración",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -314,7 +314,8 @@
                 "disabled_success": "Autenticación de dos factores desactivada",
                 "secret_copied": "Secreto copiado",
                 "invalid_token": "Código de verificación incorrecto",
-                "disable_error": "Error al desactivar el 2FA"
+                "disable_error": "Error al desactivar el 2FA",
+                "copy_secret": "Copiar secreto"
             },
             "password": {
                 "title": "Gestión de contraseña",
@@ -1392,6 +1393,9 @@
                         "rough_disabled": "El paso 'Primeras impresiones' (clasificación inicial) está en esta lista pero el estudio tiene la clasificación inicial desactivada. Los participantes no lo verán.",
                         "presort_disabled": "El paso 'Conociéndonos' (encuesta pre-clasificación) está en esta lista pero el estudio tiene la encuesta pre-clasificación desactivada. Los participantes no lo verán.",
                         "remove_action": "Eliminar"
+                    },
+                    "actions": {
+                        "delete": "Eliminar {{title}}"
                     }
                 },
                 "consent_title": "Formulario de consentimiento",
@@ -1588,7 +1592,8 @@
                     "prompt_placeholder": "¿Por qué colocó este enunciado aquí?",
                     "add": "Añadir",
                     "add_defaults": "Añadir extremos predeterminados",
-                    "select_placeholder": "Seleccionar..."
+                    "select_placeholder": "Seleccionar...",
+                    "remove": "Quitar {{score}}"
                 },
                 "random_comments": {
                     "title": "Permitir comentarios aleatorios",
@@ -1673,7 +1678,9 @@
                     "title": "Color de acento",
                     "desc": "Este color se usará para botones, enlaces y destacados en todo el estudio.",
                     "pick": "Elegir un color",
-                    "reset": "Restablecer valor predeterminado"
+                    "reset": "Restablecer valor predeterminado",
+                    "info_label": "Acerca del color de acento",
+                    "swatch": "Establecer el color de acento en {{color}}"
                 },
                 "logo": {
                     "title": "Logotipo del estudio",
@@ -1682,7 +1689,9 @@
                     "hint": "Tamaño recomendado: 200x50px. Admite PNG, SVG, JPG.",
                     "preview": "Vista previa del logotipo",
                     "help_title": "¿Dónde aparece este logotipo?",
-                    "help_desc": "El logotipo se muestra en la parte superior de cada página del estudio (barra de navegación) y en la página de bienvenida. Refuerza la identidad visual de su proyecto."
+                    "help_desc": "El logotipo se muestra en la parte superior de cada página del estudio (barra de navegación) y en la página de bienvenida. Refuerza la identidad visual de su proyecto.",
+                    "info_label": "Acerca del logotipo del estudio",
+                    "remove": "Quitar logotipo"
                 },
                 "partners": {
                     "title": "Socios institucionales",
@@ -1694,7 +1703,11 @@
                     "url_label": "Sitio web (opcional)",
                     "url_placeholder": "Https://...",
                     "help_title": "Visualización de logotipos",
-                    "help_desc": "Los logotipos de los socios se muestran en la página de inicio así como en el encabezado del estudio, junto al logotipo principal."
+                    "help_desc": "Los logotipos de los socios se muestran en la página de inicio así como en el encabezado del estudio, junto al logotipo principal.",
+                    "info_label": "Acerca de los socios institucionales",
+                    "remove_logo": "Quitar logotipo de {{name}}",
+                    "remove": "Quitar {{name}}",
+                    "unnamed": "Socio {{number}}"
                 },
                 "upload": {
                     "upload": "Cargar",
@@ -1704,7 +1717,8 @@
                     "conversion_error": "Error al procesar la imagen.",
                     "processing": "Procesando imagen...",
                     "drag_drop": "Arrastre y suelte o haga clic para cargar",
-                    "max": "Máx"
+                    "max": "Máx",
+                    "remove_default": "Quitar imagen"
                 }
             },
             "activate_dialog": {

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1484,7 +1484,10 @@
                 "actions": {
                     "add_option": "Añadir opción",
                     "copy_from": "Importar desde idioma",
-                    "copy_success": "Importado"
+                    "copy_success": "Importado",
+                    "copy_from_aria": "Importar {{label}} desde otro idioma",
+                    "delete": "Eliminar {{label}}",
+                    "remove_option": "Quitar {{option}}"
                 },
                 "logic": {
                     "title": "Lógica de visibilidad",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1848,7 +1848,8 @@
                 "has_audio": "Tiene respuestas de audio",
                 "email_provided": "Correo electrónico proporcionado",
                 "newsletter_consent": "Quiere resultados",
-                "interview_consent": "Acepta seguimiento"
+                "interview_consent": "Acepta seguimiento",
+                "recruitment_link": "Enlace de reclutamiento"
             },
             "toast": {
                 "discarded": "Participante descartado",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1646,7 +1646,8 @@
                         "next": "Pasar al siguiente paso",
                         "submit": "Enviar los resultados al final",
                         "confirm": "Botón de validación genérico"
-                    }
+                    },
+                    "info_label": "Acerca de {{label}}"
                 },
                 "terms": {
                     "title": "Terminología de clasificación",
@@ -1664,7 +1665,9 @@
                     "desc": "Añada o modifique sugerencias flotantes para ayudar a los participantes durante la fase de clasificación en cuadrícula.",
                     "placeholder": "Introduzca un consejo metodológico...",
                     "add": "Añadir consejo",
-                    "reset": "Restablecer valores predeterminados"
+                    "reset": "Restablecer valores predeterminados",
+                    "remove": "Quitar {{tip}}",
+                    "unnamed": "Consejo {{number}}"
                 },
                 "help": {
                     "title": "Orientación por paso (qué/por qué)",
@@ -2147,8 +2150,11 @@
                         "success": "¡Enlace de invitación generado!",
                         "error": "Error al crear la invitación.",
                         "send": "Crear y enviar invitación",
-                        "copy_success": "¡Enlace copiado al portapapeles!"
-                    }
+                        "copy_success": "¡Enlace copiado al portapapeles!",
+                        "copy_link": "Copiar enlace",
+                        "copied": "Copiado"
+                    },
+                    "role_for": "Rol de {{name}}"
                 }
             }
         },

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1535,7 +1535,9 @@
                     "imported": "{{count}} enunciados importados correctamente",
                     "reset_codes": "Restablecer códigos",
                     "confirm_reset_codes": "¿Está seguro de que desea renumerar todos los códigos de enunciados (s1, s2, s3...)?",
-                    "codes_reset": "Códigos de enunciados renumerados"
+                    "codes_reset": "Códigos de enunciados renumerados",
+                    "save_item": "Guardar {{code}}",
+                    "cancel_edit": "Cancelar edición de {{code}}"
                 },
                 "settings": {
                     "title": "Configuración de investigación",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1557,7 +1557,8 @@
                         "next": "Siirry seuraavaan vaiheeseen",
                         "submit": "Lähetä tulokset lopussa",
                         "confirm": "Yleinen vahvistuspainike"
-                    }
+                    },
+                    "info_label": "Tietoa: {{label}}"
                 },
                 "terms": {
                     "title": "Lajittelutermistö",
@@ -1575,7 +1576,9 @@
                     "desc": "Lisää tai muokkaa kelluvia vinkkejä auttaaksesi osallistujia ruudukkolajitteluvaiheessa.",
                     "placeholder": "Kirjoita metodologinen vinkki...",
                     "add": "Lisää vinkki",
-                    "reset": "Palauta oletukset"
+                    "reset": "Palauta oletukset",
+                    "remove": "Poista {{tip}}",
+                    "unnamed": "Vihje {{number}}"
                 },
                 "help": {
                     "title": "Vaiheittainen ohjaus (Mitä/Miksi)",
@@ -2005,8 +2008,11 @@
                         "success": "Kutsulinkki luotu!",
                         "error": "Kutsun luominen epäonnistui.",
                         "send": "Luo ja lähetä kutsu",
-                        "copy_success": "Linkki kopioitu leikepöydälle!"
-                    }
+                        "copy_success": "Linkki kopioitu leikepöydälle!",
+                        "copy_link": "Kopioi linkki",
+                        "copied": "Kopioitu"
+                    },
+                    "role_for": "Rooli: {{name}}"
                 }
             }
         },

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -176,11 +176,7 @@
                     "ListChecks": "Tarkistuslista"
                 }
             },
-            "click_to_edit": "Napsauta muokataksesi",
-            "audio_player": {
-                "play": "Toista ääni",
-                "pause": "Keskeytä ääni"
-            }
+            "click_to_edit": "Napsauta muokataksesi"
         },
         "layout": {
             "title": "Ylläpito",
@@ -2316,6 +2312,13 @@
                 "success": "Sähköposti päivitetty.",
                 "title": "Aseta käyttäjän sähköposti"
             }
+        },
+        "audio": {
+            "download": "Lataa ääni",
+            "recording": "Äänitallenne",
+            "play": "Toista ääni",
+            "pause": "Keskeytä ääni",
+            "seek": "Toistokohta"
         }
     }
 }

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -387,7 +387,15 @@
             "import_csv_hint": "CSV/TSV: sarakkeet code, language, text.",
             "import_csv_no_match": "Mikään rivi ei vastaa valittua kieltä ({{lang}}).",
             "import_csv_skipped": "Ohitettu {{count}} rivi(ä) muilla kielillä: {{langs}}.",
-            "import_csv_more_errors": "{{count}} lisää ongelmaa"
+            "import_csv_more_errors": "{{count}} lisää ongelmaa",
+            "filters": {
+                "status": "Suodata tilan mukaan",
+                "tag": "Suodata tunnisteen mukaan"
+            },
+            "status_for": "Tila: {{code}}",
+            "create_tag": "Luo tunniste",
+            "delete_tag": "Poista {{tag}}",
+            "cancel_delete_tag": "Peruuta tunnisteen {{tag}} poisto"
         },
         "concourse_import": {
             "title": "Tuo lausekokoelmasta",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -176,7 +176,11 @@
                     "ListChecks": "Tarkistuslista"
                 }
             },
-            "click_to_edit": "Napsauta muokataksesi"
+            "click_to_edit": "Napsauta muokataksesi",
+            "audio_player": {
+                "play": "Toista ääni",
+                "pause": "Keskeytä ääni"
+            }
         },
         "layout": {
             "title": "Ylläpito",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1826,7 +1826,9 @@
                 "contract_cta": "Avaa tutkimuksen yleisnäkymä"
             },
             "pagination": {
-                "showing": "Näytetään {{from}}–{{to}} / {{total}}"
+                "showing": "Näytetään {{from}}–{{to}} / {{total}}",
+                "previous": "Edellinen sivu",
+                "next": "Seuraava sivu"
             }
         },
         "team": {

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -226,7 +226,8 @@
                 "disabled_success": "Kaksivaiheinen todennus poistettu käytöstä",
                 "secret_copied": "Salaisuus kopioitu",
                 "invalid_token": "Virheellinen vahvistuskoodi",
-                "disable_error": "2FA-tunnistautumisen poistaminen epäonnistui"
+                "disable_error": "2FA-tunnistautumisen poistaminen epäonnistui",
+                "copy_secret": "Kopioi salaisuus"
             },
             "password": {
                 "title": "Salasanan hallinta",
@@ -1304,6 +1305,9 @@
                         "rough_disabled": "Vaihe 'Ensivaikutelma' (esilajittelu) on tässä luettelossa, mutta tutkimuksessa esilajittelu on poistettu käytöstä. Osallistujat eivät näe sitä.",
                         "presort_disabled": "Vaihe 'Tutustutaan' (esilajittelukysely) on tässä luettelossa, mutta tutkimuksessa esilajittelukysely on poistettu käytöstä. Osallistujat eivät näe sitä.",
                         "remove_action": "Poista"
+                    },
+                    "actions": {
+                        "delete": "Poista {{title}}"
                     }
                 },
                 "consent_title": "Suostumuslomake",
@@ -1499,7 +1503,8 @@
                     "prompt_placeholder": "Miksi sijoitit tämän väittämän tähän?",
                     "add": "Lisää",
                     "add_defaults": "Lisää oletusarvot (ääripäät)",
-                    "select_placeholder": "Valitse..."
+                    "select_placeholder": "Valitse...",
+                    "remove": "Poista {{score}}"
                 },
                 "random_comments": {
                     "title": "Salli vapaat kommentit",
@@ -1584,7 +1589,9 @@
                     "title": "Korostusväri",
                     "desc": "Tätä väriä käytetään painikkeissa, linkeissä ja korostuksissa koko tutkimuksen ajan.",
                     "pick": "Valitse väri",
-                    "reset": "Palauta oletus"
+                    "reset": "Palauta oletus",
+                    "info_label": "Tietoa korostusväristä",
+                    "swatch": "Aseta korostusväriksi {{color}}"
                 },
                 "logo": {
                     "title": "Tutkimuksen logo",
@@ -1593,7 +1600,9 @@
                     "hint": "Suositeltu koko: 200x50px. Tukee PNG, SVG, JPG.",
                     "preview": "Logon esikatselu",
                     "help_title": "Missä tämä logo näkyy?",
-                    "help_desc": "Logo näytetään jokaisen tutkimussivun yläosassa (navigointipalkki) ja tervetulosivulla. Se vahvistaa projektisi visuaalista identiteettiä."
+                    "help_desc": "Logo näytetään jokaisen tutkimussivun yläosassa (navigointipalkki) ja tervetulosivulla. Se vahvistaa projektisi visuaalista identiteettiä.",
+                    "info_label": "Tietoa tutkimuksen logosta",
+                    "remove": "Poista logo"
                 },
                 "partners": {
                     "title": "Institutionaaliset kumppanit",
@@ -1605,7 +1614,11 @@
                     "url_label": "Verkkosivusto (valinnainen)",
                     "url_placeholder": "https://...",
                     "help_title": "Logojen näyttäminen",
-                    "help_desc": "Kumppanien logot näytetään aloitussivulla sekä tutkimuksen otsikossa päälogon vieressä."
+                    "help_desc": "Kumppanien logot näytetään aloitussivulla sekä tutkimuksen otsikossa päälogon vieressä.",
+                    "info_label": "Tietoa institutionaalisista kumppaneista",
+                    "remove_logo": "Poista logo kumppanilta {{name}}",
+                    "remove": "Poista {{name}}",
+                    "unnamed": "Kumppani {{number}}"
                 },
                 "upload": {
                     "upload": "Lataa",
@@ -1615,7 +1628,8 @@
                     "conversion_error": "Kuvan käsittely epäonnistui.",
                     "processing": "Käsitellään kuvaa...",
                     "drag_drop": "Vedä ja pudota tai napsauta ladataksesi",
-                    "max": "Maks"
+                    "max": "Maks",
+                    "remove_default": "Poista kuva"
                 }
             },
             "title": "Tutkimuksen suunnittelu",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1446,7 +1446,9 @@
                     "imported": "{{count}} väittämää tuotu onnistuneesti",
                     "reset_codes": "Reset Codes",
                     "confirm_reset_codes": "Haluatko varmasti uudelleennumeroida kaikki väitekoodit (s1, s2, s3…)?",
-                    "codes_reset": "Väitekoodit uudelleennumeroitu"
+                    "codes_reset": "Väitekoodit uudelleennumeroitu",
+                    "save_item": "Tallenna {{code}}",
+                    "cancel_edit": "Peruuta kohteen {{code}} muokkaus"
                 },
                 "settings": {
                     "title": "Tutkimusasetukset",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1760,7 +1760,8 @@
                 "has_audio": "Sisältää äänivastauksia",
                 "email_provided": "Sähköposti annettu",
                 "newsletter_consent": "Haluaa tulokset",
-                "interview_consent": "Hyväksyy seurannan"
+                "interview_consent": "Hyväksyy seurannan",
+                "recruitment_link": "Rekrytointilinkki"
             },
             "toast": {
                 "discarded": "Osallistuja hylätty",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1395,7 +1395,10 @@
                 "actions": {
                     "add_option": "Lisää vaihtoehto",
                     "copy_from": "Kopioi kielestä",
-                    "copy_success": "Kopioitu"
+                    "copy_success": "Kopioitu",
+                    "copy_from_aria": "Tuo {{label}} toisesta kielestä",
+                    "delete": "Poista {{label}}",
+                    "remove_option": "Poista {{option}}"
                 },
                 "logic": {
                     "title": "Näkyvyyslogiikka",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -387,7 +387,15 @@
             "import_csv_hint": "CSV/TSV : colonnes code, language, text.",
             "import_csv_no_match": "Aucune ligne ne correspond à la langue sélectionnée ({{lang}}).",
             "import_csv_skipped": "{{count}} ligne(s) ignorée(s) dans d’autres langues : {{langs}}.",
-            "import_csv_more_errors": "{{count}} autres problèmes"
+            "import_csv_more_errors": "{{count}} autres problèmes",
+            "filters": {
+                "status": "Filtrer par statut",
+                "tag": "Filtrer par étiquette"
+            },
+            "status_for": "Statut de {{code}}",
+            "create_tag": "Créer une étiquette",
+            "delete_tag": "Supprimer {{tag}}",
+            "cancel_delete_tag": "Annuler la suppression de {{tag}}"
         },
         "concourse_import": {
             "title": "Importer depuis un concours",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1433,7 +1433,10 @@
                 "actions": {
                     "add_option": "Ajouter une option",
                     "copy_from": "Importer d'une langue",
-                    "copy_success": "Importé"
+                    "copy_success": "Importé",
+                    "copy_from_aria": "Importer {{label}} depuis une autre langue",
+                    "delete": "Supprimer {{label}}",
+                    "remove_option": "Retirer {{option}}"
                 },
                 "logic": {
                     "title": "Logique d'affichage",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -226,7 +226,8 @@
                 "enabled_success": "Authentification à deux facteurs activée",
                 "disabled_success": "Authentification à deux facteurs désactivée",
                 "invalid_token": "Code de vérification invalide",
-                "disable_error": "Impossible de désactiver le 2FA"
+                "disable_error": "Impossible de désactiver le 2FA",
+                "copy_secret": "Copier le secret"
             },
             "password": {
                 "title": "Mot de passe",
@@ -1342,6 +1343,9 @@
                         "rough_disabled": "L'étape « Premières impressions » (pré-tri) est dans cette liste mais l'étude a le pré-tri désactivé. Les participants ne la verront pas.",
                         "presort_disabled": "L'étape « Faisons connaissance » (questionnaire pré-tri) est dans cette liste mais l'étude a le questionnaire pré-tri désactivé. Les participants ne la verront pas.",
                         "remove_action": "Supprimer"
+                    },
+                    "actions": {
+                        "delete": "Supprimer {{title}}"
                     }
                 },
                 "consent_title": "Formulaire de consentement",
@@ -1537,7 +1541,8 @@
                     "prompt_placeholder": "Pourquoi avez-vous placé cet énoncé ici ?",
                     "add": "Ajouter",
                     "add_defaults": "Ajouter les extrêmes par défaut",
-                    "select_placeholder": "Sélectionner..."
+                    "select_placeholder": "Sélectionner...",
+                    "remove": "Retirer {{score}}"
                 },
                 "random_comments": {
                     "title": "Autoriser les commentaires libres",
@@ -1622,7 +1627,9 @@
                     "title": "Couleur d'accentuation",
                     "desc": "Cette couleur sera utilisée pour les boutons, liens et mises en évidence dans toute l'étude.",
                     "pick": "Choisir une couleur",
-                    "reset": "Réinitialiser"
+                    "reset": "Réinitialiser",
+                    "info_label": "À propos de la couleur d'accentuation",
+                    "swatch": "Définir la couleur d'accentuation sur {{color}}"
                 },
                 "logo": {
                     "title": "Logo de l'étude",
@@ -1631,7 +1638,9 @@
                     "hint": "Taille recommandée : 200x50px. Supporte PNG, SVG, JPG.",
                     "preview": "Aperçu du logo",
                     "help_title": "Où apparaît ce logo ?",
-                    "help_desc": "Le logo s'affiche en haut de chaque page de l'étude (barre de navigation) et sur la page de bienvenue. Il renforce l'identité visuelle de votre projet."
+                    "help_desc": "Le logo s'affiche en haut de chaque page de l'étude (barre de navigation) et sur la page de bienvenue. Il renforce l'identité visuelle de votre projet.",
+                    "info_label": "À propos du logo de l'étude",
+                    "remove": "Retirer le logo"
                 },
                 "partners": {
                     "title": "Logos des partenaires",
@@ -1643,7 +1652,11 @@
                     "url_label": "Site web (optionnel)",
                     "url_placeholder": "https://...",
                     "help_title": "Affichage des logos",
-                    "help_desc": "Les logos des partenaires sont affichés sur la page d'accueil ainsi que dans l'entête de l'étude, à côté du logo principal."
+                    "help_desc": "Les logos des partenaires sont affichés sur la page d'accueil ainsi que dans l'entête de l'étude, à côté du logo principal.",
+                    "info_label": "À propos des partenaires institutionnels",
+                    "remove_logo": "Retirer le logo de {{name}}",
+                    "remove": "Retirer {{name}}",
+                    "unnamed": "Partenaire {{number}}"
                 },
                 "upload": {
                     "upload": "Télécharger",
@@ -1653,7 +1666,8 @@
                     "conversion_error": "Échec du traitement de l'image.",
                     "processing": "Traitement de l'image...",
                     "drag_drop": "Glissez-déposez ou cliquez pour télécharger",
-                    "max": "Max"
+                    "max": "Max",
+                    "remove_default": "Retirer l'image"
                 }
             },
             "title": "Conception de l'étude",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1484,7 +1484,9 @@
                     "imported": "{{count}} énoncés importés avec succès",
                     "reset_codes": "Réinitialiser les codes",
                     "confirm_reset_codes": "Êtes-vous sûr de vouloir re-sequencer tous les codes d'énoncés (S1, S2, S3...) ?",
-                    "codes_reset": "Codes des énoncés réinitialisés"
+                    "codes_reset": "Codes des énoncés réinitialisés",
+                    "save_item": "Enregistrer {{code}}",
+                    "cancel_edit": "Annuler la modification de {{code}}"
                 },
                 "settings": {
                     "title": "Paramètres de recherche",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1798,7 +1798,8 @@
                 "has_audio": "A des réponses audio",
                 "email_provided": "Email fourni",
                 "newsletter_consent": "Souhaite les résultats",
-                "interview_consent": "Accepte suivi"
+                "interview_consent": "Accepte suivi",
+                "recruitment_link": "Lien de recrutement"
             },
             "toast": {
                 "discarded": "Participant écarté",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -176,11 +176,7 @@
                     "ListChecks": "Liste de contrôle"
                 }
             },
-            "click_to_edit": "Cliquer pour éditer",
-            "audio_player": {
-                "play": "Lire l'audio",
-                "pause": "Mettre l'audio en pause"
-            }
+            "click_to_edit": "Cliquer pour éditer"
         },
         "layout": {
             "title": "Admin",
@@ -2316,6 +2312,13 @@
                 "success": "E-mail mis à jour.",
                 "title": "Définir l'e-mail de l'utilisateur"
             }
+        },
+        "audio": {
+            "download": "Télécharger l'audio",
+            "recording": "Enregistrement audio",
+            "play": "Lire l'audio",
+            "pause": "Mettre l'audio en pause",
+            "seek": "Position de lecture"
         }
     }
 }

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -176,7 +176,11 @@
                     "ListChecks": "Liste de contrôle"
                 }
             },
-            "click_to_edit": "Cliquer pour éditer"
+            "click_to_edit": "Cliquer pour éditer",
+            "audio_player": {
+                "play": "Lire l'audio",
+                "pause": "Mettre l'audio en pause"
+            }
         },
         "layout": {
             "title": "Admin",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1864,7 +1864,9 @@
                 "contract_cta": "Ouvrir la vue d'ensemble"
             },
             "pagination": {
-                "showing": "{{from}}–{{to}} sur {{total}}"
+                "showing": "{{from}}–{{to}} sur {{total}}",
+                "previous": "Page précédente",
+                "next": "Page suivante"
             }
         },
         "empty_states": {

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1595,7 +1595,8 @@
                         "next": "Bouton standard utilisé pour passer d'une étape à l'autre.",
                         "submit": "Bouton final pour enregistrer la participation.",
                         "confirm": "Utilisé dans le tri sur grille pour valider le placement des cartes."
-                    }
+                    },
+                    "info_label": "À propos de {{label}}"
                 },
                 "terms": {
                     "title": "Terminologie du tri",
@@ -1613,7 +1614,9 @@
                     "desc": "Ajoutez ou modifiez des conseils flottants pour aider les participants pendant la phase de tri sur grille.",
                     "placeholder": "Entrez un conseil méthodologique...",
                     "add": "Ajouter un conseil",
-                    "reset": "Réinitialiser"
+                    "reset": "Réinitialiser",
+                    "remove": "Retirer {{tip}}",
+                    "unnamed": "Astuce {{number}}"
                 },
                 "help": {
                     "title": "Guidage par étape (Quoi/Pourquoi)",
@@ -2059,8 +2062,11 @@
                         "success": "Lien d'invitation généré !",
                         "error": "Échec de la création de l'invitation.",
                         "send": "Créer et envoyer l'invitation",
-                        "copy_success": "Lien copié dans le presse-papier !"
-                    }
+                        "copy_success": "Lien copié dans le presse-papier !",
+                        "copy_link": "Copier le lien",
+                        "copied": "Copié"
+                    },
+                    "role_for": "Rôle de {{name}}"
                 }
             }
         },

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1535,7 +1535,9 @@
                     "imported": "{{count}} affermazioni importate con successo",
                     "reset_codes": "Reimposta codici",
                     "confirm_reset_codes": "È sicuro di voler risequenziare tutti i codici delle affermazioni (s1, s2, s3...)?",
-                    "codes_reset": "Codici delle affermazioni risequenziati"
+                    "codes_reset": "Codici delle affermazioni risequenziati",
+                    "save_item": "Salva {{code}}",
+                    "cancel_edit": "Annulla la modifica di {{code}}"
                 },
                 "settings": {
                     "title": "Impostazioni di ricerca",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1484,7 +1484,10 @@
                 "actions": {
                     "add_option": "Aggiungi opzione",
                     "copy_from": "Importa da lingua",
-                    "copy_success": "Importato"
+                    "copy_success": "Importato",
+                    "copy_from_aria": "Importa {{label}} da un'altra lingua",
+                    "delete": "Elimina {{label}}",
+                    "remove_option": "Rimuovi {{option}}"
                 },
                 "logic": {
                     "title": "Logica di visibilità",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -264,11 +264,7 @@
                     "ListChecks": "Lista di controllo"
                 }
             },
-            "click_to_edit": "Clicchi per modificare",
-            "audio_player": {
-                "play": "Riproduci audio",
-                "pause": "Metti in pausa l'audio"
-            }
+            "click_to_edit": "Clicchi per modificare"
         },
         "layout": {
             "title": "Admin",
@@ -2316,6 +2312,13 @@
                 "success": "E-mail aggiornata.",
                 "title": "Imposta l'e-mail dell'utente"
             }
+        },
+        "audio": {
+            "download": "Scarica audio",
+            "recording": "Registrazione audio",
+            "play": "Riproduci audio",
+            "pause": "Metti in pausa l'audio",
+            "seek": "Posizione di riproduzione"
         }
     }
 }

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -264,7 +264,11 @@
                     "ListChecks": "Lista di controllo"
                 }
             },
-            "click_to_edit": "Clicchi per modificare"
+            "click_to_edit": "Clicchi per modificare",
+            "audio_player": {
+                "play": "Riproduci audio",
+                "pause": "Metti in pausa l'audio"
+            }
         },
         "layout": {
             "title": "Admin",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1646,7 +1646,8 @@
                         "next": "Passa al passo successivo",
                         "submit": "Invia i risultati alla fine",
                         "confirm": "Pulsante di validazione generico"
-                    }
+                    },
+                    "info_label": "Informazioni su {{label}}"
                 },
                 "terms": {
                     "title": "Terminologia di classificazione",
@@ -1664,7 +1665,9 @@
                     "desc": "Aggiunga o modifichi i suggerimenti visualizzati durante la fase di classificazione nella griglia.",
                     "placeholder": "Inserisca un suggerimento metodologico...",
                     "add": "Aggiungi suggerimento",
-                    "reset": "Ripristina valori predefiniti"
+                    "reset": "Ripristina valori predefiniti",
+                    "remove": "Rimuovi {{tip}}",
+                    "unnamed": "Suggerimento {{number}}"
                 },
                 "help": {
                     "title": "Guida del passo (cosa/perché)",
@@ -2147,8 +2150,11 @@
                         "success": "Link di invito generato!",
                         "error": "Creazione dell'invito non riuscita.",
                         "send": "Crea e invia invito",
-                        "copy_success": "Link copiato negli appunti!"
-                    }
+                        "copy_success": "Link copiato negli appunti!",
+                        "copy_link": "Copia link",
+                        "copied": "Copiato"
+                    },
+                    "role_for": "Ruolo di {{name}}"
                 }
             }
         },

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1848,7 +1848,8 @@
                 "has_audio": "Ha risposte audio",
                 "email_provided": "E-mail fornita",
                 "newsletter_consent": "Vuole i risultati",
-                "interview_consent": "Accetta follow-up"
+                "interview_consent": "Accetta follow-up",
+                "recruitment_link": "Link di reclutamento"
             },
             "toast": {
                 "discarded": "Partecipante scartato",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -314,7 +314,8 @@
                 "disabled_success": "Autenticazione a due fattori disabilitata",
                 "secret_copied": "Segreto copiato",
                 "invalid_token": "Codice di verifica non valido",
-                "disable_error": "Disabilitazione del 2FA non riuscita"
+                "disable_error": "Disabilitazione del 2FA non riuscita",
+                "copy_secret": "Copia segreto"
             },
             "password": {
                 "title": "Gestione password",
@@ -1392,6 +1393,9 @@
                         "rough_disabled": "Il passo 'Prime impressioni' (classificazione iniziale) è in questo elenco ma lo studio ha la classificazione iniziale disabilitata. I partecipanti non lo vedranno.",
                         "presort_disabled": "Il passo 'Facciamoci conoscere' (sondaggio pre-classificazione) è in questo elenco ma lo studio ha il sondaggio pre-classificazione disabilitato. I partecipanti non lo vedranno.",
                         "remove_action": "Rimuovi"
+                    },
+                    "actions": {
+                        "delete": "Elimina {{title}}"
                     }
                 },
                 "consent_title": "Modulo di consenso",
@@ -1588,7 +1592,8 @@
                     "prompt_placeholder": "Perché ha posizionato questa affermazione qui?",
                     "add": "Aggiungi",
                     "add_defaults": "Aggiungi estremi predefiniti",
-                    "select_placeholder": "Seleziona..."
+                    "select_placeholder": "Seleziona...",
+                    "remove": "Rimuovi {{score}}"
                 },
                 "random_comments": {
                     "title": "Consenti commenti liberi",
@@ -1673,7 +1678,9 @@
                     "title": "Colore di accento",
                     "desc": "Questo colore verrà utilizzato per pulsanti, link e highlights in tutto lo studio.",
                     "pick": "Scegli un colore",
-                    "reset": "Ripristina valore predefinito"
+                    "reset": "Ripristina valore predefinito",
+                    "info_label": "Informazioni sul colore di accento",
+                    "swatch": "Imposta il colore di accento su {{color}}"
                 },
                 "logo": {
                     "title": "Logo dello studio",
@@ -1682,7 +1689,9 @@
                     "hint": "Dimensione consigliata: 200x50px. Supporta PNG, SVG, JPG.",
                     "preview": "Anteprima logo",
                     "help_title": "Dove appare questo logo?",
-                    "help_desc": "Il logo viene visualizzato in cima a ogni pagina dello studio (barra di navigazione) e nella pagina di benvenuto. Rafforza l'identità visiva del suo progetto."
+                    "help_desc": "Il logo viene visualizzato in cima a ogni pagina dello studio (barra di navigazione) e nella pagina di benvenuto. Rafforza l'identità visiva del suo progetto.",
+                    "info_label": "Informazioni sul logo dello studio",
+                    "remove": "Rimuovi logo"
                 },
                 "partners": {
                     "title": "Partner istituzionali",
@@ -1694,7 +1703,11 @@
                     "url_label": "Sito web (facoltativo)",
                     "url_placeholder": "Https://...",
                     "help_title": "Visualizzazione dei loghi",
-                    "help_desc": "I loghi dei partner vengono visualizzati nella pagina di destinazione e nell'intestazione dello studio, accanto al logo principale."
+                    "help_desc": "I loghi dei partner vengono visualizzati nella pagina di destinazione e nell'intestazione dello studio, accanto al logo principale.",
+                    "info_label": "Informazioni sui partner istituzionali",
+                    "remove_logo": "Rimuovi il logo di {{name}}",
+                    "remove": "Rimuovi {{name}}",
+                    "unnamed": "Partner {{number}}"
                 },
                 "upload": {
                     "upload": "Carica",
@@ -1704,7 +1717,8 @@
                     "conversion_error": "Elaborazione dell'immagine non riuscita.",
                     "processing": "Elaborazione immagine...",
                     "drag_drop": "Trascini e rilasci o clicchi per caricare",
-                    "max": "Max"
+                    "max": "Max",
+                    "remove_default": "Rimuovi immagine"
                 }
             },
             "activate_dialog": {

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1914,7 +1914,9 @@
                 "contract_cta": "Apri panoramica studio"
             },
             "pagination": {
-                "showing": "Visualizzazione {{from}}–{{to}} di {{total}}"
+                "showing": "Visualizzazione {{from}}–{{to}} di {{total}}",
+                "previous": "Pagina precedente",
+                "next": "Pagina successiva"
             }
         },
         "team": {

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -475,7 +475,15 @@
             "import_csv_hint": "CSV/TSV richiede colonne: code, language, text.",
             "import_csv_no_match": "Nessuna riga corrisponde alla lingua selezionata ({{lang}}).",
             "import_csv_skipped": "Saltate {{count}} riga/e in altre lingue: {{langs}}.",
-            "import_csv_more_errors": "{{count}} altri problemi"
+            "import_csv_more_errors": "{{count}} altri problemi",
+            "filters": {
+                "status": "Filtra per stato",
+                "tag": "Filtra per tag"
+            },
+            "status_for": "Stato di {{code}}",
+            "create_tag": "Crea tag",
+            "delete_tag": "Elimina {{tag}}",
+            "cancel_delete_tag": "Annulla l'eliminazione di {{tag}}"
         },
         "concourse_import": {
             "title": "Importa dal concorso",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1484,7 +1484,10 @@
                 "actions": {
                     "add_option": "Optie toevoegen",
                     "copy_from": "Importeren vanuit taal",
-                    "copy_success": "Geïmporteerd"
+                    "copy_success": "Geïmporteerd",
+                    "copy_from_aria": "{{label}} uit een andere taal importeren",
+                    "delete": "{{label}} verwijderen",
+                    "remove_option": "{{option}} verwijderen"
                 },
                 "logic": {
                     "title": "Zichtbaarheidslogica",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -264,11 +264,7 @@
                     "ListChecks": "Checklist"
                 }
             },
-            "click_to_edit": "Klik om te bewerken",
-            "audio_player": {
-                "play": "Audio afspelen",
-                "pause": "Audio pauzeren"
-            }
+            "click_to_edit": "Klik om te bewerken"
         },
         "layout": {
             "title": "Beheer",
@@ -2316,6 +2312,13 @@
                 "success": "E-mail bijgewerkt.",
                 "title": "E-mail van gebruiker instellen"
             }
+        },
+        "audio": {
+            "download": "Audio downloaden",
+            "recording": "Audio-opname",
+            "play": "Audio afspelen",
+            "pause": "Audio pauzeren",
+            "seek": "Afspeelpositie"
         }
     }
 }

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -264,7 +264,11 @@
                     "ListChecks": "Checklist"
                 }
             },
-            "click_to_edit": "Klik om te bewerken"
+            "click_to_edit": "Klik om te bewerken",
+            "audio_player": {
+                "play": "Audio afspelen",
+                "pause": "Audio pauzeren"
+            }
         },
         "layout": {
             "title": "Beheer",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1848,7 +1848,8 @@
                 "has_audio": "Heeft audio-antwoorden",
                 "email_provided": "E-mailadres opgegeven",
                 "newsletter_consent": "Wil resultaten",
-                "interview_consent": "Accepteert vervolg"
+                "interview_consent": "Accepteert vervolg",
+                "recruitment_link": "Wervingslink"
             },
             "toast": {
                 "discarded": "Deelnemer verwijderd",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -314,7 +314,8 @@
                 "disabled_success": "Tweestapsverificatie uitgeschakeld",
                 "secret_copied": "Geheim gekopieerd",
                 "invalid_token": "Ongeldige verificatiecode",
-                "disable_error": "2FA uitschakelen mislukt"
+                "disable_error": "2FA uitschakelen mislukt",
+                "copy_secret": "Geheim kopiëren"
             },
             "password": {
                 "title": "Wachtwoordbeheer",
@@ -1392,6 +1393,9 @@
                         "rough_disabled": "De stap 'Eerste indrukken' (grove sortering) staat in deze lijst, maar de grove sortering is uitgeschakeld voor dit onderzoek. Deelnemers zullen deze stap niet zien.",
                         "presort_disabled": "De stap 'Laten we kennismaken' (voorsorteringsvragenlijst) staat in deze lijst, maar de voorsorteringsvragenlijst is uitgeschakeld voor dit onderzoek. Deelnemers zullen deze stap niet zien.",
                         "remove_action": "Verwijderen"
+                    },
+                    "actions": {
+                        "delete": "{{title}} verwijderen"
                     }
                 },
                 "consent_title": "Toestemmingsformulier",
@@ -1588,7 +1592,8 @@
                     "prompt_placeholder": "Waarom heeft u deze stelling hier geplaatst?",
                     "add": "Toevoegen",
                     "add_defaults": "Standaard extremen toevoegen",
-                    "select_placeholder": "Selecteren..."
+                    "select_placeholder": "Selecteren...",
+                    "remove": "{{score}} verwijderen"
                 },
                 "random_comments": {
                     "title": "Willekeurige opmerkingen toestaan",
@@ -1673,7 +1678,9 @@
                     "title": "Accentkleur",
                     "desc": "Deze kleur wordt gebruikt voor knoppen, links en markeringen in het hele onderzoek.",
                     "pick": "Kleur kiezen",
-                    "reset": "Standaardkleur herstellen"
+                    "reset": "Standaardkleur herstellen",
+                    "info_label": "Over de accentkleur",
+                    "swatch": "Accentkleur instellen op {{color}}"
                 },
                 "logo": {
                     "title": "Onderzoekslogo",
@@ -1682,7 +1689,9 @@
                     "hint": "Aanbevolen formaat: 200x50px. Ondersteunt PNG, SVG, JPG.",
                     "preview": "Logovoorbeeld",
                     "help_title": "Waar verschijnt dit logo?",
-                    "help_desc": "Het logo wordt bovenaan elke onderzoekspagina (navigatiebalk) en op de welkomstpagina weergegeven. Het versterkt de visuele identiteit van uw project."
+                    "help_desc": "Het logo wordt bovenaan elke onderzoekspagina (navigatiebalk) en op de welkomstpagina weergegeven. Het versterkt de visuele identiteit van uw project.",
+                    "info_label": "Over het onderzoekslogo",
+                    "remove": "Logo verwijderen"
                 },
                 "partners": {
                     "title": "Institutionele partners",
@@ -1694,7 +1703,11 @@
                     "url_label": "Website (optioneel)",
                     "url_placeholder": "Https://...",
                     "help_title": "Weergave van logo's",
-                    "help_desc": "Partnerlogo's worden weergegeven op de landingspagina en in de onderzoeksheader, naast het hoofdlogo."
+                    "help_desc": "Partnerlogo's worden weergegeven op de landingspagina en in de onderzoeksheader, naast het hoofdlogo.",
+                    "info_label": "Over institutionele partners",
+                    "remove_logo": "Logo van {{name}} verwijderen",
+                    "remove": "{{name}} verwijderen",
+                    "unnamed": "Partner {{number}}"
                 },
                 "upload": {
                     "upload": "Uploaden",
@@ -1704,7 +1717,8 @@
                     "conversion_error": "Verwerking van afbeelding mislukt.",
                     "processing": "Afbeelding verwerken...",
                     "drag_drop": "Slepen & neerzetten of klikken om te uploaden",
-                    "max": "Max"
+                    "max": "Max",
+                    "remove_default": "Afbeelding verwijderen"
                 }
             },
             "activate_dialog": {

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1914,7 +1914,9 @@
                 "contract_cta": "Onderzoeksoverzicht openen"
             },
             "pagination": {
-                "showing": "{{from}}–{{to}} van {{total}} weergegeven"
+                "showing": "{{from}}–{{to}} van {{total}} weergegeven",
+                "previous": "Vorige pagina",
+                "next": "Volgende pagina"
             }
         },
         "team": {

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -475,7 +475,15 @@
             "import_csv_hint": "CSV/TSV heeft kolommen nodig: code, language, text.",
             "import_csv_no_match": "Geen rijen komen overeen met de geselecteerde taal ({{lang}}).",
             "import_csv_skipped": "{{count}} rij(en) in andere talen overgeslagen: {{langs}}.",
-            "import_csv_more_errors": "{{count}} meer problemen"
+            "import_csv_more_errors": "{{count}} meer problemen",
+            "filters": {
+                "status": "Filteren op status",
+                "tag": "Filteren op label"
+            },
+            "status_for": "Status van {{code}}",
+            "create_tag": "Label maken",
+            "delete_tag": "{{tag}} verwijderen",
+            "cancel_delete_tag": "Verwijderen van {{tag}} annuleren"
         },
         "concourse_import": {
             "title": "Importeren uit concours",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1535,7 +1535,9 @@
                     "imported": "{{count}} stellingen succesvol geïmporteerd",
                     "reset_codes": "Codes herstellen",
                     "confirm_reset_codes": "Weet u zeker dat u alle stellingcodes opnieuw wilt nummeren (s1, s2, s3...)?",
-                    "codes_reset": "Stellingcodes opnieuw genummerd"
+                    "codes_reset": "Stellingcodes opnieuw genummerd",
+                    "save_item": "{{code}} opslaan",
+                    "cancel_edit": "Bewerken van {{code}} annuleren"
                 },
                 "settings": {
                     "title": "Onderzoeksinstellingen",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1646,7 +1646,8 @@
                         "next": "Naar de volgende stap gaan",
                         "submit": "Resultaten verzenden aan het einde",
                         "confirm": "Algemene validatieknop"
-                    }
+                    },
+                    "info_label": "Over {{label}}"
                 },
                 "terms": {
                     "title": "Sorteringsterminologie",
@@ -1664,7 +1665,9 @@
                     "desc": "Voeg zwevende hints toe of pas ze aan om deelnemers te helpen tijdens de rasterdsorteringsfase.",
                     "placeholder": "Voer een methodologietip in...",
                     "add": "Tip toevoegen",
-                    "reset": "Standaardinstellingen herstellen"
+                    "reset": "Standaardinstellingen herstellen",
+                    "remove": "{{tip}} verwijderen",
+                    "unnamed": "Tip {{number}}"
                 },
                 "help": {
                     "title": "Stapbegeleiding (wat/waarom)",
@@ -2147,8 +2150,11 @@
                         "success": "Uitnodigingslink gegenereerd!",
                         "error": "Uitnodiging aanmaken mislukt.",
                         "send": "Uitnodiging aanmaken en versturen",
-                        "copy_success": "Link gekopieerd naar klembord!"
-                    }
+                        "copy_success": "Link gekopieerd naar klembord!",
+                        "copy_link": "Link kopiëren",
+                        "copied": "Gekopieerd"
+                    },
+                    "role_for": "Rol van {{name}}"
                 }
             }
         },

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -264,11 +264,7 @@
           "ListChecks": "Lista kontrolna"
         }
       },
-      "click_to_edit": "Kliknij, aby edytować",
-      "audio_player": {
-        "play": "Odtwórz audio",
-        "pause": "Wstrzymaj audio"
-      }
+      "click_to_edit": "Kliknij, aby edytować"
     },
     "layout": {
       "title": "Admin",
@@ -2316,6 +2312,13 @@
         "success": "Zaktualizowano e-mail.",
         "title": "Ustaw e-mail użytkownika"
       }
+    },
+    "audio": {
+      "download": "Pobierz audio",
+      "recording": "Nagranie audio",
+      "play": "Odtwórz audio",
+      "pause": "Wstrzymaj audio",
+      "seek": "Pozycja odtwarzania"
     }
   }
 }

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -475,7 +475,15 @@
       "import_csv_hint": "CSV/TSV wymaga kolumn: code, language, text.",
       "import_csv_no_match": "Żaden wiersz nie pasuje do wybranego języka ({{lang}}).",
       "import_csv_skipped": "Pominięto {{count}} wiersz(-y) w innych językach: {{langs}}.",
-      "import_csv_more_errors": "{{count}} więcej problemów"
+      "import_csv_more_errors": "{{count}} więcej problemów",
+      "filters": {
+        "status": "Filtruj według statusu",
+        "tag": "Filtruj według tagu"
+      },
+      "status_for": "Status: {{code}}",
+      "create_tag": "Utwórz tag",
+      "delete_tag": "Usuń {{tag}}",
+      "cancel_delete_tag": "Anuluj usuwanie {{tag}}"
     },
     "concourse_import": {
       "title": "Importuj z konkursu",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1,2281 +1,2285 @@
 {
-  "auth": {
-    "login": {
-      "email_label": "Adres e-mail",
-      "password_label": "Hasło",
-      "submit": "Zaloguj się",
-      "cta": "Zaloguj się",
-      "forgot_password": "Nie pamiętasz?",
-      "loading": "Uwierzytelnianie...",
-      "card_title": "Zaloguj się",
-      "welcome_back": "Witamy z powrotem!",
-      "error_401": "Nieprawidłowy adres e-mail lub hasło",
-      "error_generic": "Coś poszło nie tak. Proszę spróbować ponownie.",
-      "reason_session_expired": "Sesja wygasła. Proszę zalogować się ponownie.",
-      "reason_auth_required": "Proszę zalogować się, aby kontynuować.",
-      "forgot_password_link": "Nie pamiętasz hasła?",
-      "reset_success_banner": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
-      "two_factor_title": "Weryfikacja dwuetapowa",
-      "two_factor_app_prompt": "Proszę wpisać 6-cyfrowy kod z aplikacji uwierzytelniającej.",
-      "two_factor_submit": "Zweryfikuj",
-      "two_factor_invalid": "Nieprawidłowy kod. Proszę spróbować ponownie.",
-      "lost_2fa_link": "Brak dostępu do weryfikacji dwuetapowej?"
-    },
-    "twofa": {
-      "recovery": {
-        "title": "Brak dostępu do weryfikacji dwuetapowej?",
-        "body": "Proszę podać adres e-mail konta. Jeśli weryfikacja dwuetapowa jest włączona, wyślemy link do jej wyłączenia.",
-        "submit": "Wyślij link wyłączający",
-        "success": "Jeśli adres e-mail istnieje i ma włączoną weryfikację dwuetapową, link jest już w drodze."
-      },
-      "disable": {
-        "title": "Wyłącz weryfikację dwuetapową",
-        "warning": "Kliknięcie przycisku poniżej trwale usunie drugi składnik uwierzytelnienia z tego konta. Logowanie będzie możliwe samym hasłem do momentu ponownego włączenia weryfikacji dwuetapowej.",
-        "warning_attacker": "Jeśli to nie Pan/Pani zażądał/a tej operacji, proszę zamknąć tę stronę i natychmiast zmienić hasło.",
-        "confirm_button": "Tak, wyłącz weryfikację dwuetapową",
-        "loading": "Wyłączanie…",
-        "success": "Weryfikacja dwuetapowa została wyłączona. Można się zalogować.",
-        "error_consumed": "Ten link został już wykorzystany.",
-        "error_expired": "Ten link wygasł lub jest nieprawidłowy.",
-        "missing_token": "Brak tokenu w adresie URL."
-      }
-    },
-    "password_reset": {
-      "request_title": "Zresetuj hasło",
-      "request_body": "Proszę podać adres e-mail, a wyślemy link do zresetowania hasła.",
-      "request_submit": "Wyślij link resetujący",
-      "request_success": "Jeśli adres e-mail istnieje, link resetujący jest już w drodze.",
-      "confirm_title": "Wybierz nowe hasło",
-      "confirm_submit": "Zresetuj hasło",
-      "success_redirect": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
-      "link_expired": "Ten link wygasł lub został już wykorzystany.",
-      "too_short": "Hasło musi mieć co najmniej 8 znaków.",
-      "mismatch": "Hasła nie są zgodne.",
-      "missing_token": "Brak tokenu resetowania w adresie URL.",
-      "new_password_placeholder": "Nowe hasło",
-      "confirm_placeholder": "Potwierdź hasło",
-      "request_success_manual": "Wysyłka e-maili nie jest skonfigurowana w tej instancji. Skontaktuj się z administratorem, aby uzyskać link resetujący."
-    },
-    "email": {
-      "verification_sent": {
-        "title": "Zweryfikuj adres e-mail",
-        "body": "Wysłaliśmy link weryfikacyjny na adres {{email}}. Proszę kliknąć link, aby aktywować konto.",
-        "resend": "Wyślij e-mail ponownie",
-        "cooldown": "Ponowne wysłanie dostępne za {{seconds}} s",
-        "error": "Nie udało się wysłać ponownie. Proszę spróbować później."
-      },
-      "verify": {
-        "verifying": "Weryfikowanie adresu e-mail…",
-        "success": "Adres e-mail zweryfikowany. Można się teraz zalogować.",
-        "expired": "Ten link wygasł lub jest nieprawidłowy.",
-        "resend_link": "Poproś o nowy e-mail weryfikacyjny"
-      }
-    },
-    "register": {
-      "title": "Utwórz konto",
-      "subtitle": "Dołącz do projektu badawczego",
-      "secure_invitation": "Bezpieczne zaproszenie",
-      "invitation_to": "Zaproszenie do:",
-      "study_label": "Badanie",
-      "role_label": "Rola",
-      "email_label": "Adres e-mail",
-      "password_label": "Wybierz hasło",
-      "confirm_password_label": "Potwierdź hasło",
-      "placeholder_password": "••••••••",
-      "submit": "Zakończ rejestrację",
-      "loading": "Tworzenie konta...",
-      "success_title": "Witamy na pokładzie!",
-      "success_desc": "Konto zostało utworzone i powiązane z badaniem.",
-      "success_cta": "Przejdź do panelu",
-      "success_hint": "Można teraz zalogować się do panelu administracyjnego i rozpocząć współpracę.",
-      "invalid_title": "Nieprawidłowe zaproszenie",
-      "invalid_desc": "Ten link zaproszenia jest nieprawidłowy lub wygasł.",
-      "missing_token_title": "Brak tokenu",
-      "missing_token_desc": "Ta strona wymaga prawidłowego tokenu zaproszenia. Proszę sprawdzić otrzymany link.",
-      "verifying": "Weryfikowanie zaproszenia...",
-      "privacy_hint": "Rejestrując się, wyrażasz zgodę na przestrzeganie wytycznych etyki badawczej skonfigurowanych dla tego badania.",
-      "errors": {
-        "password_mismatch": "Hasła nie są zgodne",
-        "generic_fail": "Rejestracja nie powiodła się"
-      }
-    }
-  },
-  "admin": {
-    "hub": {
-      "title": "Panel badacza",
-      "welcome": "Witamy z powrotem,",
-      "new_project": "Nowy projekt",
-      "your_projects": "Twoje projekty",
-      "studies_count": "badań",
-      "recent_studies": "Ostatnie badania",
-      "n_studies_one": "{{count}} badanie",
-      "n_studies_other": "{{count}} badań",
-      "n_active_one": "{{count}} aktywne",
-      "n_active_other": "{{count}} aktywnych",
-      "collecting": "Zbieranie danych",
-      "no_studies": "Brak badań",
-      "no_projects": "Brak projektów. Utwórz pierwszy projekt, aby rozpocząć.",
-      "no_projects_title": "Rozpocznij pierwszy projekt badawczy",
-      "no_projects_body": "Utwórz projekt przed dodaniem konkursów, zbiorów Q lub badań."
-    },
-    "memo": {
-      "title_concourse": "Notatki selekcji",
-      "title_study": "Notatka metodologiczna",
-      "summary_empty_concourse": "Jak i dlaczego zbudowano ten konkurs",
-      "summary_empty_study": "Opcjonalnie · do replikacji i prerejstracji",
-      "summary_filled_one": "{{n}} wpis · kliknij, aby wyświetlić",
-      "summary_filled_other": "{{n}} wpisów · kliknij, aby wyświetlić",
-      "summary_unread": "{{n}} nieprzeczytanych",
-      "add_entry": "Dodaj wpis",
-      "export": "Eksportuj",
-      "insert_template": "Wstaw z szablonu",
-      "entry_title_placeholder": "Tytuł sekcji…",
-      "entry_body_placeholder": "Udokumentuj swoje uzasadnienie…",
-      "comments_count_one": "{{n}} komentarz",
-      "comments_count_other": "{{n}} komentarzy",
-      "show_resolved": "Pokaż rozwiązane ({{n}})",
-      "hide_resolved": "Ukryj rozwiązane",
-      "comment_placeholder": "Napisz komentarz. Użyj @, aby wspomnieć.",
-      "post_comment": "Wyślij",
-      "edit": "Edytuj",
-      "delete": "Usuń",
-      "deleted_body": "[usunięty komentarz]",
-      "resolve": "Oznacz jako rozwiązane",
-      "unresolve": "Cofnij rozwiązanie",
-      "resolved_label": "[rozwiązane]",
-      "save": "Zapisz",
-      "cancel": "Anuluj",
-      "saved": "Zapisano",
-      "save_error": "Nie udało się zapisać notatki. Proszę spróbować ponownie.",
-      "load_error": "Nie udało się wczytać notatki. Odśwież stronę, aby spróbować ponownie.",
-      "mentions_for_you": "Wzmianki dla mnie",
-      "mention_user_not_found": "Nieznany użytkownik",
-      "delete_entry_confirm": "Usunąć ten wpis i wszystkie jego komentarze?",
-      "include_discussion_in_export": "Dołącz wątki dyskusji z notatki",
-      "templates": {
-        "concourse": {
-          "sources_canvassed": {
-            "title": "Przejrzane źródła"
-          },
-          "voices_retained": {
-            "title": "Zachowane głosy"
-          },
-          "voices_excluded": {
-            "title": "Wykluczone głosy"
-          },
-          "sampling_rationale": {
-            "title": "Uzasadnienie doboru próby"
-          },
-          "version_notes": {
-            "title": "Uwagi do wersji"
-          }
+    "auth": {
+        "login": {
+            "email_label": "Adres e-mail",
+            "password_label": "Hasło",
+            "submit": "Zaloguj się",
+            "cta": "Zaloguj się",
+            "forgot_password": "Nie pamiętasz?",
+            "loading": "Uwierzytelnianie...",
+            "card_title": "Zaloguj się",
+            "welcome_back": "Witamy z powrotem!",
+            "error_401": "Nieprawidłowy adres e-mail lub hasło",
+            "error_generic": "Coś poszło nie tak. Proszę spróbować ponownie.",
+            "reason_session_expired": "Sesja wygasła. Proszę zalogować się ponownie.",
+            "reason_auth_required": "Proszę zalogować się, aby kontynuować.",
+            "forgot_password_link": "Nie pamiętasz hasła?",
+            "reset_success_banner": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
+            "two_factor_title": "Weryfikacja dwuetapowa",
+            "two_factor_app_prompt": "Proszę wpisać 6-cyfrowy kod z aplikacji uwierzytelniającej.",
+            "two_factor_submit": "Zweryfikuj",
+            "two_factor_invalid": "Nieprawidłowy kod. Proszę spróbować ponownie.",
+            "lost_2fa_link": "Brak dostępu do weryfikacji dwuetapowej?"
         },
-        "study": {
-          "distribution_rationale": {
-            "title": "Uzasadnienie rozkładu"
-          },
-          "conditions_of_instruction": {
-            "title": "Warunki instrukcji"
-          },
-          "qset_size": {
-            "title": "Rozmiar zbioru Q"
-          },
-          "pre_post_design": {
-            "title": "Decyzje projektowe wstępnego/końcowego sortowania"
-          },
-          "limitations": {
-            "title": "Ograniczenia"
-          }
-        }
-      }
-    },
-    "study_design": {
-      "distribution_mode": {
-        "title": "Tryb rozkładu",
-        "helper": "Wybierz, jak ściśle wymuszany jest rozkład siatki Q. Wymuszony: każda kolumna musi być wypełniona do zadeklarowanej pojemności (najczęstszy wybór). Swobodny: dowolna liczba kart na kolumnę, łącznie = rozmiar zbioru Q. Elastyczny: łączna liczba wymuszona, kolumny to miękkie wskazówki.",
-        "forced": {
-          "label": "Wymuszony",
-          "tooltip": "Każda kolumna musi zawierać dokładnie zadeklarowaną liczbę kart."
+        "twofa": {
+            "recovery": {
+                "title": "Brak dostępu do weryfikacji dwuetapowej?",
+                "body": "Proszę podać adres e-mail konta. Jeśli weryfikacja dwuetapowa jest włączona, wyślemy link do jej wyłączenia.",
+                "submit": "Wyślij link wyłączający",
+                "success": "Jeśli adres e-mail istnieje i ma włączoną weryfikację dwuetapową, link jest już w drodze."
+            },
+            "disable": {
+                "title": "Wyłącz weryfikację dwuetapową",
+                "warning": "Kliknięcie przycisku poniżej trwale usunie drugi składnik uwierzytelnienia z tego konta. Logowanie będzie możliwe samym hasłem do momentu ponownego włączenia weryfikacji dwuetapowej.",
+                "warning_attacker": "Jeśli to nie Pan/Pani zażądał/a tej operacji, proszę zamknąć tę stronę i natychmiast zmienić hasło.",
+                "confirm_button": "Tak, wyłącz weryfikację dwuetapową",
+                "loading": "Wyłączanie…",
+                "success": "Weryfikacja dwuetapowa została wyłączona. Można się zalogować.",
+                "error_consumed": "Ten link został już wykorzystany.",
+                "error_expired": "Ten link wygasł lub jest nieprawidłowy.",
+                "missing_token": "Brak tokenu w adresie URL."
+            }
         },
-        "free": {
-          "label": "Swobodny",
-          "tooltip": "Łączna liczba kart = rozmiar zbioru Q; liczba kart na kolumnę nie jest ograniczona."
-        },
-        "flexible": {
-          "label": "Elastyczny",
-          "tooltip": "Łączna liczba kart = rozmiar zbioru Q; pojemności kolumn są miękkimi wskazówkami (tylko ostrzeżenia)."
-        }
-      },
-      "rough_sort": {
-        "toggle_label": "Włącz wstępne sortowanie (triaż na 3 stosy)",
-        "lock_banner": "Przełącznik zablokowany. {{count}} uczestnik(-ów) rozpoczął(-ęło) ankietę; zarchiwizuj lub usuń te sesje przed zmianą tego ustawienia.",
-        "deck_mode_note": "Wyłączone. Uczestnicy widzą pełny zbiór Q jako przewijany poziomo talia kart."
-      }
-    },
-    "study": {
-      "activate_error": "Nie można aktywować badania. Sprawdź, czy projekt badania jest prawidłowy, i spróbuj ponownie.",
-      "save": {
-        "success": "Zmiany zapisane pomyślnie",
-        "save_success": "Zapisano pomyślnie",
-        "synced_warnings": "Zsynchronizowano z serwerem. Zachowano zmiany w: {{fields}}",
-        "synced_concurrent": "Zsynchronizowano ze zmianami wprowadzonymi przez innego użytkownika",
-        "conflict": "Wykryto konflikt. Niektórych zmian nie można było scalić.",
-        "error": "Nie udało się zapisać zmian"
-      },
-      "postsort": {
-        "missing": {
-          "title": "Brakujące stwierdzenia",
-          "desc": "Czy w zestawie stwierdzeń brakowało jakichś idei lub perspektyw?"
-        }
-      },
-      "state": {
-        "manage": "Zarządzaj przebiegiem badania"
-      }
-    },
-    "components": {
-      "markdown": {
-        "label": "Markdown",
-        "tooltip": "Obsługuje Markdown do bogatego formatowania",
-        "bold": "Pogrubienie",
-        "italic": "Kursywa",
-        "list": "Lista",
-        "link": "Link",
-        "edit": "Edytuj",
-        "preview": "Podgląd",
-        "empty": "Brak treści do podglądu"
-      },
-      "icon_picker": {
-        "icons": {
-          "User": "Osoba",
-          "Zap": "Błyskawica",
-          "Scale": "Waga",
-          "MessageSquareText": "Wiadomość",
-          "ClipboardList": "Schowek",
-          "CheckCircle": "Znacznik wyboru",
-          "Flag": "Flaga",
-          "Info": "Informacja",
-          "HelpCircle": "Pomoc",
-          "FileText": "Dokument",
-          "LayoutGrid": "Siatka",
-          "Rocket": "Rakieta",
-          "Target": "Cel",
-          "Brain": "Mózg",
-          "Lightbulb": "Pomysł",
-          "ListChecks": "Lista kontrolna"
-        }
-      },
-      "click_to_edit": "Kliknij, aby edytować"
-    },
-    "layout": {
-      "title": "Admin",
-      "back_home": "Wróć do strony głównej",
-      "beta": "Wersja badawcza beta",
-      "logout": "Wyloguj",
-      "account": "Ustawienia konta",
-      "admin_user": "Użytkownik administracyjny",
-      "platform_settings": "Ustawienia platformy"
-    },
-    "account": {
-      "title": "Ustawienia konta",
-      "description": "Zarządzaj danymi osobowymi i bezpieczeństwem konta.",
-      "personal": {
-        "title": "Dane osobowe",
-        "email": "Adres e-mail",
-        "email_locked": "Twój adres e-mail nie może być jeszcze zmieniony tutaj. Skontaktuj się z administratorem, aby go zaktualizować.",
-        "name": "Imię i nazwisko",
-        "save": "Zapisz",
-        "saving": "Zapisywanie...",
-        "success": "Profil zaktualizowany pomyślnie",
-        "error": "Nie udało się zaktualizować profilu",
-        "cannot_remove_self": "Nie można usunąć samego siebie",
-        "name_required": "Imię i nazwisko jest wymagane"
-      },
-      "security": {
-        "title": "Bezpieczeństwo",
-        "description": "Zarządzaj weryfikacją dwuetapową i hasłem.",
-        "tfa_subtitle": "Weryfikacja dwuetapowa",
-        "password_subtitle": "Hasło",
-        "enabled": "Włączone",
-        "setup_cta": "Skonfiguruj weryfikację dwuetapową",
-        "configure_title": "Konfiguruj aplikację uwierzytelniającą",
-        "scan_desc": "Zeskanuj ten kod QR aplikacją uwierzytelniającą (Google Authenticator, Authy itp.)",
-        "enter_code": "Wpisz 6-cyfrowy kod",
-        "enable_btn": "Włącz weryfikację dwuetapową",
-        "disable_btn": "Wyłącz weryfikację dwuetapową",
-        "confirm_disable": "Potwierdź wyłączenie",
-        "confirm_password_label": "Potwierdź hasłem",
-        "verifying": "Weryfikowanie...",
-        "cancel": "Anuluj",
-        "enabled_success": "Weryfikacja dwuetapowa włączona",
-        "disabled_success": "Weryfikacja dwuetapowa wyłączona",
-        "secret_copied": "Sekret skopiowany",
-        "invalid_token": "Nieprawidłowy kod weryfikacyjny",
-        "disable_error": "Nie udało się wyłączyć weryfikacji dwuetapowej"
-      },
-      "password": {
-        "title": "Zarządzanie hasłem",
-        "current": "Aktualne hasło",
-        "new": "Nowe hasło",
-        "change_btn": "Zmień hasło",
-        "updating": "Aktualizowanie...",
-        "success": "Hasło zmienione pomyślnie",
-        "error": "Nie udało się zmienić hasła. Sprawdź aktualne hasło.",
-        "validation": {
-          "required": "Wymagane",
-          "min_length": "Min. 8 znaków"
-        }
-      }
-    },
-    "sidebar": {
-      "home": "Panel",
-      "add_study": "Dodaj badanie",
-      "create_project": "UTWÓRZ NOWY PROJEKT",
-      "dashboard": "Panel",
-      "overview": "Przegląd",
-      "design": "Projekt",
-      "recruit": "Dostęp",
-      "data": "Dane",
-      "analysis": "Analiza",
-      "privacy": "Prywatność danych",
-      "team": "Zespół",
-      "settings": "Ustawienia badania",
-      "project_settings": "Ustawienia projektu",
-      "study_tools": "Narzędzia badania",
-      "project": "Projekt",
-      "documentation": "Dokumentacja",
-      "support": "Wsparcie",
-      "study_management": "Zarządzanie badaniem",
-      "search": "Szukaj...",
-      "studies": "Badania",
-      "select_study": "Wybierz badanie",
-      "select_study_msg": "Wybierz lub utwórz badanie, aby rozpocząć.",
-      "view_all_studies": "Wszystkie badania",
-      "study": "Badanie",
-      "select_project": "Wybierz projekt",
-      "concourses": "Konkursy",
-      "concourse": "Konkurs",
-      "members": "Członkowie zespołu"
-    },
-    "concourse": {
-      "title": "Konkurs",
-      "description": "Zarządzaj stwierdzeniami kandydatów do badania metodologią Q",
-      "default_title": "Konkurs",
-      "default_title_for_project": "Konkurs {{project}}",
-      "create": "Nowy konkurs",
-      "create_success": "Konkurs utworzony",
-      "create_error": "Nie udało się utworzyć konkursu",
-      "create_dialog_title": "Utwórz konkurs",
-      "create_dialog_desc": "Konkurs to zbiór stwierdzień kandydatów, spośród których zostanie wybrany zbiór Q.",
-      "field_title": "Tytuł",
-      "field_title_placeholder": "np. Postawy wobec zmian klimatu",
-      "field_description": "Opis",
-      "field_description_placeholder": "Krótki opis tego konkursu...",
-      "field_code": "Kod",
-      "field_text": "Tekst stwierdzenia",
-      "field_text_placeholder": "Wpisz tekst stwierdzenia...",
-      "field_source": "Źródło",
-      "items_label": "elementów",
-      "updated": "Zaktualizowano",
-      "empty_title": "Brak konkursów",
-      "empty_desc": "Utwórz konkurs, aby zacząć zbierać i porządkować stwierdzenia kandydatów do badań metodologią Q.",
-      "add_item": "Dodaj element",
-      "bulk_import": "Import zbiorczy",
-      "import_desc": "Wklej stwierdzenia oddzielone nową linią. Każda linia staje się jednym elementem.",
-      "import_prefix": "Prefiks kodu",
-      "import_statements": "Stwierdzenia",
-      "import_placeholder": "Jedno stwierdzenie na wiersz...",
-      "items_to_import": "stwierdzeń do importu",
-      "import_button": "Importuj",
-      "import_success": "Zaimportowano {{count}} elementów",
-      "import_error": "Import nie powiódł się",
-      "item_created": "Element dodany",
-      "item_create_error": "Nie udało się dodać elementu",
-      "item_updated": "Element zaktualizowany",
-      "item_update_error": "Nie udało się zaktualizować elementu",
-      "item_deleted": "Element usunięty",
-      "item_delete_error": "Nie udało się usunąć elementu",
-      "status_error": "Nie udało się zmienić statusu",
-      "search_placeholder": "Szukaj elementów...",
-      "source_placeholder": "np. Wywiad nr 3, Przegląd literatury",
-      "no_items": "Brak elementów. Dodaj pierwsze stwierdzenie.",
-      "no_matches": "Żaden element nie pasuje do filtrów.",
-      "danger_zone": "Strefa zagrożenia",
-      "delete": "Usuń konkurs",
-      "delete_confirm": "Czy na pewno chcesz usunąć ten konkurs i wszystkie jego elementy?",
-      "deleted": "Konkurs usunięty",
-      "delete_error": "Nie udało się usunąć konkursu",
-      "delete_item_title": "Usuń element",
-      "delete_item_confirm": "Usunąć ten element? Tego działania nie można cofnąć.",
-      "status": {
-        "proposed": "Proponowane",
-        "accepted": "Zaakceptowane",
-        "rejected": "Odrzucone"
-      },
-      "change_note_placeholder": "Uwaga do zmiany (opcjonalnie)",
-      "history": "Historia",
-      "comments": "Komentarze",
-      "no_history": "Brak historii edycji.",
-      "no_comments": "Brak komentarzy.",
-      "add_comment": "Napisz komentarz...",
-      "send_comment": "Wyślij",
-      "comment_added": "Komentarz dodany",
-      "comment_error": "Nie udało się dodać komentarza. Proszę spróbować ponownie.",
-      "version_label": "v{{n}}",
-      "item_detail_desc": "Historia i komentarze dla tego elementu",
-      "manage_tags": "Tagi",
-      "tag_name_placeholder": "Nazwa tagu",
-      "tag_color": "Kolor tagu",
-      "tag_created": "Tag utworzony",
-      "tag_create_error": "Nie udało się utworzyć tagu",
-      "tag_deleted": "Tag usunięty",
-      "tag_delete_error": "Nie udało się usunąć tagu",
-      "no_tags": "Brak tagów. Utwórz pierwszy tag powyżej.",
-      "field_tags": "Tagi",
-      "export_csv": "Eksportuj CSV",
-      "select_language": "Język",
-      "add_language": "Dodaj język",
-      "add_language_desc": "Wpisz kod języka (np. en, fr, fi).",
-      "add_language_desc_v2": "Wybierz język tłumaczeń stwierdzeń.",
-      "add_language_tooltip": "Dodaj język tłumaczenia",
-      "field_language": "Język",
-      "import_language": "Język",
-      "select_all": "Zaznacz wszystko",
-      "select_item": "Zaznacz {{code}}",
-      "bulk_selected": "Zaznaczono {{count}}",
-      "bulk_set_status": "Ustaw status:",
-      "bulk_clear": "Wyczyść",
-      "bulk_status_success": "Zaktualizowano {{count}} elementów",
-      "bulk_status_error": "Nie udało się zaktualizować niektórych elementów",
-      "qset_title": "Kuracja",
-      "qset_reviewed_of": "{{total}} elementów przejrzanych",
-      "qset_accepted": "{{count}} zaakceptowanych",
-      "qset_pending": "{{count}} elementów do przejrzenia",
-      "qset_complete": "Wszystkie elementy przejrzane",
-      "show_pending": "Do przejrzenia",
-      "bulk_confirm_title": "Potwierdź zmianę statusu",
-      "bulk_confirm_desc": "Ustawić {{count}} elementów na \"{{status}}\"?",
-      "no_translation": "Brak tekstu",
-      "language_tooltip": "Język tekstów stwierdzeń",
-      "loading": "Konfigurowanie konkursu...",
-      "diff_code": "kod",
-      "diff_status": "status",
-      "diff_text": "tekst",
-      "diff_tags": "tagi",
-      "diff_changed": "Zmieniono:",
-      "methodological_context": {
-        "title": "Kontekst metodologiczny",
-        "subtitle": "Opcjonalne pola dokumentacyjne. Wypełnij to, co istotne dla projektu; pozostałe pozostaw puste."
-      },
-      "import_from_csv": "Importuj CSV/TSV…",
-      "import_csv_hint": "CSV/TSV wymaga kolumn: code, language, text.",
-      "import_csv_no_match": "Żaden wiersz nie pasuje do wybranego języka ({{lang}}).",
-      "import_csv_skipped": "Pominięto {{count}} wiersz(-y) w innych językach: {{langs}}.",
-      "import_csv_more_errors": "{{count}} więcej problemów"
-    },
-    "concourse_import": {
-      "title": "Importuj z konkursu",
-      "desc": "Wybierz elementy z konkursu, aby zaimportować je jako stwierdzenia badania. Elementy są kopiowane; zmiany w konkursie nie wpłyną na badanie.",
-      "button_label": "Importuj z konkursu",
-      "select_concourse": "Konkurs",
-      "select_placeholder": "Wybierz konkurs...",
-      "code_prefix": "Prefiks kodu",
-      "code_prefix_placeholder": "np. S",
-      "only_accepted": "Tylko zaakceptowane",
-      "replace_existing": "Zastąp istniejące stwierdzenia",
-      "replace_warning": "Wszystkie istniejące stwierdzenia zostaną trwale usunięte i zastąpione wybranymi elementami.",
-      "selected": "Wybrano: {{count}}",
-      "select_all": "Zaznacz wszystkie",
-      "import_button": "Importuj {{count}} stwierdzenia(-n)",
-      "success": "Zaimportowano {{count}} stwierdzenia(-n)",
-      "error": "Nie można zaimportować elementów z konkursu. Spróbuj ponownie.",
-      "no_accepted": "Brak zaakceptowanych elementów w tym konkursie. Odznacz opcję \"Tylko zaakceptowane\", aby zobaczyć wszystkie.",
-      "no_items": "Ten konkurs nie ma żadnych elementów.",
-      "no_concourses": "Brak konkursów w tym projekcie. Najpierw utwórz konkurs."
-    },
-    "concourse_sync": {
-      "update_available": "Aktualizacja",
-      "source_deleted": "Źródło usunięte",
-      "source_deleted_tip": "Element źródłowy konkursu został usunięty.",
-      "new_version": "Nowa wersja w konkursie:",
-      "synced": "Stwierdzenie zaktualizowane z konkursu",
-      "error": "Nie można zsynchronizować z konkursem. Spróbuj ponownie.",
-      "stale_banner": "{{count}} stwierdzenie(-n) ma dostępne aktualizacje z konkursu."
-    },
-    "analysis": {
-      "title": "Analiza",
-      "description": "Analiza czynnikowa danych z sortowania Q: wyodrębnianie punktów widzenia z odpowiedzi uczestników",
-      "configuration": "Konfiguracja",
-      "configuration_description": "Wybierz metodę ekstrakcji, liczbę czynników i rotację",
-      "extraction_method": "Ekstrakcja",
-      "centroid": "Centroid",
-      "n_factors": "Czynniki",
-      "rotation_method": "Rotacja",
-      "none": "Brak",
-      "run": "Uruchom analizę",
-      "run_will_replace": "Ponowne uruchomienie zastąpi bieżący widok wyników. Użyj panelu historii, aby porównać przebiegi.",
-      "running": "Analizowanie...",
-      "reanalyzing": "Ponowne analizowanie...",
-      "success": "Analiza zakończona. Wyodrębniono {{n}} czynników.",
-      "error": "Analiza nie powiodła się: {{message}}",
-      "scree_hint": "Każdy słupek pokazuje, ile wariancji wyjaśnia dany czynnik (jego wartość własna). Przerywana linia oznacza wartość własną = 1 (kryterium Kaisera). Kliknij słupek, aby wybrać liczbę czynników do wyodrębnienia.",
-      "kaiser_suggestion": "{{n}} czynnik(-ów) ma wartości własne powyżej 1 (kryterium Kaisera)",
-      "factor": "Czynnik",
-      "factor_n": "Czynnik {{n}}",
-      "eigenvalue": "Wartość własna",
-      "too_few_participants": "Do uruchomienia analizy potrzebne są co najmniej 2 ukończone sortowania.",
-      "eigenvalue_error": "Nie udało się wczytać danych analizy. Proszę spróbować ponownie.",
-      "scree_plot_label": "Wykres osypiska pokazujący wartości własne dla {{n}} czynników",
-      "loading_eigenvalues": "Wczytywanie wartości własnych...",
-      "empty_state": "Ustaw parametry i uruchom analizę.",
-      "empty": {
-        "contract_title": "Za mało danych z sortowania Q",
-        "contract_body": "Analiza czynnikowa metodologii Q wymaga co najmniej 2 uczestników, którzy ukończyli sortowanie. Opcje konfiguracji (ekstrakcja, czynniki, rotacja, oznaczanie) nabierają znaczenia po zgromadzeniu danych. Udostępnij link do badania z widoku ogólnego, aby zacząć zbierać odpowiedzi.",
-        "contract_cta": "Otwórz widok ogólny badania"
-      },
-      "advanced": {
-        "title": "Ustawienia zaawansowane",
-        "summary": "Rotacja: {{rotation}} · Oznaczanie: {{flagging}} · Bootstrap: {{bootstrap}}",
-        "bootstrap_off": "wyłączony",
-        "bootstrap_on": "{{n}} iteracji"
-      },
-      "tab_loadings": "Ładunki",
-      "tab_factor_arrays": "Tablice czynnikowe",
-      "tab_statements": "Stwierdzenia",
-      "tab_summary": "Podsumowanie",
-      "participant": "Uczestnik",
-      "flagged": "Oznaczony",
-      "significance_threshold": "Próg istotności (p<0,05): ±{{threshold}}",
-      "sorts": "sortowania",
-      "distinguishing_legend": "Stwierdzenie różnicujące",
-      "code": "Kod",
-      "statement": "Stwierdzenie",
-      "type": "Typ",
-      "distinguishing": "Różnicujące",
-      "consensus": "Konsensusowe",
-      "variance_explained": "Wyjaśniona wariancja (%)",
-      "cumulative_variance": "Skumulowana wariancja (%)",
-      "n_flagged": "Liczba oznaczonych sortowań",
-      "composite_reliability": "Rzetelność złożona",
-      "se_factor_scores": "Błąd standardowy wyników czynnikowych",
-      "factor_correlations": "Korelacje czynników",
-      "high_correlation": "Wysoka korelacja",
-      "total_variance": "Łączna wyjaśniona wariancja",
-      "method_used": "Metoda",
-      "statements_label": "stwierdzenia",
-      "pca": "PCA",
-      "varimax": "Varimax",
-      "metric": "Metryka",
-      "caption_loadings": "Ładunki czynnikowe na uczestnika",
-      "caption_statements": "Wyniki z i tablice czynnikowe na czynnik",
-      "caption_characteristics": "Charakterystyki czynników i statystyki rzetelności",
-      "caption_correlations": "Macierz korelacji między czynnikami",
-      "retry": "Spróbuj ponownie",
-      "flagging_method": "Oznaczanie",
-      "auto": "Auto",
-      "manual": "Ręczny",
-      "manual_flag_hint": "Kliknij komórkę ładunku, aby oznaczyć/odznaczyć uczestnika dla danego czynnika. Uruchom ponownie analizę, aby zaktualizować wyniki.",
-      "no_flagged_participants": "Żaden uczestnik nie jest oznaczony dla żadnego czynnika. Spróbuj dostosować liczbę czynników lub metodę oznaczania.",
-      "no_statement_scores": "Brak dostępnych wyników stwierdzeń. Upewnij się, że uczestnicy są oznaczeni dla co najmniej jednego czynnika.",
-      "no_characteristics": "Brak dostępnych charakterystyk czynników.",
-      "export": "Eksportuj",
-      "export_loadings": "Ładunki czynnikowe (CSV)",
-      "export_scores": "Wyniki stwierdzeń (CSV)",
-      "export_xlsx": "Pełna analiza (XLSX)",
-      "export_error": "Nie udało się wygenerować eksportu XLSX.",
-      "select_factors": "Wybierz liczbę czynników",
-      "loadings_help": "Ładunki czynnikowe pokazują, jak silnie sortowanie każdego uczestnika koreluje z każdym czynnikiem. Wyróżnione komórki przekraczają próg istotności podany powyżej.",
-      "factor_array_help": "Złożone sortowanie Q pokazujące wyidealizowany wzorzec sortowania dla tego czynnika. Stwierdzenia są rozmieszczone w rozkładzie na podstawie ważonych wyników z.",
-      "factor_array_label": "Złożone sortowanie czynnika {{n}}",
-      "factor_arrays": {
-        "toggle_narratives": "Pokaż interpretacje czynników",
-        "toggle_narratives_aria": "Przełącz interpretacje poszczególnych czynników"
-      },
-      "statements_help": "Wyniki z pokazują standardową pozycję każdego czynnika na każdym stwierdzeniu. D = różnicujące (istotnie różne między czynnikami), C = konsensusowe (brak istotnych różnic).",
-      "z_scores_description": "Wyniki z i pozycje tablicy czynnikowej na stwierdzenie",
-      "factor_statistics": "Statystyki czynników",
-      "characteristics_help": "Wartości własne odzwierciedlają ilość wyjaśnionej wariancji. Rzetelność złożona odzwierciedla wewnętrzną spójność oznaczonych sortowań. Błąd standardowy wyników czynnikowych odzwierciedla precyzję estymacji złożonej.",
-      "help_extraction": "PCA maksymalizuje wyjaśnianą wariancję. Centroid jest mniej ograniczony matematycznie.",
-      "help_n_factors": "Każdy czynnik reprezentuje odrębny punkt widzenia.",
-      "help_rotation": "Varimax rozdziela czynniki dla prostszej struktury.",
-      "help_flagging": "Auto: oznaczaj uczestników ładujących się na dokładnie jeden czynnik. Ręczny: nadpisuj ręcznie dla każdego uczestnika.",
-      "guide_loadings_title": "Odczytywanie ładunków czynnikowych",
-      "guide_loadings_1": "Każdy ładunek to korelacja (od −1 do +1) między uczestnikiem a czynnikiem (wspólnym punktem widzenia).",
-      "guide_loadings_2": "Wyróżnione wartości przekraczają próg istotności pokazany powyżej tabeli.",
-      "guide_arrays_title": "Interpretacja tablic czynnikowych",
-      "guide_arrays_1": "Każda tablica czynnikowa to złożone sortowanie Q reprezentujące jeden wspólny punkt widzenia.",
-      "guide_arrays_2": "Czytaj od lewej do prawej: od największego braku zgody do największej zgody. Pozycje skrajne niosą najsilniejszy sygnał interpretacyjny.",
-      "guide_statements_title": "Rozumienie wyników stwierdzeń",
-      "guide_statements_1": "Wyniki z pokazują, jak silnie każdy czynnik zgadza się lub nie zgadza z każdym stwierdzeniem (0 = neutralnie).",
-      "guide_statements_2": "D = różnicujące (umieszczone istotnie różnie między czynnikami). Gwiazdki wskazują poziom istotności.",
-      "guide_summary_title": "Ocena rozwiązania",
-      "guide_summary_1": "Wartości własne mierzą, ile wariancji wyjaśnia dany czynnik. Kryterium Kaisera (wartość własna > 1) to jedna z popularnych heurystyk decydowania o liczbie czynników do zachowania.",
-      "guide_summary_2": "Rzetelność złożona odzwierciedla, jak spójnie oznaczone sortowania definiują dany czynnik. Wyższe wartości oznaczają, że estymacja czynnika opiera się na większej zgodności sortowań go definiujących.",
-      "benchmark_above": "Powyżej progu",
-      "benchmark_below": "Poniżej progu",
-      "history": {
-        "title": "Historia analiz",
-        "loading": "Wczytywanie historii…",
-        "fetch_error": "Nie udało się wczytać historii analiz.",
-        "empty": "Brak poprzednich analiz dla tego badania. Uruchom jedną, aby rozpocząć ślad audytu.",
-        "empty_explainer": "Każde uruchomienie jest tutaj rejestrowane, aby można było dokumentować i ponownie przeglądać każdą decyzję.",
-        "load_error": "Nie udało się wczytać tego przebiegu analizy. Odśwież stronę, aby spróbować ponownie.",
-        "load_run_aria": "Wczytaj przebieg analizy z {{date}}",
-        "loading_run": "Wczytywanie…",
-        "current_tag": "bieżący",
-        "n_factors_label": "{{n}}C",
-        "edit_notes": "Edytuj notatki",
-        "edit_notes_aria": "Edytuj notatki dla tego przebiegu",
-        "notes_placeholder": "Dodaj notatkę o tym przebiegu…",
-        "notes_aria": "Edytuj notatki dla tego przebiegu",
-        "save_notes_aria": "Zapisz notatki",
-        "cancel_edit_aria": "Anuluj edycję",
-        "notes_saved": "Notatki zapisane.",
-        "notes_error": "Nie udało się zapisać notatek. Sprawdź połączenie i spróbuj ponownie.",
-        "delete_run": "Usuń przebieg",
-        "delete_run_aria": "Usuń ten przebieg analizy",
-        "delete_dialog_title": "Usunąć przebieg analizy?",
-        "delete_dialog_description": "Usunięcie przebiegu analizy usuwa dowód analitycznego wyboru ze śladu audytu. Czy na pewno?",
-        "cancel": "Anuluj",
-        "delete_confirm": "Usuń",
-        "deleted": "Przebieg analizy usunięty.",
-        "delete_error": "Nie udało się usunąć przebiegu.",
-        "viewing_banner": "Podgląd przebiegu z {{date}}: {{extraction}} · {{n}}C · {{rotation}}",
-        "back_to_current": "Wróć do bieżącego"
-      },
-      "factor_voices": {
-        "title": "Głosy przy czynniku {{n}}",
-        "no_audio": "Brak nagrań audio po sortowaniu od uczestników oznaczonych dla tego czynnika.",
-        "no_material": "Brak nagrań audio po sortowaniu ani pisemnych komentarzy od uczestników oznaczonych dla tego czynnika.",
-        "loading": "Wczytywanie nagrań…",
-        "error": "Nie udało się wczytać nagrań audio. Proszę spróbować ponownie.",
-        "context": "Osadź interpretację czynnika we własnych słowach uczestników: ich uzasadnieniach audio i pisemnych komentarzach do kart.",
-        "context_aria": "O tym panelu",
-        "audio_label": "Nagranie: {{key}} — {{participant}}",
-        "url_unavailable": "URL audio niedostępny.",
-        "comments_label": "Komentarze do kart",
-        "question_default": "Komentarz głosowy"
-      },
-      "factor_note": {
-        "label": "Interpretacja czynnika",
-        "placeholder": "Napisz interpretację tego czynnika: dyskurs, głosy i napięcia, które eksponuje.",
-        "empty_hint": "Dodaj interpretację dla tego czynnika",
-        "char_count": "{{n}}/{{max}}",
-        "edit_aria": "Edytuj interpretację czynnika {{n}}",
-        "save_aria": "Zapisz interpretację czynnika",
-        "cancel_aria": "Anuluj edycję",
-        "aria": "Edytuj interpretację czynnika {{n}}",
-        "saved": "Interpretacja czynnika zapisana.",
-        "error": "Nie udało się zapisać interpretacji czynnika."
-      },
-      "rotation": {
-        "judgmental": {
-          "label": "Ekspercka (ręczna)",
-          "short": "Ekspercka",
-          "tooltip": "Ręcznie obracaj pary czynników o wybrane kąty, aby ustawić je w merytorycznie sensownych pozycjach."
-        }
-      },
-      "manual_rotations": {
-        "title": "Rotacje ręczne",
-        "helper": "Podaj rotacje w formie: 'obróć czynnik F o Δ° wokół czynnika G'. Rotacje są stosowane w kolejności.",
-        "add": "Dodaj rotację",
-        "remove_aria": "Usuń rotację",
-        "empty": "Dodaj co najmniej jedną rotację, aby uruchomić analizę.",
-        "factor_a_label": "Obróć czynnik",
-        "angle_label": "o",
-        "factor_b_label": "wokół czynnika"
-      },
-      "bootstrap": {
-        "toggle_label": "Uruchom bootstrap stabilności",
-        "iterations_label": "Iteracje (B)",
-        "helper": "Opcjonalnie. Próbkuje sortowania Q B razy, aby oszacować przedziały ufności dla wyników czynnikowych.",
-        "running": "Trwa bootstrap…",
-        "se_column": "Średni błąd standardowy (z)",
-        "tooltip": "Nieparametryczny bootstrap sortowań Q (próbkowanie ze zwracaniem); analiza jest powtarzana B razy, aby oszacować 95% przedziały ufności dla wyników z."
-      },
-      "explore": {
-        "diagnostics_title": "Diagnostyka",
-        "kaiser": "Kaiser",
-        "parallel": "Analiza równoległa",
-        "map": "MAP Velicera",
-        "advisory": "Wyłącznie orientacyjne. Decyzja o liczbie czynników w metodologii Q zależy też od interpretowalności i stabilności (Watts i Stenner 2012).",
-        "preview_range_title": "Podgląd zakresu",
-        "preview_range_disabled": "Podgląd zakresu obsługuje tylko PCA + varimax. Ekstrakcja centroidów i rotacja ekspercka są zależne od ścieżki; zatwierdź rzeczywisty przebieg, aby sprawdzić.",
-        "select_k": "{{k}} czynników",
-        "empty_factor": "Pusty czynnik (nadmierna faktoryzacja)",
-        "cumvar": "skum. war. %",
-        "pct_flagged": "% oznaczonych",
-        "n_distinguishing": "# różnicujące",
-        "n_cross_loaders": "# wieloczynnikowe",
-        "min_def_sorts": "min. sortowań def.",
-        "advanced_title": "Konfiguracja zaawansowana",
-        "commit_cta": "Zatwierdź i interpretuj"
-      },
-      "interpret": {
-        "def_sorts": "Sortowania definiujące: {{n}}",
-        "statements_title": "Stwierdzenia",
-        "narrative_title": "Interpretacja C{{n}}",
-        "insert_comment_quote": "Wstaw komentarz jako cytat",
-        "focus_mode": "Fokus na czynnik",
-        "overview_mode": "Widok ogólny",
-        "mode_toggle": "Tryb widoku"
-      },
-      "compare": {
-        "pin_cta": "Przypnij do porównania",
-        "no_other_runs": "Brak innych dostępnych przebiegów",
-        "run_label": "Przebieg #{{id}} ({{n}} czynników)",
-        "pinned": "Porównanie z przebiegiem #{{id}}",
-        "phi": "φ = {{phi}}",
-        "ambiguous": "niejednoznaczne dopasowanie (interpretuj różnice ostrożnie)",
-        "unpin": "Odepnij",
-        "delta_z_aria": "Δz {{delta}} vs przebieg porównawczy",
-        "delta_loading_aria": "Δładunek {{delta}} vs przebieg porównawczy"
-      },
-      "quote_insert_format": "> {{text}}\n> {{p}}, o stwierdzeniu {{code}}: \"{{stmt}}\""
-    },
-    "project": {
-      "remove_member": "Usuń członka",
-      "table_caption": "Członkowie projektu",
-      "switcher": {
-        "settings": "Ustawienia projektu",
-        "settings_desc": "Członkowie i profile",
-        "new_project": "Nowy projekt",
-        "new_project_desc": "Utwórz nowy projekt"
-      },
-      "roles": {
-        "owner": "Właściciel",
-        "admin": "Administrator",
-        "viewer": "Obserwator",
-        "member": "Członek"
-      },
-      "study_states": {
-        "active": "Aktywne",
-        "draft": "Szkic",
-        "paused": "Wstrzymane",
-        "closed": "Zamknięte"
-      },
-      "create": {
-        "title": "Utwórz projekt",
-        "card_title": "Szczegóły projektu",
-        "name_label": "Nazwa projektu",
-        "name_placeholder": "Badanie Q postaw wobec klimatu",
-        "url_label": "URL projektu",
-        "url_placeholder": "badanie-q-postawy-klimat",
-        "url_description": "To staje sie sciezka projektu pod /app/.",
-        "cancel": "Anuluj",
-        "create_button": "Utwórz projekt",
-        "creating": "Tworzenie...",
-        "success": "Projekt został pomyślnie utworzony",
-        "error": "Nie udało się utworzyć projektu"
-      }
-    },
-    "recruitment": {
-      "title": "Dostęp",
-      "description": "Skonfiguruj URL badania, zarządzaj dostępem uczestników i śledź efektywność rekrutacji.",
-      "study_url": {
-        "title": "URL badania",
-        "description": "Publiczny adres, pod którym uczestnicy mają dostęp do badania.",
-        "full_url_label": "Pełny URL",
-        "slug_label": "URL slug",
-        "slug_description": "Unikalny identyfikator używany w URL badania. Tylko małe litery, cyfry i myślniki.",
-        "slug_locked": "Slug URL można zmieniać tylko w trybie szkicu."
-      },
-      "state_draft": "Tryb szkicu. Linki będą działać po aktywowaniu badania.",
-      "state_closed": "To badanie jest zamknięte. Istniejące linki pozostają widoczne, ale nowi uczestnicy nie mogą rozpocząć.",
-      "state_archived": "To badanie jest zarchiwizowane. Wszystkie dane rekrutacji są tylko do odczytu.",
-      "empty_title": "Brak linków rekrutacyjnych",
-      "empty_description": "Utwórz pierwszy link, aby zacząć zapraszać uczestników.",
-      "empty_cta": "Utwórz link dostępu",
-      "stats_summary": {
-        "links": "linków",
-        "started": "rozpoczętych",
-        "submitted": "przesłanych"
-      },
-      "access_rules": {
-        "title": "Reguły dostępu",
-        "description": "Kontroluj, kiedy i jak uczestnicy mają dostęp do badania.",
-        "password_toggle": "Wymagaj hasła",
-        "password_toggle_desc": "Uczestnicy muszą wpisać hasło przed rozpoczęciem badania.",
-        "password_label": "Hasło dostępu",
-        "password_placeholder": "Wpisz hasło dostępu",
-        "password_locked": "Ochrona hasłem może być zmieniana tylko w trybie szkicu.",
-        "password_set": "Hasło jest aktualnie ustawione. Wpisz nową wartość, aby je zmienić, lub wyłącz przełącznik, aby je usunąć.",
-        "collection_window": "Okno zbierania danych",
-        "window_toggle": "Ogranicz okno zbierania danych",
-        "window_toggle_help": "Ogranicz dostęp uczestników do określonego zakresu czasu.",
-        "start_date_label": "Otwiera się o",
-        "end_date_label": "Zamyka się o",
-        "date_hint": "Pozostaw puste, aby nie ograniczać czasu.",
-        "clear_date": "Wyczyść datę",
-        "save_button": "Zapisz reguły dostępu",
-        "save_success": "Reguły dostępu zaktualizowane",
-        "save_error": "Nie udało się zaktualizować reguł dostępu",
-        "non_draft_notice": "Poza trybem szkicu można edytować tylko okno zbierania danych. Przełącz badanie z powrotem na szkic, aby zmienić inne reguły dostępu.",
-        "archived_notice": "To badanie jest zarchiwizowane. Reguły dostępu są tylko do odczytu."
-      },
-      "new_link": "Nowy link dostępu",
-      "create_title": "Utwórz linki dostępu",
-      "link_type": "Strategia dostępu",
-      "select_type": "Wybierz typ rekrutacji...",
-      "campaign_name": "Kanał / nazwa kampanii",
-      "name_placeholder": "Np. LinkedIn, e-mail partia a, lista studentów...",
-      "link_count": "Rozmiar partii",
-      "capacity_label": "Maks. zgłoszeń",
-      "generate_links": "Generuj linki",
-      "no_links": "Nie wygenerowano jeszcze żadnych linków rekrutacyjnych.",
-      "unnamed": "Kanał bez nazwy",
-      "revoked": "Dostęp odwołany",
-      "qr_title": "Udostępnij przez QR",
-      "copy_link": "Kopiuj URL",
-      "table_title": "Linki rekrutacyjne",
-      "share_title": "Udostępnij badanie",
-      "share_desc": "Rozprowadź URL badania, aby zaprosić uczestników.",
-      "public_url_label": "Publiczny URL uczestnictwa",
-      "hide_qr": "Ukryj QR",
-      "show_qr": "Pokaż kod QR",
-      "delete_link": "Usuń link",
-      "qr_alt": "Kod QR dla {{url}}",
-      "table_caption": "Linki rekrutacyjne",
-      "progress_label": "{{count}} z {{max}} odpowiedzi",
-      "usage": {
-        "started": "rozpoczęte",
-        "submitted": "przesłane",
-        "completed": "Ukończone",
-        "in_progress": "W toku",
-        "unused": "Nieużyte"
-      },
-      "live_study": "Badanie na żywo",
-      "download_qr": "Pobierz obraz",
-      "qr_print_hint": "Zeskanuj lub wydrukuj ten kod do fizycznych materiałów rekrutacyjnych (ulotki, plakaty).",
-      "analytics_title": "Analityka kampanii",
-      "analytics_desc": "Bezpośrednie linki i skany QR są automatycznie śledzone w panelu zdrowia powyżej.",
-      "copy_success": "Link do badania skopiowany do schowka",
-      "types": {
-        "public": "Dostęp otwarty (publiczny)",
-        "individual": "Jednorazowy kod dostępu",
-        "limited": "Ograniczone uczestnictwo"
-      },
-      "guidance": {
-        "public": "Najlepszy do rekrutacji na dużą skalę. Jeden URL dla wszystkich uczestników.",
-        "individual": "Maksymalne bezpieczeństwo. Generuje unikalne linki wygasające po jednym pomyślnym ukończeniu.",
-        "limited": "Kontrolowany dostęp. Jeden link, który przestaje działać po określonej liczbie zgłoszeń."
-      },
-      "stats": {
-        "total_links": "Łącznie kanałów",
-        "active_channels": "Aktywne partie rekrutacyjne",
-        "started": "Łącznie sesji",
-        "engagements": "Uczestnicy, którzy rozpoczęli",
-        "submitted": "Prawidłowe dane",
-        "completions": "Ukończone zgłoszenia",
-        "conversion": "Wskaźnik przechwycenia",
-        "efficiency": "Ostateczny wynik danych"
-      },
-      "table": {
-        "name": "Kampania / partia",
-        "type": "Typ wejścia",
-        "token": "Token bezpieczeństwa",
-        "usage": "Pojemność",
-        "status": "Stan",
-        "actions": "Zarządzaj",
-        "type_help": "Publiczny, jednorazowy lub z ograniczoną pojemnością. Patrz opisy strategii w oknie dialogowym 'Nowy link dostępu'."
-      },
-      "status": {
-        "public": "Publiczny",
-        "individual": "Indywidualny",
-        "limited": "Ograniczony"
-      },
-      "toasts": {
-        "created": "Linki rekrutacyjne utworzone pomyślnie",
-        "failed": "Nie udało się utworzyć linków rekrutacyjnych. Sprawdź dane wejściowe i spróbuj ponownie.",
-        "revoked": "Link odwołany",
-        "revoke_failed": "Nie udało się odwołać tego linku. Możliwe, że jest już w użyciu.",
-        "copied": "Skopiowano do schowka"
-      }
-    },
-    "analytics": {
-      "charts": {
-        "recruitment_funnel": {
-          "title": "Lejek rekrutacyjny",
-          "subtitle": "Łączna wydajność konwersji",
-          "initial_contact": "Pierwszy kontakt",
-          "completion": "Ukończenie",
-          "started_study": "Rozpoczęto badanie",
-          "submitted": "Przesłano",
-          "yield": "Wynik",
-          "success_rate": "Wskaźnik sukcesu",
-          "completion_rate": "{{rate}}% uczestników ukończyło badanie"
-        },
-        "link_performance": {
-          "title": "Śledzenie skuteczności linków",
-          "subtitle": "Monitorowanie efektywności poszczególnych kanałów rekrutacyjnych",
-          "volume": "Wolumen",
-          "yield": "Wynik",
-          "conversion_rate": "Wskaźnik konwersji",
-          "total_responses": "odpowiedzi"
-        }
-      }
-    },
-    "breadcrumbs": {
-      "admin": "Admin",
-      "dashboard": "Dashboard",
-      "study_dashboard": "Overview",
-      "design": "Design",
-      "participants": "Participants",
-      "team": "Team",
-      "recruitment": "Access",
-      "exports": "Data",
-      "data": "Data",
-      "privacy": "Data privacy",
-      "account": "Account settings",
-      "participant_n": "Participant {{code}}",
-      "analysis": "Analysis",
-      "settings": "Settings",
-      "concourse": "Concourse",
-      "members": "Team members"
-    },
-    "command_menu": {
-      "title": "Globalne menu poleceń",
-      "placeholder": "Wpisz polecenie lub wyszukaj...",
-      "no_results": "Brak wyników.",
-      "switch_project": "Przełącz projekt",
-      "switch_study": "Przełącz badanie",
-      "study_actions": "Akcje badania",
-      "system": "System",
-      "no_studies": "Brak badań w tym projekcie.",
-      "open_dashboard": "Otwórz panel",
-      "design_study": "Projekt badania",
-      "collaborators": "Współpracownicy",
-      "copy_link": "Kopiuj publiczny link",
-      "toggle_theme": "Przełącz motyw",
-      "logout": "Wyloguj",
-      "search_label": "Szukaj lub uruchom polecenia",
-      "to_open": "Otwórz",
-      "active": "Aktywne",
-      "link_copied": "Link do badania skopiowany!",
-      "logged_out": "Wylogowano pomyślnie",
-      "switched_project": "Przełączono na {{name}}"
-    },
-    "dashboard": {
-      "title": "Panel projektu",
-      "welcome": "Witamy z powrotem,",
-      "snapshot": "Oto migawka aktywności badawczej.",
-      "create_study": "Utwórz badanie",
-      "total_studies": "Łącznie badań",
-      "across_statuses": "Wszystkich statusów",
-      "active_data_collection": "Aktywne zbieranie danych",
-      "receiving_responses": "Badania przyjmujące odpowiedzi",
-      "total_participants": "Łącznie uczestników",
-      "all_studies": "Wszystkie badania",
-      "all_studies_description": "Wszystkie badania w tym projekcie.",
-      "languages_count_one": "{{count}} język",
-      "languages_count_other": "{{count}} języków",
-      "n_participants_one": "{{count}} uczestnik",
-      "n_participants_other": "{{count}} uczestników",
-      "n_studies_one": "{{count}} badanie",
-      "n_studies_other": "{{count}} badań",
-      "n_active_one": "{{count}} aktywne",
-      "n_active_other": "{{count}} aktywnych",
-      "n_participants_total_one": "{{count}} uczestnik",
-      "n_participants_total_other": "{{count}} uczestników",
-      "concourse_n_items_one": "{{count}} stwierdzenie",
-      "concourse_n_items_other": "{{count}} stwierdzeń",
-      "concourse_open_hint": "Kuracja stwierdzeń kandydatów",
-      "created": "Utworzono",
-      "no_studies": "Nie znaleziono badań. Utwórz pierwsze badanie, aby zacząć!",
-      "import_study": "Importuj badanie",
-      "get_started": "Zacznij swój projekt badawczy",
-      "onboarding_title": "Pierwsze kroki",
-      "step_create_project": "Utwórz projekt",
-      "step_create_project_desc": "Projekt jest gotowy.",
-      "step_concourse": "Zbierz stwierdzenia w konkursie",
-      "step_concourse_desc": "Dodaj stwierdzenia kandydatów z przeglądu literatury.",
-      "step_qset": "Wybierz zbiór Q",
-      "step_qset_desc": "Przejrzyj i zaakceptuj elementy tworzące zbiór Q.",
-      "step_study": "Utwórz badanie",
-      "step_study_desc": "Zdefiniuj siatkę sortowania Q.",
-      "step_import": "Zaimportuj zbiór Q do badania",
-      "step_import_desc": "Zaimportuj zaakceptowane elementy konkursu jako stwierdzenia badania.",
-      "step_configure": "Skonfiguruj przepływ uczestnika",
-      "step_configure_desc": "Skonfiguruj instrukcje, wstępne sortowanie i pytania końcowe.",
-      "step_launch": "Uruchom rekrutację",
-      "step_launch_desc": "Generuj linki uczestnictwa i udostępniaj je.",
-      "go_to_concourse": "Otwórz konkurs",
-      "go_to_qset": "Otwórz zbiór Q",
-      "concourse": "Konkurs",
-      "concourse_empty": "Brak elementów. Zacznij budować kolekcję stwierdzeń.",
-      "team": "Zespół",
-      "team_loading": "Ładowanie...",
-      "studies": "Badania",
-      "active_studies": "Aktywne",
-      "paused_studies": "Wstrzymane",
-      "draft_studies": "Szkice",
-      "closed_studies": "Ukończone",
-      "attention": "Wymaga uwagi",
-      "alert_deadline": "{{study}}: zamknięcie za {{days}} dni, {{count}} uczestników",
-      "view": "Pokaż",
-      "open_study": "Otwórz badanie",
-      "add_study": "Dodaj badanie",
-      "closes": "Zamknięcie",
-      "timeline": {
-        "title": "Oś czasu zgłoszeń",
-        "subtitle": "Dzienne trendy uczestnictwa",
-        "started": "Rozpoczęto",
-        "completed": "Ukończono"
-      },
-      "devices": {
-        "title": "Rozkład urządzeń",
-        "subtitle": "Jak uczestnicy korzystają z badania",
-        "types": {
-          "desktop": "Komputer",
-          "mobile": "Telefon",
-          "tablet": "Tablet",
-          "unknown": "Nieznane"
-        }
-      },
-      "n_studies_help": "Łączna liczba badań w tym projekcie, w tym szkice i zamknięte.",
-      "n_active_help": "Badania aktualnie przyjmujące zgłoszenia uczestników (stan = aktywne).",
-      "n_participants_total_help": "Suma ukończonych uczestników we wszystkich badaniach tego projektu.",
-      "tool_help": {
-        "design": "Konfiguruj badanie: siatka rozkładu, warunki instrukcji, stwierdzenia, zgoda.",
-        "recruit": "Linki rekrutacyjne, reguły dostępu i ustawienia URL badania.",
-        "data": "Odpowiedzi uczestników i eksporty (CSV, zrzuty sortowania Q).",
-        "analysis": "Konfiguracja analizy czynnikowej i historia przebiegów."
-      }
-    },
-    "export": {
-      "config": "Eksportuj konfigurację",
-      "exporting": "Eksportowanie...",
-      "config_success": "Konfiguracja wyeksportowana pomyślnie",
-      "config_error": "Nie można wyeksportować konfiguracji. Spróbuj ponownie.",
-      "label": "Eksportuj dane",
-      "success": "Eksport zakończony pomyślnie",
-      "error": "Eksport nie powiódł się. Spróbuj ponownie.",
-      "csv": "Eksportuj CSV",
-      "json": "Eksportuj JSON",
-      "audio": "Eksportuj nagrania audio (ZIP)",
-      "formats": {
-        "csv": "CSV",
-        "pqmethod": "PQMethod (ZIP)",
-        "rkit": "R-Kit (ZIP)",
-        "package": "Pakiet badawczy (ZIP)",
-        "json": "Zrzut JSON"
-      },
-      "download": "Pobierz",
-      "package_dialog": {
-        "title": "Pobierz pakiet badawczy",
-        "description": "Łączy wszystkie dane badania w jeden plik ZIP do OSF lub rejestracji wstępnej.",
-        "discussion_hint": "Dodaje plik memo/memo-discussion.md ze wszystkimi wątkami komentarzy (podpisanymi i opatrzonymi datą). Domyślnie wyłączone; zachowaj czysty eksport, chyba że potrzebna jest ścieżka deliberacji."
-      }
-    },
-    "import": {
-      "title": "Importuj konfigurację badania",
-      "config": "Importuj konfigurację",
-      "upload_desc": "Prześlij wcześniej wyeksportowany plik konfiguracji badania",
-      "validate_desc": "Przejrzyj konfigurację i podaj unikalny slug",
-      "creating_desc": "Tworzenie badania...",
-      "file_upload": "Prześlij plik",
-      "paste_json": "Wklej JSON",
-      "drop_here": "Upuść plik tutaj",
-      "drag_drop": "Przeciągnij i upuść plik JSON lub kliknij, aby przeglądać",
-      "supported": "Obsługiwany format: .json",
-      "paste_label": "Wklej konfigurację JSON",
-      "validate": "Sprawdź poprawność i kontynuuj",
-      "valid": "Konfiguracja jest prawidłowa",
-      "invalid": "Konfiguracja zawiera błędy",
-      "errors": "Błędy",
-      "warnings": "Ostrzeżenia",
-      "summary": "Podsumowanie badania",
-      "title_field": "Tytuł",
-      "languages": "Języki",
-      "statements": "Stwierdzenia",
-      "grid": "Zakres siatki",
-      "new_slug": "Nowy slug badania",
-      "slug_help": "Musi być unikalny, 3–100 znaków, tylko małe litery, cyfry i myślniki",
-      "creating": "Tworzenie badania z konfiguracji...",
-      "create_study": "Utwórz badanie",
-      "invalid_json": "Nieprawidłowy plik JSON",
-      "validation_failed": "Konfiguracja jest nieprawidłowa",
-      "success": "Badanie zaimportowane pomyślnie",
-      "redirecting": "Otwieranie projektanta badania...",
-      "failed": "Nie udało się zaimportować badania. Zapoznaj się ze szczegółami poniżej i spróbuj ponownie.",
-      "validation": {
-        "errors": {
-          "missing_version": "Brak pola wersji",
-          "unsupported_version": "Nieobsługiwana wersja: {{version}}",
-          "missing_field": "Brak wymaganego pola: {{field}}",
-          "no_translations": "Wymagane jest co najmniej jedno tłumaczenie",
-          "missing_translation_field": "Tłumaczeniu {{index}} brakuje wymaganego pola: {{field}}",
-          "invalid_lang_code": "Nieprawidłowy kod języka: {{lang}}",
-          "no_statements": "Wymagane jest co najmniej jedno stwierdzenie",
-          "duplicate_codes": "Zduplikowane kody stwierdzeń: {{codes}}",
-          "missing_stmt_translations": "Stwierdzeniu {{index}} brakuje tłumaczeń",
-          "invalid_grid_config": "Nieprawidłowy grid_config: musi być listą",
-          "invalid_grid_structure": "Nieprawidłowa struktura grid_config: {{error}}"
-        },
-        "warnings": {
-          "grid_capacity_mismatch": "Liczba stwierdzeń ({{count}}) nie odpowiada pojemności siatki ({{capacity}})",
-          "missing_consent_draft": "Brak tytułu lub opisu formularza zgody (badanie w szkicu)",
-          "external_branding_logo": "Logo marki używa zewnętrznego URL: {{url}}",
-          "external_partner_logo": "Logo partnera '{{name}}' używa zewnętrznego URL: {{url}}",
-          "external_logo": "URL logo odwołuje się do zasobu zewnętrznego — może być niedostępny"
-        }
-      }
-    },
-    "dialogs": {
-      "create_study": {
-        "title": "Utwórz nowe badanie",
-        "description": "Rozpocznij nowe badanie metodologią Q. Stwierdzenia i ustawienia można skonfigurować później.",
-        "study_title": "Tytuł badania",
-        "study_title_placeholder": "Np. Perspektywy dotyczące AI",
-        "url_slug": "URL slug",
-        "url_slug_placeholder": "np. perspektywy-ai-2025",
-        "cancel": "Anuluj",
-        "create": "Utwórz badanie",
-        "success": "Badanie zostało pomyślnie utworzone",
-        "error": "Nie udało się utworzyć badania",
-        "languages": "Języki",
-        "languages_desc": "Wybierz języki do włączenia. Treść zostanie zainicjowana zlokalizowanymi wartościami domyślnymi."
-      }
-    },
-    "validation": {
-      "required": "Wymagane",
-      "slug_min": "Slug musi mieć co najmniej 3 znaki",
-      "slug_regex": "Slug może zawierać tylko małe litery, cyfry i myślniki"
-    },
-    "study_overview": {
-      "title": "Przegląd",
-      "back_to_overview": "Wróć do przeglądu",
-      "sample_size": "Liczba uczestników (P-Set)",
-      "valid": "prawidłowe",
-      "completion_rate": "Wskaźnik ukończenia",
-      "active": "aktywne",
-      "mobile": "mobilne",
-      "median_duration": "Mediana czasu trwania",
-      "suspect": "Podejrzane",
-      "recent_activity": "Ostatnia aktywność",
-      "latest_participants": "Ostatni uczestnicy ({{count}} z {{total}})",
-      "recently_completed": "Ostatnio ukończone",
-      "in_progress": "W toku",
-      "discarded": "Odrzucone",
-      "started": "Rozpoczęto",
-      "view_all": "Zobacz wszystkich uczestników i szczegóły danych",
-      "no_participants": "Brak uczestników.",
-      "view_data": "Pokaż",
-      "submitted": "Przesłano",
-      "edit_design": "Edytuj projekt",
-      "export_csv": "Pobierz CSV",
-      "export_json": "Pobierz JSON",
-      "steps": {
-        "welcome": "Powitanie",
-        "consent": "Zgoda",
-        "rough_sort": "Sortowanie zgrubne",
-        "fine_sort": "Sortowanie Q",
-        "final": "Ostatnie kroki"
-      }
-    },
-    "overview": {
-      "copy_id": "Copy participant ID"
-    },
-    "study_status": {
-      "dialog": {
-        "draft": {
-          "title": "Przywrócić do szkicu?",
-          "desc": "Spowoduje to zatrzymanie zbierania danych, ale umożliwi modyfikację projektu badania. Istniejące dane zostaną zachowane.",
-          "action": "Przywróć do szkicu"
-        },
-        "active": {
-          "title": "Uruchomić badanie?",
-          "desc": "Aktywowanie badania otworzy je dla uczestników.",
-          "action": "Ustaw jako aktywne"
-        },
-        "paused": {
-          "title": "Wstrzymać badanie?",
-          "desc": "Uczestnicy nie będą mogli wziąć udziału w badaniu, gdy jest ono wstrzymane. Można je wznowić później.",
-          "action": "Wstrzymaj badanie"
-        },
-        "closed": {
-          "title": "Zamknąć badanie?",
-          "desc": "Uniemożliwi to nowym uczestnikom wejście do badania. Trwające sesje mogą zostać ukończone. Można je ponownie otworzyć później.",
-          "action": "Zamknij badanie"
-        }
-      },
-      "steps": {
-        "draft": {
-          "label": "Szkic",
-          "description": "Konfiguracja i projekt"
-        },
-        "active": {
-          "label": "Aktywne",
-          "description": "Zbieranie odpowiedzi"
-        },
-        "paused": {
-          "label": "Wstrzymane",
-          "description": "Wstrzymano"
-        },
-        "closed": {
-          "label": "Zamknięte",
-          "description": "Analiza i eksport"
-        }
-      },
-      "state": {
-        "activate": "Aktywuj badanie",
-        "switch_to_draft": "Tryb szkicu",
-        "manage": "Zarządzaj statusem"
-      },
-      "notifications": {
-        "success": {
-          "draft": "Badanie pomyślnie przywrócono do szkicu",
-          "active": "Badanie zostało pomyślnie uruchomione",
-          "paused": "Badanie zostało pomyślnie wstrzymane",
-          "closed": "Badanie zostało pomyślnie zamknięte"
-        },
-        "error": "Nie można zmienić stanu badania. Sprawdź swoje uprawnienia i spróbuj ponownie.",
-        "state_changed_active": "Badanie jest teraz aktywne!"
-      }
-    },
-    "design": {
-      "title": "Projekt badania",
-      "translation_needed": "Wymaga weryfikacji (kopia)",
-      "reset_defaults": "Przywróć wartości domyślne",
-      "editing_language_banner": "Edytowanie wersji {{language}}. Aby przełączyć, użyj selektora języka na pasku narzędzi.",
-      "multilang": {
-        "view_others": "Pokaż w innych językach",
-        "other_formulations": "Inne sformułowania"
-      },
-      "guidance": {
-        "title": "Wskazówki projektowe",
-        "intro_title": "Witamy w studiu",
-        "intro_desc": "Zacznij od określenia celu badania. Informacje te będą widoczne dla uczestników przed rozpoczęciem sortowania.",
-        "qsort_title": "Równowaga stwierdzeń i siatki",
-        "qsort_desc": "Upewnij się, że pojemność siatki dokładnie odpowiada liczbie stwierdzeń. Wyważony zbiór Q zwykle podąża za rozkładem quasi-normalnym (w kształcie krzywej dzwonowej)."
-      },
-      "checklist": {
-        "title": "Lista kontrolna",
-        "statements": "Stwierdzenia",
-        "grid_balance": "Siatka wyważona",
-        "branding": "Logo i kolory",
-        "instructions": "Instrukcje",
-        "ready": "Wszystkie niezbędne elementy są gotowe. Możesz teraz uruchomić badanie!",
-        "pending": "Wykonaj wymagane kroki powyżej, aby umożliwić aktywację badania.",
-        "study_title": "Tytuł badania",
-        "consent_defined": "Formularz zgody",
-        "progress": "Postęp",
-        "languages": "Języki",
-        "status_ready": "Gotowe",
-        "status_pending": "Oczekuje",
-        "required": "Wymagane",
-        "reset_defaults": "Przywróć wartości domyślne"
-      },
-      "unsaved_changes": {
-        "title": "Niezapisane zmiany",
-        "description": "W projekcie badania są niezapisane zmiany. Opuszczenie strony spowoduje ich utratę.",
-        "confirm": "Opuść bez zapisywania",
-        "cancel": "Kontynuuj edycję"
-      },
-      "tips": {
-        "title": "Szybka wskazówka",
-        "pilot": "Zawsze przeprowadź testowe sortowanie samodzielnie przed udostępnieniem linku uczestnikom."
-      },
-      "toolbar": {
-        "title": "Projekt",
-        "back": "Wstecz",
-        "preview": "Pokaż podgląd",
-        "hide_preview": "Ukryj podgląd",
-        "popout": "Otwórz podgląd w oknie",
-        "discard": "Odrzuć niezapisane zmiany",
-        "test_run": "Uruchomienie testowe",
-        "save": "Zapisz",
-        "saved": "Zapisano",
-        "closed": "Zamknięte",
-        "back_to_study": "Wróć do badania",
-        "editing_language": "Edytowany język",
-        "manage_langs": "Zarządzaj językami",
-        "select_lang": "Wybierz język",
-        "test_run_help": "Podgląd z perspektywy uczestnika. Te sesje nie są uwzględniane w danych.",
-        "more_actions": "Więcej działań"
-      },
-      "sync": {
-        "saving": "Zapisywanie...",
-        "error": "Błąd zapisu",
-        "modified": "Niezapisane zmiany",
-        "synced": "Zmiany zapisane",
-        "wait_save": "Trwa zapisywanie... Proszę chwilę poczekać.",
-        "recovered": "Szkic przywrócony z lokalnej kopii zapasowej!",
-        "recovery_title": "Znaleziono niezapisane zmiany",
-        "recovery_desc": "Znaleziono lokalną wersję tego badania nowszą niż wersja na serwerze. Czy chcesz ją przywrócić?",
-        "recovery_restore": "Przywróć wersję lokalną",
-        "recovery_discard": "Odrzuć wersję lokalną"
-      },
-      "validation": {
-        "failed_title": "Konfiguracja niekompletna",
-        "failed_desc": "Proszę poprawić te problemy, aby aktywować:",
-        "errors": {
-          "no_statements": "Badanie musi zawierać co najmniej jedno stwierdzenie.",
-          "no_grid": "Brak konfiguracji siatki.",
-          "capacity_mismatch": "Pojemność siatki ({{total}}) nie odpowiada liczbie stwierdzeń ({{count}}).",
-          "no_translations": "Badanie musi mieć co najmniej jedno tłumaczenie językowe.",
-          "missing_default_lang": "Brak tłumaczenia dla języka domyślnego ({{lang}}).",
-          "missing_title": "Brak tytułu dla języka '{{lang}}'.",
-          "missing_consent_title": "Brak tytułu formularza zgody dla języka '{{lang}}'.",
-          "missing_consent_description": "Brak opisu formularza zgody dla języka '{{lang}}'.",
-          "missing_grid_instructions": "Brak instrukcji sortowania Q dla języka '{{lang}}'.",
-          "missing_step_title": "Brak tytułu kroku {{index}} dla języka '{{lang}}'.",
-          "missing_statement_translation": "Stwierdzenie '{{code}}' nie ma tłumaczeń dla: {{missing}}.",
-          "empty_statement_text": "Stwierdzenie '{{code}}' ma pusty tekst dla języka '{{lang}}'.",
-          "missing_question_label": "Pytanie '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}}).",
-          "missing_option_label": "Opcja {{index}} pytania '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}})."
-        }
-      },
-      "languages": {
-        "manage_title": "Zarządzaj językami",
-        "manage_desc": "Włącz lub wyłącz języki dostępne dla uczestników w tym badaniu.",
-        "auto_translate": "Automatyczne tłumaczenie",
-        "auto_translate_desc": "Wkrótce będzie można używać AI do automatycznego tłumaczenia badania na ponad 30 języków.",
-        "activate_title": "Aktywuj język",
-        "activate_desc": "Wybierz język źródłowy, z którego zostaną skopiowane tłumaczenia. Zapobiega to pustym polom widocznym dla uczestników.",
-        "source_label": "Język źródłowy",
-        "copy_notice": "Wszystkie pola zostaną skopiowane. Pola wymagające tłumaczenia będą oznaczone wizualnie.",
-        "confirm_activate": "Aktywuj i skopiuj"
-      },
-      "tabs": {
-        "welcome": "Ogólne",
-        "presort": "Wstępne sortowanie",
-        "condition": "Warunek",
-        "qsort": "Sortowanie Q",
-        "postsort": "Sortowanie końcowe",
-        "interface": "Interfejs",
-        "theme": "Motyw",
-        "general": "Ogólne",
-        "statements": "Stwierdzenia",
-        "grid": "Siatka",
-        "survey": "Ankieta",
-        "branding": "Identyfikacja wizualna"
-      },
-      "view_mode": {
-        "mobile": "Widok mobilny",
-        "desktop": "Widok komputerowy"
-      },
-      "intro": {
-        "general_settings": "Ustawienia ogólne",
-        "welcome_title": "Wiadomość powitalna",
-        "process_title": "Przegląd kroków badania",
-        "process_steps": {
-          "title": "Przegląd kroków badania",
-          "desc": "Zdefiniuj etapy wyświetlane uczestnikom na stronie powitalnej. Jeśli pozostawione puste, zostaną użyte domyślne kroki.",
-          "add_step": "Dodaj krok",
-          "empty": {
-            "title": "Brak niestandardowych kroków",
-            "desc": "Badanie użyje standardowego przepływu metodologii Q (poznajmy się, pierwsze wrażenia, perspektywa, dlaczego)."
-          },
-          "fields": {
-            "title": "Tytuł kroku",
-            "description": "Krótki opis",
-            "icon": "Ikona",
-            "toggle": "Przełącznik"
-          },
-          "defaults": {
-            "new_step": "Nowy krok badania",
-            "new_desc": "Wyjaśnij, co uczestnik będzie robił na tym etapie."
-          },
-          "reset": {
-            "instructions": "Przywróć instrukcje",
-            "consent_title": "Przywróć tytuł zgody",
-            "consent_description": "Przywróć opis zgody",
-            "process_steps": "Przywróć kroki procesu",
-            "process_steps_confirm": "Czy na pewno chcesz przywrócić wszystkie kroki procesu do wartości domyślnych? Zastąpi to niestandardowe kroki."
-          },
-          "inconsistent": {
-            "banner_title": "Niespójne kroki procesu",
-            "rough_disabled": "Krok 'Pierwsze wrażenia' (sortowanie zgrubne) jest na tej liście, ale sortowanie zgrubne jest w badaniu wyłączone. Uczestnicy go nie zobaczą.",
-            "presort_disabled": "Krok 'Poznajmy się' (ankieta wstępna) jest na tej liście, ale ankieta wstępna jest wyłączona. Uczestnicy go nie zobaczą.",
-            "remove_action": "Usuń"
-          }
-        },
-        "consent_title": "Formularz zgody",
-        "reset": "Przywróć instrukcję",
-        "consent_details": "Szczegóły formularza zgody",
-        "fields": {
-          "default_lang": "Język domyślny",
-          "default_lang_help": "Ten język będzie domyślnie wyświetlany uczestnikom, jeśli język przeglądarki nie jest obsługiwany.",
-          "title": "Tytuł badania",
-          "title_placeholder": "Wpisz tytuł publiczny...",
-          "subtitle": "Podtytuł (opcjonalnie)",
-          "subtitle_placeholder": "Krótkie hasło...",
-          "objective": "Cel badania",
-          "objective_placeholder": "Jakie jest pytanie badawcze lub cel tego badania?",
-          "task_overview": "Wprowadzenie",
-          "task_placeholder": "Opisz tutaj przebieg badania (liczba kroków, szacowany czas itp.). To pole jest opcjonalne, jeśli używasz niestandardowych kroków powyżej.",
-          "consent_title_label": "Tytuł zgody",
-          "legal_text": "Tekst prawny / umowa",
-          "legal_placeholder": "Wpisz pełny tekst umowy prawnej..."
-        },
-        "consent_desc": "Uczestnicy muszą zaakceptować te warunki przed rozpoczęciem."
-      },
-      "condition": {
-        "title": "Warunek instrukcji",
-        "label": "Zdefiniuj warunek instrukcji",
-        "desc": "To jest główna instrukcja, która prowadzi uczestników przez cały proces sortowania.",
-        "field_label": "Treść instrukcji",
-        "placeholder": "Np. Proszę uszeregować poniższe stwierdzenia od tych, z którymi najbardziej się Pan/Pani zgadza, do tych, z którymi najbardziej się nie zgadza",
-        "grid_title": "Instrukcja sortowania Q",
-        "grid_desc": "To jest główna instrukcja prowadząca uczestników podczas procesu sortowania Q.",
-        "pre_title": "Instrukcja wstępnego sortowania",
-        "pre_desc": "Instrukcja podawana uczestnikom podczas wstępnego sortowania zgrubnego.",
-        "pre_field_label": "Treść instrukcji",
-        "pre_placeholder": "Np. Na podstawie własnego punktu widzenia podziel karty na trzy stosy...",
-        "enable_pre": "Włącz etap wstępnej instrukcji",
-        "pre_label": "Treść wstępnej instrukcji",
-        "tips": {
-          "title": "Dlaczego to ważne?",
-          "desc": "W metodologii Q 'warunek instrukcji' określa punkt widzenia, z którego uczestnik sortuje stwierdzenia. Powinien być jasny i spójny we wszystkich fazach sortowania."
-        }
-      },
-      "questions": {
-        "enable_presort": "Włącz ankietę wstępną",
-        "enable_presort_desc": "Zbierz dane demograficzne lub inne informacje przed zadaniem sortowania.",
-        "add_field": "Dodaj nowe pole",
-        "basic_fields": "Pola podstawowe",
-        "choice_fields": "Pola wyboru",
-        "scale_fields": "Pola skali",
-        "labels": {
-          "question": "Etykieta pytania",
-          "required": "Pole wymagane",
-          "options": "Opcje",
-          "option_ordinal": "Opcja {{number}}",
-          "multiple": "(Dozwolony wielokrotny wybór)",
-          "single": "(Pojedynczy wybór)",
-          "placeholder": "Wpisz tutaj swoje pytanie...",
-          "scale": "Skala ocen",
-          "scale_points": "Liczba punktów",
-          "scale_left": "Etykieta lewego krańca",
-          "scale_right": "Etykieta prawego krańca"
-        },
-        "types": {
-          "text": "Tekst",
-          "long_text": "Tekst długi",
-          "number": "Liczba",
-          "date": "Data",
-          "email": "E-mail",
-          "dropdown": "Lista rozwijana",
-          "radio": "Przycisk radiowy",
-          "checkboxes": "Pola wyboru",
-          "text_audio": "Tekst + audio",
-          "rating": "Skala ocen"
-        },
-        "empty": {
-          "title": "Brak pytań",
-          "desc": "Kliknij powyżej, aby dodać pierwsze pytanie"
-        },
-        "defaults": {
-          "new_question": "Nowe pytanie",
-          "option": "Opcja",
-          "enter_answer": "Wpisz swoją odpowiedź...",
-          "untitled": "Pytanie bez tytułu",
-          "scale_left": "Zdecydowanie się nie zgadzam",
-          "scale_right": "Zdecydowanie się zgadzam"
-        },
-        "actions": {
-          "add_option": "Dodaj opcję",
-          "copy_from": "Importuj z języka",
-          "copy_success": "Zaimportowano"
-        },
-        "logic": {
-          "title": "Logika widoczności",
-          "enable": "Dodaj warunek widoczności",
-          "depends_on": "Pokaż to pytanie tylko jeśli...",
-          "select_placeholder": "Wybierz pytanie nadrzędne",
-          "operator": "Operator",
-          "value": "Wartość porównania",
-          "operators": {
-            "equals": "Równa się",
-            "not_equals": "Nie równa się",
-            "contains": "Zawiera",
-            "greater_than": "Większe niż",
-            "less_than": "Mniejsze niż"
-          }
-        }
-      },
-      "qsort": {
-        "tabs": {
-          "statements": "Stwierdzenia",
-          "distribution": "Rozkład"
-        },
-        "bulk": {
-          "title": "Edytor zbiorczy (szybkie wklejanie)",
-          "desc": "Jedno stwierdzenie w każdym wierszu. Obsługuje format 'kod: tekst' i kopiowanie z Excela (wielojęzyczne).",
-          "replace_all": "Zastąp wszystko",
-          "append": "Dołącz do listy",
-          "sync_by_code": "Synchronizuj/scal wg kodu",
-          "placeholder": "Proste: Moje stwierdzenie",
-          "detected": "Wykryto {{count}} stwierdzeń",
-          "process_replace": "Przetwórz i zastąp stwierdzenia",
-          "process_append": "Przetwórz i dołącz stwierdzenia",
-          "process_sync": "Przetwórz i synchronizuj tłumaczenia",
-          "detected_format": {
-            "excel": "Wykryto format Excel (tabulatory)",
-            "list": "Wykryto format listy (kod: tekst)",
-            "simple": "Wykryto prostą listę (jeden wiersz = jedno stwierdzenie)",
-            "multi_lang": "Wielojęzyczne: {{langs}}",
-            "with_codes": "Z niestandardowymi kodami"
-          }
-        },
-        "set": {
-          "title": "Zbiór Q",
-          "clear": "Wyczyść wszystko",
-          "confirm_clear": "Czy na pewno chcesz usunąć WSZYSTKIE stwierdzenia? Tego działania nie można cofnąć.",
-          "updated": "Stwierdzenie zaktualizowane",
-          "cleared": "Wszystkie stwierdzenia wyczyszczone",
-          "imported": "Pomyślnie zaimportowano {{count}} stwierdzeń",
-          "reset_codes": "Resetuj kody",
-          "confirm_reset_codes": "Czy na pewno chcesz ponownie nadać numery wszystkim kodom stwierdzeń (s1, s2, s3...)?",
-          "codes_reset": "Kody stwierdzeń ponownie ponumerowane"
-        },
-        "settings": {
-          "title": "Ustawienia badawcze",
-          "desc": "Skonfiguruj sposób prezentacji stwierdzeń uczestnikom",
-          "show_codes": "Pokaż kody stwierdzeń",
-          "show_codes_desc": "Wyświetlaj kody stwierdzeń (np. 'S1', 'S2') obok tekstu.",
-          "randomize": "Losuj kolejność stwierdzeń",
-          "randomize_desc": "Prezentuj stwierdzenia w losowej kolejności każdemu uczestnikowi (spójnie w ramach sesji)"
-        },
-        "grid": {
-          "title": "Siatka rozkładu sortowania Q",
-          "desc": "Kształt siatki zmusza uczestników do różnicowania stwierdzeń, przybliżając rozkład normalny.",
-          "slot_count": "Przydzielono {{count}} miejsc",
-          "stat_count": "{{count}} stwierdzeń",
-          "perfect": "Idealna równowaga",
-          "too_many": "{{count}} stwierdzeń za dużo",
-          "too_few": "Brakuje {{count}} stwierdzeń",
-          "min_reached": "Osiągnięto minimalny zakres (±2)",
-          "max_reached": "Osiągnięto maksymalny zakres (±6)",
-          "remove_extreme_columns": "Usuń skrajne kolumny",
-          "add_extreme_columns": "Dodaj skrajne kolumny",
-          "symmetry_lock": "Blokada symetrii",
-          "symmetry_lock_desc": "Automatycznie stosuj zmiany do kolumn przeciwnych, aby zachować wyważony rozkład.",
-          "auto_balance": "Auto-wyważenie",
-          "auto_balance_desc": "Przekształć siatkę w wyważony rozkład półnormalny",
-          "reshaped": "Siatka przekształcona do wyważonego rozkładu",
-          "balanced": "Siatka wyważona do standardowego rozkładu",
-          "no_statements": "Najpierw dodaj stwierdzenia, aby automatycznie ukształtować siatkę",
-          "statements": "stwierdzenia",
-          "ideal_shape": "Idealny kształt",
-          "symmetric": "Symetryczna",
-          "asymmetric": "Asymetryczna",
-          "tooltip_title": "Dlaczego rozkład wymuszony?",
-          "tooltip_desc": "Metodologia Q używa rozkładu quasi-normalnego (kurtoza > 0), aby zapewnić, że uczestnicy dokonują znaczących rozróżnień. Kształt piramidy zapobiega błędowi tendencji centralnej.",
-          "locked": "Projekt zablokowany",
-          "locked_desc": "Zmiany strukturalne (kody stwierdzeń, siatka) są wyłączone, ponieważ badanie zebrało dane lub nie jest już w trybie szkicu. Nadal można edytować tłumaczenia tekstowe.",
-          "locked_active": "To badanie jest aktywne. Przełącz na tryb szkicu, aby edytować.",
-          "locked_paused": "To badanie jest wstrzymane. Przełącz na tryb szkicu, aby edytować.",
-          "locked_closed": "To badanie jest zamknięte. Projekt jest zarchiwizowany.",
-          "view_read_only": "Podgląd tylko do odczytu",
-          "locked_dialog_desc": "Edycja jest zablokowana, gdy badanie jest w tym stanie. Zamknij to powiadomienie, aby przeczytać konfigurację bez wprowadzania zmian.",
-          "mismatch_title": "Niezgodność pojemności siatki",
-          "mismatch_desc": "Masz {{statements}} stwierdzeń, ale siatka ma tylko miejsca dla {{slots}} elementów. Dostosuj kolumny poniżej.",
-          "unlock_hint": "Przejdź do eksploratora danych, aby wyczyścić sesje i odblokować strukturę"
-        }
-      },
-      "postsort": {
-        "extreme": {
-          "title": "Kolumny docelowe",
-          "desc": "Wybierz kolumny, które wyzwalają pytania uzupełniające.",
-          "no_columns": "Nie wybrano żadnych kolumn.",
-          "add_label": "Dodaj kolumnę:",
-          "prompt_label": "Pytanie o stwierdzenia",
-          "prompt_placeholder": "Dlaczego umieścił/a Pan/Pani to stwierdzenie w tym miejscu?",
-          "add": "Dodaj",
-          "add_defaults": "Dodaj domyślne skrajności",
-          "select_placeholder": "Wybierz..."
-        },
-        "random_comments": {
-          "title": "Zezwalaj na swobodne komentarze",
-          "desc": "Pozwól uczestnikom dodawać komentarze do dowolnego stwierdzenia na siatce."
-        },
-        "custom": {
-          "title": "Pytania niestandardowe",
-          "desc": "Dodaj niestandardowe pytania do ankiety po sortowaniu."
-        },
-        "missing": {
-          "title": "Pytaj o brakujące stwierdzenia",
-          "desc": "Jeśli tak, proszę opisać je krótko.",
-          "prompt_label": "Treść pytania",
-          "prompt_placeholder": "Proszę śmiało sugerować i wyjaśniać."
-        },
-        "steps": {
-          "step1": "Krok 1: informacja zwrotna",
-          "step2": "Krok 2: pytania"
+        "password_reset": {
+            "request_title": "Zresetuj hasło",
+            "request_body": "Proszę podać adres e-mail, a wyślemy link do zresetowania hasła.",
+            "request_submit": "Wyślij link resetujący",
+            "request_success": "Jeśli adres e-mail istnieje, link resetujący jest już w drodze.",
+            "confirm_title": "Wybierz nowe hasło",
+            "confirm_submit": "Zresetuj hasło",
+            "success_redirect": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
+            "link_expired": "Ten link wygasł lub został już wykorzystany.",
+            "too_short": "Hasło musi mieć co najmniej 8 znaków.",
+            "mismatch": "Hasła nie są zgodne.",
+            "missing_token": "Brak tokenu resetowania w adresie URL.",
+            "new_password_placeholder": "Nowe hasło",
+            "confirm_placeholder": "Potwierdź hasło",
+            "request_success_manual": "Wysyłka e-maili nie jest skonfigurowana w tej instancji. Skontaktuj się z administratorem, aby uzyskać link resetujący."
         },
         "email": {
-          "title": "Kontakt uzupełniający z uczestnikiem",
-          "desc": "Zbieraj adresy e-mail do celów kontaktu uzupełniającego lub przekazania wyników badania.",
-          "interview": "Zaproponuj kontakt uzupełniający",
-          "results": "Zaproponuj zapis na listę mailingową z wynikami badania",
-          "interview_warning": "Uwaga: zgoda na kontakt znosi anonimowość wobec badacza.",
-          "results_hint": "E-mail wyłącznie do celów przekazania wyników, anonimowość zachowana."
-        },
-        "audio": {
-          "title": "Nagranie audio",
-          "desc": "Pozwól uczestnikom nagrywać odpowiedzi audio zamiast tekstu.",
-          "max_duration": "Maksymalny czas trwania",
-          "seconds": "sekund",
-          "max_duration_help": "Maksymalny czas nagrywania na pytanie (30–600 sekund).",
-          "participant_choice_info": "Uczestnicy mogą odpowiadać tekstem, nagraniem audio lub obydwoma sposobami na każde pytanie.",
-          "storage_unavailable_body": "Magazyn obiektów nie jest skonfigurowany, więc nie można zbierać odpowiedzi audio. Nadal możesz włączyć audio, ale uczestnicy będą odpowiadać wyłącznie tekstem i żadne nagranie nie zostanie wykonane. Skonfiguruj magazyn obiektów i uruchom ponownie serwer, aby włączyć przechwytywanie audio.",
-          "storage_unavailable_title": "Przechwytywanie audio jest niedostępne na tym serwerze"
-        }
-      },
-      "interface": {
-        "title": "Dostosowanie interfejsu",
-        "desc": "Dostosuj przyciski i etykiety interfejsu do tonu badania (np. zastępując 'zgadzam się/nie zgadzam się' słowami 'lubię/nie lubię').",
-        "nav": {
-          "title": "Przyciski nawigacyjne",
-          "start": "Przycisk start",
-          "next": "Przycisk następnego kroku",
-          "submit": "Przycisk wyślij",
-          "confirm": "Przycisk potwierdzenia sortowania",
-          "tooltips": {
-            "start": "Przycisk rozpoczynający badanie",
-            "next": "Przejście do następnego kroku",
-            "submit": "Wyślij wyniki na końcu",
-            "confirm": "Ogólny przycisk zatwierdzania"
-          }
-        },
-        "terms": {
-          "title": "Terminologia sortowania",
-          "desc": "Zdefiniuj etykiety dla sortowania spontanicznego i spektrum siatki.",
-          "rough": "Etykiety sortowania zgrubnego",
-          "agree": "Zgadzam się",
-          "neutral": "Neutralnie",
-          "disagree": "Nie zgadzam się",
-          "grid": "Legendy siatki (skrajności)",
-          "most_agree": "Najbardziej zgadzam się",
-          "most_disagree": "Najbardziej nie zgadzam się"
-        },
-        "hints": {
-          "title": "Wskazówki metodologiczne",
-          "desc": "Dodaj lub zmodyfikuj pływające wskazówki pomagające uczestnikom podczas fazy sortowania na siatce.",
-          "placeholder": "Wpisz wskazówkę metodologiczną...",
-          "add": "Dodaj wskazówkę",
-          "reset": "Przywróć wartości domyślne"
-        },
-        "help": {
-          "title": "Wskazówki dla kroków (co/dlaczego)",
-          "desc": "Dostosuj kontekstową pomoc dostępną dla uczestników na każdym kroku przez nakładkę '?'.",
-          "step_disabled": "(krok wyłączony)"
-        }
-      },
-      "theme": {
-        "title": "Identyfikacja wizualna",
-        "accent": {
-          "title": "Kolor akcentu",
-          "desc": "Ten kolor będzie używany dla przycisków, linków i wyróżnień w całym badaniu.",
-          "pick": "Wybierz kolor",
-          "reset": "Przywróć domyślny"
-        },
-        "logo": {
-          "title": "Logo badania",
-          "desc": "Prześlij niestandardowe logo zastępujące domyślną markę Qualis.",
-          "label": "URL logo",
-          "hint": "Zalecany rozmiar: 200×50 px. Obsługiwane formaty: PNG, SVG, JPG.",
-          "preview": "Podgląd logo",
-          "help_title": "Gdzie pojawia się to logo?",
-          "help_desc": "Logo jest wyświetlane na górze każdej strony badania (pasek nawigacyjny) i na stronie powitalnej. Wzmacnia identyfikację wizualną projektu."
-        },
-        "partners": {
-          "title": "Partnerzy instytucjonalni",
-          "desc": "Dodaj logo wspierających instytucji lub partnerów.",
-          "add": "Dodaj partnera",
-          "name_label": "Nazwa partnera",
-          "name_placeholder": "Nazwa instytucji",
-          "logo_label": "URL logo",
-          "url_label": "Strona internetowa (opcjonalnie)",
-          "url_placeholder": "https://...",
-          "help_title": "Wyświetlanie logo",
-          "help_desc": "Logo partnerów są wyświetlane na stronie startowej oraz w nagłówku badania, obok głównego logo."
-        },
-        "upload": {
-          "upload": "Prześlij",
-          "recommended": "Zalecane",
-          "invalid_type": "Nieprawidłowy typ pliku. Użyj PNG, JPG lub SVG.",
-          "file_too_large": "Plik jest za duży. Maksymalny rozmiar: {{size}} kB.",
-          "conversion_error": "Nie udało się przetworzyć obrazu.",
-          "processing": "Przetwarzanie obrazu...",
-          "drag_drop": "Przeciągnij i upuść lub kliknij, aby przesłać",
-          "max": "Maks."
-        }
-      },
-      "activate_dialog": {
-        "title": "Aktywować to badanie?",
-        "description": "Aktywacja otwiera rekrutację i odblokowuje publiczne linki. Prawdziwi uczestnicy będą mogli zacząć przesyłać odpowiedzi.",
-        "checklist_title": "Kontrola przed startem",
-        "languages_title": "Języki",
-        "lang_ready": "Gotowe",
-        "lang_incomplete": "Niekompletne",
-        "required": "(wymagane)",
-        "attestation": "Zapoznałem/am się z tekstem zgody i polityką przechowywania danych i potwierdzam, że badanie jest gotowe do przyjęcia prawdziwych uczestników.",
-        "confirm": "Aktywuj badanie"
-      }
-    },
-    "data": {
-      "title": "Dane",
-      "description": "Monitoruj uczestnictwo w czasie rzeczywistym, analizuj jakość danych i zarządzaj sesjami badawczymi.",
-      "sections": {
-        "key_indicators": "Kluczowe wskaźniki",
-        "responses": "Odpowiedzi",
-        "key_statistics": "Kluczowe statystyki"
-      },
-      "stats": {
-        "email_collection": "Zbieranie e-maili",
-        "participants": "łącznie",
-        "newsletter": "Chce wyniki",
-        "opt_in": "Wskaźnik odpowiedzi",
-        "follow_up": "Potencjał kontaktu uzupełniającego",
-        "interested": "zainteresowanych",
-        "click_to_filter": "Kliknij, aby filtrować",
-        "click_to_export": "Kliknij, aby eksportować listę",
-        "completed": "Ukończone",
-        "in_progress": "W toku",
-        "abandoned_count": "{{count}} porzuconych",
-        "interview_interested": "Akceptuje kontakt uzupełniający",
-        "interview": "Akceptuje kontakt uzupełniający",
-        "email": "E-maile"
-      },
-      "tabs": {
-        "live": "Uczestnicy na żywo",
-        "test": "Sesje testowe",
-        "browse": "Widok interaktywny",
-        "export": "Centrum eksportu"
-      },
-      "status": {
-        "started": "rozpoczęte",
-        "completed": "Ukończone",
-        "in_progress": "W toku",
-        "abandoned": "Porzucone",
-        "discarded": "odrzucone"
-      },
-      "step": {
-        "consent": "Zgoda",
-        "presort": "Ankieta wstępna",
-        "rough": "Sortowanie zgrubne",
-        "fine": "Sortowanie Q",
-        "post": "Ankieta końcowa"
-      },
-      "actions": {
-        "discard": "Odrzuć",
-        "restore": "Przywróć",
-        "export": "Eksportuj",
-        "clear_all": "Resetuj wszystkie dane",
-        "clear_all_confirm": "UWAGA: Spowoduje to trwałe usunięcie WSZYSTKICH danych uczestników dla tego badania. Tego działania nie można cofnąć.",
-        "clear_all_success": "Wszystkie dane wyczyszczone",
-        "clear_all_error": "Nie udało się wyczyścić danych. Sprawdź uprawnienia i spróbuj ponownie."
-      },
-      "confirm_discard": {
-        "title": "Odrzucić uczestnika?",
-        "description": "Ten uczestnik zostanie wykluczony z eksportów i analiz. Można go przywrócić później.",
-        "reason_label": "Powód (opcjonalnie)",
-        "reason_placeholder": "Dlaczego ten uczestnik jest odrzucany?"
-      },
-      "confirm_restore": {
-        "title": "Przywrócić uczestnika?",
-        "description": "Ten uczestnik zostanie ponownie uwzględniony w eksportach i analizach."
-      },
-      "guide": {
-        "title": "Przewodnik formatów",
-        "csv": {
-          "title": "Uniwersalny CSV",
-          "desc": "Surowe dane prostokątne. Najlepsze do analizy w R, Pythonie, SPSS lub Excelu. Zawiera wszystkie metadane."
-        },
-        "json": {
-          "title": "KenQ JSON",
-          "desc": "Zoptymalizowane dla narzędzia web-kenq. Zawiera definicję badania i sortowania."
-        },
-        "zip": {
-          "title": "Pakiet PQMethod (ZIP)",
-          "desc": "Zawiera starsze pliki .DAT i .STA do analizy DOS PQMethod."
-        }
-      },
-      "table": {
-        "participant": "Uczestnik",
-        "lang": "Język",
-        "status": "Status",
-        "consent": "Zgoda",
-        "flags": "Oznaczenia",
-        "duration": "Czas trwania",
-        "submitted": "Przesłano",
-        "last_step": "Ostatni krok",
-        "current_step": "Aktualny krok",
-        "view": "Pokaż",
-        "actions": "Szczegóły",
-        "duplicate_ip": "Duplikat IP",
-        "duplicate_ip_hint": "Współdzieli hash IP z innymi uczestnikami"
-      },
-      "tooltips": {
-        "suspect": "Potencjalnie podejrzane: czas trwania sesji < 2 minuty",
-        "has_comments": "Zawiera komentarze uczestnika do kart",
-        "has_audio": "Ma odpowiedzi audio",
-        "email_provided": "Podano e-mail",
-        "newsletter_consent": "Chce wyniki",
-        "interview_consent": "Akceptuje kontakt uzupełniający"
-      },
-      "toast": {
-        "discarded": "Uczestnik odrzucony",
-        "restored": "Uczestnik przywrócony",
-        "error": "Nie udało się zaktualizować uczestnika. Sprawdź połączenie i spróbuj ponownie."
-      },
-      "detail": {
-        "participant": "Uczestnik",
-        "participant_n": "Uczestnik {{code}}",
-        "not_found": "Uczestnik nie znaleziony",
-        "title": "Profil uczestnika",
-        "session": "Sesja",
-        "discarded_badge": "Odrzucony",
-        "description": "Pełne wyniki sortowania Q i metadane.",
-        "stats": {
-          "duration": "Łączny czas trwania",
-          "language": "Użyty język"
-        },
-        "actions": {
-          "discard": "Odrzuć uczestnika",
-          "restore": "Przywróć uczestnika"
-        },
-        "sort_config": "Konfiguracja sortowania",
-        "survey": {
-          "title": "Odpowiedzi ankietowe",
-          "csv_note": "Pełne odpowiedzi dostępne w eksporcie CSV."
-        }
-      },
-      "filter": {
-        "show_discarded": "Uwzględnij odrzucone rekordy",
-        "all_states": "Wszystkie stany",
-        "only_active": "Tylko aktywne",
-        "only_flagged": "Oznaczona jakość"
-      },
-      "filters": {
-        "active": "Aktywne filtry",
-        "has_email": "Podano e-mail",
-        "newsletter": "Chce wyniki",
-        "interview": "Akceptuje kontakt uzupełniający",
-        "flagged": "Tylko oznaczone",
-        "clear_all": "Wyczyść filtry",
-        "remove_filter": "Usuń filtr",
-        "all_statuses": "Wszystkie statusy",
-        "all_consents": "Wszystkie",
-        "all_indicators": "Wszystkie",
-        "all_steps": "Wszystkie kroki",
-        "has_comments": "Ma komentarze",
-        "has_audio": "Ma audio",
-        "has_recruitment": "Ma link rekrutacyjny"
-      },
-      "charts": {
-        "section_title": "Rozkłady odpowiedzi",
-        "distribution_label": "Rozkład dla {{question}}",
-        "multi_select_note": "Dozwolony wielokrotny wybór",
-        "responses_count": "{{count}} odpowiedzi",
-        "no_answer": "Brak odpowiedzi",
-        "option": "Opcja",
-        "count": "Liczba"
-      },
-      "search": {
-        "placeholder": "Szukaj po ID lub tokenie rekrutacyjnym...",
-        "records_found": "Wykryte rekordy",
-        "no_results": "Żaden rekord nie pasuje do zapytania"
-      },
-      "errors": {
-        "load_failed": "Synchronizacja z chmurą przerwana. Proszę sprawdzić połączenie."
-      },
-      "export_emails_success": "E-maile wyeksportowane pomyślnie",
-      "empty": {
-        "no_participants_title": "Brak uczestników",
-        "no_participants_desc": "Udostępnij link do badania, aby zacząć zbierać odpowiedzi.",
-        "contract_title": "Brak zgłoszeń",
-        "contract_body": "Zgłoszenia i eksporty pojawią się tutaj. Udostępnij link do badania, aby zacząć zbierać dane.",
-        "contract_cta": "Otwórz widok ogólny badania"
-      },
-      "pagination": {
-        "showing": "Pokazuję {{from}}–{{to}} z {{total}}"
-      }
-    },
-    "team": {
-      "title": "Zespół badania",
-      "description": "Zarządzaj współpracownikami i kontrolą dostępu na poziomie badania.",
-      "invite_title": "Zaproś współpracownika",
-      "invite_description": "Wygeneruj bezpieczny link, aby zaprosić nowego członka do tego badania.",
-      "email_label": "Adres e-mail",
-      "role_label": "Rola",
-      "select_role": "Wybierz rolę",
-      "generate_link": "Generuj link",
-      "invite_success": "Link zaproszenia wygenerowany!",
-      "invite_error": "Nie udało się wygenerować zaproszenia",
-      "copy_success": "Link skopiowany do schowka",
-      "share_label": "Udostępnij ten link zaproszonej osobie:",
-      "collab_overview": "Przegląd współpracy",
-      "active_members": "Aktywni członkowie",
-      "permissions_info": "Informacje o uprawnieniach",
-      "list_title": "Zespół badawczy",
-      "list_description": "Zarządzaj dostępem dla istniejących współpracowników.",
-      "added_on": "Dodano",
-      "headers": {
-        "collaborator": "Współpracownik",
-        "role": "Rola",
-        "actions": "Akcje"
-      },
-      "roles": {
-        "owner": "Właściciel (pełna kontrola)",
-        "editor": "Redaktor (projekt i analiza)",
-        "viewer": "Obserwator (tylko odczyt)",
-        "owner_badge": "WŁAŚCICIEL",
-        "editor_badge": "REDAKTOR",
-        "viewer_badge": "OBSERWATOR"
-      },
-      "permissions": {
-        "owner": "Może usunąć badanie i zarządzać zespołem.",
-        "editor": "Może modyfikować projekt i przeglądać wyniki.",
-        "viewer": "Dostęp tylko do odczytu do wszystkich modułów."
-      }
-    },
-    "empty_states": {
-      "participants": {
-        "title": "Gotowe do uruchomienia?",
-        "desc": "Udostępnij link do badania, aby rozpocząć zbieranie odpowiedzi. Pierwszy uczestnik jest o jedno kliknięcie.",
-        "action": "Kopiuj link do badania",
-        "hint": "Lub zeskanuj kod QR",
-        "copy_success": "Link do badania skopiowany do schowka!"
-      },
-      "team": {
-        "title": "Działasz samodzielnie",
-        "desc": "Zaproś współpracowników, aby pomogli zarządzać tym badaniem. Mogą przeglądać dane, edytować projekt lub jedynie obserwować.",
-        "action": "Zaproś pierwszego współpracownika"
-      },
-      "designer": {
-        "title": "Tabula rasa",
-        "desc": "To badanie nie ma jeszcze żadnych stwierdzeń. Dodaj elementy zbioru Q, aby rozpocząć projektowanie sortowania.",
-        "action": "Wczytaj przykładowy zbiór Q"
-      }
-    },
-    "status": {
-      "active": "Active",
-      "paused": "Paused",
-      "closed": "Closed",
-      "draft": "Draft"
-    },
-    "settings": {
-      "title": "Ustawienia",
-      "description": "Przechowywanie danych, archiwizacja i usuwanie badania.",
-      "lifecycle": {
-        "title": "Archiwizacja",
-        "description": "Zarchiwizuj badanie, aby uczynić je tylko do odczytu dla wszystkich.",
-        "notice": "Aby zarchiwizować badanie, należy je najpierw zamknąć. Po archiwizacji nie można wprowadzać żadnych zmian.",
-        "archived_status": "Badanie jest zarchiwizowane",
-        "archive_button": "Archiwizuj badanie",
-        "current_state": "Aktualny stan"
-      },
-      "danger": {
-        "title": "Strefa zagrożenia",
-        "description": "Działania tutaj są nieodwracalne.",
-        "notice": "Usunięcie badania trwale usuwa WSZYSTKIE dane (uczestników, odpowiedzi, konfigurację). Badanie musi być zarchiwizowane przed usunięciem.",
-        "delete_button": "Usuń badanie",
-        "delete_confirm": "Czy na pewno? To działanie jest NIEODWRACALNE.",
-        "delete_dialog_title": "Usunąć to badanie?",
-        "delete_dialog_intro": "Trwale usuwa sortowania, nagrania audio i przebiegi analiz.",
-        "delete_dialog_typed_label": "Wpisz slug badania, aby potwierdzić",
-        "delete_dialog_action": "Usuń trwale"
-      },
-      "save_button": "Zapisz",
-      "save_success": "Ustawienia zaktualizowane",
-      "save_success_desc": "Ustawienia badania zostały zapisane.",
-      "save_error": "Nie udało się zapisać ustawień. Sprawdź wartości i spróbuj ponownie.",
-      "save_error_desc": "Nie udało się zaktualizować ustawień. Możliwe, że slug jest już zajęty.",
-      "archive_success": "Badanie zarchiwizowane",
-      "archive_success_desc": "Badanie jest teraz zarchiwizowane i tylko do odczytu.",
-      "archive_error": "Błąd archiwizacji badania",
-      "archive_error_desc": "Nie udało się zarchiwizować badania. Czy zostało zamknięte?",
-      "delete_success": "Badanie usunięte",
-      "delete_success_desc": "Badanie zostało trwale usunięte.",
-      "delete_error": "Nie udało się usunąć badania. Upewnij się, że wszystkie dane zostały wcześniej wyczyszczone.",
-      "delete_error_desc": "Nie udało się usunąć badania.",
-      "storage": {
-        "title": "Użycie pamięci audio",
-        "used": "Używana pamięć",
-        "quota": "Limit",
-        "quota_label": "Limit pamięci",
-        "quota_help": "Maksymalna łączna pamięć audio dla tego badania (10–1000 MB).",
-        "error": "Nie udało się wczytać informacji o użyciu pamięci.",
-        "warning_high_usage": "Użycie pamięci jest wysokie. Rozważ zwiększenie limitu lub usunięcie starych nagrań.",
-        "save_success": "Limit pamięci zaktualizowany",
-        "save_error": "Nie udało się zaktualizować limitu pamięci. Proszę spróbować ponownie."
-      },
-      "retention": {
-        "title": "Przechowywanie danych",
-        "months_label": "Okres przechowywania (miesiące)",
-        "help": "Typowe wartości: 6, 12, 24, 60 miesięcy. Pozostaw puste, aby użyć wartości domyślnej systemu (12).",
-        "save_success": "Polityka przechowywania danych zaktualizowana",
-        "save_error": "Nie udało się zaktualizować polityki przechowywania danych",
-        "range_error": "Okres przechowywania musi być liczbą całkowitą od 1 do 240 miesięcy."
-      }
-    },
-    "privacy": {
-      "title": "Ochrona danych",
-      "header_desc": "Zgoda, inwentarz i anonimizacja",
-      "load_error": "Nie udało się wczytać inwentarza danych.",
-      "participants_title": "Migawka uczestników",
-      "stat_started": "Rozpoczętych",
-      "stat_completed": "Ukończonych",
-      "stat_discarded": "Odrzuconych",
-      "stat_anonymised": "Zanonimizowanych",
-      "older_1y": "Starsze niż 1 rok (niezanonimizowane)",
-      "older_2y": "Starsze niż 2 lata (niezanonimizowane)",
-      "audio_title": "Pamięć audio",
-      "audio_count": "Nagrania",
-      "audio_mb": "Łączny rozmiar",
-      "locale_title": "Podział według języka",
-      "locale_col": "Język",
-      "locale_count_col": "Uczestnicy",
-      "locale_empty": "Brak danych językowych.",
-      "timeline_title": "Oś czasu",
-      "tl_first": "Pierwsze zgłoszenie",
-      "tl_last": "Ostatnie zgłoszenie",
-      "tl_anon": "Ostatnia anonimizacja",
-      "bulk_title": "Anonimizacja zbiorcza",
-      "bulk_desc": "Usuń dane osobowe ukończonych uczestników, którzy przesłali zgłoszenia przed datą graniczną. Ranking sortowania Q jest zachowany.",
-      "cutoff_label": "Data graniczna",
-      "cutoff_help": "Zanonimizowani zostaną tylko ukończeni uczestnicy, którzy przesłali zgłoszenia ściśle przed tą datą.",
-      "preview_label": "Kandydaci:",
-      "preview_zero": "Żaden uczestnik nie kwalifikuje się do tej daty granicznej. Spróbuj wcześniejszej daty.",
-      "anonymise_button": "Anonimizuj",
-      "anonymise_success": "Anonimizacja zakończona",
-      "anonymise_success_desc": "Zanonimizowano {{n}} uczestnika(-ów), {{s}} już anonimowych.",
-      "anonymise_error": "Anonimizacja nie powiodła się",
-      "confirm_title": "Zanonimizować dane uczestników?",
-      "confirm_candidates": "Zostanie zanonimizowanych {{count}} ukończony(-ch) uczestnik(-ów), którzy przesłali zgłoszenia przed {{date}}.",
-      "confirm_preserved": "Ranking sortowania Q jest zachowany; tożsamość jest usuwana.",
-      "confirm_irreversible": "To działanie jest natychmiastowe i nie można go cofnąć.",
-      "confirm_in_progress": "Anonimizowanie…",
-      "confirm_action": "Tak, zanonimizuj",
-      "cutoff_from_policy": "Wartość domyślna wynikająca z polityki przechowywania badania ({{months}} miesięcy).",
-      "empty": {
-        "title": "Brak danych uczestników",
-        "body": "Ta strona aktywuje się po przesłaniu zgłoszeń przez uczestników. Najpierw udostępnij link do badania.",
-        "cta": "Otwórz widok ogólny badania"
-      },
-      "consent": {
-        "title": "Formularz zgody",
-        "description": "To, co uczestnicy widzą przed wejściem do badania. Edytowane w projekcie badania.",
-        "no_text": "Brak tekstu zgody.",
-        "no_title": "(brak tytułu)",
-        "no_body": "(puste)",
-        "edit_in_design": "Edytuj w projekcie badania",
-        "view": "Pokaż"
-      }
-    },
-    "projects": {
-      "title": "Projekty",
-      "settings": {
-        "title": "Ustawienia projektu",
-        "identity_desc": "Zarządzaj tożsamością projektu.",
-        "general": {
-          "title": "Ustawienia ogólne",
-          "desc": "Tożsamość i podstawowa identyfikacja projektu.",
-          "label_title": "Tytuł projektu",
-          "placeholder_title": "Moje świetne laboratorium",
-          "label_slug": "URL slug",
-          "placeholder_slug": "moje-laboratorium",
-          "slug_hint": "Zmiana slugu zaktualizuje wszystkie linki do panelu badawczego.",
-          "save": "Zapisz",
-          "save_success": "Projekt zaktualizowany pomyślnie",
-          "save_error": "Nie udało się zaktualizować projektu."
-        },
-        "team_growth_title": "Zarządzanie zespołem",
-        "team_growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
-        "team": {
-          "title": "Członkowie zespołu",
-          "desc": "Lista użytkowników mających dostęp do tego projektu.",
-          "col_user": "Użytkownik",
-          "col_role": "Rola",
-          "col_joined": "Dołączył/a",
-          "col_actions": "Działania",
-          "remove_confirm": "Czy na pewno chcesz usunąć tego członka?",
-          "remove_dialog_title": "Usunąć członka zespołu?",
-          "remove_dialog_body": "{{name}} straci dostęp do tego projektu. Można go zaprosić ponownie później.",
-          "remove_dialog_action": "Usuń",
-          "remove_member_aria": "Usuń {{name}}",
-          "remove_success": "Członek usunięty pomyślnie",
-          "remove_error": "Nie udało się usunąć członka",
-          "growth_title": "Rozwój zespołu",
-          "growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
-          "invite_button": "Zaproś współpracownika",
-          "permissions_matrix": {
-            "title": "Macierz uprawnień",
-            "admin": {
-              "label": "Administrator",
-              "desc": "Może zarządzać ustawieniami projektu, członkami i wszystkimi badaniami."
+            "verification_sent": {
+                "title": "Zweryfikuj adres e-mail",
+                "body": "Wysłaliśmy link weryfikacyjny na adres {{email}}. Proszę kliknąć link, aby aktywować konto.",
+                "resend": "Wyślij e-mail ponownie",
+                "cooldown": "Ponowne wysłanie dostępne za {{seconds}} s",
+                "error": "Nie udało się wysłać ponownie. Proszę spróbować później."
             },
-            "owner": {
-              "label": "Właściciel",
-              "desc": "Pełna kontrola nad projektem, członkami i badaniami."
-            },
-            "member": {
-              "label": "Członek",
-              "desc": "Może tworzyć i zarządzać wszystkimi badaniami. Brak dostępu do ustawień projektu."
-            },
-            "viewer": {
-              "label": "Obserwator",
-              "desc": "Dostęp tylko do odczytu do wszystkich badań i danych w projekcie."
+            "verify": {
+                "verifying": "Weryfikowanie adresu e-mail…",
+                "success": "Adres e-mail zweryfikowany. Można się teraz zalogować.",
+                "expired": "Ten link wygasł lub jest nieprawidłowy.",
+                "resend_link": "Poproś o nowy e-mail weryfikacyjny"
             }
-          },
-          "coming_soon": "Wkrótce",
-          "invite_modal": {
-            "title": "Zaproś współpracownika",
-            "email_label": "E-mail współpracownika",
-            "role_label": "Przypisana rola",
-            "success": "Link zaproszenia wygenerowany!",
-            "error": "Nie udało się utworzyć zaproszenia.",
-            "send": "Utwórz i wyślij zaproszenie",
-            "copy_success": "Link skopiowany do schowka!"
-          }
+        },
+        "register": {
+            "title": "Utwórz konto",
+            "subtitle": "Dołącz do projektu badawczego",
+            "secure_invitation": "Bezpieczne zaproszenie",
+            "invitation_to": "Zaproszenie do:",
+            "study_label": "Badanie",
+            "role_label": "Rola",
+            "email_label": "Adres e-mail",
+            "password_label": "Wybierz hasło",
+            "confirm_password_label": "Potwierdź hasło",
+            "placeholder_password": "••••••••",
+            "submit": "Zakończ rejestrację",
+            "loading": "Tworzenie konta...",
+            "success_title": "Witamy na pokładzie!",
+            "success_desc": "Konto zostało utworzone i powiązane z badaniem.",
+            "success_cta": "Przejdź do panelu",
+            "success_hint": "Można teraz zalogować się do panelu administracyjnego i rozpocząć współpracę.",
+            "invalid_title": "Nieprawidłowe zaproszenie",
+            "invalid_desc": "Ten link zaproszenia jest nieprawidłowy lub wygasł.",
+            "missing_token_title": "Brak tokenu",
+            "missing_token_desc": "Ta strona wymaga prawidłowego tokenu zaproszenia. Proszę sprawdzić otrzymany link.",
+            "verifying": "Weryfikowanie zaproszenia...",
+            "privacy_hint": "Rejestrując się, wyrażasz zgodę na przestrzeganie wytycznych etyki badawczej skonfigurowanych dla tego badania.",
+            "errors": {
+                "password_mismatch": "Hasła nie są zgodne",
+                "generic_fail": "Rejestracja nie powiodła się"
+            }
         }
-      }
     },
-    "members": {
-      "title": "Członkowie zespołu",
-      "description": "Zarządzaj dostępem do projektu i uprawnieniami."
-    },
-    "participants": {
-      "title": "Uczestnicy",
-      "description": "Zarządzaj uczestnikami i przeglądaj przesłane dane.",
-      "table": {
-        "id": "ID",
-        "status": "Status",
-        "started": "Rozpoczęto o",
-        "completed": "Ukończono o",
-        "duration": "Czas trwania",
-        "actions": "Akcje"
-      }
-    },
-    "participant": {
-      "tabs": {
-        "session": "Metadane",
-        "presort": "Wstępne sortowanie",
-        "grid": "Siatka sortowania Q",
-        "postsort": "Sortowanie końcowe"
-      },
-      "grid": {
-        "detail_view": "Szczegóły karty",
-        "no_comment": "Brak komentarza.",
-        "select_instruction": "Wybierz kartę na siatce, aby zobaczyć szczegóły.",
-        "read_only_mode": "Tryb obserwatora",
-        "score": "Wynik"
-      },
-      "metadata": {
-        "title": "Metadane sesji",
-        "technology": "Technologia",
-        "browser": "Przeglądarka",
-        "session": "Szczegóły sesji",
-        "duration": "Łączny czas",
-        "started": "Rozpoczęto",
-        "submitted": "Przesłano",
-        "id": "Wewnętrzny identyfikator",
-        "ip_hash": "Hash IP",
-        "recruitment_token": "Token rekrutacyjny",
-        "device": {
-          "mobile": "Telefon",
-          "tablet": "Tablet",
-          "desktop": "Komputer"
+    "admin": {
+        "hub": {
+            "title": "Panel badacza",
+            "welcome": "Witamy z powrotem,",
+            "new_project": "Nowy projekt",
+            "your_projects": "Twoje projekty",
+            "studies_count": "badań",
+            "recent_studies": "Ostatnie badania",
+            "n_studies_one": "{{count}} badanie",
+            "n_studies_other": "{{count}} badań",
+            "n_active_one": "{{count}} aktywne",
+            "n_active_other": "{{count}} aktywnych",
+            "collecting": "Zbieranie danych",
+            "no_studies": "Brak badań",
+            "no_projects": "Brak projektów. Utwórz pierwszy projekt, aby rozpocząć.",
+            "no_projects_title": "Rozpocznij pierwszy projekt badawczy",
+            "no_projects_body": "Utwórz projekt przed dodaniem konkursów, zbiorów Q lub badań."
+        },
+        "memo": {
+            "title_concourse": "Notatki selekcji",
+            "title_study": "Notatka metodologiczna",
+            "summary_empty_concourse": "Jak i dlaczego zbudowano ten konkurs",
+            "summary_empty_study": "Opcjonalnie · do replikacji i prerejstracji",
+            "summary_filled_one": "{{n}} wpis · kliknij, aby wyświetlić",
+            "summary_filled_other": "{{n}} wpisów · kliknij, aby wyświetlić",
+            "summary_unread": "{{n}} nieprzeczytanych",
+            "add_entry": "Dodaj wpis",
+            "export": "Eksportuj",
+            "insert_template": "Wstaw z szablonu",
+            "entry_title_placeholder": "Tytuł sekcji…",
+            "entry_body_placeholder": "Udokumentuj swoje uzasadnienie…",
+            "comments_count_one": "{{n}} komentarz",
+            "comments_count_other": "{{n}} komentarzy",
+            "show_resolved": "Pokaż rozwiązane ({{n}})",
+            "hide_resolved": "Ukryj rozwiązane",
+            "comment_placeholder": "Napisz komentarz. Użyj @, aby wspomnieć.",
+            "post_comment": "Wyślij",
+            "edit": "Edytuj",
+            "delete": "Usuń",
+            "deleted_body": "[usunięty komentarz]",
+            "resolve": "Oznacz jako rozwiązane",
+            "unresolve": "Cofnij rozwiązanie",
+            "resolved_label": "[rozwiązane]",
+            "save": "Zapisz",
+            "cancel": "Anuluj",
+            "saved": "Zapisano",
+            "save_error": "Nie udało się zapisać notatki. Proszę spróbować ponownie.",
+            "load_error": "Nie udało się wczytać notatki. Odśwież stronę, aby spróbować ponownie.",
+            "mentions_for_you": "Wzmianki dla mnie",
+            "mention_user_not_found": "Nieznany użytkownik",
+            "delete_entry_confirm": "Usunąć ten wpis i wszystkie jego komentarze?",
+            "include_discussion_in_export": "Dołącz wątki dyskusji z notatki",
+            "templates": {
+                "concourse": {
+                    "sources_canvassed": {
+                        "title": "Przejrzane źródła"
+                    },
+                    "voices_retained": {
+                        "title": "Zachowane głosy"
+                    },
+                    "voices_excluded": {
+                        "title": "Wykluczone głosy"
+                    },
+                    "sampling_rationale": {
+                        "title": "Uzasadnienie doboru próby"
+                    },
+                    "version_notes": {
+                        "title": "Uwagi do wersji"
+                    }
+                },
+                "study": {
+                    "distribution_rationale": {
+                        "title": "Uzasadnienie rozkładu"
+                    },
+                    "conditions_of_instruction": {
+                        "title": "Warunki instrukcji"
+                    },
+                    "qset_size": {
+                        "title": "Rozmiar zbioru Q"
+                    },
+                    "pre_post_design": {
+                        "title": "Decyzje projektowe wstępnego/końcowego sortowania"
+                    },
+                    "limitations": {
+                        "title": "Ograniczenia"
+                    }
+                }
+            }
+        },
+        "study_design": {
+            "distribution_mode": {
+                "title": "Tryb rozkładu",
+                "helper": "Wybierz, jak ściśle wymuszany jest rozkład siatki Q. Wymuszony: każda kolumna musi być wypełniona do zadeklarowanej pojemności (najczęstszy wybór). Swobodny: dowolna liczba kart na kolumnę, łącznie = rozmiar zbioru Q. Elastyczny: łączna liczba wymuszona, kolumny to miękkie wskazówki.",
+                "forced": {
+                    "label": "Wymuszony",
+                    "tooltip": "Każda kolumna musi zawierać dokładnie zadeklarowaną liczbę kart."
+                },
+                "free": {
+                    "label": "Swobodny",
+                    "tooltip": "Łączna liczba kart = rozmiar zbioru Q; liczba kart na kolumnę nie jest ograniczona."
+                },
+                "flexible": {
+                    "label": "Elastyczny",
+                    "tooltip": "Łączna liczba kart = rozmiar zbioru Q; pojemności kolumn są miękkimi wskazówkami (tylko ostrzeżenia)."
+                }
+            },
+            "rough_sort": {
+                "toggle_label": "Włącz wstępne sortowanie (triaż na 3 stosy)",
+                "lock_banner": "Przełącznik zablokowany. {{count}} uczestnik(-ów) rozpoczął(-ęło) ankietę; zarchiwizuj lub usuń te sesje przed zmianą tego ustawienia.",
+                "deck_mode_note": "Wyłączone. Uczestnicy widzą pełny zbiór Q jako przewijany poziomo talia kart."
+            }
+        },
+        "study": {
+            "activate_error": "Nie można aktywować badania. Sprawdź, czy projekt badania jest prawidłowy, i spróbuj ponownie.",
+            "save": {
+                "success": "Zmiany zapisane pomyślnie",
+                "save_success": "Zapisano pomyślnie",
+                "synced_warnings": "Zsynchronizowano z serwerem. Zachowano zmiany w: {{fields}}",
+                "synced_concurrent": "Zsynchronizowano ze zmianami wprowadzonymi przez innego użytkownika",
+                "conflict": "Wykryto konflikt. Niektórych zmian nie można było scalić.",
+                "error": "Nie udało się zapisać zmian"
+            },
+            "postsort": {
+                "missing": {
+                    "title": "Brakujące stwierdzenia",
+                    "desc": "Czy w zestawie stwierdzeń brakowało jakichś idei lub perspektyw?"
+                }
+            },
+            "state": {
+                "manage": "Zarządzaj przebiegiem badania"
+            }
+        },
+        "components": {
+            "markdown": {
+                "label": "Markdown",
+                "tooltip": "Obsługuje Markdown do bogatego formatowania",
+                "bold": "Pogrubienie",
+                "italic": "Kursywa",
+                "list": "Lista",
+                "link": "Link",
+                "edit": "Edytuj",
+                "preview": "Podgląd",
+                "empty": "Brak treści do podglądu"
+            },
+            "icon_picker": {
+                "icons": {
+                    "User": "Osoba",
+                    "Zap": "Błyskawica",
+                    "Scale": "Waga",
+                    "MessageSquareText": "Wiadomość",
+                    "ClipboardList": "Schowek",
+                    "CheckCircle": "Znacznik wyboru",
+                    "Flag": "Flaga",
+                    "Info": "Informacja",
+                    "HelpCircle": "Pomoc",
+                    "FileText": "Dokument",
+                    "LayoutGrid": "Siatka",
+                    "Rocket": "Rakieta",
+                    "Target": "Cel",
+                    "Brain": "Mózg",
+                    "Lightbulb": "Pomysł",
+                    "ListChecks": "Lista kontrolna"
+                }
+            },
+            "click_to_edit": "Kliknij, aby edytować",
+            "audio_player": {
+                "play": "Odtwórz audio",
+                "pause": "Wstrzymaj audio"
+            }
+        },
+        "layout": {
+            "title": "Admin",
+            "back_home": "Wróć do strony głównej",
+            "beta": "Wersja badawcza beta",
+            "logout": "Wyloguj",
+            "account": "Ustawienia konta",
+            "admin_user": "Użytkownik administracyjny",
+            "platform_settings": "Ustawienia platformy"
+        },
+        "account": {
+            "title": "Ustawienia konta",
+            "description": "Zarządzaj danymi osobowymi i bezpieczeństwem konta.",
+            "personal": {
+                "title": "Dane osobowe",
+                "email": "Adres e-mail",
+                "email_locked": "Twój adres e-mail nie może być jeszcze zmieniony tutaj. Skontaktuj się z administratorem, aby go zaktualizować.",
+                "name": "Imię i nazwisko",
+                "save": "Zapisz",
+                "saving": "Zapisywanie...",
+                "success": "Profil zaktualizowany pomyślnie",
+                "error": "Nie udało się zaktualizować profilu",
+                "cannot_remove_self": "Nie można usunąć samego siebie",
+                "name_required": "Imię i nazwisko jest wymagane"
+            },
+            "security": {
+                "title": "Bezpieczeństwo",
+                "description": "Zarządzaj weryfikacją dwuetapową i hasłem.",
+                "tfa_subtitle": "Weryfikacja dwuetapowa",
+                "password_subtitle": "Hasło",
+                "enabled": "Włączone",
+                "setup_cta": "Skonfiguruj weryfikację dwuetapową",
+                "configure_title": "Konfiguruj aplikację uwierzytelniającą",
+                "scan_desc": "Zeskanuj ten kod QR aplikacją uwierzytelniającą (Google Authenticator, Authy itp.)",
+                "enter_code": "Wpisz 6-cyfrowy kod",
+                "enable_btn": "Włącz weryfikację dwuetapową",
+                "disable_btn": "Wyłącz weryfikację dwuetapową",
+                "confirm_disable": "Potwierdź wyłączenie",
+                "confirm_password_label": "Potwierdź hasłem",
+                "verifying": "Weryfikowanie...",
+                "cancel": "Anuluj",
+                "enabled_success": "Weryfikacja dwuetapowa włączona",
+                "disabled_success": "Weryfikacja dwuetapowa wyłączona",
+                "secret_copied": "Sekret skopiowany",
+                "invalid_token": "Nieprawidłowy kod weryfikacyjny",
+                "disable_error": "Nie udało się wyłączyć weryfikacji dwuetapowej"
+            },
+            "password": {
+                "title": "Zarządzanie hasłem",
+                "current": "Aktualne hasło",
+                "new": "Nowe hasło",
+                "change_btn": "Zmień hasło",
+                "updating": "Aktualizowanie...",
+                "success": "Hasło zmienione pomyślnie",
+                "error": "Nie udało się zmienić hasła. Sprawdź aktualne hasło.",
+                "validation": {
+                    "required": "Wymagane",
+                    "min_length": "Min. 8 znaków"
+                }
+            }
+        },
+        "sidebar": {
+            "home": "Panel",
+            "add_study": "Dodaj badanie",
+            "create_project": "UTWÓRZ NOWY PROJEKT",
+            "dashboard": "Panel",
+            "overview": "Przegląd",
+            "design": "Projekt",
+            "recruit": "Dostęp",
+            "data": "Dane",
+            "analysis": "Analiza",
+            "privacy": "Prywatność danych",
+            "team": "Zespół",
+            "settings": "Ustawienia badania",
+            "project_settings": "Ustawienia projektu",
+            "study_tools": "Narzędzia badania",
+            "project": "Projekt",
+            "documentation": "Dokumentacja",
+            "support": "Wsparcie",
+            "study_management": "Zarządzanie badaniem",
+            "search": "Szukaj...",
+            "studies": "Badania",
+            "select_study": "Wybierz badanie",
+            "select_study_msg": "Wybierz lub utwórz badanie, aby rozpocząć.",
+            "view_all_studies": "Wszystkie badania",
+            "study": "Badanie",
+            "select_project": "Wybierz projekt",
+            "concourses": "Konkursy",
+            "concourse": "Konkurs",
+            "members": "Członkowie zespołu"
+        },
+        "concourse": {
+            "title": "Konkurs",
+            "description": "Zarządzaj stwierdzeniami kandydatów do badania metodologią Q",
+            "default_title": "Konkurs",
+            "default_title_for_project": "Konkurs {{project}}",
+            "create": "Nowy konkurs",
+            "create_success": "Konkurs utworzony",
+            "create_error": "Nie udało się utworzyć konkursu",
+            "create_dialog_title": "Utwórz konkurs",
+            "create_dialog_desc": "Konkurs to zbiór stwierdzień kandydatów, spośród których zostanie wybrany zbiór Q.",
+            "field_title": "Tytuł",
+            "field_title_placeholder": "np. Postawy wobec zmian klimatu",
+            "field_description": "Opis",
+            "field_description_placeholder": "Krótki opis tego konkursu...",
+            "field_code": "Kod",
+            "field_text": "Tekst stwierdzenia",
+            "field_text_placeholder": "Wpisz tekst stwierdzenia...",
+            "field_source": "Źródło",
+            "items_label": "elementów",
+            "updated": "Zaktualizowano",
+            "empty_title": "Brak konkursów",
+            "empty_desc": "Utwórz konkurs, aby zacząć zbierać i porządkować stwierdzenia kandydatów do badań metodologią Q.",
+            "add_item": "Dodaj element",
+            "bulk_import": "Import zbiorczy",
+            "import_desc": "Wklej stwierdzenia oddzielone nową linią. Każda linia staje się jednym elementem.",
+            "import_prefix": "Prefiks kodu",
+            "import_statements": "Stwierdzenia",
+            "import_placeholder": "Jedno stwierdzenie na wiersz...",
+            "items_to_import": "stwierdzeń do importu",
+            "import_button": "Importuj",
+            "import_success": "Zaimportowano {{count}} elementów",
+            "import_error": "Import nie powiódł się",
+            "item_created": "Element dodany",
+            "item_create_error": "Nie udało się dodać elementu",
+            "item_updated": "Element zaktualizowany",
+            "item_update_error": "Nie udało się zaktualizować elementu",
+            "item_deleted": "Element usunięty",
+            "item_delete_error": "Nie udało się usunąć elementu",
+            "status_error": "Nie udało się zmienić statusu",
+            "search_placeholder": "Szukaj elementów...",
+            "source_placeholder": "np. Wywiad nr 3, Przegląd literatury",
+            "no_items": "Brak elementów. Dodaj pierwsze stwierdzenie.",
+            "no_matches": "Żaden element nie pasuje do filtrów.",
+            "danger_zone": "Strefa zagrożenia",
+            "delete": "Usuń konkurs",
+            "delete_confirm": "Czy na pewno chcesz usunąć ten konkurs i wszystkie jego elementy?",
+            "deleted": "Konkurs usunięty",
+            "delete_error": "Nie udało się usunąć konkursu",
+            "delete_item_title": "Usuń element",
+            "delete_item_confirm": "Usunąć ten element? Tego działania nie można cofnąć.",
+            "status": {
+                "proposed": "Proponowane",
+                "accepted": "Zaakceptowane",
+                "rejected": "Odrzucone"
+            },
+            "change_note_placeholder": "Uwaga do zmiany (opcjonalnie)",
+            "history": "Historia",
+            "comments": "Komentarze",
+            "no_history": "Brak historii edycji.",
+            "no_comments": "Brak komentarzy.",
+            "add_comment": "Napisz komentarz...",
+            "send_comment": "Wyślij",
+            "comment_added": "Komentarz dodany",
+            "comment_error": "Nie udało się dodać komentarza. Proszę spróbować ponownie.",
+            "version_label": "v{{n}}",
+            "item_detail_desc": "Historia i komentarze dla tego elementu",
+            "manage_tags": "Tagi",
+            "tag_name_placeholder": "Nazwa tagu",
+            "tag_color": "Kolor tagu",
+            "tag_created": "Tag utworzony",
+            "tag_create_error": "Nie udało się utworzyć tagu",
+            "tag_deleted": "Tag usunięty",
+            "tag_delete_error": "Nie udało się usunąć tagu",
+            "no_tags": "Brak tagów. Utwórz pierwszy tag powyżej.",
+            "field_tags": "Tagi",
+            "export_csv": "Eksportuj CSV",
+            "select_language": "Język",
+            "add_language": "Dodaj język",
+            "add_language_desc": "Wpisz kod języka (np. en, fr, fi).",
+            "add_language_desc_v2": "Wybierz język tłumaczeń stwierdzeń.",
+            "add_language_tooltip": "Dodaj język tłumaczenia",
+            "field_language": "Język",
+            "import_language": "Język",
+            "select_all": "Zaznacz wszystko",
+            "select_item": "Zaznacz {{code}}",
+            "bulk_selected": "Zaznaczono {{count}}",
+            "bulk_set_status": "Ustaw status:",
+            "bulk_clear": "Wyczyść",
+            "bulk_status_success": "Zaktualizowano {{count}} elementów",
+            "bulk_status_error": "Nie udało się zaktualizować niektórych elementów",
+            "qset_title": "Kuracja",
+            "qset_reviewed_of": "{{total}} elementów przejrzanych",
+            "qset_accepted": "{{count}} zaakceptowanych",
+            "qset_pending": "{{count}} elementów do przejrzenia",
+            "qset_complete": "Wszystkie elementy przejrzane",
+            "show_pending": "Do przejrzenia",
+            "bulk_confirm_title": "Potwierdź zmianę statusu",
+            "bulk_confirm_desc": "Ustawić {{count}} elementów na \"{{status}}\"?",
+            "no_translation": "Brak tekstu",
+            "language_tooltip": "Język tekstów stwierdzeń",
+            "loading": "Konfigurowanie konkursu...",
+            "diff_code": "kod",
+            "diff_status": "status",
+            "diff_text": "tekst",
+            "diff_tags": "tagi",
+            "diff_changed": "Zmieniono:",
+            "methodological_context": {
+                "title": "Kontekst metodologiczny",
+                "subtitle": "Opcjonalne pola dokumentacyjne. Wypełnij to, co istotne dla projektu; pozostałe pozostaw puste."
+            },
+            "import_from_csv": "Importuj CSV/TSV…",
+            "import_csv_hint": "CSV/TSV wymaga kolumn: code, language, text.",
+            "import_csv_no_match": "Żaden wiersz nie pasuje do wybranego języka ({{lang}}).",
+            "import_csv_skipped": "Pominięto {{count}} wiersz(-y) w innych językach: {{langs}}.",
+            "import_csv_more_errors": "{{count}} więcej problemów"
+        },
+        "concourse_import": {
+            "title": "Importuj z konkursu",
+            "desc": "Wybierz elementy z konkursu, aby zaimportować je jako stwierdzenia badania. Elementy są kopiowane; zmiany w konkursie nie wpłyną na badanie.",
+            "button_label": "Importuj z konkursu",
+            "select_concourse": "Konkurs",
+            "select_placeholder": "Wybierz konkurs...",
+            "code_prefix": "Prefiks kodu",
+            "code_prefix_placeholder": "np. S",
+            "only_accepted": "Tylko zaakceptowane",
+            "replace_existing": "Zastąp istniejące stwierdzenia",
+            "replace_warning": "Wszystkie istniejące stwierdzenia zostaną trwale usunięte i zastąpione wybranymi elementami.",
+            "selected": "Wybrano: {{count}}",
+            "select_all": "Zaznacz wszystkie",
+            "import_button": "Importuj {{count}} stwierdzenia(-n)",
+            "success": "Zaimportowano {{count}} stwierdzenia(-n)",
+            "error": "Nie można zaimportować elementów z konkursu. Spróbuj ponownie.",
+            "no_accepted": "Brak zaakceptowanych elementów w tym konkursie. Odznacz opcję \"Tylko zaakceptowane\", aby zobaczyć wszystkie.",
+            "no_items": "Ten konkurs nie ma żadnych elementów.",
+            "no_concourses": "Brak konkursów w tym projekcie. Najpierw utwórz konkurs."
+        },
+        "concourse_sync": {
+            "update_available": "Aktualizacja",
+            "source_deleted": "Źródło usunięte",
+            "source_deleted_tip": "Element źródłowy konkursu został usunięty.",
+            "new_version": "Nowa wersja w konkursie:",
+            "synced": "Stwierdzenie zaktualizowane z konkursu",
+            "error": "Nie można zsynchronizować z konkursem. Spróbuj ponownie.",
+            "stale_banner": "{{count}} stwierdzenie(-n) ma dostępne aktualizacje z konkursu."
+        },
+        "analysis": {
+            "title": "Analiza",
+            "description": "Analiza czynnikowa danych z sortowania Q: wyodrębnianie punktów widzenia z odpowiedzi uczestników",
+            "configuration": "Konfiguracja",
+            "configuration_description": "Wybierz metodę ekstrakcji, liczbę czynników i rotację",
+            "extraction_method": "Ekstrakcja",
+            "centroid": "Centroid",
+            "n_factors": "Czynniki",
+            "rotation_method": "Rotacja",
+            "none": "Brak",
+            "run": "Uruchom analizę",
+            "run_will_replace": "Ponowne uruchomienie zastąpi bieżący widok wyników. Użyj panelu historii, aby porównać przebiegi.",
+            "running": "Analizowanie...",
+            "reanalyzing": "Ponowne analizowanie...",
+            "success": "Analiza zakończona. Wyodrębniono {{n}} czynników.",
+            "error": "Analiza nie powiodła się: {{message}}",
+            "scree_hint": "Każdy słupek pokazuje, ile wariancji wyjaśnia dany czynnik (jego wartość własna). Przerywana linia oznacza wartość własną = 1 (kryterium Kaisera). Kliknij słupek, aby wybrać liczbę czynników do wyodrębnienia.",
+            "kaiser_suggestion": "{{n}} czynnik(-ów) ma wartości własne powyżej 1 (kryterium Kaisera)",
+            "factor": "Czynnik",
+            "factor_n": "Czynnik {{n}}",
+            "eigenvalue": "Wartość własna",
+            "too_few_participants": "Do uruchomienia analizy potrzebne są co najmniej 2 ukończone sortowania.",
+            "eigenvalue_error": "Nie udało się wczytać danych analizy. Proszę spróbować ponownie.",
+            "scree_plot_label": "Wykres osypiska pokazujący wartości własne dla {{n}} czynników",
+            "loading_eigenvalues": "Wczytywanie wartości własnych...",
+            "empty_state": "Ustaw parametry i uruchom analizę.",
+            "empty": {
+                "contract_title": "Za mało danych z sortowania Q",
+                "contract_body": "Analiza czynnikowa metodologii Q wymaga co najmniej 2 uczestników, którzy ukończyli sortowanie. Opcje konfiguracji (ekstrakcja, czynniki, rotacja, oznaczanie) nabierają znaczenia po zgromadzeniu danych. Udostępnij link do badania z widoku ogólnego, aby zacząć zbierać odpowiedzi.",
+                "contract_cta": "Otwórz widok ogólny badania"
+            },
+            "advanced": {
+                "title": "Ustawienia zaawansowane",
+                "summary": "Rotacja: {{rotation}} · Oznaczanie: {{flagging}} · Bootstrap: {{bootstrap}}",
+                "bootstrap_off": "wyłączony",
+                "bootstrap_on": "{{n}} iteracji"
+            },
+            "tab_loadings": "Ładunki",
+            "tab_factor_arrays": "Tablice czynnikowe",
+            "tab_statements": "Stwierdzenia",
+            "tab_summary": "Podsumowanie",
+            "participant": "Uczestnik",
+            "flagged": "Oznaczony",
+            "significance_threshold": "Próg istotności (p<0,05): ±{{threshold}}",
+            "sorts": "sortowania",
+            "distinguishing_legend": "Stwierdzenie różnicujące",
+            "code": "Kod",
+            "statement": "Stwierdzenie",
+            "type": "Typ",
+            "distinguishing": "Różnicujące",
+            "consensus": "Konsensusowe",
+            "variance_explained": "Wyjaśniona wariancja (%)",
+            "cumulative_variance": "Skumulowana wariancja (%)",
+            "n_flagged": "Liczba oznaczonych sortowań",
+            "composite_reliability": "Rzetelność złożona",
+            "se_factor_scores": "Błąd standardowy wyników czynnikowych",
+            "factor_correlations": "Korelacje czynników",
+            "high_correlation": "Wysoka korelacja",
+            "total_variance": "Łączna wyjaśniona wariancja",
+            "method_used": "Metoda",
+            "statements_label": "stwierdzenia",
+            "pca": "PCA",
+            "varimax": "Varimax",
+            "metric": "Metryka",
+            "caption_loadings": "Ładunki czynnikowe na uczestnika",
+            "caption_statements": "Wyniki z i tablice czynnikowe na czynnik",
+            "caption_characteristics": "Charakterystyki czynników i statystyki rzetelności",
+            "caption_correlations": "Macierz korelacji między czynnikami",
+            "retry": "Spróbuj ponownie",
+            "flagging_method": "Oznaczanie",
+            "auto": "Auto",
+            "manual": "Ręczny",
+            "manual_flag_hint": "Kliknij komórkę ładunku, aby oznaczyć/odznaczyć uczestnika dla danego czynnika. Uruchom ponownie analizę, aby zaktualizować wyniki.",
+            "no_flagged_participants": "Żaden uczestnik nie jest oznaczony dla żadnego czynnika. Spróbuj dostosować liczbę czynników lub metodę oznaczania.",
+            "no_statement_scores": "Brak dostępnych wyników stwierdzeń. Upewnij się, że uczestnicy są oznaczeni dla co najmniej jednego czynnika.",
+            "no_characteristics": "Brak dostępnych charakterystyk czynników.",
+            "export": "Eksportuj",
+            "export_loadings": "Ładunki czynnikowe (CSV)",
+            "export_scores": "Wyniki stwierdzeń (CSV)",
+            "export_xlsx": "Pełna analiza (XLSX)",
+            "export_error": "Nie udało się wygenerować eksportu XLSX.",
+            "select_factors": "Wybierz liczbę czynników",
+            "loadings_help": "Ładunki czynnikowe pokazują, jak silnie sortowanie każdego uczestnika koreluje z każdym czynnikiem. Wyróżnione komórki przekraczają próg istotności podany powyżej.",
+            "factor_array_help": "Złożone sortowanie Q pokazujące wyidealizowany wzorzec sortowania dla tego czynnika. Stwierdzenia są rozmieszczone w rozkładzie na podstawie ważonych wyników z.",
+            "factor_array_label": "Złożone sortowanie czynnika {{n}}",
+            "factor_arrays": {
+                "toggle_narratives": "Pokaż interpretacje czynników",
+                "toggle_narratives_aria": "Przełącz interpretacje poszczególnych czynników"
+            },
+            "statements_help": "Wyniki z pokazują standardową pozycję każdego czynnika na każdym stwierdzeniu. D = różnicujące (istotnie różne między czynnikami), C = konsensusowe (brak istotnych różnic).",
+            "z_scores_description": "Wyniki z i pozycje tablicy czynnikowej na stwierdzenie",
+            "factor_statistics": "Statystyki czynników",
+            "characteristics_help": "Wartości własne odzwierciedlają ilość wyjaśnionej wariancji. Rzetelność złożona odzwierciedla wewnętrzną spójność oznaczonych sortowań. Błąd standardowy wyników czynnikowych odzwierciedla precyzję estymacji złożonej.",
+            "help_extraction": "PCA maksymalizuje wyjaśnianą wariancję. Centroid jest mniej ograniczony matematycznie.",
+            "help_n_factors": "Każdy czynnik reprezentuje odrębny punkt widzenia.",
+            "help_rotation": "Varimax rozdziela czynniki dla prostszej struktury.",
+            "help_flagging": "Auto: oznaczaj uczestników ładujących się na dokładnie jeden czynnik. Ręczny: nadpisuj ręcznie dla każdego uczestnika.",
+            "guide_loadings_title": "Odczytywanie ładunków czynnikowych",
+            "guide_loadings_1": "Każdy ładunek to korelacja (od −1 do +1) między uczestnikiem a czynnikiem (wspólnym punktem widzenia).",
+            "guide_loadings_2": "Wyróżnione wartości przekraczają próg istotności pokazany powyżej tabeli.",
+            "guide_arrays_title": "Interpretacja tablic czynnikowych",
+            "guide_arrays_1": "Każda tablica czynnikowa to złożone sortowanie Q reprezentujące jeden wspólny punkt widzenia.",
+            "guide_arrays_2": "Czytaj od lewej do prawej: od największego braku zgody do największej zgody. Pozycje skrajne niosą najsilniejszy sygnał interpretacyjny.",
+            "guide_statements_title": "Rozumienie wyników stwierdzeń",
+            "guide_statements_1": "Wyniki z pokazują, jak silnie każdy czynnik zgadza się lub nie zgadza z każdym stwierdzeniem (0 = neutralnie).",
+            "guide_statements_2": "D = różnicujące (umieszczone istotnie różnie między czynnikami). Gwiazdki wskazują poziom istotności.",
+            "guide_summary_title": "Ocena rozwiązania",
+            "guide_summary_1": "Wartości własne mierzą, ile wariancji wyjaśnia dany czynnik. Kryterium Kaisera (wartość własna > 1) to jedna z popularnych heurystyk decydowania o liczbie czynników do zachowania.",
+            "guide_summary_2": "Rzetelność złożona odzwierciedla, jak spójnie oznaczone sortowania definiują dany czynnik. Wyższe wartości oznaczają, że estymacja czynnika opiera się na większej zgodności sortowań go definiujących.",
+            "benchmark_above": "Powyżej progu",
+            "benchmark_below": "Poniżej progu",
+            "history": {
+                "title": "Historia analiz",
+                "loading": "Wczytywanie historii…",
+                "fetch_error": "Nie udało się wczytać historii analiz.",
+                "empty": "Brak poprzednich analiz dla tego badania. Uruchom jedną, aby rozpocząć ślad audytu.",
+                "empty_explainer": "Każde uruchomienie jest tutaj rejestrowane, aby można było dokumentować i ponownie przeglądać każdą decyzję.",
+                "load_error": "Nie udało się wczytać tego przebiegu analizy. Odśwież stronę, aby spróbować ponownie.",
+                "load_run_aria": "Wczytaj przebieg analizy z {{date}}",
+                "loading_run": "Wczytywanie…",
+                "current_tag": "bieżący",
+                "n_factors_label": "{{n}}C",
+                "edit_notes": "Edytuj notatki",
+                "edit_notes_aria": "Edytuj notatki dla tego przebiegu",
+                "notes_placeholder": "Dodaj notatkę o tym przebiegu…",
+                "notes_aria": "Edytuj notatki dla tego przebiegu",
+                "save_notes_aria": "Zapisz notatki",
+                "cancel_edit_aria": "Anuluj edycję",
+                "notes_saved": "Notatki zapisane.",
+                "notes_error": "Nie udało się zapisać notatek. Sprawdź połączenie i spróbuj ponownie.",
+                "delete_run": "Usuń przebieg",
+                "delete_run_aria": "Usuń ten przebieg analizy",
+                "delete_dialog_title": "Usunąć przebieg analizy?",
+                "delete_dialog_description": "Usunięcie przebiegu analizy usuwa dowód analitycznego wyboru ze śladu audytu. Czy na pewno?",
+                "cancel": "Anuluj",
+                "delete_confirm": "Usuń",
+                "deleted": "Przebieg analizy usunięty.",
+                "delete_error": "Nie udało się usunąć przebiegu.",
+                "viewing_banner": "Podgląd przebiegu z {{date}}: {{extraction}} · {{n}}C · {{rotation}}",
+                "back_to_current": "Wróć do bieżącego"
+            },
+            "factor_voices": {
+                "title": "Głosy przy czynniku {{n}}",
+                "no_audio": "Brak nagrań audio po sortowaniu od uczestników oznaczonych dla tego czynnika.",
+                "no_material": "Brak nagrań audio po sortowaniu ani pisemnych komentarzy od uczestników oznaczonych dla tego czynnika.",
+                "loading": "Wczytywanie nagrań…",
+                "error": "Nie udało się wczytać nagrań audio. Proszę spróbować ponownie.",
+                "context": "Osadź interpretację czynnika we własnych słowach uczestników: ich uzasadnieniach audio i pisemnych komentarzach do kart.",
+                "context_aria": "O tym panelu",
+                "audio_label": "Nagranie: {{key}} — {{participant}}",
+                "url_unavailable": "URL audio niedostępny.",
+                "comments_label": "Komentarze do kart",
+                "question_default": "Komentarz głosowy"
+            },
+            "factor_note": {
+                "label": "Interpretacja czynnika",
+                "placeholder": "Napisz interpretację tego czynnika: dyskurs, głosy i napięcia, które eksponuje.",
+                "empty_hint": "Dodaj interpretację dla tego czynnika",
+                "char_count": "{{n}}/{{max}}",
+                "edit_aria": "Edytuj interpretację czynnika {{n}}",
+                "save_aria": "Zapisz interpretację czynnika",
+                "cancel_aria": "Anuluj edycję",
+                "aria": "Edytuj interpretację czynnika {{n}}",
+                "saved": "Interpretacja czynnika zapisana.",
+                "error": "Nie udało się zapisać interpretacji czynnika."
+            },
+            "rotation": {
+                "judgmental": {
+                    "label": "Ekspercka (ręczna)",
+                    "short": "Ekspercka",
+                    "tooltip": "Ręcznie obracaj pary czynników o wybrane kąty, aby ustawić je w merytorycznie sensownych pozycjach."
+                }
+            },
+            "manual_rotations": {
+                "title": "Rotacje ręczne",
+                "helper": "Podaj rotacje w formie: 'obróć czynnik F o Δ° wokół czynnika G'. Rotacje są stosowane w kolejności.",
+                "add": "Dodaj rotację",
+                "remove_aria": "Usuń rotację",
+                "empty": "Dodaj co najmniej jedną rotację, aby uruchomić analizę.",
+                "factor_a_label": "Obróć czynnik",
+                "angle_label": "o",
+                "factor_b_label": "wokół czynnika"
+            },
+            "bootstrap": {
+                "toggle_label": "Uruchom bootstrap stabilności",
+                "iterations_label": "Iteracje (B)",
+                "helper": "Opcjonalnie. Próbkuje sortowania Q B razy, aby oszacować przedziały ufności dla wyników czynnikowych.",
+                "running": "Trwa bootstrap…",
+                "se_column": "Średni błąd standardowy (z)",
+                "tooltip": "Nieparametryczny bootstrap sortowań Q (próbkowanie ze zwracaniem); analiza jest powtarzana B razy, aby oszacować 95% przedziały ufności dla wyników z."
+            },
+            "explore": {
+                "diagnostics_title": "Diagnostyka",
+                "kaiser": "Kaiser",
+                "parallel": "Analiza równoległa",
+                "map": "MAP Velicera",
+                "advisory": "Wyłącznie orientacyjne. Decyzja o liczbie czynników w metodologii Q zależy też od interpretowalności i stabilności (Watts i Stenner 2012).",
+                "preview_range_title": "Podgląd zakresu",
+                "preview_range_disabled": "Podgląd zakresu obsługuje tylko PCA + varimax. Ekstrakcja centroidów i rotacja ekspercka są zależne od ścieżki; zatwierdź rzeczywisty przebieg, aby sprawdzić.",
+                "select_k": "{{k}} czynników",
+                "empty_factor": "Pusty czynnik (nadmierna faktoryzacja)",
+                "cumvar": "skum. war. %",
+                "pct_flagged": "% oznaczonych",
+                "n_distinguishing": "# różnicujące",
+                "n_cross_loaders": "# wieloczynnikowe",
+                "min_def_sorts": "min. sortowań def.",
+                "advanced_title": "Konfiguracja zaawansowana",
+                "commit_cta": "Zatwierdź i interpretuj"
+            },
+            "interpret": {
+                "def_sorts": "Sortowania definiujące: {{n}}",
+                "statements_title": "Stwierdzenia",
+                "narrative_title": "Interpretacja C{{n}}",
+                "insert_comment_quote": "Wstaw komentarz jako cytat",
+                "focus_mode": "Fokus na czynnik",
+                "overview_mode": "Widok ogólny",
+                "mode_toggle": "Tryb widoku"
+            },
+            "compare": {
+                "pin_cta": "Przypnij do porównania",
+                "no_other_runs": "Brak innych dostępnych przebiegów",
+                "run_label": "Przebieg #{{id}} ({{n}} czynników)",
+                "pinned": "Porównanie z przebiegiem #{{id}}",
+                "phi": "φ = {{phi}}",
+                "ambiguous": "niejednoznaczne dopasowanie (interpretuj różnice ostrożnie)",
+                "unpin": "Odepnij",
+                "delta_z_aria": "Δz {{delta}} vs przebieg porównawczy",
+                "delta_loading_aria": "Δładunek {{delta}} vs przebieg porównawczy"
+            },
+            "quote_insert_format": "> {{text}}\n> {{p}}, o stwierdzeniu {{code}}: \"{{stmt}}\""
+        },
+        "project": {
+            "remove_member": "Usuń członka",
+            "table_caption": "Członkowie projektu",
+            "switcher": {
+                "settings": "Ustawienia projektu",
+                "settings_desc": "Członkowie i profile",
+                "new_project": "Nowy projekt",
+                "new_project_desc": "Utwórz nowy projekt"
+            },
+            "roles": {
+                "owner": "Właściciel",
+                "admin": "Administrator",
+                "viewer": "Obserwator",
+                "member": "Członek"
+            },
+            "study_states": {
+                "active": "Aktywne",
+                "draft": "Szkic",
+                "paused": "Wstrzymane",
+                "closed": "Zamknięte"
+            },
+            "create": {
+                "title": "Utwórz projekt",
+                "card_title": "Szczegóły projektu",
+                "name_label": "Nazwa projektu",
+                "name_placeholder": "Badanie Q postaw wobec klimatu",
+                "url_label": "URL projektu",
+                "url_placeholder": "badanie-q-postawy-klimat",
+                "url_description": "To staje sie sciezka projektu pod /app/.",
+                "cancel": "Anuluj",
+                "create_button": "Utwórz projekt",
+                "creating": "Tworzenie...",
+                "success": "Projekt został pomyślnie utworzony",
+                "error": "Nie udało się utworzyć projektu"
+            }
+        },
+        "recruitment": {
+            "title": "Dostęp",
+            "description": "Skonfiguruj URL badania, zarządzaj dostępem uczestników i śledź efektywność rekrutacji.",
+            "study_url": {
+                "title": "URL badania",
+                "description": "Publiczny adres, pod którym uczestnicy mają dostęp do badania.",
+                "full_url_label": "Pełny URL",
+                "slug_label": "URL slug",
+                "slug_description": "Unikalny identyfikator używany w URL badania. Tylko małe litery, cyfry i myślniki.",
+                "slug_locked": "Slug URL można zmieniać tylko w trybie szkicu."
+            },
+            "state_draft": "Tryb szkicu. Linki będą działać po aktywowaniu badania.",
+            "state_closed": "To badanie jest zamknięte. Istniejące linki pozostają widoczne, ale nowi uczestnicy nie mogą rozpocząć.",
+            "state_archived": "To badanie jest zarchiwizowane. Wszystkie dane rekrutacji są tylko do odczytu.",
+            "empty_title": "Brak linków rekrutacyjnych",
+            "empty_description": "Utwórz pierwszy link, aby zacząć zapraszać uczestników.",
+            "empty_cta": "Utwórz link dostępu",
+            "stats_summary": {
+                "links": "linków",
+                "started": "rozpoczętych",
+                "submitted": "przesłanych"
+            },
+            "access_rules": {
+                "title": "Reguły dostępu",
+                "description": "Kontroluj, kiedy i jak uczestnicy mają dostęp do badania.",
+                "password_toggle": "Wymagaj hasła",
+                "password_toggle_desc": "Uczestnicy muszą wpisać hasło przed rozpoczęciem badania.",
+                "password_label": "Hasło dostępu",
+                "password_placeholder": "Wpisz hasło dostępu",
+                "password_locked": "Ochrona hasłem może być zmieniana tylko w trybie szkicu.",
+                "password_set": "Hasło jest aktualnie ustawione. Wpisz nową wartość, aby je zmienić, lub wyłącz przełącznik, aby je usunąć.",
+                "collection_window": "Okno zbierania danych",
+                "window_toggle": "Ogranicz okno zbierania danych",
+                "window_toggle_help": "Ogranicz dostęp uczestników do określonego zakresu czasu.",
+                "start_date_label": "Otwiera się o",
+                "end_date_label": "Zamyka się o",
+                "date_hint": "Pozostaw puste, aby nie ograniczać czasu.",
+                "clear_date": "Wyczyść datę",
+                "save_button": "Zapisz reguły dostępu",
+                "save_success": "Reguły dostępu zaktualizowane",
+                "save_error": "Nie udało się zaktualizować reguł dostępu",
+                "non_draft_notice": "Poza trybem szkicu można edytować tylko okno zbierania danych. Przełącz badanie z powrotem na szkic, aby zmienić inne reguły dostępu.",
+                "archived_notice": "To badanie jest zarchiwizowane. Reguły dostępu są tylko do odczytu."
+            },
+            "new_link": "Nowy link dostępu",
+            "create_title": "Utwórz linki dostępu",
+            "link_type": "Strategia dostępu",
+            "select_type": "Wybierz typ rekrutacji...",
+            "campaign_name": "Kanał / nazwa kampanii",
+            "name_placeholder": "Np. LinkedIn, e-mail partia a, lista studentów...",
+            "link_count": "Rozmiar partii",
+            "capacity_label": "Maks. zgłoszeń",
+            "generate_links": "Generuj linki",
+            "no_links": "Nie wygenerowano jeszcze żadnych linków rekrutacyjnych.",
+            "unnamed": "Kanał bez nazwy",
+            "revoked": "Dostęp odwołany",
+            "qr_title": "Udostępnij przez QR",
+            "copy_link": "Kopiuj URL",
+            "table_title": "Linki rekrutacyjne",
+            "share_title": "Udostępnij badanie",
+            "share_desc": "Rozprowadź URL badania, aby zaprosić uczestników.",
+            "public_url_label": "Publiczny URL uczestnictwa",
+            "hide_qr": "Ukryj QR",
+            "show_qr": "Pokaż kod QR",
+            "delete_link": "Usuń link",
+            "qr_alt": "Kod QR dla {{url}}",
+            "table_caption": "Linki rekrutacyjne",
+            "progress_label": "{{count}} z {{max}} odpowiedzi",
+            "usage": {
+                "started": "rozpoczęte",
+                "submitted": "przesłane",
+                "completed": "Ukończone",
+                "in_progress": "W toku",
+                "unused": "Nieużyte"
+            },
+            "live_study": "Badanie na żywo",
+            "download_qr": "Pobierz obraz",
+            "qr_print_hint": "Zeskanuj lub wydrukuj ten kod do fizycznych materiałów rekrutacyjnych (ulotki, plakaty).",
+            "analytics_title": "Analityka kampanii",
+            "analytics_desc": "Bezpośrednie linki i skany QR są automatycznie śledzone w panelu zdrowia powyżej.",
+            "copy_success": "Link do badania skopiowany do schowka",
+            "types": {
+                "public": "Dostęp otwarty (publiczny)",
+                "individual": "Jednorazowy kod dostępu",
+                "limited": "Ograniczone uczestnictwo"
+            },
+            "guidance": {
+                "public": "Najlepszy do rekrutacji na dużą skalę. Jeden URL dla wszystkich uczestników.",
+                "individual": "Maksymalne bezpieczeństwo. Generuje unikalne linki wygasające po jednym pomyślnym ukończeniu.",
+                "limited": "Kontrolowany dostęp. Jeden link, który przestaje działać po określonej liczbie zgłoszeń."
+            },
+            "stats": {
+                "total_links": "Łącznie kanałów",
+                "active_channels": "Aktywne partie rekrutacyjne",
+                "started": "Łącznie sesji",
+                "engagements": "Uczestnicy, którzy rozpoczęli",
+                "submitted": "Prawidłowe dane",
+                "completions": "Ukończone zgłoszenia",
+                "conversion": "Wskaźnik przechwycenia",
+                "efficiency": "Ostateczny wynik danych"
+            },
+            "table": {
+                "name": "Kampania / partia",
+                "type": "Typ wejścia",
+                "token": "Token bezpieczeństwa",
+                "usage": "Pojemność",
+                "status": "Stan",
+                "actions": "Zarządzaj",
+                "type_help": "Publiczny, jednorazowy lub z ograniczoną pojemnością. Patrz opisy strategii w oknie dialogowym 'Nowy link dostępu'."
+            },
+            "status": {
+                "public": "Publiczny",
+                "individual": "Indywidualny",
+                "limited": "Ograniczony"
+            },
+            "toasts": {
+                "created": "Linki rekrutacyjne utworzone pomyślnie",
+                "failed": "Nie udało się utworzyć linków rekrutacyjnych. Sprawdź dane wejściowe i spróbuj ponownie.",
+                "revoked": "Link odwołany",
+                "revoke_failed": "Nie udało się odwołać tego linku. Możliwe, że jest już w użyciu.",
+                "copied": "Skopiowano do schowka"
+            }
+        },
+        "analytics": {
+            "charts": {
+                "recruitment_funnel": {
+                    "title": "Lejek rekrutacyjny",
+                    "subtitle": "Łączna wydajność konwersji",
+                    "initial_contact": "Pierwszy kontakt",
+                    "completion": "Ukończenie",
+                    "started_study": "Rozpoczęto badanie",
+                    "submitted": "Przesłano",
+                    "yield": "Wynik",
+                    "success_rate": "Wskaźnik sukcesu",
+                    "completion_rate": "{{rate}}% uczestników ukończyło badanie"
+                },
+                "link_performance": {
+                    "title": "Śledzenie skuteczności linków",
+                    "subtitle": "Monitorowanie efektywności poszczególnych kanałów rekrutacyjnych",
+                    "volume": "Wolumen",
+                    "yield": "Wynik",
+                    "conversion_rate": "Wskaźnik konwersji",
+                    "total_responses": "odpowiedzi"
+                }
+            }
+        },
+        "breadcrumbs": {
+            "admin": "Admin",
+            "dashboard": "Dashboard",
+            "study_dashboard": "Overview",
+            "design": "Design",
+            "participants": "Participants",
+            "team": "Team",
+            "recruitment": "Access",
+            "exports": "Data",
+            "data": "Data",
+            "privacy": "Data privacy",
+            "account": "Account settings",
+            "participant_n": "Participant {{code}}",
+            "analysis": "Analysis",
+            "settings": "Settings",
+            "concourse": "Concourse",
+            "members": "Team members"
+        },
+        "command_menu": {
+            "title": "Globalne menu poleceń",
+            "placeholder": "Wpisz polecenie lub wyszukaj...",
+            "no_results": "Brak wyników.",
+            "switch_project": "Przełącz projekt",
+            "switch_study": "Przełącz badanie",
+            "study_actions": "Akcje badania",
+            "system": "System",
+            "no_studies": "Brak badań w tym projekcie.",
+            "open_dashboard": "Otwórz panel",
+            "design_study": "Projekt badania",
+            "collaborators": "Współpracownicy",
+            "copy_link": "Kopiuj publiczny link",
+            "toggle_theme": "Przełącz motyw",
+            "logout": "Wyloguj",
+            "search_label": "Szukaj lub uruchom polecenia",
+            "to_open": "Otwórz",
+            "active": "Aktywne",
+            "link_copied": "Link do badania skopiowany!",
+            "logged_out": "Wylogowano pomyślnie",
+            "switched_project": "Przełączono na {{name}}"
+        },
+        "dashboard": {
+            "title": "Panel projektu",
+            "welcome": "Witamy z powrotem,",
+            "snapshot": "Oto migawka aktywności badawczej.",
+            "create_study": "Utwórz badanie",
+            "total_studies": "Łącznie badań",
+            "across_statuses": "Wszystkich statusów",
+            "active_data_collection": "Aktywne zbieranie danych",
+            "receiving_responses": "Badania przyjmujące odpowiedzi",
+            "total_participants": "Łącznie uczestników",
+            "all_studies": "Wszystkie badania",
+            "all_studies_description": "Wszystkie badania w tym projekcie.",
+            "languages_count_one": "{{count}} język",
+            "languages_count_other": "{{count}} języków",
+            "n_participants_one": "{{count}} uczestnik",
+            "n_participants_other": "{{count}} uczestników",
+            "n_studies_one": "{{count}} badanie",
+            "n_studies_other": "{{count}} badań",
+            "n_active_one": "{{count}} aktywne",
+            "n_active_other": "{{count}} aktywnych",
+            "n_participants_total_one": "{{count}} uczestnik",
+            "n_participants_total_other": "{{count}} uczestników",
+            "concourse_n_items_one": "{{count}} stwierdzenie",
+            "concourse_n_items_other": "{{count}} stwierdzeń",
+            "concourse_open_hint": "Kuracja stwierdzeń kandydatów",
+            "created": "Utworzono",
+            "no_studies": "Nie znaleziono badań. Utwórz pierwsze badanie, aby zacząć!",
+            "import_study": "Importuj badanie",
+            "get_started": "Zacznij swój projekt badawczy",
+            "onboarding_title": "Pierwsze kroki",
+            "step_create_project": "Utwórz projekt",
+            "step_create_project_desc": "Projekt jest gotowy.",
+            "step_concourse": "Zbierz stwierdzenia w konkursie",
+            "step_concourse_desc": "Dodaj stwierdzenia kandydatów z przeglądu literatury.",
+            "step_qset": "Wybierz zbiór Q",
+            "step_qset_desc": "Przejrzyj i zaakceptuj elementy tworzące zbiór Q.",
+            "step_study": "Utwórz badanie",
+            "step_study_desc": "Zdefiniuj siatkę sortowania Q.",
+            "step_import": "Zaimportuj zbiór Q do badania",
+            "step_import_desc": "Zaimportuj zaakceptowane elementy konkursu jako stwierdzenia badania.",
+            "step_configure": "Skonfiguruj przepływ uczestnika",
+            "step_configure_desc": "Skonfiguruj instrukcje, wstępne sortowanie i pytania końcowe.",
+            "step_launch": "Uruchom rekrutację",
+            "step_launch_desc": "Generuj linki uczestnictwa i udostępniaj je.",
+            "go_to_concourse": "Otwórz konkurs",
+            "go_to_qset": "Otwórz zbiór Q",
+            "concourse": "Konkurs",
+            "concourse_empty": "Brak elementów. Zacznij budować kolekcję stwierdzeń.",
+            "team": "Zespół",
+            "team_loading": "Ładowanie...",
+            "studies": "Badania",
+            "active_studies": "Aktywne",
+            "paused_studies": "Wstrzymane",
+            "draft_studies": "Szkice",
+            "closed_studies": "Ukończone",
+            "attention": "Wymaga uwagi",
+            "alert_deadline": "{{study}}: zamknięcie za {{days}} dni, {{count}} uczestników",
+            "view": "Pokaż",
+            "open_study": "Otwórz badanie",
+            "add_study": "Dodaj badanie",
+            "closes": "Zamknięcie",
+            "timeline": {
+                "title": "Oś czasu zgłoszeń",
+                "subtitle": "Dzienne trendy uczestnictwa",
+                "started": "Rozpoczęto",
+                "completed": "Ukończono"
+            },
+            "devices": {
+                "title": "Rozkład urządzeń",
+                "subtitle": "Jak uczestnicy korzystają z badania",
+                "types": {
+                    "desktop": "Komputer",
+                    "mobile": "Telefon",
+                    "tablet": "Tablet",
+                    "unknown": "Nieznane"
+                }
+            },
+            "n_studies_help": "Łączna liczba badań w tym projekcie, w tym szkice i zamknięte.",
+            "n_active_help": "Badania aktualnie przyjmujące zgłoszenia uczestników (stan = aktywne).",
+            "n_participants_total_help": "Suma ukończonych uczestników we wszystkich badaniach tego projektu.",
+            "tool_help": {
+                "design": "Konfiguruj badanie: siatka rozkładu, warunki instrukcji, stwierdzenia, zgoda.",
+                "recruit": "Linki rekrutacyjne, reguły dostępu i ustawienia URL badania.",
+                "data": "Odpowiedzi uczestników i eksporty (CSV, zrzuty sortowania Q).",
+                "analysis": "Konfiguracja analizy czynnikowej i historia przebiegów."
+            }
+        },
+        "export": {
+            "config": "Eksportuj konfigurację",
+            "exporting": "Eksportowanie...",
+            "config_success": "Konfiguracja wyeksportowana pomyślnie",
+            "config_error": "Nie można wyeksportować konfiguracji. Spróbuj ponownie.",
+            "label": "Eksportuj dane",
+            "success": "Eksport zakończony pomyślnie",
+            "error": "Eksport nie powiódł się. Spróbuj ponownie.",
+            "csv": "Eksportuj CSV",
+            "json": "Eksportuj JSON",
+            "audio": "Eksportuj nagrania audio (ZIP)",
+            "formats": {
+                "csv": "CSV",
+                "pqmethod": "PQMethod (ZIP)",
+                "rkit": "R-Kit (ZIP)",
+                "package": "Pakiet badawczy (ZIP)",
+                "json": "Zrzut JSON"
+            },
+            "download": "Pobierz",
+            "package_dialog": {
+                "title": "Pobierz pakiet badawczy",
+                "description": "Łączy wszystkie dane badania w jeden plik ZIP do OSF lub rejestracji wstępnej.",
+                "discussion_hint": "Dodaje plik memo/memo-discussion.md ze wszystkimi wątkami komentarzy (podpisanymi i opatrzonymi datą). Domyślnie wyłączone; zachowaj czysty eksport, chyba że potrzebna jest ścieżka deliberacji."
+            }
+        },
+        "import": {
+            "title": "Importuj konfigurację badania",
+            "config": "Importuj konfigurację",
+            "upload_desc": "Prześlij wcześniej wyeksportowany plik konfiguracji badania",
+            "validate_desc": "Przejrzyj konfigurację i podaj unikalny slug",
+            "creating_desc": "Tworzenie badania...",
+            "file_upload": "Prześlij plik",
+            "paste_json": "Wklej JSON",
+            "drop_here": "Upuść plik tutaj",
+            "drag_drop": "Przeciągnij i upuść plik JSON lub kliknij, aby przeglądać",
+            "supported": "Obsługiwany format: .json",
+            "paste_label": "Wklej konfigurację JSON",
+            "validate": "Sprawdź poprawność i kontynuuj",
+            "valid": "Konfiguracja jest prawidłowa",
+            "invalid": "Konfiguracja zawiera błędy",
+            "errors": "Błędy",
+            "warnings": "Ostrzeżenia",
+            "summary": "Podsumowanie badania",
+            "title_field": "Tytuł",
+            "languages": "Języki",
+            "statements": "Stwierdzenia",
+            "grid": "Zakres siatki",
+            "new_slug": "Nowy slug badania",
+            "slug_help": "Musi być unikalny, 3–100 znaków, tylko małe litery, cyfry i myślniki",
+            "creating": "Tworzenie badania z konfiguracji...",
+            "create_study": "Utwórz badanie",
+            "invalid_json": "Nieprawidłowy plik JSON",
+            "validation_failed": "Konfiguracja jest nieprawidłowa",
+            "success": "Badanie zaimportowane pomyślnie",
+            "redirecting": "Otwieranie projektanta badania...",
+            "failed": "Nie udało się zaimportować badania. Zapoznaj się ze szczegółami poniżej i spróbuj ponownie.",
+            "validation": {
+                "errors": {
+                    "missing_version": "Brak pola wersji",
+                    "unsupported_version": "Nieobsługiwana wersja: {{version}}",
+                    "missing_field": "Brak wymaganego pola: {{field}}",
+                    "no_translations": "Wymagane jest co najmniej jedno tłumaczenie",
+                    "missing_translation_field": "Tłumaczeniu {{index}} brakuje wymaganego pola: {{field}}",
+                    "invalid_lang_code": "Nieprawidłowy kod języka: {{lang}}",
+                    "no_statements": "Wymagane jest co najmniej jedno stwierdzenie",
+                    "duplicate_codes": "Zduplikowane kody stwierdzeń: {{codes}}",
+                    "missing_stmt_translations": "Stwierdzeniu {{index}} brakuje tłumaczeń",
+                    "invalid_grid_config": "Nieprawidłowy grid_config: musi być listą",
+                    "invalid_grid_structure": "Nieprawidłowa struktura grid_config: {{error}}"
+                },
+                "warnings": {
+                    "grid_capacity_mismatch": "Liczba stwierdzeń ({{count}}) nie odpowiada pojemności siatki ({{capacity}})",
+                    "missing_consent_draft": "Brak tytułu lub opisu formularza zgody (badanie w szkicu)",
+                    "external_branding_logo": "Logo marki używa zewnętrznego URL: {{url}}",
+                    "external_partner_logo": "Logo partnera '{{name}}' używa zewnętrznego URL: {{url}}",
+                    "external_logo": "URL logo odwołuje się do zasobu zewnętrznego — może być niedostępny"
+                }
+            }
+        },
+        "dialogs": {
+            "create_study": {
+                "title": "Utwórz nowe badanie",
+                "description": "Rozpocznij nowe badanie metodologią Q. Stwierdzenia i ustawienia można skonfigurować później.",
+                "study_title": "Tytuł badania",
+                "study_title_placeholder": "Np. Perspektywy dotyczące AI",
+                "url_slug": "URL slug",
+                "url_slug_placeholder": "np. perspektywy-ai-2025",
+                "cancel": "Anuluj",
+                "create": "Utwórz badanie",
+                "success": "Badanie zostało pomyślnie utworzone",
+                "error": "Nie udało się utworzyć badania",
+                "languages": "Języki",
+                "languages_desc": "Wybierz języki do włączenia. Treść zostanie zainicjowana zlokalizowanymi wartościami domyślnymi."
+            }
+        },
+        "validation": {
+            "required": "Wymagane",
+            "slug_min": "Slug musi mieć co najmniej 3 znaki",
+            "slug_regex": "Slug może zawierać tylko małe litery, cyfry i myślniki"
+        },
+        "study_overview": {
+            "title": "Przegląd",
+            "back_to_overview": "Wróć do przeglądu",
+            "sample_size": "Liczba uczestników (P-Set)",
+            "valid": "prawidłowe",
+            "completion_rate": "Wskaźnik ukończenia",
+            "active": "aktywne",
+            "mobile": "mobilne",
+            "median_duration": "Mediana czasu trwania",
+            "suspect": "Podejrzane",
+            "recent_activity": "Ostatnia aktywność",
+            "latest_participants": "Ostatni uczestnicy ({{count}} z {{total}})",
+            "recently_completed": "Ostatnio ukończone",
+            "in_progress": "W toku",
+            "discarded": "Odrzucone",
+            "started": "Rozpoczęto",
+            "view_all": "Zobacz wszystkich uczestników i szczegóły danych",
+            "no_participants": "Brak uczestników.",
+            "view_data": "Pokaż",
+            "submitted": "Przesłano",
+            "edit_design": "Edytuj projekt",
+            "export_csv": "Pobierz CSV",
+            "export_json": "Pobierz JSON",
+            "steps": {
+                "welcome": "Powitanie",
+                "consent": "Zgoda",
+                "rough_sort": "Sortowanie zgrubne",
+                "fine_sort": "Sortowanie Q",
+                "final": "Ostatnie kroki"
+            }
+        },
+        "overview": {
+            "copy_id": "Copy participant ID"
+        },
+        "study_status": {
+            "dialog": {
+                "draft": {
+                    "title": "Przywrócić do szkicu?",
+                    "desc": "Spowoduje to zatrzymanie zbierania danych, ale umożliwi modyfikację projektu badania. Istniejące dane zostaną zachowane.",
+                    "action": "Przywróć do szkicu"
+                },
+                "active": {
+                    "title": "Uruchomić badanie?",
+                    "desc": "Aktywowanie badania otworzy je dla uczestników.",
+                    "action": "Ustaw jako aktywne"
+                },
+                "paused": {
+                    "title": "Wstrzymać badanie?",
+                    "desc": "Uczestnicy nie będą mogli wziąć udziału w badaniu, gdy jest ono wstrzymane. Można je wznowić później.",
+                    "action": "Wstrzymaj badanie"
+                },
+                "closed": {
+                    "title": "Zamknąć badanie?",
+                    "desc": "Uniemożliwi to nowym uczestnikom wejście do badania. Trwające sesje mogą zostać ukończone. Można je ponownie otworzyć później.",
+                    "action": "Zamknij badanie"
+                }
+            },
+            "steps": {
+                "draft": {
+                    "label": "Szkic",
+                    "description": "Konfiguracja i projekt"
+                },
+                "active": {
+                    "label": "Aktywne",
+                    "description": "Zbieranie odpowiedzi"
+                },
+                "paused": {
+                    "label": "Wstrzymane",
+                    "description": "Wstrzymano"
+                },
+                "closed": {
+                    "label": "Zamknięte",
+                    "description": "Analiza i eksport"
+                }
+            },
+            "state": {
+                "activate": "Aktywuj badanie",
+                "switch_to_draft": "Tryb szkicu",
+                "manage": "Zarządzaj statusem"
+            },
+            "notifications": {
+                "success": {
+                    "draft": "Badanie pomyślnie przywrócono do szkicu",
+                    "active": "Badanie zostało pomyślnie uruchomione",
+                    "paused": "Badanie zostało pomyślnie wstrzymane",
+                    "closed": "Badanie zostało pomyślnie zamknięte"
+                },
+                "error": "Nie można zmienić stanu badania. Sprawdź swoje uprawnienia i spróbuj ponownie.",
+                "state_changed_active": "Badanie jest teraz aktywne!"
+            }
+        },
+        "design": {
+            "title": "Projekt badania",
+            "translation_needed": "Wymaga weryfikacji (kopia)",
+            "reset_defaults": "Przywróć wartości domyślne",
+            "editing_language_banner": "Edytowanie wersji {{language}}. Aby przełączyć, użyj selektora języka na pasku narzędzi.",
+            "multilang": {
+                "view_others": "Pokaż w innych językach",
+                "other_formulations": "Inne sformułowania"
+            },
+            "guidance": {
+                "title": "Wskazówki projektowe",
+                "intro_title": "Witamy w studiu",
+                "intro_desc": "Zacznij od określenia celu badania. Informacje te będą widoczne dla uczestników przed rozpoczęciem sortowania.",
+                "qsort_title": "Równowaga stwierdzeń i siatki",
+                "qsort_desc": "Upewnij się, że pojemność siatki dokładnie odpowiada liczbie stwierdzeń. Wyważony zbiór Q zwykle podąża za rozkładem quasi-normalnym (w kształcie krzywej dzwonowej)."
+            },
+            "checklist": {
+                "title": "Lista kontrolna",
+                "statements": "Stwierdzenia",
+                "grid_balance": "Siatka wyważona",
+                "branding": "Logo i kolory",
+                "instructions": "Instrukcje",
+                "ready": "Wszystkie niezbędne elementy są gotowe. Możesz teraz uruchomić badanie!",
+                "pending": "Wykonaj wymagane kroki powyżej, aby umożliwić aktywację badania.",
+                "study_title": "Tytuł badania",
+                "consent_defined": "Formularz zgody",
+                "progress": "Postęp",
+                "languages": "Języki",
+                "status_ready": "Gotowe",
+                "status_pending": "Oczekuje",
+                "required": "Wymagane",
+                "reset_defaults": "Przywróć wartości domyślne"
+            },
+            "unsaved_changes": {
+                "title": "Niezapisane zmiany",
+                "description": "W projekcie badania są niezapisane zmiany. Opuszczenie strony spowoduje ich utratę.",
+                "confirm": "Opuść bez zapisywania",
+                "cancel": "Kontynuuj edycję"
+            },
+            "tips": {
+                "title": "Szybka wskazówka",
+                "pilot": "Zawsze przeprowadź testowe sortowanie samodzielnie przed udostępnieniem linku uczestnikom."
+            },
+            "toolbar": {
+                "title": "Projekt",
+                "back": "Wstecz",
+                "preview": "Pokaż podgląd",
+                "hide_preview": "Ukryj podgląd",
+                "popout": "Otwórz podgląd w oknie",
+                "discard": "Odrzuć niezapisane zmiany",
+                "test_run": "Uruchomienie testowe",
+                "save": "Zapisz",
+                "saved": "Zapisano",
+                "closed": "Zamknięte",
+                "back_to_study": "Wróć do badania",
+                "editing_language": "Edytowany język",
+                "manage_langs": "Zarządzaj językami",
+                "select_lang": "Wybierz język",
+                "test_run_help": "Podgląd z perspektywy uczestnika. Te sesje nie są uwzględniane w danych.",
+                "more_actions": "Więcej działań"
+            },
+            "sync": {
+                "saving": "Zapisywanie...",
+                "error": "Błąd zapisu",
+                "modified": "Niezapisane zmiany",
+                "synced": "Zmiany zapisane",
+                "wait_save": "Trwa zapisywanie... Proszę chwilę poczekać.",
+                "recovered": "Szkic przywrócony z lokalnej kopii zapasowej!",
+                "recovery_title": "Znaleziono niezapisane zmiany",
+                "recovery_desc": "Znaleziono lokalną wersję tego badania nowszą niż wersja na serwerze. Czy chcesz ją przywrócić?",
+                "recovery_restore": "Przywróć wersję lokalną",
+                "recovery_discard": "Odrzuć wersję lokalną"
+            },
+            "validation": {
+                "failed_title": "Konfiguracja niekompletna",
+                "failed_desc": "Proszę poprawić te problemy, aby aktywować:",
+                "errors": {
+                    "no_statements": "Badanie musi zawierać co najmniej jedno stwierdzenie.",
+                    "no_grid": "Brak konfiguracji siatki.",
+                    "capacity_mismatch": "Pojemność siatki ({{total}}) nie odpowiada liczbie stwierdzeń ({{count}}).",
+                    "no_translations": "Badanie musi mieć co najmniej jedno tłumaczenie językowe.",
+                    "missing_default_lang": "Brak tłumaczenia dla języka domyślnego ({{lang}}).",
+                    "missing_title": "Brak tytułu dla języka '{{lang}}'.",
+                    "missing_consent_title": "Brak tytułu formularza zgody dla języka '{{lang}}'.",
+                    "missing_consent_description": "Brak opisu formularza zgody dla języka '{{lang}}'.",
+                    "missing_grid_instructions": "Brak instrukcji sortowania Q dla języka '{{lang}}'.",
+                    "missing_step_title": "Brak tytułu kroku {{index}} dla języka '{{lang}}'.",
+                    "missing_statement_translation": "Stwierdzenie '{{code}}' nie ma tłumaczeń dla: {{missing}}.",
+                    "empty_statement_text": "Stwierdzenie '{{code}}' ma pusty tekst dla języka '{{lang}}'.",
+                    "missing_question_label": "Pytanie '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}}).",
+                    "missing_option_label": "Opcja {{index}} pytania '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}})."
+                }
+            },
+            "languages": {
+                "manage_title": "Zarządzaj językami",
+                "manage_desc": "Włącz lub wyłącz języki dostępne dla uczestników w tym badaniu.",
+                "auto_translate": "Automatyczne tłumaczenie",
+                "auto_translate_desc": "Wkrótce będzie można używać AI do automatycznego tłumaczenia badania na ponad 30 języków.",
+                "activate_title": "Aktywuj język",
+                "activate_desc": "Wybierz język źródłowy, z którego zostaną skopiowane tłumaczenia. Zapobiega to pustym polom widocznym dla uczestników.",
+                "source_label": "Język źródłowy",
+                "copy_notice": "Wszystkie pola zostaną skopiowane. Pola wymagające tłumaczenia będą oznaczone wizualnie.",
+                "confirm_activate": "Aktywuj i skopiuj"
+            },
+            "tabs": {
+                "welcome": "Ogólne",
+                "presort": "Wstępne sortowanie",
+                "condition": "Warunek",
+                "qsort": "Sortowanie Q",
+                "postsort": "Sortowanie końcowe",
+                "interface": "Interfejs",
+                "theme": "Motyw",
+                "general": "Ogólne",
+                "statements": "Stwierdzenia",
+                "grid": "Siatka",
+                "survey": "Ankieta",
+                "branding": "Identyfikacja wizualna"
+            },
+            "view_mode": {
+                "mobile": "Widok mobilny",
+                "desktop": "Widok komputerowy"
+            },
+            "intro": {
+                "general_settings": "Ustawienia ogólne",
+                "welcome_title": "Wiadomość powitalna",
+                "process_title": "Przegląd kroków badania",
+                "process_steps": {
+                    "title": "Przegląd kroków badania",
+                    "desc": "Zdefiniuj etapy wyświetlane uczestnikom na stronie powitalnej. Jeśli pozostawione puste, zostaną użyte domyślne kroki.",
+                    "add_step": "Dodaj krok",
+                    "empty": {
+                        "title": "Brak niestandardowych kroków",
+                        "desc": "Badanie użyje standardowego przepływu metodologii Q (poznajmy się, pierwsze wrażenia, perspektywa, dlaczego)."
+                    },
+                    "fields": {
+                        "title": "Tytuł kroku",
+                        "description": "Krótki opis",
+                        "icon": "Ikona",
+                        "toggle": "Przełącznik"
+                    },
+                    "defaults": {
+                        "new_step": "Nowy krok badania",
+                        "new_desc": "Wyjaśnij, co uczestnik będzie robił na tym etapie."
+                    },
+                    "reset": {
+                        "instructions": "Przywróć instrukcje",
+                        "consent_title": "Przywróć tytuł zgody",
+                        "consent_description": "Przywróć opis zgody",
+                        "process_steps": "Przywróć kroki procesu",
+                        "process_steps_confirm": "Czy na pewno chcesz przywrócić wszystkie kroki procesu do wartości domyślnych? Zastąpi to niestandardowe kroki."
+                    },
+                    "inconsistent": {
+                        "banner_title": "Niespójne kroki procesu",
+                        "rough_disabled": "Krok 'Pierwsze wrażenia' (sortowanie zgrubne) jest na tej liście, ale sortowanie zgrubne jest w badaniu wyłączone. Uczestnicy go nie zobaczą.",
+                        "presort_disabled": "Krok 'Poznajmy się' (ankieta wstępna) jest na tej liście, ale ankieta wstępna jest wyłączona. Uczestnicy go nie zobaczą.",
+                        "remove_action": "Usuń"
+                    }
+                },
+                "consent_title": "Formularz zgody",
+                "reset": "Przywróć instrukcję",
+                "consent_details": "Szczegóły formularza zgody",
+                "fields": {
+                    "default_lang": "Język domyślny",
+                    "default_lang_help": "Ten język będzie domyślnie wyświetlany uczestnikom, jeśli język przeglądarki nie jest obsługiwany.",
+                    "title": "Tytuł badania",
+                    "title_placeholder": "Wpisz tytuł publiczny...",
+                    "subtitle": "Podtytuł (opcjonalnie)",
+                    "subtitle_placeholder": "Krótkie hasło...",
+                    "objective": "Cel badania",
+                    "objective_placeholder": "Jakie jest pytanie badawcze lub cel tego badania?",
+                    "task_overview": "Wprowadzenie",
+                    "task_placeholder": "Opisz tutaj przebieg badania (liczba kroków, szacowany czas itp.). To pole jest opcjonalne, jeśli używasz niestandardowych kroków powyżej.",
+                    "consent_title_label": "Tytuł zgody",
+                    "legal_text": "Tekst prawny / umowa",
+                    "legal_placeholder": "Wpisz pełny tekst umowy prawnej..."
+                },
+                "consent_desc": "Uczestnicy muszą zaakceptować te warunki przed rozpoczęciem."
+            },
+            "condition": {
+                "title": "Warunek instrukcji",
+                "label": "Zdefiniuj warunek instrukcji",
+                "desc": "To jest główna instrukcja, która prowadzi uczestników przez cały proces sortowania.",
+                "field_label": "Treść instrukcji",
+                "placeholder": "Np. Proszę uszeregować poniższe stwierdzenia od tych, z którymi najbardziej się Pan/Pani zgadza, do tych, z którymi najbardziej się nie zgadza",
+                "grid_title": "Instrukcja sortowania Q",
+                "grid_desc": "To jest główna instrukcja prowadząca uczestników podczas procesu sortowania Q.",
+                "pre_title": "Instrukcja wstępnego sortowania",
+                "pre_desc": "Instrukcja podawana uczestnikom podczas wstępnego sortowania zgrubnego.",
+                "pre_field_label": "Treść instrukcji",
+                "pre_placeholder": "Np. Na podstawie własnego punktu widzenia podziel karty na trzy stosy...",
+                "enable_pre": "Włącz etap wstępnej instrukcji",
+                "pre_label": "Treść wstępnej instrukcji",
+                "tips": {
+                    "title": "Dlaczego to ważne?",
+                    "desc": "W metodologii Q 'warunek instrukcji' określa punkt widzenia, z którego uczestnik sortuje stwierdzenia. Powinien być jasny i spójny we wszystkich fazach sortowania."
+                }
+            },
+            "questions": {
+                "enable_presort": "Włącz ankietę wstępną",
+                "enable_presort_desc": "Zbierz dane demograficzne lub inne informacje przed zadaniem sortowania.",
+                "add_field": "Dodaj nowe pole",
+                "basic_fields": "Pola podstawowe",
+                "choice_fields": "Pola wyboru",
+                "scale_fields": "Pola skali",
+                "labels": {
+                    "question": "Etykieta pytania",
+                    "required": "Pole wymagane",
+                    "options": "Opcje",
+                    "option_ordinal": "Opcja {{number}}",
+                    "multiple": "(Dozwolony wielokrotny wybór)",
+                    "single": "(Pojedynczy wybór)",
+                    "placeholder": "Wpisz tutaj swoje pytanie...",
+                    "scale": "Skala ocen",
+                    "scale_points": "Liczba punktów",
+                    "scale_left": "Etykieta lewego krańca",
+                    "scale_right": "Etykieta prawego krańca"
+                },
+                "types": {
+                    "text": "Tekst",
+                    "long_text": "Tekst długi",
+                    "number": "Liczba",
+                    "date": "Data",
+                    "email": "E-mail",
+                    "dropdown": "Lista rozwijana",
+                    "radio": "Przycisk radiowy",
+                    "checkboxes": "Pola wyboru",
+                    "text_audio": "Tekst + audio",
+                    "rating": "Skala ocen"
+                },
+                "empty": {
+                    "title": "Brak pytań",
+                    "desc": "Kliknij powyżej, aby dodać pierwsze pytanie"
+                },
+                "defaults": {
+                    "new_question": "Nowe pytanie",
+                    "option": "Opcja",
+                    "enter_answer": "Wpisz swoją odpowiedź...",
+                    "untitled": "Pytanie bez tytułu",
+                    "scale_left": "Zdecydowanie się nie zgadzam",
+                    "scale_right": "Zdecydowanie się zgadzam"
+                },
+                "actions": {
+                    "add_option": "Dodaj opcję",
+                    "copy_from": "Importuj z języka",
+                    "copy_success": "Zaimportowano"
+                },
+                "logic": {
+                    "title": "Logika widoczności",
+                    "enable": "Dodaj warunek widoczności",
+                    "depends_on": "Pokaż to pytanie tylko jeśli...",
+                    "select_placeholder": "Wybierz pytanie nadrzędne",
+                    "operator": "Operator",
+                    "value": "Wartość porównania",
+                    "operators": {
+                        "equals": "Równa się",
+                        "not_equals": "Nie równa się",
+                        "contains": "Zawiera",
+                        "greater_than": "Większe niż",
+                        "less_than": "Mniejsze niż"
+                    }
+                }
+            },
+            "qsort": {
+                "tabs": {
+                    "statements": "Stwierdzenia",
+                    "distribution": "Rozkład"
+                },
+                "bulk": {
+                    "title": "Edytor zbiorczy (szybkie wklejanie)",
+                    "desc": "Jedno stwierdzenie w każdym wierszu. Obsługuje format 'kod: tekst' i kopiowanie z Excela (wielojęzyczne).",
+                    "replace_all": "Zastąp wszystko",
+                    "append": "Dołącz do listy",
+                    "sync_by_code": "Synchronizuj/scal wg kodu",
+                    "placeholder": "Proste: Moje stwierdzenie",
+                    "detected": "Wykryto {{count}} stwierdzeń",
+                    "process_replace": "Przetwórz i zastąp stwierdzenia",
+                    "process_append": "Przetwórz i dołącz stwierdzenia",
+                    "process_sync": "Przetwórz i synchronizuj tłumaczenia",
+                    "detected_format": {
+                        "excel": "Wykryto format Excel (tabulatory)",
+                        "list": "Wykryto format listy (kod: tekst)",
+                        "simple": "Wykryto prostą listę (jeden wiersz = jedno stwierdzenie)",
+                        "multi_lang": "Wielojęzyczne: {{langs}}",
+                        "with_codes": "Z niestandardowymi kodami"
+                    }
+                },
+                "set": {
+                    "title": "Zbiór Q",
+                    "clear": "Wyczyść wszystko",
+                    "confirm_clear": "Czy na pewno chcesz usunąć WSZYSTKIE stwierdzenia? Tego działania nie można cofnąć.",
+                    "updated": "Stwierdzenie zaktualizowane",
+                    "cleared": "Wszystkie stwierdzenia wyczyszczone",
+                    "imported": "Pomyślnie zaimportowano {{count}} stwierdzeń",
+                    "reset_codes": "Resetuj kody",
+                    "confirm_reset_codes": "Czy na pewno chcesz ponownie nadać numery wszystkim kodom stwierdzeń (s1, s2, s3...)?",
+                    "codes_reset": "Kody stwierdzeń ponownie ponumerowane"
+                },
+                "settings": {
+                    "title": "Ustawienia badawcze",
+                    "desc": "Skonfiguruj sposób prezentacji stwierdzeń uczestnikom",
+                    "show_codes": "Pokaż kody stwierdzeń",
+                    "show_codes_desc": "Wyświetlaj kody stwierdzeń (np. 'S1', 'S2') obok tekstu.",
+                    "randomize": "Losuj kolejność stwierdzeń",
+                    "randomize_desc": "Prezentuj stwierdzenia w losowej kolejności każdemu uczestnikowi (spójnie w ramach sesji)"
+                },
+                "grid": {
+                    "title": "Siatka rozkładu sortowania Q",
+                    "desc": "Kształt siatki zmusza uczestników do różnicowania stwierdzeń, przybliżając rozkład normalny.",
+                    "slot_count": "Przydzielono {{count}} miejsc",
+                    "stat_count": "{{count}} stwierdzeń",
+                    "perfect": "Idealna równowaga",
+                    "too_many": "{{count}} stwierdzeń za dużo",
+                    "too_few": "Brakuje {{count}} stwierdzeń",
+                    "min_reached": "Osiągnięto minimalny zakres (±2)",
+                    "max_reached": "Osiągnięto maksymalny zakres (±6)",
+                    "remove_extreme_columns": "Usuń skrajne kolumny",
+                    "add_extreme_columns": "Dodaj skrajne kolumny",
+                    "symmetry_lock": "Blokada symetrii",
+                    "symmetry_lock_desc": "Automatycznie stosuj zmiany do kolumn przeciwnych, aby zachować wyważony rozkład.",
+                    "auto_balance": "Auto-wyważenie",
+                    "auto_balance_desc": "Przekształć siatkę w wyważony rozkład półnormalny",
+                    "reshaped": "Siatka przekształcona do wyważonego rozkładu",
+                    "balanced": "Siatka wyważona do standardowego rozkładu",
+                    "no_statements": "Najpierw dodaj stwierdzenia, aby automatycznie ukształtować siatkę",
+                    "statements": "stwierdzenia",
+                    "ideal_shape": "Idealny kształt",
+                    "symmetric": "Symetryczna",
+                    "asymmetric": "Asymetryczna",
+                    "tooltip_title": "Dlaczego rozkład wymuszony?",
+                    "tooltip_desc": "Metodologia Q używa rozkładu quasi-normalnego (kurtoza > 0), aby zapewnić, że uczestnicy dokonują znaczących rozróżnień. Kształt piramidy zapobiega błędowi tendencji centralnej.",
+                    "locked": "Projekt zablokowany",
+                    "locked_desc": "Zmiany strukturalne (kody stwierdzeń, siatka) są wyłączone, ponieważ badanie zebrało dane lub nie jest już w trybie szkicu. Nadal można edytować tłumaczenia tekstowe.",
+                    "locked_active": "To badanie jest aktywne. Przełącz na tryb szkicu, aby edytować.",
+                    "locked_paused": "To badanie jest wstrzymane. Przełącz na tryb szkicu, aby edytować.",
+                    "locked_closed": "To badanie jest zamknięte. Projekt jest zarchiwizowany.",
+                    "view_read_only": "Podgląd tylko do odczytu",
+                    "locked_dialog_desc": "Edycja jest zablokowana, gdy badanie jest w tym stanie. Zamknij to powiadomienie, aby przeczytać konfigurację bez wprowadzania zmian.",
+                    "mismatch_title": "Niezgodność pojemności siatki",
+                    "mismatch_desc": "Masz {{statements}} stwierdzeń, ale siatka ma tylko miejsca dla {{slots}} elementów. Dostosuj kolumny poniżej.",
+                    "unlock_hint": "Przejdź do eksploratora danych, aby wyczyścić sesje i odblokować strukturę"
+                }
+            },
+            "postsort": {
+                "extreme": {
+                    "title": "Kolumny docelowe",
+                    "desc": "Wybierz kolumny, które wyzwalają pytania uzupełniające.",
+                    "no_columns": "Nie wybrano żadnych kolumn.",
+                    "add_label": "Dodaj kolumnę:",
+                    "prompt_label": "Pytanie o stwierdzenia",
+                    "prompt_placeholder": "Dlaczego umieścił/a Pan/Pani to stwierdzenie w tym miejscu?",
+                    "add": "Dodaj",
+                    "add_defaults": "Dodaj domyślne skrajności",
+                    "select_placeholder": "Wybierz..."
+                },
+                "random_comments": {
+                    "title": "Zezwalaj na swobodne komentarze",
+                    "desc": "Pozwól uczestnikom dodawać komentarze do dowolnego stwierdzenia na siatce."
+                },
+                "custom": {
+                    "title": "Pytania niestandardowe",
+                    "desc": "Dodaj niestandardowe pytania do ankiety po sortowaniu."
+                },
+                "missing": {
+                    "title": "Pytaj o brakujące stwierdzenia",
+                    "desc": "Jeśli tak, proszę opisać je krótko.",
+                    "prompt_label": "Treść pytania",
+                    "prompt_placeholder": "Proszę śmiało sugerować i wyjaśniać."
+                },
+                "steps": {
+                    "step1": "Krok 1: informacja zwrotna",
+                    "step2": "Krok 2: pytania"
+                },
+                "email": {
+                    "title": "Kontakt uzupełniający z uczestnikiem",
+                    "desc": "Zbieraj adresy e-mail do celów kontaktu uzupełniającego lub przekazania wyników badania.",
+                    "interview": "Zaproponuj kontakt uzupełniający",
+                    "results": "Zaproponuj zapis na listę mailingową z wynikami badania",
+                    "interview_warning": "Uwaga: zgoda na kontakt znosi anonimowość wobec badacza.",
+                    "results_hint": "E-mail wyłącznie do celów przekazania wyników, anonimowość zachowana."
+                },
+                "audio": {
+                    "title": "Nagranie audio",
+                    "desc": "Pozwól uczestnikom nagrywać odpowiedzi audio zamiast tekstu.",
+                    "max_duration": "Maksymalny czas trwania",
+                    "seconds": "sekund",
+                    "max_duration_help": "Maksymalny czas nagrywania na pytanie (30–600 sekund).",
+                    "participant_choice_info": "Uczestnicy mogą odpowiadać tekstem, nagraniem audio lub obydwoma sposobami na każde pytanie.",
+                    "storage_unavailable_body": "Magazyn obiektów nie jest skonfigurowany, więc nie można zbierać odpowiedzi audio. Nadal możesz włączyć audio, ale uczestnicy będą odpowiadać wyłącznie tekstem i żadne nagranie nie zostanie wykonane. Skonfiguruj magazyn obiektów i uruchom ponownie serwer, aby włączyć przechwytywanie audio.",
+                    "storage_unavailable_title": "Przechwytywanie audio jest niedostępne na tym serwerze"
+                }
+            },
+            "interface": {
+                "title": "Dostosowanie interfejsu",
+                "desc": "Dostosuj przyciski i etykiety interfejsu do tonu badania (np. zastępując 'zgadzam się/nie zgadzam się' słowami 'lubię/nie lubię').",
+                "nav": {
+                    "title": "Przyciski nawigacyjne",
+                    "start": "Przycisk start",
+                    "next": "Przycisk następnego kroku",
+                    "submit": "Przycisk wyślij",
+                    "confirm": "Przycisk potwierdzenia sortowania",
+                    "tooltips": {
+                        "start": "Przycisk rozpoczynający badanie",
+                        "next": "Przejście do następnego kroku",
+                        "submit": "Wyślij wyniki na końcu",
+                        "confirm": "Ogólny przycisk zatwierdzania"
+                    }
+                },
+                "terms": {
+                    "title": "Terminologia sortowania",
+                    "desc": "Zdefiniuj etykiety dla sortowania spontanicznego i spektrum siatki.",
+                    "rough": "Etykiety sortowania zgrubnego",
+                    "agree": "Zgadzam się",
+                    "neutral": "Neutralnie",
+                    "disagree": "Nie zgadzam się",
+                    "grid": "Legendy siatki (skrajności)",
+                    "most_agree": "Najbardziej zgadzam się",
+                    "most_disagree": "Najbardziej nie zgadzam się"
+                },
+                "hints": {
+                    "title": "Wskazówki metodologiczne",
+                    "desc": "Dodaj lub zmodyfikuj pływające wskazówki pomagające uczestnikom podczas fazy sortowania na siatce.",
+                    "placeholder": "Wpisz wskazówkę metodologiczną...",
+                    "add": "Dodaj wskazówkę",
+                    "reset": "Przywróć wartości domyślne"
+                },
+                "help": {
+                    "title": "Wskazówki dla kroków (co/dlaczego)",
+                    "desc": "Dostosuj kontekstową pomoc dostępną dla uczestników na każdym kroku przez nakładkę '?'.",
+                    "step_disabled": "(krok wyłączony)"
+                }
+            },
+            "theme": {
+                "title": "Identyfikacja wizualna",
+                "accent": {
+                    "title": "Kolor akcentu",
+                    "desc": "Ten kolor będzie używany dla przycisków, linków i wyróżnień w całym badaniu.",
+                    "pick": "Wybierz kolor",
+                    "reset": "Przywróć domyślny"
+                },
+                "logo": {
+                    "title": "Logo badania",
+                    "desc": "Prześlij niestandardowe logo zastępujące domyślną markę Qualis.",
+                    "label": "URL logo",
+                    "hint": "Zalecany rozmiar: 200×50 px. Obsługiwane formaty: PNG, SVG, JPG.",
+                    "preview": "Podgląd logo",
+                    "help_title": "Gdzie pojawia się to logo?",
+                    "help_desc": "Logo jest wyświetlane na górze każdej strony badania (pasek nawigacyjny) i na stronie powitalnej. Wzmacnia identyfikację wizualną projektu."
+                },
+                "partners": {
+                    "title": "Partnerzy instytucjonalni",
+                    "desc": "Dodaj logo wspierających instytucji lub partnerów.",
+                    "add": "Dodaj partnera",
+                    "name_label": "Nazwa partnera",
+                    "name_placeholder": "Nazwa instytucji",
+                    "logo_label": "URL logo",
+                    "url_label": "Strona internetowa (opcjonalnie)",
+                    "url_placeholder": "https://...",
+                    "help_title": "Wyświetlanie logo",
+                    "help_desc": "Logo partnerów są wyświetlane na stronie startowej oraz w nagłówku badania, obok głównego logo."
+                },
+                "upload": {
+                    "upload": "Prześlij",
+                    "recommended": "Zalecane",
+                    "invalid_type": "Nieprawidłowy typ pliku. Użyj PNG, JPG lub SVG.",
+                    "file_too_large": "Plik jest za duży. Maksymalny rozmiar: {{size}} kB.",
+                    "conversion_error": "Nie udało się przetworzyć obrazu.",
+                    "processing": "Przetwarzanie obrazu...",
+                    "drag_drop": "Przeciągnij i upuść lub kliknij, aby przesłać",
+                    "max": "Maks."
+                }
+            },
+            "activate_dialog": {
+                "title": "Aktywować to badanie?",
+                "description": "Aktywacja otwiera rekrutację i odblokowuje publiczne linki. Prawdziwi uczestnicy będą mogli zacząć przesyłać odpowiedzi.",
+                "checklist_title": "Kontrola przed startem",
+                "languages_title": "Języki",
+                "lang_ready": "Gotowe",
+                "lang_incomplete": "Niekompletne",
+                "required": "(wymagane)",
+                "attestation": "Zapoznałem/am się z tekstem zgody i polityką przechowywania danych i potwierdzam, że badanie jest gotowe do przyjęcia prawdziwych uczestników.",
+                "confirm": "Aktywuj badanie"
+            }
+        },
+        "data": {
+            "title": "Dane",
+            "description": "Monitoruj uczestnictwo w czasie rzeczywistym, analizuj jakość danych i zarządzaj sesjami badawczymi.",
+            "sections": {
+                "key_indicators": "Kluczowe wskaźniki",
+                "responses": "Odpowiedzi",
+                "key_statistics": "Kluczowe statystyki"
+            },
+            "stats": {
+                "email_collection": "Zbieranie e-maili",
+                "participants": "łącznie",
+                "newsletter": "Chce wyniki",
+                "opt_in": "Wskaźnik odpowiedzi",
+                "follow_up": "Potencjał kontaktu uzupełniającego",
+                "interested": "zainteresowanych",
+                "click_to_filter": "Kliknij, aby filtrować",
+                "click_to_export": "Kliknij, aby eksportować listę",
+                "completed": "Ukończone",
+                "in_progress": "W toku",
+                "abandoned_count": "{{count}} porzuconych",
+                "interview_interested": "Akceptuje kontakt uzupełniający",
+                "interview": "Akceptuje kontakt uzupełniający",
+                "email": "E-maile"
+            },
+            "tabs": {
+                "live": "Uczestnicy na żywo",
+                "test": "Sesje testowe",
+                "browse": "Widok interaktywny",
+                "export": "Centrum eksportu"
+            },
+            "status": {
+                "started": "rozpoczęte",
+                "completed": "Ukończone",
+                "in_progress": "W toku",
+                "abandoned": "Porzucone",
+                "discarded": "odrzucone"
+            },
+            "step": {
+                "consent": "Zgoda",
+                "presort": "Ankieta wstępna",
+                "rough": "Sortowanie zgrubne",
+                "fine": "Sortowanie Q",
+                "post": "Ankieta końcowa"
+            },
+            "actions": {
+                "discard": "Odrzuć",
+                "restore": "Przywróć",
+                "export": "Eksportuj",
+                "clear_all": "Resetuj wszystkie dane",
+                "clear_all_confirm": "UWAGA: Spowoduje to trwałe usunięcie WSZYSTKICH danych uczestników dla tego badania. Tego działania nie można cofnąć.",
+                "clear_all_success": "Wszystkie dane wyczyszczone",
+                "clear_all_error": "Nie udało się wyczyścić danych. Sprawdź uprawnienia i spróbuj ponownie."
+            },
+            "confirm_discard": {
+                "title": "Odrzucić uczestnika?",
+                "description": "Ten uczestnik zostanie wykluczony z eksportów i analiz. Można go przywrócić później.",
+                "reason_label": "Powód (opcjonalnie)",
+                "reason_placeholder": "Dlaczego ten uczestnik jest odrzucany?"
+            },
+            "confirm_restore": {
+                "title": "Przywrócić uczestnika?",
+                "description": "Ten uczestnik zostanie ponownie uwzględniony w eksportach i analizach."
+            },
+            "guide": {
+                "title": "Przewodnik formatów",
+                "csv": {
+                    "title": "Uniwersalny CSV",
+                    "desc": "Surowe dane prostokątne. Najlepsze do analizy w R, Pythonie, SPSS lub Excelu. Zawiera wszystkie metadane."
+                },
+                "json": {
+                    "title": "KenQ JSON",
+                    "desc": "Zoptymalizowane dla narzędzia web-kenq. Zawiera definicję badania i sortowania."
+                },
+                "zip": {
+                    "title": "Pakiet PQMethod (ZIP)",
+                    "desc": "Zawiera starsze pliki .DAT i .STA do analizy DOS PQMethod."
+                }
+            },
+            "table": {
+                "participant": "Uczestnik",
+                "lang": "Język",
+                "status": "Status",
+                "consent": "Zgoda",
+                "flags": "Oznaczenia",
+                "duration": "Czas trwania",
+                "submitted": "Przesłano",
+                "last_step": "Ostatni krok",
+                "current_step": "Aktualny krok",
+                "view": "Pokaż",
+                "actions": "Szczegóły",
+                "duplicate_ip": "Duplikat IP",
+                "duplicate_ip_hint": "Współdzieli hash IP z innymi uczestnikami"
+            },
+            "tooltips": {
+                "suspect": "Potencjalnie podejrzane: czas trwania sesji < 2 minuty",
+                "has_comments": "Zawiera komentarze uczestnika do kart",
+                "has_audio": "Ma odpowiedzi audio",
+                "email_provided": "Podano e-mail",
+                "newsletter_consent": "Chce wyniki",
+                "interview_consent": "Akceptuje kontakt uzupełniający"
+            },
+            "toast": {
+                "discarded": "Uczestnik odrzucony",
+                "restored": "Uczestnik przywrócony",
+                "error": "Nie udało się zaktualizować uczestnika. Sprawdź połączenie i spróbuj ponownie."
+            },
+            "detail": {
+                "participant": "Uczestnik",
+                "participant_n": "Uczestnik {{code}}",
+                "not_found": "Uczestnik nie znaleziony",
+                "title": "Profil uczestnika",
+                "session": "Sesja",
+                "discarded_badge": "Odrzucony",
+                "description": "Pełne wyniki sortowania Q i metadane.",
+                "stats": {
+                    "duration": "Łączny czas trwania",
+                    "language": "Użyty język"
+                },
+                "actions": {
+                    "discard": "Odrzuć uczestnika",
+                    "restore": "Przywróć uczestnika"
+                },
+                "sort_config": "Konfiguracja sortowania",
+                "survey": {
+                    "title": "Odpowiedzi ankietowe",
+                    "csv_note": "Pełne odpowiedzi dostępne w eksporcie CSV."
+                }
+            },
+            "filter": {
+                "show_discarded": "Uwzględnij odrzucone rekordy",
+                "all_states": "Wszystkie stany",
+                "only_active": "Tylko aktywne",
+                "only_flagged": "Oznaczona jakość"
+            },
+            "filters": {
+                "active": "Aktywne filtry",
+                "has_email": "Podano e-mail",
+                "newsletter": "Chce wyniki",
+                "interview": "Akceptuje kontakt uzupełniający",
+                "flagged": "Tylko oznaczone",
+                "clear_all": "Wyczyść filtry",
+                "remove_filter": "Usuń filtr",
+                "all_statuses": "Wszystkie statusy",
+                "all_consents": "Wszystkie",
+                "all_indicators": "Wszystkie",
+                "all_steps": "Wszystkie kroki",
+                "has_comments": "Ma komentarze",
+                "has_audio": "Ma audio",
+                "has_recruitment": "Ma link rekrutacyjny"
+            },
+            "charts": {
+                "section_title": "Rozkłady odpowiedzi",
+                "distribution_label": "Rozkład dla {{question}}",
+                "multi_select_note": "Dozwolony wielokrotny wybór",
+                "responses_count": "{{count}} odpowiedzi",
+                "no_answer": "Brak odpowiedzi",
+                "option": "Opcja",
+                "count": "Liczba"
+            },
+            "search": {
+                "placeholder": "Szukaj po ID lub tokenie rekrutacyjnym...",
+                "records_found": "Wykryte rekordy",
+                "no_results": "Żaden rekord nie pasuje do zapytania"
+            },
+            "errors": {
+                "load_failed": "Synchronizacja z chmurą przerwana. Proszę sprawdzić połączenie."
+            },
+            "export_emails_success": "E-maile wyeksportowane pomyślnie",
+            "empty": {
+                "no_participants_title": "Brak uczestników",
+                "no_participants_desc": "Udostępnij link do badania, aby zacząć zbierać odpowiedzi.",
+                "contract_title": "Brak zgłoszeń",
+                "contract_body": "Zgłoszenia i eksporty pojawią się tutaj. Udostępnij link do badania, aby zacząć zbierać dane.",
+                "contract_cta": "Otwórz widok ogólny badania"
+            },
+            "pagination": {
+                "showing": "Pokazuję {{from}}–{{to}} z {{total}}"
+            }
+        },
+        "team": {
+            "title": "Zespół badania",
+            "description": "Zarządzaj współpracownikami i kontrolą dostępu na poziomie badania.",
+            "invite_title": "Zaproś współpracownika",
+            "invite_description": "Wygeneruj bezpieczny link, aby zaprosić nowego członka do tego badania.",
+            "email_label": "Adres e-mail",
+            "role_label": "Rola",
+            "select_role": "Wybierz rolę",
+            "generate_link": "Generuj link",
+            "invite_success": "Link zaproszenia wygenerowany!",
+            "invite_error": "Nie udało się wygenerować zaproszenia",
+            "copy_success": "Link skopiowany do schowka",
+            "share_label": "Udostępnij ten link zaproszonej osobie:",
+            "collab_overview": "Przegląd współpracy",
+            "active_members": "Aktywni członkowie",
+            "permissions_info": "Informacje o uprawnieniach",
+            "list_title": "Zespół badawczy",
+            "list_description": "Zarządzaj dostępem dla istniejących współpracowników.",
+            "added_on": "Dodano",
+            "headers": {
+                "collaborator": "Współpracownik",
+                "role": "Rola",
+                "actions": "Akcje"
+            },
+            "roles": {
+                "owner": "Właściciel (pełna kontrola)",
+                "editor": "Redaktor (projekt i analiza)",
+                "viewer": "Obserwator (tylko odczyt)",
+                "owner_badge": "WŁAŚCICIEL",
+                "editor_badge": "REDAKTOR",
+                "viewer_badge": "OBSERWATOR"
+            },
+            "permissions": {
+                "owner": "Może usunąć badanie i zarządzać zespołem.",
+                "editor": "Może modyfikować projekt i przeglądać wyniki.",
+                "viewer": "Dostęp tylko do odczytu do wszystkich modułów."
+            }
+        },
+        "empty_states": {
+            "participants": {
+                "title": "Gotowe do uruchomienia?",
+                "desc": "Udostępnij link do badania, aby rozpocząć zbieranie odpowiedzi. Pierwszy uczestnik jest o jedno kliknięcie.",
+                "action": "Kopiuj link do badania",
+                "hint": "Lub zeskanuj kod QR",
+                "copy_success": "Link do badania skopiowany do schowka!"
+            },
+            "team": {
+                "title": "Działasz samodzielnie",
+                "desc": "Zaproś współpracowników, aby pomogli zarządzać tym badaniem. Mogą przeglądać dane, edytować projekt lub jedynie obserwować.",
+                "action": "Zaproś pierwszego współpracownika"
+            },
+            "designer": {
+                "title": "Tabula rasa",
+                "desc": "To badanie nie ma jeszcze żadnych stwierdzeń. Dodaj elementy zbioru Q, aby rozpocząć projektowanie sortowania.",
+                "action": "Wczytaj przykładowy zbiór Q"
+            }
+        },
+        "status": {
+            "active": "Active",
+            "paused": "Paused",
+            "closed": "Closed",
+            "draft": "Draft"
+        },
+        "settings": {
+            "title": "Ustawienia",
+            "description": "Przechowywanie danych, archiwizacja i usuwanie badania.",
+            "lifecycle": {
+                "title": "Archiwizacja",
+                "description": "Zarchiwizuj badanie, aby uczynić je tylko do odczytu dla wszystkich.",
+                "notice": "Aby zarchiwizować badanie, należy je najpierw zamknąć. Po archiwizacji nie można wprowadzać żadnych zmian.",
+                "archived_status": "Badanie jest zarchiwizowane",
+                "archive_button": "Archiwizuj badanie",
+                "current_state": "Aktualny stan"
+            },
+            "danger": {
+                "title": "Strefa zagrożenia",
+                "description": "Działania tutaj są nieodwracalne.",
+                "notice": "Usunięcie badania trwale usuwa WSZYSTKIE dane (uczestników, odpowiedzi, konfigurację). Badanie musi być zarchiwizowane przed usunięciem.",
+                "delete_button": "Usuń badanie",
+                "delete_confirm": "Czy na pewno? To działanie jest NIEODWRACALNE.",
+                "delete_dialog_title": "Usunąć to badanie?",
+                "delete_dialog_intro": "Trwale usuwa sortowania, nagrania audio i przebiegi analiz.",
+                "delete_dialog_typed_label": "Wpisz slug badania, aby potwierdzić",
+                "delete_dialog_action": "Usuń trwale"
+            },
+            "save_button": "Zapisz",
+            "save_success": "Ustawienia zaktualizowane",
+            "save_success_desc": "Ustawienia badania zostały zapisane.",
+            "save_error": "Nie udało się zapisać ustawień. Sprawdź wartości i spróbuj ponownie.",
+            "save_error_desc": "Nie udało się zaktualizować ustawień. Możliwe, że slug jest już zajęty.",
+            "archive_success": "Badanie zarchiwizowane",
+            "archive_success_desc": "Badanie jest teraz zarchiwizowane i tylko do odczytu.",
+            "archive_error": "Błąd archiwizacji badania",
+            "archive_error_desc": "Nie udało się zarchiwizować badania. Czy zostało zamknięte?",
+            "delete_success": "Badanie usunięte",
+            "delete_success_desc": "Badanie zostało trwale usunięte.",
+            "delete_error": "Nie udało się usunąć badania. Upewnij się, że wszystkie dane zostały wcześniej wyczyszczone.",
+            "delete_error_desc": "Nie udało się usunąć badania.",
+            "storage": {
+                "title": "Użycie pamięci audio",
+                "used": "Używana pamięć",
+                "quota": "Limit",
+                "quota_label": "Limit pamięci",
+                "quota_help": "Maksymalna łączna pamięć audio dla tego badania (10–1000 MB).",
+                "error": "Nie udało się wczytać informacji o użyciu pamięci.",
+                "warning_high_usage": "Użycie pamięci jest wysokie. Rozważ zwiększenie limitu lub usunięcie starych nagrań.",
+                "save_success": "Limit pamięci zaktualizowany",
+                "save_error": "Nie udało się zaktualizować limitu pamięci. Proszę spróbować ponownie."
+            },
+            "retention": {
+                "title": "Przechowywanie danych",
+                "months_label": "Okres przechowywania (miesiące)",
+                "help": "Typowe wartości: 6, 12, 24, 60 miesięcy. Pozostaw puste, aby użyć wartości domyślnej systemu (12).",
+                "save_success": "Polityka przechowywania danych zaktualizowana",
+                "save_error": "Nie udało się zaktualizować polityki przechowywania danych",
+                "range_error": "Okres przechowywania musi być liczbą całkowitą od 1 do 240 miesięcy."
+            }
+        },
+        "privacy": {
+            "title": "Ochrona danych",
+            "header_desc": "Zgoda, inwentarz i anonimizacja",
+            "load_error": "Nie udało się wczytać inwentarza danych.",
+            "participants_title": "Migawka uczestników",
+            "stat_started": "Rozpoczętych",
+            "stat_completed": "Ukończonych",
+            "stat_discarded": "Odrzuconych",
+            "stat_anonymised": "Zanonimizowanych",
+            "older_1y": "Starsze niż 1 rok (niezanonimizowane)",
+            "older_2y": "Starsze niż 2 lata (niezanonimizowane)",
+            "audio_title": "Pamięć audio",
+            "audio_count": "Nagrania",
+            "audio_mb": "Łączny rozmiar",
+            "locale_title": "Podział według języka",
+            "locale_col": "Język",
+            "locale_count_col": "Uczestnicy",
+            "locale_empty": "Brak danych językowych.",
+            "timeline_title": "Oś czasu",
+            "tl_first": "Pierwsze zgłoszenie",
+            "tl_last": "Ostatnie zgłoszenie",
+            "tl_anon": "Ostatnia anonimizacja",
+            "bulk_title": "Anonimizacja zbiorcza",
+            "bulk_desc": "Usuń dane osobowe ukończonych uczestników, którzy przesłali zgłoszenia przed datą graniczną. Ranking sortowania Q jest zachowany.",
+            "cutoff_label": "Data graniczna",
+            "cutoff_help": "Zanonimizowani zostaną tylko ukończeni uczestnicy, którzy przesłali zgłoszenia ściśle przed tą datą.",
+            "preview_label": "Kandydaci:",
+            "preview_zero": "Żaden uczestnik nie kwalifikuje się do tej daty granicznej. Spróbuj wcześniejszej daty.",
+            "anonymise_button": "Anonimizuj",
+            "anonymise_success": "Anonimizacja zakończona",
+            "anonymise_success_desc": "Zanonimizowano {{n}} uczestnika(-ów), {{s}} już anonimowych.",
+            "anonymise_error": "Anonimizacja nie powiodła się",
+            "confirm_title": "Zanonimizować dane uczestników?",
+            "confirm_candidates": "Zostanie zanonimizowanych {{count}} ukończony(-ch) uczestnik(-ów), którzy przesłali zgłoszenia przed {{date}}.",
+            "confirm_preserved": "Ranking sortowania Q jest zachowany; tożsamość jest usuwana.",
+            "confirm_irreversible": "To działanie jest natychmiastowe i nie można go cofnąć.",
+            "confirm_in_progress": "Anonimizowanie…",
+            "confirm_action": "Tak, zanonimizuj",
+            "cutoff_from_policy": "Wartość domyślna wynikająca z polityki przechowywania badania ({{months}} miesięcy).",
+            "empty": {
+                "title": "Brak danych uczestników",
+                "body": "Ta strona aktywuje się po przesłaniu zgłoszeń przez uczestników. Najpierw udostępnij link do badania.",
+                "cta": "Otwórz widok ogólny badania"
+            },
+            "consent": {
+                "title": "Formularz zgody",
+                "description": "To, co uczestnicy widzą przed wejściem do badania. Edytowane w projekcie badania.",
+                "no_text": "Brak tekstu zgody.",
+                "no_title": "(brak tytułu)",
+                "no_body": "(puste)",
+                "edit_in_design": "Edytuj w projekcie badania",
+                "view": "Pokaż"
+            }
+        },
+        "projects": {
+            "title": "Projekty",
+            "settings": {
+                "title": "Ustawienia projektu",
+                "identity_desc": "Zarządzaj tożsamością projektu.",
+                "general": {
+                    "title": "Ustawienia ogólne",
+                    "desc": "Tożsamość i podstawowa identyfikacja projektu.",
+                    "label_title": "Tytuł projektu",
+                    "placeholder_title": "Moje świetne laboratorium",
+                    "label_slug": "URL slug",
+                    "placeholder_slug": "moje-laboratorium",
+                    "slug_hint": "Zmiana slugu zaktualizuje wszystkie linki do panelu badawczego.",
+                    "save": "Zapisz",
+                    "save_success": "Projekt zaktualizowany pomyślnie",
+                    "save_error": "Nie udało się zaktualizować projektu."
+                },
+                "team_growth_title": "Zarządzanie zespołem",
+                "team_growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
+                "team": {
+                    "title": "Członkowie zespołu",
+                    "desc": "Lista użytkowników mających dostęp do tego projektu.",
+                    "col_user": "Użytkownik",
+                    "col_role": "Rola",
+                    "col_joined": "Dołączył/a",
+                    "col_actions": "Działania",
+                    "remove_confirm": "Czy na pewno chcesz usunąć tego członka?",
+                    "remove_dialog_title": "Usunąć członka zespołu?",
+                    "remove_dialog_body": "{{name}} straci dostęp do tego projektu. Można go zaprosić ponownie później.",
+                    "remove_dialog_action": "Usuń",
+                    "remove_member_aria": "Usuń {{name}}",
+                    "remove_success": "Członek usunięty pomyślnie",
+                    "remove_error": "Nie udało się usunąć członka",
+                    "growth_title": "Rozwój zespołu",
+                    "growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
+                    "invite_button": "Zaproś współpracownika",
+                    "permissions_matrix": {
+                        "title": "Macierz uprawnień",
+                        "admin": {
+                            "label": "Administrator",
+                            "desc": "Może zarządzać ustawieniami projektu, członkami i wszystkimi badaniami."
+                        },
+                        "owner": {
+                            "label": "Właściciel",
+                            "desc": "Pełna kontrola nad projektem, członkami i badaniami."
+                        },
+                        "member": {
+                            "label": "Członek",
+                            "desc": "Może tworzyć i zarządzać wszystkimi badaniami. Brak dostępu do ustawień projektu."
+                        },
+                        "viewer": {
+                            "label": "Obserwator",
+                            "desc": "Dostęp tylko do odczytu do wszystkich badań i danych w projekcie."
+                        }
+                    },
+                    "coming_soon": "Wkrótce",
+                    "invite_modal": {
+                        "title": "Zaproś współpracownika",
+                        "email_label": "E-mail współpracownika",
+                        "role_label": "Przypisana rola",
+                        "success": "Link zaproszenia wygenerowany!",
+                        "error": "Nie udało się utworzyć zaproszenia.",
+                        "send": "Utwórz i wyślij zaproszenie",
+                        "copy_success": "Link skopiowany do schowka!"
+                    }
+                }
+            }
+        },
+        "members": {
+            "title": "Członkowie zespołu",
+            "description": "Zarządzaj dostępem do projektu i uprawnieniami."
+        },
+        "participants": {
+            "title": "Uczestnicy",
+            "description": "Zarządzaj uczestnikami i przeglądaj przesłane dane.",
+            "table": {
+                "id": "ID",
+                "status": "Status",
+                "started": "Rozpoczęto o",
+                "completed": "Ukończono o",
+                "duration": "Czas trwania",
+                "actions": "Akcje"
+            }
+        },
+        "participant": {
+            "tabs": {
+                "session": "Metadane",
+                "presort": "Wstępne sortowanie",
+                "grid": "Siatka sortowania Q",
+                "postsort": "Sortowanie końcowe"
+            },
+            "grid": {
+                "detail_view": "Szczegóły karty",
+                "no_comment": "Brak komentarza.",
+                "select_instruction": "Wybierz kartę na siatce, aby zobaczyć szczegóły.",
+                "read_only_mode": "Tryb obserwatora",
+                "score": "Wynik"
+            },
+            "metadata": {
+                "title": "Metadane sesji",
+                "technology": "Technologia",
+                "browser": "Przeglądarka",
+                "session": "Szczegóły sesji",
+                "duration": "Łączny czas",
+                "started": "Rozpoczęto",
+                "submitted": "Przesłano",
+                "id": "Wewnętrzny identyfikator",
+                "ip_hash": "Hash IP",
+                "recruitment_token": "Token rekrutacyjny",
+                "device": {
+                    "mobile": "Telefon",
+                    "tablet": "Tablet",
+                    "desktop": "Komputer"
+                }
+            },
+            "status": {
+                "started": "Rozpoczęto",
+                "completed": "Ukończone",
+                "discarded": "Odrzucone",
+                "in_progress": "W toku"
+            },
+            "survey": {
+                "presort": "Pytania wstępne",
+                "postsort": "Pytania końcowe",
+                "no_answers": "Brak zapisanych odpowiedzi dla tej sekcji.",
+                "question_default": "Odpowiedź głosowa",
+                "answer_default": "Odpowiedź",
+                "categories": {
+                    "identity": "Tożsamość i kontakt",
+                    "questions": "Odpowiedzi na pytania",
+                    "comments": "Komentarze do kart",
+                    "feedback": "Opinie ogólne"
+                }
+            }
+        },
+        "users": {
+            "title": "Użytkownicy",
+            "subtitle": "Zarządzaj kontami platformy i sprawdzaj higienę dostępów.",
+            "error_title": "Akcja nie powiodła się",
+            "generic_error": "Coś poszło nie tak. Spróbuj ponownie.",
+            "search_placeholder": "Szukaj według e-mail lub nazwy",
+            "empty": "Brak pasujących użytkowników.",
+            "inactive": "Nieaktywny",
+            "no_name": "Brak nazwy",
+            "last_seen": "Ostatnio widziany {{when}}",
+            "never_logged_in": "Nigdy się nie logował",
+            "actions_aria": "Akcje dla {{email}}",
+            "menu_label": "Zarządzaj kontem",
+            "filter": {
+                "all": "Wszyscy użytkownicy",
+                "superusers": "Superużytkownicy",
+                "no_2fa": "Bez 2FA",
+                "unverified": "E-mail niezweryfikowany",
+                "dormant": "Nieaktywny"
+            },
+            "risk": {
+                "superuser_no_2fa": "Superużytkownik bez 2FA",
+                "email_unverified": "E-mail niezweryfikowany",
+                "password_stale": "Hasło starsze niż rok",
+                "email_change_pending": "Zmiana e-mail w toku",
+                "dormant": "Nieaktywny (90+ dni)"
+            },
+            "role": {
+                "superuser": "Superużytkownik",
+                "user": "Użytkownik"
+            },
+            "action": {
+                "demote": "Odbierz uprawnienia superużytkownika",
+                "promote": "Nadaj uprawnienia superużytkownika",
+                "deactivate": "Dezaktywuj konto",
+                "reactivate": "Reaktywuj konto",
+                "force_password_reset": "Wymuś reset hasła",
+                "reset_totp": "Zresetuj 2FA",
+                "delete": "Usuń użytkownika",
+                "generate_reset_link": "Wygeneruj link resetujący hasło",
+                "set_email": "Ustaw e-mail"
+            },
+            "confirm": {
+                "cancel": "Anuluj",
+                "confirm": "Potwierdź",
+                "delete_title": "Usunąć tego użytkownika?",
+                "delete_body": "Trwale usuń {{email}}. Tej operacji nie można cofnąć.",
+                "reset-totp_title": "Zresetować uwierzytelnianie dwuskładnikowe?",
+                "reset-totp_body": "Wyłącz 2FA dla {{email}}. Użytkownik będzie musiał je skonfigurować ponownie.",
+                "force-password-reset_title": "Wymusić reset hasła?",
+                "force-password-reset_body": "Unieważnij hasło {{email}} i zażądaj jego zmiany przy następnym logowaniu.",
+                "deactivate_title": "Dezaktywować to konto?",
+                "deactivate_body": "Natychmiast wyloguj {{email}} i zablokuj logowanie do czasu reaktywacji.",
+                "demote_title": "Odebrać dostęp superużytkownika?",
+                "demote_body": "Usuń uprawnienia superużytkownika od {{email}}.",
+                "promote_title": "Przyznać dostęp superużytkownika?",
+                "promote_body": "Przyznaj {{email}} pełne uprawnienia superużytkownika na platformie."
+            },
+            "email_manual_note": "Wysyłka e-maili nie jest skonfigurowana. Do odzyskania konta użyj poniższego linku resetującego hasło oraz akcji ustawienia adresu e-mail — żaden e-mail nie jest wysyłany.",
+            "load_error_body": "Nie udało się pobrać listy użytkowników. Odśwież stronę lub spróbuj ponownie później.",
+            "load_error_title": "Nie można załadować użytkowników",
+            "recovery_link": {
+                "copy": "Kopiuj link",
+                "help": "Udostępnij ten jednorazowy link użytkownikowi innym kanałem. Wygasa zgodnie z oknem resetowania hasła.",
+                "title": "Link resetujący hasło"
+            },
+            "set_email_dialog": {
+                "current": "Bieżący",
+                "description": "Spowoduje to wylogowanie {{email}}; użytkownik musi zalogować się ponownie przy użyciu nowego adresu. Żaden e-mail potwierdzający nie jest wysyłany.",
+                "error": "Nie można ustawić adresu e-mail.",
+                "label": "Nowy adres e-mail",
+                "submit": "Ustaw e-mail",
+                "success": "Zaktualizowano e-mail.",
+                "title": "Ustaw e-mail użytkownika"
+            }
         }
-      },
-      "status": {
-        "started": "Rozpoczęto",
-        "completed": "Ukończone",
-        "discarded": "Odrzucone",
-        "in_progress": "W toku"
-      },
-      "survey": {
-        "presort": "Pytania wstępne",
-        "postsort": "Pytania końcowe",
-        "no_answers": "Brak zapisanych odpowiedzi dla tej sekcji.",
-        "question_default": "Odpowiedź głosowa",
-        "answer_default": "Odpowiedź",
-        "categories": {
-          "identity": "Tożsamość i kontakt",
-          "questions": "Odpowiedzi na pytania",
-          "comments": "Komentarze do kart",
-          "feedback": "Opinie ogólne"
-        }
-      }
-    },
-    "users": {
-      "title": "Użytkownicy",
-      "subtitle": "Zarządzaj kontami platformy i sprawdzaj higienę dostępów.",
-      "error_title": "Akcja nie powiodła się",
-      "generic_error": "Coś poszło nie tak. Spróbuj ponownie.",
-      "search_placeholder": "Szukaj według e-mail lub nazwy",
-      "empty": "Brak pasujących użytkowników.",
-      "inactive": "Nieaktywny",
-      "no_name": "Brak nazwy",
-      "last_seen": "Ostatnio widziany {{when}}",
-      "never_logged_in": "Nigdy się nie logował",
-      "actions_aria": "Akcje dla {{email}}",
-      "menu_label": "Zarządzaj kontem",
-      "filter": {
-        "all": "Wszyscy użytkownicy",
-        "superusers": "Superużytkownicy",
-        "no_2fa": "Bez 2FA",
-        "unverified": "E-mail niezweryfikowany",
-        "dormant": "Nieaktywny"
-      },
-      "risk": {
-        "superuser_no_2fa": "Superużytkownik bez 2FA",
-        "email_unverified": "E-mail niezweryfikowany",
-        "password_stale": "Hasło starsze niż rok",
-        "email_change_pending": "Zmiana e-mail w toku",
-        "dormant": "Nieaktywny (90+ dni)"
-      },
-      "role": {
-        "superuser": "Superużytkownik",
-        "user": "Użytkownik"
-      },
-      "action": {
-        "demote": "Odbierz uprawnienia superużytkownika",
-        "promote": "Nadaj uprawnienia superużytkownika",
-        "deactivate": "Dezaktywuj konto",
-        "reactivate": "Reaktywuj konto",
-        "force_password_reset": "Wymuś reset hasła",
-        "reset_totp": "Zresetuj 2FA",
-        "delete": "Usuń użytkownika",
-        "generate_reset_link": "Wygeneruj link resetujący hasło",
-        "set_email": "Ustaw e-mail"
-      },
-      "confirm": {
-        "cancel": "Anuluj",
-        "confirm": "Potwierdź",
-        "delete_title": "Usunąć tego użytkownika?",
-        "delete_body": "Trwale usuń {{email}}. Tej operacji nie można cofnąć.",
-        "reset-totp_title": "Zresetować uwierzytelnianie dwuskładnikowe?",
-        "reset-totp_body": "Wyłącz 2FA dla {{email}}. Użytkownik będzie musiał je skonfigurować ponownie.",
-        "force-password-reset_title": "Wymusić reset hasła?",
-        "force-password-reset_body": "Unieważnij hasło {{email}} i zażądaj jego zmiany przy następnym logowaniu.",
-        "deactivate_title": "Dezaktywować to konto?",
-        "deactivate_body": "Natychmiast wyloguj {{email}} i zablokuj logowanie do czasu reaktywacji.",
-        "demote_title": "Odebrać dostęp superużytkownika?",
-        "demote_body": "Usuń uprawnienia superużytkownika od {{email}}.",
-        "promote_title": "Przyznać dostęp superużytkownika?",
-        "promote_body": "Przyznaj {{email}} pełne uprawnienia superużytkownika na platformie."
-      },
-      "email_manual_note": "Wysyłka e-maili nie jest skonfigurowana. Do odzyskania konta użyj poniższego linku resetującego hasło oraz akcji ustawienia adresu e-mail — żaden e-mail nie jest wysyłany.",
-      "load_error_body": "Nie udało się pobrać listy użytkowników. Odśwież stronę lub spróbuj ponownie później.",
-      "load_error_title": "Nie można załadować użytkowników",
-      "recovery_link": {
-        "copy": "Kopiuj link",
-        "help": "Udostępnij ten jednorazowy link użytkownikowi innym kanałem. Wygasa zgodnie z oknem resetowania hasła.",
-        "title": "Link resetujący hasło"
-      },
-      "set_email_dialog": {
-        "current": "Bieżący",
-        "description": "Spowoduje to wylogowanie {{email}}; użytkownik musi zalogować się ponownie przy użyciu nowego adresu. Żaden e-mail potwierdzający nie jest wysyłany.",
-        "error": "Nie można ustawić adresu e-mail.",
-        "label": "Nowy adres e-mail",
-        "submit": "Ustaw e-mail",
-        "success": "Zaktualizowano e-mail.",
-        "title": "Ustaw e-mail użytkownika"
-      }
     }
-  }
 }

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1646,7 +1646,8 @@
             "next": "Przejście do następnego kroku",
             "submit": "Wyślij wyniki na końcu",
             "confirm": "Ogólny przycisk zatwierdzania"
-          }
+          },
+          "info_label": "O {{label}}"
         },
         "terms": {
           "title": "Terminologia sortowania",
@@ -1664,7 +1665,9 @@
           "desc": "Dodaj lub zmodyfikuj pływające wskazówki pomagające uczestnikom podczas fazy sortowania na siatce.",
           "placeholder": "Wpisz wskazówkę metodologiczną...",
           "add": "Dodaj wskazówkę",
-          "reset": "Przywróć wartości domyślne"
+          "reset": "Przywróć wartości domyślne",
+          "remove": "Usuń {{tip}}",
+          "unnamed": "Wskazówka {{number}}"
         },
         "help": {
           "title": "Wskazówki dla kroków (co/dlaczego)",
@@ -2147,8 +2150,11 @@
             "success": "Link zaproszenia wygenerowany!",
             "error": "Nie udało się utworzyć zaproszenia.",
             "send": "Utwórz i wyślij zaproszenie",
-            "copy_success": "Link skopiowany do schowka!"
-          }
+            "copy_success": "Link skopiowany do schowka!",
+            "copy_link": "Kopiuj link",
+            "copied": "Skopiowano"
+          },
+          "role_for": "Rola: {{name}}"
         }
       }
     },

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1848,7 +1848,8 @@
         "has_audio": "Ma odpowiedzi audio",
         "email_provided": "Podano e-mail",
         "newsletter_consent": "Chce wyniki",
-        "interview_consent": "Akceptuje kontakt uzupełniający"
+        "interview_consent": "Akceptuje kontakt uzupełniający",
+        "recruitment_link": "Link rekrutacyjny"
       },
       "toast": {
         "discarded": "Uczestnik odrzucony",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1484,7 +1484,10 @@
         "actions": {
           "add_option": "Dodaj opcję",
           "copy_from": "Importuj z języka",
-          "copy_success": "Zaimportowano"
+          "copy_success": "Zaimportowano",
+          "copy_from_aria": "Importuj {{label}} z innego języka",
+          "delete": "Usuń {{label}}",
+          "remove_option": "Usuń {{option}}"
         },
         "logic": {
           "title": "Logika widoczności",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1,2285 +1,2285 @@
 {
-    "auth": {
-        "login": {
-            "email_label": "Adres e-mail",
-            "password_label": "Hasło",
-            "submit": "Zaloguj się",
-            "cta": "Zaloguj się",
-            "forgot_password": "Nie pamiętasz?",
-            "loading": "Uwierzytelnianie...",
-            "card_title": "Zaloguj się",
-            "welcome_back": "Witamy z powrotem!",
-            "error_401": "Nieprawidłowy adres e-mail lub hasło",
-            "error_generic": "Coś poszło nie tak. Proszę spróbować ponownie.",
-            "reason_session_expired": "Sesja wygasła. Proszę zalogować się ponownie.",
-            "reason_auth_required": "Proszę zalogować się, aby kontynuować.",
-            "forgot_password_link": "Nie pamiętasz hasła?",
-            "reset_success_banner": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
-            "two_factor_title": "Weryfikacja dwuetapowa",
-            "two_factor_app_prompt": "Proszę wpisać 6-cyfrowy kod z aplikacji uwierzytelniającej.",
-            "two_factor_submit": "Zweryfikuj",
-            "two_factor_invalid": "Nieprawidłowy kod. Proszę spróbować ponownie.",
-            "lost_2fa_link": "Brak dostępu do weryfikacji dwuetapowej?"
-        },
-        "twofa": {
-            "recovery": {
-                "title": "Brak dostępu do weryfikacji dwuetapowej?",
-                "body": "Proszę podać adres e-mail konta. Jeśli weryfikacja dwuetapowa jest włączona, wyślemy link do jej wyłączenia.",
-                "submit": "Wyślij link wyłączający",
-                "success": "Jeśli adres e-mail istnieje i ma włączoną weryfikację dwuetapową, link jest już w drodze."
-            },
-            "disable": {
-                "title": "Wyłącz weryfikację dwuetapową",
-                "warning": "Kliknięcie przycisku poniżej trwale usunie drugi składnik uwierzytelnienia z tego konta. Logowanie będzie możliwe samym hasłem do momentu ponownego włączenia weryfikacji dwuetapowej.",
-                "warning_attacker": "Jeśli to nie Pan/Pani zażądał/a tej operacji, proszę zamknąć tę stronę i natychmiast zmienić hasło.",
-                "confirm_button": "Tak, wyłącz weryfikację dwuetapową",
-                "loading": "Wyłączanie…",
-                "success": "Weryfikacja dwuetapowa została wyłączona. Można się zalogować.",
-                "error_consumed": "Ten link został już wykorzystany.",
-                "error_expired": "Ten link wygasł lub jest nieprawidłowy.",
-                "missing_token": "Brak tokenu w adresie URL."
-            }
-        },
-        "password_reset": {
-            "request_title": "Zresetuj hasło",
-            "request_body": "Proszę podać adres e-mail, a wyślemy link do zresetowania hasła.",
-            "request_submit": "Wyślij link resetujący",
-            "request_success": "Jeśli adres e-mail istnieje, link resetujący jest już w drodze.",
-            "confirm_title": "Wybierz nowe hasło",
-            "confirm_submit": "Zresetuj hasło",
-            "success_redirect": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
-            "link_expired": "Ten link wygasł lub został już wykorzystany.",
-            "too_short": "Hasło musi mieć co najmniej 8 znaków.",
-            "mismatch": "Hasła nie są zgodne.",
-            "missing_token": "Brak tokenu resetowania w adresie URL.",
-            "new_password_placeholder": "Nowe hasło",
-            "confirm_placeholder": "Potwierdź hasło",
-            "request_success_manual": "Wysyłka e-maili nie jest skonfigurowana w tej instancji. Skontaktuj się z administratorem, aby uzyskać link resetujący."
-        },
-        "email": {
-            "verification_sent": {
-                "title": "Zweryfikuj adres e-mail",
-                "body": "Wysłaliśmy link weryfikacyjny na adres {{email}}. Proszę kliknąć link, aby aktywować konto.",
-                "resend": "Wyślij e-mail ponownie",
-                "cooldown": "Ponowne wysłanie dostępne za {{seconds}} s",
-                "error": "Nie udało się wysłać ponownie. Proszę spróbować później."
-            },
-            "verify": {
-                "verifying": "Weryfikowanie adresu e-mail…",
-                "success": "Adres e-mail zweryfikowany. Można się teraz zalogować.",
-                "expired": "Ten link wygasł lub jest nieprawidłowy.",
-                "resend_link": "Poproś o nowy e-mail weryfikacyjny"
-            }
-        },
-        "register": {
-            "title": "Utwórz konto",
-            "subtitle": "Dołącz do projektu badawczego",
-            "secure_invitation": "Bezpieczne zaproszenie",
-            "invitation_to": "Zaproszenie do:",
-            "study_label": "Badanie",
-            "role_label": "Rola",
-            "email_label": "Adres e-mail",
-            "password_label": "Wybierz hasło",
-            "confirm_password_label": "Potwierdź hasło",
-            "placeholder_password": "••••••••",
-            "submit": "Zakończ rejestrację",
-            "loading": "Tworzenie konta...",
-            "success_title": "Witamy na pokładzie!",
-            "success_desc": "Konto zostało utworzone i powiązane z badaniem.",
-            "success_cta": "Przejdź do panelu",
-            "success_hint": "Można teraz zalogować się do panelu administracyjnego i rozpocząć współpracę.",
-            "invalid_title": "Nieprawidłowe zaproszenie",
-            "invalid_desc": "Ten link zaproszenia jest nieprawidłowy lub wygasł.",
-            "missing_token_title": "Brak tokenu",
-            "missing_token_desc": "Ta strona wymaga prawidłowego tokenu zaproszenia. Proszę sprawdzić otrzymany link.",
-            "verifying": "Weryfikowanie zaproszenia...",
-            "privacy_hint": "Rejestrując się, wyrażasz zgodę na przestrzeganie wytycznych etyki badawczej skonfigurowanych dla tego badania.",
-            "errors": {
-                "password_mismatch": "Hasła nie są zgodne",
-                "generic_fail": "Rejestracja nie powiodła się"
-            }
-        }
+  "auth": {
+    "login": {
+      "email_label": "Adres e-mail",
+      "password_label": "Hasło",
+      "submit": "Zaloguj się",
+      "cta": "Zaloguj się",
+      "forgot_password": "Nie pamiętasz?",
+      "loading": "Uwierzytelnianie...",
+      "card_title": "Zaloguj się",
+      "welcome_back": "Witamy z powrotem!",
+      "error_401": "Nieprawidłowy adres e-mail lub hasło",
+      "error_generic": "Coś poszło nie tak. Proszę spróbować ponownie.",
+      "reason_session_expired": "Sesja wygasła. Proszę zalogować się ponownie.",
+      "reason_auth_required": "Proszę zalogować się, aby kontynuować.",
+      "forgot_password_link": "Nie pamiętasz hasła?",
+      "reset_success_banner": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
+      "two_factor_title": "Weryfikacja dwuetapowa",
+      "two_factor_app_prompt": "Proszę wpisać 6-cyfrowy kod z aplikacji uwierzytelniającej.",
+      "two_factor_submit": "Zweryfikuj",
+      "two_factor_invalid": "Nieprawidłowy kod. Proszę spróbować ponownie.",
+      "lost_2fa_link": "Brak dostępu do weryfikacji dwuetapowej?"
     },
-    "admin": {
-        "hub": {
-            "title": "Panel badacza",
-            "welcome": "Witamy z powrotem,",
-            "new_project": "Nowy projekt",
-            "your_projects": "Twoje projekty",
-            "studies_count": "badań",
-            "recent_studies": "Ostatnie badania",
-            "n_studies_one": "{{count}} badanie",
-            "n_studies_other": "{{count}} badań",
-            "n_active_one": "{{count}} aktywne",
-            "n_active_other": "{{count}} aktywnych",
-            "collecting": "Zbieranie danych",
-            "no_studies": "Brak badań",
-            "no_projects": "Brak projektów. Utwórz pierwszy projekt, aby rozpocząć.",
-            "no_projects_title": "Rozpocznij pierwszy projekt badawczy",
-            "no_projects_body": "Utwórz projekt przed dodaniem konkursów, zbiorów Q lub badań."
-        },
-        "memo": {
-            "title_concourse": "Notatki selekcji",
-            "title_study": "Notatka metodologiczna",
-            "summary_empty_concourse": "Jak i dlaczego zbudowano ten konkurs",
-            "summary_empty_study": "Opcjonalnie · do replikacji i prerejstracji",
-            "summary_filled_one": "{{n}} wpis · kliknij, aby wyświetlić",
-            "summary_filled_other": "{{n}} wpisów · kliknij, aby wyświetlić",
-            "summary_unread": "{{n}} nieprzeczytanych",
-            "add_entry": "Dodaj wpis",
-            "export": "Eksportuj",
-            "insert_template": "Wstaw z szablonu",
-            "entry_title_placeholder": "Tytuł sekcji…",
-            "entry_body_placeholder": "Udokumentuj swoje uzasadnienie…",
-            "comments_count_one": "{{n}} komentarz",
-            "comments_count_other": "{{n}} komentarzy",
-            "show_resolved": "Pokaż rozwiązane ({{n}})",
-            "hide_resolved": "Ukryj rozwiązane",
-            "comment_placeholder": "Napisz komentarz. Użyj @, aby wspomnieć.",
-            "post_comment": "Wyślij",
-            "edit": "Edytuj",
-            "delete": "Usuń",
-            "deleted_body": "[usunięty komentarz]",
-            "resolve": "Oznacz jako rozwiązane",
-            "unresolve": "Cofnij rozwiązanie",
-            "resolved_label": "[rozwiązane]",
-            "save": "Zapisz",
-            "cancel": "Anuluj",
-            "saved": "Zapisano",
-            "save_error": "Nie udało się zapisać notatki. Proszę spróbować ponownie.",
-            "load_error": "Nie udało się wczytać notatki. Odśwież stronę, aby spróbować ponownie.",
-            "mentions_for_you": "Wzmianki dla mnie",
-            "mention_user_not_found": "Nieznany użytkownik",
-            "delete_entry_confirm": "Usunąć ten wpis i wszystkie jego komentarze?",
-            "include_discussion_in_export": "Dołącz wątki dyskusji z notatki",
-            "templates": {
-                "concourse": {
-                    "sources_canvassed": {
-                        "title": "Przejrzane źródła"
-                    },
-                    "voices_retained": {
-                        "title": "Zachowane głosy"
-                    },
-                    "voices_excluded": {
-                        "title": "Wykluczone głosy"
-                    },
-                    "sampling_rationale": {
-                        "title": "Uzasadnienie doboru próby"
-                    },
-                    "version_notes": {
-                        "title": "Uwagi do wersji"
-                    }
-                },
-                "study": {
-                    "distribution_rationale": {
-                        "title": "Uzasadnienie rozkładu"
-                    },
-                    "conditions_of_instruction": {
-                        "title": "Warunki instrukcji"
-                    },
-                    "qset_size": {
-                        "title": "Rozmiar zbioru Q"
-                    },
-                    "pre_post_design": {
-                        "title": "Decyzje projektowe wstępnego/końcowego sortowania"
-                    },
-                    "limitations": {
-                        "title": "Ograniczenia"
-                    }
-                }
-            }
-        },
-        "study_design": {
-            "distribution_mode": {
-                "title": "Tryb rozkładu",
-                "helper": "Wybierz, jak ściśle wymuszany jest rozkład siatki Q. Wymuszony: każda kolumna musi być wypełniona do zadeklarowanej pojemności (najczęstszy wybór). Swobodny: dowolna liczba kart na kolumnę, łącznie = rozmiar zbioru Q. Elastyczny: łączna liczba wymuszona, kolumny to miękkie wskazówki.",
-                "forced": {
-                    "label": "Wymuszony",
-                    "tooltip": "Każda kolumna musi zawierać dokładnie zadeklarowaną liczbę kart."
-                },
-                "free": {
-                    "label": "Swobodny",
-                    "tooltip": "Łączna liczba kart = rozmiar zbioru Q; liczba kart na kolumnę nie jest ograniczona."
-                },
-                "flexible": {
-                    "label": "Elastyczny",
-                    "tooltip": "Łączna liczba kart = rozmiar zbioru Q; pojemności kolumn są miękkimi wskazówkami (tylko ostrzeżenia)."
-                }
-            },
-            "rough_sort": {
-                "toggle_label": "Włącz wstępne sortowanie (triaż na 3 stosy)",
-                "lock_banner": "Przełącznik zablokowany. {{count}} uczestnik(-ów) rozpoczął(-ęło) ankietę; zarchiwizuj lub usuń te sesje przed zmianą tego ustawienia.",
-                "deck_mode_note": "Wyłączone. Uczestnicy widzą pełny zbiór Q jako przewijany poziomo talia kart."
-            }
+    "twofa": {
+      "recovery": {
+        "title": "Brak dostępu do weryfikacji dwuetapowej?",
+        "body": "Proszę podać adres e-mail konta. Jeśli weryfikacja dwuetapowa jest włączona, wyślemy link do jej wyłączenia.",
+        "submit": "Wyślij link wyłączający",
+        "success": "Jeśli adres e-mail istnieje i ma włączoną weryfikację dwuetapową, link jest już w drodze."
+      },
+      "disable": {
+        "title": "Wyłącz weryfikację dwuetapową",
+        "warning": "Kliknięcie przycisku poniżej trwale usunie drugi składnik uwierzytelnienia z tego konta. Logowanie będzie możliwe samym hasłem do momentu ponownego włączenia weryfikacji dwuetapowej.",
+        "warning_attacker": "Jeśli to nie Pan/Pani zażądał/a tej operacji, proszę zamknąć tę stronę i natychmiast zmienić hasło.",
+        "confirm_button": "Tak, wyłącz weryfikację dwuetapową",
+        "loading": "Wyłączanie…",
+        "success": "Weryfikacja dwuetapowa została wyłączona. Można się zalogować.",
+        "error_consumed": "Ten link został już wykorzystany.",
+        "error_expired": "Ten link wygasł lub jest nieprawidłowy.",
+        "missing_token": "Brak tokenu w adresie URL."
+      }
+    },
+    "password_reset": {
+      "request_title": "Zresetuj hasło",
+      "request_body": "Proszę podać adres e-mail, a wyślemy link do zresetowania hasła.",
+      "request_submit": "Wyślij link resetujący",
+      "request_success": "Jeśli adres e-mail istnieje, link resetujący jest już w drodze.",
+      "confirm_title": "Wybierz nowe hasło",
+      "confirm_submit": "Zresetuj hasło",
+      "success_redirect": "Hasło zostało zaktualizowane. Można teraz zalogować się nowym hasłem.",
+      "link_expired": "Ten link wygasł lub został już wykorzystany.",
+      "too_short": "Hasło musi mieć co najmniej 8 znaków.",
+      "mismatch": "Hasła nie są zgodne.",
+      "missing_token": "Brak tokenu resetowania w adresie URL.",
+      "new_password_placeholder": "Nowe hasło",
+      "confirm_placeholder": "Potwierdź hasło",
+      "request_success_manual": "Wysyłka e-maili nie jest skonfigurowana w tej instancji. Skontaktuj się z administratorem, aby uzyskać link resetujący."
+    },
+    "email": {
+      "verification_sent": {
+        "title": "Zweryfikuj adres e-mail",
+        "body": "Wysłaliśmy link weryfikacyjny na adres {{email}}. Proszę kliknąć link, aby aktywować konto.",
+        "resend": "Wyślij e-mail ponownie",
+        "cooldown": "Ponowne wysłanie dostępne za {{seconds}} s",
+        "error": "Nie udało się wysłać ponownie. Proszę spróbować później."
+      },
+      "verify": {
+        "verifying": "Weryfikowanie adresu e-mail…",
+        "success": "Adres e-mail zweryfikowany. Można się teraz zalogować.",
+        "expired": "Ten link wygasł lub jest nieprawidłowy.",
+        "resend_link": "Poproś o nowy e-mail weryfikacyjny"
+      }
+    },
+    "register": {
+      "title": "Utwórz konto",
+      "subtitle": "Dołącz do projektu badawczego",
+      "secure_invitation": "Bezpieczne zaproszenie",
+      "invitation_to": "Zaproszenie do:",
+      "study_label": "Badanie",
+      "role_label": "Rola",
+      "email_label": "Adres e-mail",
+      "password_label": "Wybierz hasło",
+      "confirm_password_label": "Potwierdź hasło",
+      "placeholder_password": "••••••••",
+      "submit": "Zakończ rejestrację",
+      "loading": "Tworzenie konta...",
+      "success_title": "Witamy na pokładzie!",
+      "success_desc": "Konto zostało utworzone i powiązane z badaniem.",
+      "success_cta": "Przejdź do panelu",
+      "success_hint": "Można teraz zalogować się do panelu administracyjnego i rozpocząć współpracę.",
+      "invalid_title": "Nieprawidłowe zaproszenie",
+      "invalid_desc": "Ten link zaproszenia jest nieprawidłowy lub wygasł.",
+      "missing_token_title": "Brak tokenu",
+      "missing_token_desc": "Ta strona wymaga prawidłowego tokenu zaproszenia. Proszę sprawdzić otrzymany link.",
+      "verifying": "Weryfikowanie zaproszenia...",
+      "privacy_hint": "Rejestrując się, wyrażasz zgodę na przestrzeganie wytycznych etyki badawczej skonfigurowanych dla tego badania.",
+      "errors": {
+        "password_mismatch": "Hasła nie są zgodne",
+        "generic_fail": "Rejestracja nie powiodła się"
+      }
+    }
+  },
+  "admin": {
+    "hub": {
+      "title": "Panel badacza",
+      "welcome": "Witamy z powrotem,",
+      "new_project": "Nowy projekt",
+      "your_projects": "Twoje projekty",
+      "studies_count": "badań",
+      "recent_studies": "Ostatnie badania",
+      "n_studies_one": "{{count}} badanie",
+      "n_studies_other": "{{count}} badań",
+      "n_active_one": "{{count}} aktywne",
+      "n_active_other": "{{count}} aktywnych",
+      "collecting": "Zbieranie danych",
+      "no_studies": "Brak badań",
+      "no_projects": "Brak projektów. Utwórz pierwszy projekt, aby rozpocząć.",
+      "no_projects_title": "Rozpocznij pierwszy projekt badawczy",
+      "no_projects_body": "Utwórz projekt przed dodaniem konkursów, zbiorów Q lub badań."
+    },
+    "memo": {
+      "title_concourse": "Notatki selekcji",
+      "title_study": "Notatka metodologiczna",
+      "summary_empty_concourse": "Jak i dlaczego zbudowano ten konkurs",
+      "summary_empty_study": "Opcjonalnie · do replikacji i prerejstracji",
+      "summary_filled_one": "{{n}} wpis · kliknij, aby wyświetlić",
+      "summary_filled_other": "{{n}} wpisów · kliknij, aby wyświetlić",
+      "summary_unread": "{{n}} nieprzeczytanych",
+      "add_entry": "Dodaj wpis",
+      "export": "Eksportuj",
+      "insert_template": "Wstaw z szablonu",
+      "entry_title_placeholder": "Tytuł sekcji…",
+      "entry_body_placeholder": "Udokumentuj swoje uzasadnienie…",
+      "comments_count_one": "{{n}} komentarz",
+      "comments_count_other": "{{n}} komentarzy",
+      "show_resolved": "Pokaż rozwiązane ({{n}})",
+      "hide_resolved": "Ukryj rozwiązane",
+      "comment_placeholder": "Napisz komentarz. Użyj @, aby wspomnieć.",
+      "post_comment": "Wyślij",
+      "edit": "Edytuj",
+      "delete": "Usuń",
+      "deleted_body": "[usunięty komentarz]",
+      "resolve": "Oznacz jako rozwiązane",
+      "unresolve": "Cofnij rozwiązanie",
+      "resolved_label": "[rozwiązane]",
+      "save": "Zapisz",
+      "cancel": "Anuluj",
+      "saved": "Zapisano",
+      "save_error": "Nie udało się zapisać notatki. Proszę spróbować ponownie.",
+      "load_error": "Nie udało się wczytać notatki. Odśwież stronę, aby spróbować ponownie.",
+      "mentions_for_you": "Wzmianki dla mnie",
+      "mention_user_not_found": "Nieznany użytkownik",
+      "delete_entry_confirm": "Usunąć ten wpis i wszystkie jego komentarze?",
+      "include_discussion_in_export": "Dołącz wątki dyskusji z notatki",
+      "templates": {
+        "concourse": {
+          "sources_canvassed": {
+            "title": "Przejrzane źródła"
+          },
+          "voices_retained": {
+            "title": "Zachowane głosy"
+          },
+          "voices_excluded": {
+            "title": "Wykluczone głosy"
+          },
+          "sampling_rationale": {
+            "title": "Uzasadnienie doboru próby"
+          },
+          "version_notes": {
+            "title": "Uwagi do wersji"
+          }
         },
         "study": {
-            "activate_error": "Nie można aktywować badania. Sprawdź, czy projekt badania jest prawidłowy, i spróbuj ponownie.",
-            "save": {
-                "success": "Zmiany zapisane pomyślnie",
-                "save_success": "Zapisano pomyślnie",
-                "synced_warnings": "Zsynchronizowano z serwerem. Zachowano zmiany w: {{fields}}",
-                "synced_concurrent": "Zsynchronizowano ze zmianami wprowadzonymi przez innego użytkownika",
-                "conflict": "Wykryto konflikt. Niektórych zmian nie można było scalić.",
-                "error": "Nie udało się zapisać zmian"
-            },
-            "postsort": {
-                "missing": {
-                    "title": "Brakujące stwierdzenia",
-                    "desc": "Czy w zestawie stwierdzeń brakowało jakichś idei lub perspektyw?"
-                }
-            },
-            "state": {
-                "manage": "Zarządzaj przebiegiem badania"
-            }
+          "distribution_rationale": {
+            "title": "Uzasadnienie rozkładu"
+          },
+          "conditions_of_instruction": {
+            "title": "Warunki instrukcji"
+          },
+          "qset_size": {
+            "title": "Rozmiar zbioru Q"
+          },
+          "pre_post_design": {
+            "title": "Decyzje projektowe wstępnego/końcowego sortowania"
+          },
+          "limitations": {
+            "title": "Ograniczenia"
+          }
+        }
+      }
+    },
+    "study_design": {
+      "distribution_mode": {
+        "title": "Tryb rozkładu",
+        "helper": "Wybierz, jak ściśle wymuszany jest rozkład siatki Q. Wymuszony: każda kolumna musi być wypełniona do zadeklarowanej pojemności (najczęstszy wybór). Swobodny: dowolna liczba kart na kolumnę, łącznie = rozmiar zbioru Q. Elastyczny: łączna liczba wymuszona, kolumny to miękkie wskazówki.",
+        "forced": {
+          "label": "Wymuszony",
+          "tooltip": "Każda kolumna musi zawierać dokładnie zadeklarowaną liczbę kart."
         },
-        "components": {
-            "markdown": {
-                "label": "Markdown",
-                "tooltip": "Obsługuje Markdown do bogatego formatowania",
-                "bold": "Pogrubienie",
-                "italic": "Kursywa",
-                "list": "Lista",
-                "link": "Link",
-                "edit": "Edytuj",
-                "preview": "Podgląd",
-                "empty": "Brak treści do podglądu"
-            },
-            "icon_picker": {
-                "icons": {
-                    "User": "Osoba",
-                    "Zap": "Błyskawica",
-                    "Scale": "Waga",
-                    "MessageSquareText": "Wiadomość",
-                    "ClipboardList": "Schowek",
-                    "CheckCircle": "Znacznik wyboru",
-                    "Flag": "Flaga",
-                    "Info": "Informacja",
-                    "HelpCircle": "Pomoc",
-                    "FileText": "Dokument",
-                    "LayoutGrid": "Siatka",
-                    "Rocket": "Rakieta",
-                    "Target": "Cel",
-                    "Brain": "Mózg",
-                    "Lightbulb": "Pomysł",
-                    "ListChecks": "Lista kontrolna"
-                }
-            },
-            "click_to_edit": "Kliknij, aby edytować",
-            "audio_player": {
-                "play": "Odtwórz audio",
-                "pause": "Wstrzymaj audio"
-            }
+        "free": {
+          "label": "Swobodny",
+          "tooltip": "Łączna liczba kart = rozmiar zbioru Q; liczba kart na kolumnę nie jest ograniczona."
         },
-        "layout": {
-            "title": "Admin",
-            "back_home": "Wróć do strony głównej",
-            "beta": "Wersja badawcza beta",
-            "logout": "Wyloguj",
-            "account": "Ustawienia konta",
-            "admin_user": "Użytkownik administracyjny",
-            "platform_settings": "Ustawienia platformy"
-        },
-        "account": {
-            "title": "Ustawienia konta",
-            "description": "Zarządzaj danymi osobowymi i bezpieczeństwem konta.",
-            "personal": {
-                "title": "Dane osobowe",
-                "email": "Adres e-mail",
-                "email_locked": "Twój adres e-mail nie może być jeszcze zmieniony tutaj. Skontaktuj się z administratorem, aby go zaktualizować.",
-                "name": "Imię i nazwisko",
-                "save": "Zapisz",
-                "saving": "Zapisywanie...",
-                "success": "Profil zaktualizowany pomyślnie",
-                "error": "Nie udało się zaktualizować profilu",
-                "cannot_remove_self": "Nie można usunąć samego siebie",
-                "name_required": "Imię i nazwisko jest wymagane"
-            },
-            "security": {
-                "title": "Bezpieczeństwo",
-                "description": "Zarządzaj weryfikacją dwuetapową i hasłem.",
-                "tfa_subtitle": "Weryfikacja dwuetapowa",
-                "password_subtitle": "Hasło",
-                "enabled": "Włączone",
-                "setup_cta": "Skonfiguruj weryfikację dwuetapową",
-                "configure_title": "Konfiguruj aplikację uwierzytelniającą",
-                "scan_desc": "Zeskanuj ten kod QR aplikacją uwierzytelniającą (Google Authenticator, Authy itp.)",
-                "enter_code": "Wpisz 6-cyfrowy kod",
-                "enable_btn": "Włącz weryfikację dwuetapową",
-                "disable_btn": "Wyłącz weryfikację dwuetapową",
-                "confirm_disable": "Potwierdź wyłączenie",
-                "confirm_password_label": "Potwierdź hasłem",
-                "verifying": "Weryfikowanie...",
-                "cancel": "Anuluj",
-                "enabled_success": "Weryfikacja dwuetapowa włączona",
-                "disabled_success": "Weryfikacja dwuetapowa wyłączona",
-                "secret_copied": "Sekret skopiowany",
-                "invalid_token": "Nieprawidłowy kod weryfikacyjny",
-                "disable_error": "Nie udało się wyłączyć weryfikacji dwuetapowej"
-            },
-            "password": {
-                "title": "Zarządzanie hasłem",
-                "current": "Aktualne hasło",
-                "new": "Nowe hasło",
-                "change_btn": "Zmień hasło",
-                "updating": "Aktualizowanie...",
-                "success": "Hasło zmienione pomyślnie",
-                "error": "Nie udało się zmienić hasła. Sprawdź aktualne hasło.",
-                "validation": {
-                    "required": "Wymagane",
-                    "min_length": "Min. 8 znaków"
-                }
-            }
-        },
-        "sidebar": {
-            "home": "Panel",
-            "add_study": "Dodaj badanie",
-            "create_project": "UTWÓRZ NOWY PROJEKT",
-            "dashboard": "Panel",
-            "overview": "Przegląd",
-            "design": "Projekt",
-            "recruit": "Dostęp",
-            "data": "Dane",
-            "analysis": "Analiza",
-            "privacy": "Prywatność danych",
-            "team": "Zespół",
-            "settings": "Ustawienia badania",
-            "project_settings": "Ustawienia projektu",
-            "study_tools": "Narzędzia badania",
-            "project": "Projekt",
-            "documentation": "Dokumentacja",
-            "support": "Wsparcie",
-            "study_management": "Zarządzanie badaniem",
-            "search": "Szukaj...",
-            "studies": "Badania",
-            "select_study": "Wybierz badanie",
-            "select_study_msg": "Wybierz lub utwórz badanie, aby rozpocząć.",
-            "view_all_studies": "Wszystkie badania",
-            "study": "Badanie",
-            "select_project": "Wybierz projekt",
-            "concourses": "Konkursy",
-            "concourse": "Konkurs",
-            "members": "Członkowie zespołu"
-        },
-        "concourse": {
-            "title": "Konkurs",
-            "description": "Zarządzaj stwierdzeniami kandydatów do badania metodologią Q",
-            "default_title": "Konkurs",
-            "default_title_for_project": "Konkurs {{project}}",
-            "create": "Nowy konkurs",
-            "create_success": "Konkurs utworzony",
-            "create_error": "Nie udało się utworzyć konkursu",
-            "create_dialog_title": "Utwórz konkurs",
-            "create_dialog_desc": "Konkurs to zbiór stwierdzień kandydatów, spośród których zostanie wybrany zbiór Q.",
-            "field_title": "Tytuł",
-            "field_title_placeholder": "np. Postawy wobec zmian klimatu",
-            "field_description": "Opis",
-            "field_description_placeholder": "Krótki opis tego konkursu...",
-            "field_code": "Kod",
-            "field_text": "Tekst stwierdzenia",
-            "field_text_placeholder": "Wpisz tekst stwierdzenia...",
-            "field_source": "Źródło",
-            "items_label": "elementów",
-            "updated": "Zaktualizowano",
-            "empty_title": "Brak konkursów",
-            "empty_desc": "Utwórz konkurs, aby zacząć zbierać i porządkować stwierdzenia kandydatów do badań metodologią Q.",
-            "add_item": "Dodaj element",
-            "bulk_import": "Import zbiorczy",
-            "import_desc": "Wklej stwierdzenia oddzielone nową linią. Każda linia staje się jednym elementem.",
-            "import_prefix": "Prefiks kodu",
-            "import_statements": "Stwierdzenia",
-            "import_placeholder": "Jedno stwierdzenie na wiersz...",
-            "items_to_import": "stwierdzeń do importu",
-            "import_button": "Importuj",
-            "import_success": "Zaimportowano {{count}} elementów",
-            "import_error": "Import nie powiódł się",
-            "item_created": "Element dodany",
-            "item_create_error": "Nie udało się dodać elementu",
-            "item_updated": "Element zaktualizowany",
-            "item_update_error": "Nie udało się zaktualizować elementu",
-            "item_deleted": "Element usunięty",
-            "item_delete_error": "Nie udało się usunąć elementu",
-            "status_error": "Nie udało się zmienić statusu",
-            "search_placeholder": "Szukaj elementów...",
-            "source_placeholder": "np. Wywiad nr 3, Przegląd literatury",
-            "no_items": "Brak elementów. Dodaj pierwsze stwierdzenie.",
-            "no_matches": "Żaden element nie pasuje do filtrów.",
-            "danger_zone": "Strefa zagrożenia",
-            "delete": "Usuń konkurs",
-            "delete_confirm": "Czy na pewno chcesz usunąć ten konkurs i wszystkie jego elementy?",
-            "deleted": "Konkurs usunięty",
-            "delete_error": "Nie udało się usunąć konkursu",
-            "delete_item_title": "Usuń element",
-            "delete_item_confirm": "Usunąć ten element? Tego działania nie można cofnąć.",
-            "status": {
-                "proposed": "Proponowane",
-                "accepted": "Zaakceptowane",
-                "rejected": "Odrzucone"
-            },
-            "change_note_placeholder": "Uwaga do zmiany (opcjonalnie)",
-            "history": "Historia",
-            "comments": "Komentarze",
-            "no_history": "Brak historii edycji.",
-            "no_comments": "Brak komentarzy.",
-            "add_comment": "Napisz komentarz...",
-            "send_comment": "Wyślij",
-            "comment_added": "Komentarz dodany",
-            "comment_error": "Nie udało się dodać komentarza. Proszę spróbować ponownie.",
-            "version_label": "v{{n}}",
-            "item_detail_desc": "Historia i komentarze dla tego elementu",
-            "manage_tags": "Tagi",
-            "tag_name_placeholder": "Nazwa tagu",
-            "tag_color": "Kolor tagu",
-            "tag_created": "Tag utworzony",
-            "tag_create_error": "Nie udało się utworzyć tagu",
-            "tag_deleted": "Tag usunięty",
-            "tag_delete_error": "Nie udało się usunąć tagu",
-            "no_tags": "Brak tagów. Utwórz pierwszy tag powyżej.",
-            "field_tags": "Tagi",
-            "export_csv": "Eksportuj CSV",
-            "select_language": "Język",
-            "add_language": "Dodaj język",
-            "add_language_desc": "Wpisz kod języka (np. en, fr, fi).",
-            "add_language_desc_v2": "Wybierz język tłumaczeń stwierdzeń.",
-            "add_language_tooltip": "Dodaj język tłumaczenia",
-            "field_language": "Język",
-            "import_language": "Język",
-            "select_all": "Zaznacz wszystko",
-            "select_item": "Zaznacz {{code}}",
-            "bulk_selected": "Zaznaczono {{count}}",
-            "bulk_set_status": "Ustaw status:",
-            "bulk_clear": "Wyczyść",
-            "bulk_status_success": "Zaktualizowano {{count}} elementów",
-            "bulk_status_error": "Nie udało się zaktualizować niektórych elementów",
-            "qset_title": "Kuracja",
-            "qset_reviewed_of": "{{total}} elementów przejrzanych",
-            "qset_accepted": "{{count}} zaakceptowanych",
-            "qset_pending": "{{count}} elementów do przejrzenia",
-            "qset_complete": "Wszystkie elementy przejrzane",
-            "show_pending": "Do przejrzenia",
-            "bulk_confirm_title": "Potwierdź zmianę statusu",
-            "bulk_confirm_desc": "Ustawić {{count}} elementów na \"{{status}}\"?",
-            "no_translation": "Brak tekstu",
-            "language_tooltip": "Język tekstów stwierdzeń",
-            "loading": "Konfigurowanie konkursu...",
-            "diff_code": "kod",
-            "diff_status": "status",
-            "diff_text": "tekst",
-            "diff_tags": "tagi",
-            "diff_changed": "Zmieniono:",
-            "methodological_context": {
-                "title": "Kontekst metodologiczny",
-                "subtitle": "Opcjonalne pola dokumentacyjne. Wypełnij to, co istotne dla projektu; pozostałe pozostaw puste."
-            },
-            "import_from_csv": "Importuj CSV/TSV…",
-            "import_csv_hint": "CSV/TSV wymaga kolumn: code, language, text.",
-            "import_csv_no_match": "Żaden wiersz nie pasuje do wybranego języka ({{lang}}).",
-            "import_csv_skipped": "Pominięto {{count}} wiersz(-y) w innych językach: {{langs}}.",
-            "import_csv_more_errors": "{{count}} więcej problemów"
-        },
-        "concourse_import": {
-            "title": "Importuj z konkursu",
-            "desc": "Wybierz elementy z konkursu, aby zaimportować je jako stwierdzenia badania. Elementy są kopiowane; zmiany w konkursie nie wpłyną na badanie.",
-            "button_label": "Importuj z konkursu",
-            "select_concourse": "Konkurs",
-            "select_placeholder": "Wybierz konkurs...",
-            "code_prefix": "Prefiks kodu",
-            "code_prefix_placeholder": "np. S",
-            "only_accepted": "Tylko zaakceptowane",
-            "replace_existing": "Zastąp istniejące stwierdzenia",
-            "replace_warning": "Wszystkie istniejące stwierdzenia zostaną trwale usunięte i zastąpione wybranymi elementami.",
-            "selected": "Wybrano: {{count}}",
-            "select_all": "Zaznacz wszystkie",
-            "import_button": "Importuj {{count}} stwierdzenia(-n)",
-            "success": "Zaimportowano {{count}} stwierdzenia(-n)",
-            "error": "Nie można zaimportować elementów z konkursu. Spróbuj ponownie.",
-            "no_accepted": "Brak zaakceptowanych elementów w tym konkursie. Odznacz opcję \"Tylko zaakceptowane\", aby zobaczyć wszystkie.",
-            "no_items": "Ten konkurs nie ma żadnych elementów.",
-            "no_concourses": "Brak konkursów w tym projekcie. Najpierw utwórz konkurs."
-        },
-        "concourse_sync": {
-            "update_available": "Aktualizacja",
-            "source_deleted": "Źródło usunięte",
-            "source_deleted_tip": "Element źródłowy konkursu został usunięty.",
-            "new_version": "Nowa wersja w konkursie:",
-            "synced": "Stwierdzenie zaktualizowane z konkursu",
-            "error": "Nie można zsynchronizować z konkursem. Spróbuj ponownie.",
-            "stale_banner": "{{count}} stwierdzenie(-n) ma dostępne aktualizacje z konkursu."
-        },
-        "analysis": {
-            "title": "Analiza",
-            "description": "Analiza czynnikowa danych z sortowania Q: wyodrębnianie punktów widzenia z odpowiedzi uczestników",
-            "configuration": "Konfiguracja",
-            "configuration_description": "Wybierz metodę ekstrakcji, liczbę czynników i rotację",
-            "extraction_method": "Ekstrakcja",
-            "centroid": "Centroid",
-            "n_factors": "Czynniki",
-            "rotation_method": "Rotacja",
-            "none": "Brak",
-            "run": "Uruchom analizę",
-            "run_will_replace": "Ponowne uruchomienie zastąpi bieżący widok wyników. Użyj panelu historii, aby porównać przebiegi.",
-            "running": "Analizowanie...",
-            "reanalyzing": "Ponowne analizowanie...",
-            "success": "Analiza zakończona. Wyodrębniono {{n}} czynników.",
-            "error": "Analiza nie powiodła się: {{message}}",
-            "scree_hint": "Każdy słupek pokazuje, ile wariancji wyjaśnia dany czynnik (jego wartość własna). Przerywana linia oznacza wartość własną = 1 (kryterium Kaisera). Kliknij słupek, aby wybrać liczbę czynników do wyodrębnienia.",
-            "kaiser_suggestion": "{{n}} czynnik(-ów) ma wartości własne powyżej 1 (kryterium Kaisera)",
-            "factor": "Czynnik",
-            "factor_n": "Czynnik {{n}}",
-            "eigenvalue": "Wartość własna",
-            "too_few_participants": "Do uruchomienia analizy potrzebne są co najmniej 2 ukończone sortowania.",
-            "eigenvalue_error": "Nie udało się wczytać danych analizy. Proszę spróbować ponownie.",
-            "scree_plot_label": "Wykres osypiska pokazujący wartości własne dla {{n}} czynników",
-            "loading_eigenvalues": "Wczytywanie wartości własnych...",
-            "empty_state": "Ustaw parametry i uruchom analizę.",
-            "empty": {
-                "contract_title": "Za mało danych z sortowania Q",
-                "contract_body": "Analiza czynnikowa metodologii Q wymaga co najmniej 2 uczestników, którzy ukończyli sortowanie. Opcje konfiguracji (ekstrakcja, czynniki, rotacja, oznaczanie) nabierają znaczenia po zgromadzeniu danych. Udostępnij link do badania z widoku ogólnego, aby zacząć zbierać odpowiedzi.",
-                "contract_cta": "Otwórz widok ogólny badania"
-            },
-            "advanced": {
-                "title": "Ustawienia zaawansowane",
-                "summary": "Rotacja: {{rotation}} · Oznaczanie: {{flagging}} · Bootstrap: {{bootstrap}}",
-                "bootstrap_off": "wyłączony",
-                "bootstrap_on": "{{n}} iteracji"
-            },
-            "tab_loadings": "Ładunki",
-            "tab_factor_arrays": "Tablice czynnikowe",
-            "tab_statements": "Stwierdzenia",
-            "tab_summary": "Podsumowanie",
-            "participant": "Uczestnik",
-            "flagged": "Oznaczony",
-            "significance_threshold": "Próg istotności (p<0,05): ±{{threshold}}",
-            "sorts": "sortowania",
-            "distinguishing_legend": "Stwierdzenie różnicujące",
-            "code": "Kod",
-            "statement": "Stwierdzenie",
-            "type": "Typ",
-            "distinguishing": "Różnicujące",
-            "consensus": "Konsensusowe",
-            "variance_explained": "Wyjaśniona wariancja (%)",
-            "cumulative_variance": "Skumulowana wariancja (%)",
-            "n_flagged": "Liczba oznaczonych sortowań",
-            "composite_reliability": "Rzetelność złożona",
-            "se_factor_scores": "Błąd standardowy wyników czynnikowych",
-            "factor_correlations": "Korelacje czynników",
-            "high_correlation": "Wysoka korelacja",
-            "total_variance": "Łączna wyjaśniona wariancja",
-            "method_used": "Metoda",
-            "statements_label": "stwierdzenia",
-            "pca": "PCA",
-            "varimax": "Varimax",
-            "metric": "Metryka",
-            "caption_loadings": "Ładunki czynnikowe na uczestnika",
-            "caption_statements": "Wyniki z i tablice czynnikowe na czynnik",
-            "caption_characteristics": "Charakterystyki czynników i statystyki rzetelności",
-            "caption_correlations": "Macierz korelacji między czynnikami",
-            "retry": "Spróbuj ponownie",
-            "flagging_method": "Oznaczanie",
-            "auto": "Auto",
-            "manual": "Ręczny",
-            "manual_flag_hint": "Kliknij komórkę ładunku, aby oznaczyć/odznaczyć uczestnika dla danego czynnika. Uruchom ponownie analizę, aby zaktualizować wyniki.",
-            "no_flagged_participants": "Żaden uczestnik nie jest oznaczony dla żadnego czynnika. Spróbuj dostosować liczbę czynników lub metodę oznaczania.",
-            "no_statement_scores": "Brak dostępnych wyników stwierdzeń. Upewnij się, że uczestnicy są oznaczeni dla co najmniej jednego czynnika.",
-            "no_characteristics": "Brak dostępnych charakterystyk czynników.",
-            "export": "Eksportuj",
-            "export_loadings": "Ładunki czynnikowe (CSV)",
-            "export_scores": "Wyniki stwierdzeń (CSV)",
-            "export_xlsx": "Pełna analiza (XLSX)",
-            "export_error": "Nie udało się wygenerować eksportu XLSX.",
-            "select_factors": "Wybierz liczbę czynników",
-            "loadings_help": "Ładunki czynnikowe pokazują, jak silnie sortowanie każdego uczestnika koreluje z każdym czynnikiem. Wyróżnione komórki przekraczają próg istotności podany powyżej.",
-            "factor_array_help": "Złożone sortowanie Q pokazujące wyidealizowany wzorzec sortowania dla tego czynnika. Stwierdzenia są rozmieszczone w rozkładzie na podstawie ważonych wyników z.",
-            "factor_array_label": "Złożone sortowanie czynnika {{n}}",
-            "factor_arrays": {
-                "toggle_narratives": "Pokaż interpretacje czynników",
-                "toggle_narratives_aria": "Przełącz interpretacje poszczególnych czynników"
-            },
-            "statements_help": "Wyniki z pokazują standardową pozycję każdego czynnika na każdym stwierdzeniu. D = różnicujące (istotnie różne między czynnikami), C = konsensusowe (brak istotnych różnic).",
-            "z_scores_description": "Wyniki z i pozycje tablicy czynnikowej na stwierdzenie",
-            "factor_statistics": "Statystyki czynników",
-            "characteristics_help": "Wartości własne odzwierciedlają ilość wyjaśnionej wariancji. Rzetelność złożona odzwierciedla wewnętrzną spójność oznaczonych sortowań. Błąd standardowy wyników czynnikowych odzwierciedla precyzję estymacji złożonej.",
-            "help_extraction": "PCA maksymalizuje wyjaśnianą wariancję. Centroid jest mniej ograniczony matematycznie.",
-            "help_n_factors": "Każdy czynnik reprezentuje odrębny punkt widzenia.",
-            "help_rotation": "Varimax rozdziela czynniki dla prostszej struktury.",
-            "help_flagging": "Auto: oznaczaj uczestników ładujących się na dokładnie jeden czynnik. Ręczny: nadpisuj ręcznie dla każdego uczestnika.",
-            "guide_loadings_title": "Odczytywanie ładunków czynnikowych",
-            "guide_loadings_1": "Każdy ładunek to korelacja (od −1 do +1) między uczestnikiem a czynnikiem (wspólnym punktem widzenia).",
-            "guide_loadings_2": "Wyróżnione wartości przekraczają próg istotności pokazany powyżej tabeli.",
-            "guide_arrays_title": "Interpretacja tablic czynnikowych",
-            "guide_arrays_1": "Każda tablica czynnikowa to złożone sortowanie Q reprezentujące jeden wspólny punkt widzenia.",
-            "guide_arrays_2": "Czytaj od lewej do prawej: od największego braku zgody do największej zgody. Pozycje skrajne niosą najsilniejszy sygnał interpretacyjny.",
-            "guide_statements_title": "Rozumienie wyników stwierdzeń",
-            "guide_statements_1": "Wyniki z pokazują, jak silnie każdy czynnik zgadza się lub nie zgadza z każdym stwierdzeniem (0 = neutralnie).",
-            "guide_statements_2": "D = różnicujące (umieszczone istotnie różnie między czynnikami). Gwiazdki wskazują poziom istotności.",
-            "guide_summary_title": "Ocena rozwiązania",
-            "guide_summary_1": "Wartości własne mierzą, ile wariancji wyjaśnia dany czynnik. Kryterium Kaisera (wartość własna > 1) to jedna z popularnych heurystyk decydowania o liczbie czynników do zachowania.",
-            "guide_summary_2": "Rzetelność złożona odzwierciedla, jak spójnie oznaczone sortowania definiują dany czynnik. Wyższe wartości oznaczają, że estymacja czynnika opiera się na większej zgodności sortowań go definiujących.",
-            "benchmark_above": "Powyżej progu",
-            "benchmark_below": "Poniżej progu",
-            "history": {
-                "title": "Historia analiz",
-                "loading": "Wczytywanie historii…",
-                "fetch_error": "Nie udało się wczytać historii analiz.",
-                "empty": "Brak poprzednich analiz dla tego badania. Uruchom jedną, aby rozpocząć ślad audytu.",
-                "empty_explainer": "Każde uruchomienie jest tutaj rejestrowane, aby można było dokumentować i ponownie przeglądać każdą decyzję.",
-                "load_error": "Nie udało się wczytać tego przebiegu analizy. Odśwież stronę, aby spróbować ponownie.",
-                "load_run_aria": "Wczytaj przebieg analizy z {{date}}",
-                "loading_run": "Wczytywanie…",
-                "current_tag": "bieżący",
-                "n_factors_label": "{{n}}C",
-                "edit_notes": "Edytuj notatki",
-                "edit_notes_aria": "Edytuj notatki dla tego przebiegu",
-                "notes_placeholder": "Dodaj notatkę o tym przebiegu…",
-                "notes_aria": "Edytuj notatki dla tego przebiegu",
-                "save_notes_aria": "Zapisz notatki",
-                "cancel_edit_aria": "Anuluj edycję",
-                "notes_saved": "Notatki zapisane.",
-                "notes_error": "Nie udało się zapisać notatek. Sprawdź połączenie i spróbuj ponownie.",
-                "delete_run": "Usuń przebieg",
-                "delete_run_aria": "Usuń ten przebieg analizy",
-                "delete_dialog_title": "Usunąć przebieg analizy?",
-                "delete_dialog_description": "Usunięcie przebiegu analizy usuwa dowód analitycznego wyboru ze śladu audytu. Czy na pewno?",
-                "cancel": "Anuluj",
-                "delete_confirm": "Usuń",
-                "deleted": "Przebieg analizy usunięty.",
-                "delete_error": "Nie udało się usunąć przebiegu.",
-                "viewing_banner": "Podgląd przebiegu z {{date}}: {{extraction}} · {{n}}C · {{rotation}}",
-                "back_to_current": "Wróć do bieżącego"
-            },
-            "factor_voices": {
-                "title": "Głosy przy czynniku {{n}}",
-                "no_audio": "Brak nagrań audio po sortowaniu od uczestników oznaczonych dla tego czynnika.",
-                "no_material": "Brak nagrań audio po sortowaniu ani pisemnych komentarzy od uczestników oznaczonych dla tego czynnika.",
-                "loading": "Wczytywanie nagrań…",
-                "error": "Nie udało się wczytać nagrań audio. Proszę spróbować ponownie.",
-                "context": "Osadź interpretację czynnika we własnych słowach uczestników: ich uzasadnieniach audio i pisemnych komentarzach do kart.",
-                "context_aria": "O tym panelu",
-                "audio_label": "Nagranie: {{key}} — {{participant}}",
-                "url_unavailable": "URL audio niedostępny.",
-                "comments_label": "Komentarze do kart",
-                "question_default": "Komentarz głosowy"
-            },
-            "factor_note": {
-                "label": "Interpretacja czynnika",
-                "placeholder": "Napisz interpretację tego czynnika: dyskurs, głosy i napięcia, które eksponuje.",
-                "empty_hint": "Dodaj interpretację dla tego czynnika",
-                "char_count": "{{n}}/{{max}}",
-                "edit_aria": "Edytuj interpretację czynnika {{n}}",
-                "save_aria": "Zapisz interpretację czynnika",
-                "cancel_aria": "Anuluj edycję",
-                "aria": "Edytuj interpretację czynnika {{n}}",
-                "saved": "Interpretacja czynnika zapisana.",
-                "error": "Nie udało się zapisać interpretacji czynnika."
-            },
-            "rotation": {
-                "judgmental": {
-                    "label": "Ekspercka (ręczna)",
-                    "short": "Ekspercka",
-                    "tooltip": "Ręcznie obracaj pary czynników o wybrane kąty, aby ustawić je w merytorycznie sensownych pozycjach."
-                }
-            },
-            "manual_rotations": {
-                "title": "Rotacje ręczne",
-                "helper": "Podaj rotacje w formie: 'obróć czynnik F o Δ° wokół czynnika G'. Rotacje są stosowane w kolejności.",
-                "add": "Dodaj rotację",
-                "remove_aria": "Usuń rotację",
-                "empty": "Dodaj co najmniej jedną rotację, aby uruchomić analizę.",
-                "factor_a_label": "Obróć czynnik",
-                "angle_label": "o",
-                "factor_b_label": "wokół czynnika"
-            },
-            "bootstrap": {
-                "toggle_label": "Uruchom bootstrap stabilności",
-                "iterations_label": "Iteracje (B)",
-                "helper": "Opcjonalnie. Próbkuje sortowania Q B razy, aby oszacować przedziały ufności dla wyników czynnikowych.",
-                "running": "Trwa bootstrap…",
-                "se_column": "Średni błąd standardowy (z)",
-                "tooltip": "Nieparametryczny bootstrap sortowań Q (próbkowanie ze zwracaniem); analiza jest powtarzana B razy, aby oszacować 95% przedziały ufności dla wyników z."
-            },
-            "explore": {
-                "diagnostics_title": "Diagnostyka",
-                "kaiser": "Kaiser",
-                "parallel": "Analiza równoległa",
-                "map": "MAP Velicera",
-                "advisory": "Wyłącznie orientacyjne. Decyzja o liczbie czynników w metodologii Q zależy też od interpretowalności i stabilności (Watts i Stenner 2012).",
-                "preview_range_title": "Podgląd zakresu",
-                "preview_range_disabled": "Podgląd zakresu obsługuje tylko PCA + varimax. Ekstrakcja centroidów i rotacja ekspercka są zależne od ścieżki; zatwierdź rzeczywisty przebieg, aby sprawdzić.",
-                "select_k": "{{k}} czynników",
-                "empty_factor": "Pusty czynnik (nadmierna faktoryzacja)",
-                "cumvar": "skum. war. %",
-                "pct_flagged": "% oznaczonych",
-                "n_distinguishing": "# różnicujące",
-                "n_cross_loaders": "# wieloczynnikowe",
-                "min_def_sorts": "min. sortowań def.",
-                "advanced_title": "Konfiguracja zaawansowana",
-                "commit_cta": "Zatwierdź i interpretuj"
-            },
-            "interpret": {
-                "def_sorts": "Sortowania definiujące: {{n}}",
-                "statements_title": "Stwierdzenia",
-                "narrative_title": "Interpretacja C{{n}}",
-                "insert_comment_quote": "Wstaw komentarz jako cytat",
-                "focus_mode": "Fokus na czynnik",
-                "overview_mode": "Widok ogólny",
-                "mode_toggle": "Tryb widoku"
-            },
-            "compare": {
-                "pin_cta": "Przypnij do porównania",
-                "no_other_runs": "Brak innych dostępnych przebiegów",
-                "run_label": "Przebieg #{{id}} ({{n}} czynników)",
-                "pinned": "Porównanie z przebiegiem #{{id}}",
-                "phi": "φ = {{phi}}",
-                "ambiguous": "niejednoznaczne dopasowanie (interpretuj różnice ostrożnie)",
-                "unpin": "Odepnij",
-                "delta_z_aria": "Δz {{delta}} vs przebieg porównawczy",
-                "delta_loading_aria": "Δładunek {{delta}} vs przebieg porównawczy"
-            },
-            "quote_insert_format": "> {{text}}\n> {{p}}, o stwierdzeniu {{code}}: \"{{stmt}}\""
-        },
-        "project": {
-            "remove_member": "Usuń członka",
-            "table_caption": "Członkowie projektu",
-            "switcher": {
-                "settings": "Ustawienia projektu",
-                "settings_desc": "Członkowie i profile",
-                "new_project": "Nowy projekt",
-                "new_project_desc": "Utwórz nowy projekt"
-            },
-            "roles": {
-                "owner": "Właściciel",
-                "admin": "Administrator",
-                "viewer": "Obserwator",
-                "member": "Członek"
-            },
-            "study_states": {
-                "active": "Aktywne",
-                "draft": "Szkic",
-                "paused": "Wstrzymane",
-                "closed": "Zamknięte"
-            },
-            "create": {
-                "title": "Utwórz projekt",
-                "card_title": "Szczegóły projektu",
-                "name_label": "Nazwa projektu",
-                "name_placeholder": "Badanie Q postaw wobec klimatu",
-                "url_label": "URL projektu",
-                "url_placeholder": "badanie-q-postawy-klimat",
-                "url_description": "To staje sie sciezka projektu pod /app/.",
-                "cancel": "Anuluj",
-                "create_button": "Utwórz projekt",
-                "creating": "Tworzenie...",
-                "success": "Projekt został pomyślnie utworzony",
-                "error": "Nie udało się utworzyć projektu"
-            }
-        },
-        "recruitment": {
-            "title": "Dostęp",
-            "description": "Skonfiguruj URL badania, zarządzaj dostępem uczestników i śledź efektywność rekrutacji.",
-            "study_url": {
-                "title": "URL badania",
-                "description": "Publiczny adres, pod którym uczestnicy mają dostęp do badania.",
-                "full_url_label": "Pełny URL",
-                "slug_label": "URL slug",
-                "slug_description": "Unikalny identyfikator używany w URL badania. Tylko małe litery, cyfry i myślniki.",
-                "slug_locked": "Slug URL można zmieniać tylko w trybie szkicu."
-            },
-            "state_draft": "Tryb szkicu. Linki będą działać po aktywowaniu badania.",
-            "state_closed": "To badanie jest zamknięte. Istniejące linki pozostają widoczne, ale nowi uczestnicy nie mogą rozpocząć.",
-            "state_archived": "To badanie jest zarchiwizowane. Wszystkie dane rekrutacji są tylko do odczytu.",
-            "empty_title": "Brak linków rekrutacyjnych",
-            "empty_description": "Utwórz pierwszy link, aby zacząć zapraszać uczestników.",
-            "empty_cta": "Utwórz link dostępu",
-            "stats_summary": {
-                "links": "linków",
-                "started": "rozpoczętych",
-                "submitted": "przesłanych"
-            },
-            "access_rules": {
-                "title": "Reguły dostępu",
-                "description": "Kontroluj, kiedy i jak uczestnicy mają dostęp do badania.",
-                "password_toggle": "Wymagaj hasła",
-                "password_toggle_desc": "Uczestnicy muszą wpisać hasło przed rozpoczęciem badania.",
-                "password_label": "Hasło dostępu",
-                "password_placeholder": "Wpisz hasło dostępu",
-                "password_locked": "Ochrona hasłem może być zmieniana tylko w trybie szkicu.",
-                "password_set": "Hasło jest aktualnie ustawione. Wpisz nową wartość, aby je zmienić, lub wyłącz przełącznik, aby je usunąć.",
-                "collection_window": "Okno zbierania danych",
-                "window_toggle": "Ogranicz okno zbierania danych",
-                "window_toggle_help": "Ogranicz dostęp uczestników do określonego zakresu czasu.",
-                "start_date_label": "Otwiera się o",
-                "end_date_label": "Zamyka się o",
-                "date_hint": "Pozostaw puste, aby nie ograniczać czasu.",
-                "clear_date": "Wyczyść datę",
-                "save_button": "Zapisz reguły dostępu",
-                "save_success": "Reguły dostępu zaktualizowane",
-                "save_error": "Nie udało się zaktualizować reguł dostępu",
-                "non_draft_notice": "Poza trybem szkicu można edytować tylko okno zbierania danych. Przełącz badanie z powrotem na szkic, aby zmienić inne reguły dostępu.",
-                "archived_notice": "To badanie jest zarchiwizowane. Reguły dostępu są tylko do odczytu."
-            },
-            "new_link": "Nowy link dostępu",
-            "create_title": "Utwórz linki dostępu",
-            "link_type": "Strategia dostępu",
-            "select_type": "Wybierz typ rekrutacji...",
-            "campaign_name": "Kanał / nazwa kampanii",
-            "name_placeholder": "Np. LinkedIn, e-mail partia a, lista studentów...",
-            "link_count": "Rozmiar partii",
-            "capacity_label": "Maks. zgłoszeń",
-            "generate_links": "Generuj linki",
-            "no_links": "Nie wygenerowano jeszcze żadnych linków rekrutacyjnych.",
-            "unnamed": "Kanał bez nazwy",
-            "revoked": "Dostęp odwołany",
-            "qr_title": "Udostępnij przez QR",
-            "copy_link": "Kopiuj URL",
-            "table_title": "Linki rekrutacyjne",
-            "share_title": "Udostępnij badanie",
-            "share_desc": "Rozprowadź URL badania, aby zaprosić uczestników.",
-            "public_url_label": "Publiczny URL uczestnictwa",
-            "hide_qr": "Ukryj QR",
-            "show_qr": "Pokaż kod QR",
-            "delete_link": "Usuń link",
-            "qr_alt": "Kod QR dla {{url}}",
-            "table_caption": "Linki rekrutacyjne",
-            "progress_label": "{{count}} z {{max}} odpowiedzi",
-            "usage": {
-                "started": "rozpoczęte",
-                "submitted": "przesłane",
-                "completed": "Ukończone",
-                "in_progress": "W toku",
-                "unused": "Nieużyte"
-            },
-            "live_study": "Badanie na żywo",
-            "download_qr": "Pobierz obraz",
-            "qr_print_hint": "Zeskanuj lub wydrukuj ten kod do fizycznych materiałów rekrutacyjnych (ulotki, plakaty).",
-            "analytics_title": "Analityka kampanii",
-            "analytics_desc": "Bezpośrednie linki i skany QR są automatycznie śledzone w panelu zdrowia powyżej.",
-            "copy_success": "Link do badania skopiowany do schowka",
-            "types": {
-                "public": "Dostęp otwarty (publiczny)",
-                "individual": "Jednorazowy kod dostępu",
-                "limited": "Ograniczone uczestnictwo"
-            },
-            "guidance": {
-                "public": "Najlepszy do rekrutacji na dużą skalę. Jeden URL dla wszystkich uczestników.",
-                "individual": "Maksymalne bezpieczeństwo. Generuje unikalne linki wygasające po jednym pomyślnym ukończeniu.",
-                "limited": "Kontrolowany dostęp. Jeden link, który przestaje działać po określonej liczbie zgłoszeń."
-            },
-            "stats": {
-                "total_links": "Łącznie kanałów",
-                "active_channels": "Aktywne partie rekrutacyjne",
-                "started": "Łącznie sesji",
-                "engagements": "Uczestnicy, którzy rozpoczęli",
-                "submitted": "Prawidłowe dane",
-                "completions": "Ukończone zgłoszenia",
-                "conversion": "Wskaźnik przechwycenia",
-                "efficiency": "Ostateczny wynik danych"
-            },
-            "table": {
-                "name": "Kampania / partia",
-                "type": "Typ wejścia",
-                "token": "Token bezpieczeństwa",
-                "usage": "Pojemność",
-                "status": "Stan",
-                "actions": "Zarządzaj",
-                "type_help": "Publiczny, jednorazowy lub z ograniczoną pojemnością. Patrz opisy strategii w oknie dialogowym 'Nowy link dostępu'."
-            },
-            "status": {
-                "public": "Publiczny",
-                "individual": "Indywidualny",
-                "limited": "Ograniczony"
-            },
-            "toasts": {
-                "created": "Linki rekrutacyjne utworzone pomyślnie",
-                "failed": "Nie udało się utworzyć linków rekrutacyjnych. Sprawdź dane wejściowe i spróbuj ponownie.",
-                "revoked": "Link odwołany",
-                "revoke_failed": "Nie udało się odwołać tego linku. Możliwe, że jest już w użyciu.",
-                "copied": "Skopiowano do schowka"
-            }
-        },
-        "analytics": {
-            "charts": {
-                "recruitment_funnel": {
-                    "title": "Lejek rekrutacyjny",
-                    "subtitle": "Łączna wydajność konwersji",
-                    "initial_contact": "Pierwszy kontakt",
-                    "completion": "Ukończenie",
-                    "started_study": "Rozpoczęto badanie",
-                    "submitted": "Przesłano",
-                    "yield": "Wynik",
-                    "success_rate": "Wskaźnik sukcesu",
-                    "completion_rate": "{{rate}}% uczestników ukończyło badanie"
-                },
-                "link_performance": {
-                    "title": "Śledzenie skuteczności linków",
-                    "subtitle": "Monitorowanie efektywności poszczególnych kanałów rekrutacyjnych",
-                    "volume": "Wolumen",
-                    "yield": "Wynik",
-                    "conversion_rate": "Wskaźnik konwersji",
-                    "total_responses": "odpowiedzi"
-                }
-            }
-        },
-        "breadcrumbs": {
-            "admin": "Admin",
-            "dashboard": "Dashboard",
-            "study_dashboard": "Overview",
-            "design": "Design",
-            "participants": "Participants",
-            "team": "Team",
-            "recruitment": "Access",
-            "exports": "Data",
-            "data": "Data",
-            "privacy": "Data privacy",
-            "account": "Account settings",
-            "participant_n": "Participant {{code}}",
-            "analysis": "Analysis",
-            "settings": "Settings",
-            "concourse": "Concourse",
-            "members": "Team members"
-        },
-        "command_menu": {
-            "title": "Globalne menu poleceń",
-            "placeholder": "Wpisz polecenie lub wyszukaj...",
-            "no_results": "Brak wyników.",
-            "switch_project": "Przełącz projekt",
-            "switch_study": "Przełącz badanie",
-            "study_actions": "Akcje badania",
-            "system": "System",
-            "no_studies": "Brak badań w tym projekcie.",
-            "open_dashboard": "Otwórz panel",
-            "design_study": "Projekt badania",
-            "collaborators": "Współpracownicy",
-            "copy_link": "Kopiuj publiczny link",
-            "toggle_theme": "Przełącz motyw",
-            "logout": "Wyloguj",
-            "search_label": "Szukaj lub uruchom polecenia",
-            "to_open": "Otwórz",
-            "active": "Aktywne",
-            "link_copied": "Link do badania skopiowany!",
-            "logged_out": "Wylogowano pomyślnie",
-            "switched_project": "Przełączono na {{name}}"
-        },
-        "dashboard": {
-            "title": "Panel projektu",
-            "welcome": "Witamy z powrotem,",
-            "snapshot": "Oto migawka aktywności badawczej.",
-            "create_study": "Utwórz badanie",
-            "total_studies": "Łącznie badań",
-            "across_statuses": "Wszystkich statusów",
-            "active_data_collection": "Aktywne zbieranie danych",
-            "receiving_responses": "Badania przyjmujące odpowiedzi",
-            "total_participants": "Łącznie uczestników",
-            "all_studies": "Wszystkie badania",
-            "all_studies_description": "Wszystkie badania w tym projekcie.",
-            "languages_count_one": "{{count}} język",
-            "languages_count_other": "{{count}} języków",
-            "n_participants_one": "{{count}} uczestnik",
-            "n_participants_other": "{{count}} uczestników",
-            "n_studies_one": "{{count}} badanie",
-            "n_studies_other": "{{count}} badań",
-            "n_active_one": "{{count}} aktywne",
-            "n_active_other": "{{count}} aktywnych",
-            "n_participants_total_one": "{{count}} uczestnik",
-            "n_participants_total_other": "{{count}} uczestników",
-            "concourse_n_items_one": "{{count}} stwierdzenie",
-            "concourse_n_items_other": "{{count}} stwierdzeń",
-            "concourse_open_hint": "Kuracja stwierdzeń kandydatów",
-            "created": "Utworzono",
-            "no_studies": "Nie znaleziono badań. Utwórz pierwsze badanie, aby zacząć!",
-            "import_study": "Importuj badanie",
-            "get_started": "Zacznij swój projekt badawczy",
-            "onboarding_title": "Pierwsze kroki",
-            "step_create_project": "Utwórz projekt",
-            "step_create_project_desc": "Projekt jest gotowy.",
-            "step_concourse": "Zbierz stwierdzenia w konkursie",
-            "step_concourse_desc": "Dodaj stwierdzenia kandydatów z przeglądu literatury.",
-            "step_qset": "Wybierz zbiór Q",
-            "step_qset_desc": "Przejrzyj i zaakceptuj elementy tworzące zbiór Q.",
-            "step_study": "Utwórz badanie",
-            "step_study_desc": "Zdefiniuj siatkę sortowania Q.",
-            "step_import": "Zaimportuj zbiór Q do badania",
-            "step_import_desc": "Zaimportuj zaakceptowane elementy konkursu jako stwierdzenia badania.",
-            "step_configure": "Skonfiguruj przepływ uczestnika",
-            "step_configure_desc": "Skonfiguruj instrukcje, wstępne sortowanie i pytania końcowe.",
-            "step_launch": "Uruchom rekrutację",
-            "step_launch_desc": "Generuj linki uczestnictwa i udostępniaj je.",
-            "go_to_concourse": "Otwórz konkurs",
-            "go_to_qset": "Otwórz zbiór Q",
-            "concourse": "Konkurs",
-            "concourse_empty": "Brak elementów. Zacznij budować kolekcję stwierdzeń.",
-            "team": "Zespół",
-            "team_loading": "Ładowanie...",
-            "studies": "Badania",
-            "active_studies": "Aktywne",
-            "paused_studies": "Wstrzymane",
-            "draft_studies": "Szkice",
-            "closed_studies": "Ukończone",
-            "attention": "Wymaga uwagi",
-            "alert_deadline": "{{study}}: zamknięcie za {{days}} dni, {{count}} uczestników",
-            "view": "Pokaż",
-            "open_study": "Otwórz badanie",
-            "add_study": "Dodaj badanie",
-            "closes": "Zamknięcie",
-            "timeline": {
-                "title": "Oś czasu zgłoszeń",
-                "subtitle": "Dzienne trendy uczestnictwa",
-                "started": "Rozpoczęto",
-                "completed": "Ukończono"
-            },
-            "devices": {
-                "title": "Rozkład urządzeń",
-                "subtitle": "Jak uczestnicy korzystają z badania",
-                "types": {
-                    "desktop": "Komputer",
-                    "mobile": "Telefon",
-                    "tablet": "Tablet",
-                    "unknown": "Nieznane"
-                }
-            },
-            "n_studies_help": "Łączna liczba badań w tym projekcie, w tym szkice i zamknięte.",
-            "n_active_help": "Badania aktualnie przyjmujące zgłoszenia uczestników (stan = aktywne).",
-            "n_participants_total_help": "Suma ukończonych uczestników we wszystkich badaniach tego projektu.",
-            "tool_help": {
-                "design": "Konfiguruj badanie: siatka rozkładu, warunki instrukcji, stwierdzenia, zgoda.",
-                "recruit": "Linki rekrutacyjne, reguły dostępu i ustawienia URL badania.",
-                "data": "Odpowiedzi uczestników i eksporty (CSV, zrzuty sortowania Q).",
-                "analysis": "Konfiguracja analizy czynnikowej i historia przebiegów."
-            }
-        },
-        "export": {
-            "config": "Eksportuj konfigurację",
-            "exporting": "Eksportowanie...",
-            "config_success": "Konfiguracja wyeksportowana pomyślnie",
-            "config_error": "Nie można wyeksportować konfiguracji. Spróbuj ponownie.",
-            "label": "Eksportuj dane",
-            "success": "Eksport zakończony pomyślnie",
-            "error": "Eksport nie powiódł się. Spróbuj ponownie.",
-            "csv": "Eksportuj CSV",
-            "json": "Eksportuj JSON",
-            "audio": "Eksportuj nagrania audio (ZIP)",
-            "formats": {
-                "csv": "CSV",
-                "pqmethod": "PQMethod (ZIP)",
-                "rkit": "R-Kit (ZIP)",
-                "package": "Pakiet badawczy (ZIP)",
-                "json": "Zrzut JSON"
-            },
-            "download": "Pobierz",
-            "package_dialog": {
-                "title": "Pobierz pakiet badawczy",
-                "description": "Łączy wszystkie dane badania w jeden plik ZIP do OSF lub rejestracji wstępnej.",
-                "discussion_hint": "Dodaje plik memo/memo-discussion.md ze wszystkimi wątkami komentarzy (podpisanymi i opatrzonymi datą). Domyślnie wyłączone; zachowaj czysty eksport, chyba że potrzebna jest ścieżka deliberacji."
-            }
-        },
-        "import": {
-            "title": "Importuj konfigurację badania",
-            "config": "Importuj konfigurację",
-            "upload_desc": "Prześlij wcześniej wyeksportowany plik konfiguracji badania",
-            "validate_desc": "Przejrzyj konfigurację i podaj unikalny slug",
-            "creating_desc": "Tworzenie badania...",
-            "file_upload": "Prześlij plik",
-            "paste_json": "Wklej JSON",
-            "drop_here": "Upuść plik tutaj",
-            "drag_drop": "Przeciągnij i upuść plik JSON lub kliknij, aby przeglądać",
-            "supported": "Obsługiwany format: .json",
-            "paste_label": "Wklej konfigurację JSON",
-            "validate": "Sprawdź poprawność i kontynuuj",
-            "valid": "Konfiguracja jest prawidłowa",
-            "invalid": "Konfiguracja zawiera błędy",
-            "errors": "Błędy",
-            "warnings": "Ostrzeżenia",
-            "summary": "Podsumowanie badania",
-            "title_field": "Tytuł",
-            "languages": "Języki",
-            "statements": "Stwierdzenia",
-            "grid": "Zakres siatki",
-            "new_slug": "Nowy slug badania",
-            "slug_help": "Musi być unikalny, 3–100 znaków, tylko małe litery, cyfry i myślniki",
-            "creating": "Tworzenie badania z konfiguracji...",
-            "create_study": "Utwórz badanie",
-            "invalid_json": "Nieprawidłowy plik JSON",
-            "validation_failed": "Konfiguracja jest nieprawidłowa",
-            "success": "Badanie zaimportowane pomyślnie",
-            "redirecting": "Otwieranie projektanta badania...",
-            "failed": "Nie udało się zaimportować badania. Zapoznaj się ze szczegółami poniżej i spróbuj ponownie.",
-            "validation": {
-                "errors": {
-                    "missing_version": "Brak pola wersji",
-                    "unsupported_version": "Nieobsługiwana wersja: {{version}}",
-                    "missing_field": "Brak wymaganego pola: {{field}}",
-                    "no_translations": "Wymagane jest co najmniej jedno tłumaczenie",
-                    "missing_translation_field": "Tłumaczeniu {{index}} brakuje wymaganego pola: {{field}}",
-                    "invalid_lang_code": "Nieprawidłowy kod języka: {{lang}}",
-                    "no_statements": "Wymagane jest co najmniej jedno stwierdzenie",
-                    "duplicate_codes": "Zduplikowane kody stwierdzeń: {{codes}}",
-                    "missing_stmt_translations": "Stwierdzeniu {{index}} brakuje tłumaczeń",
-                    "invalid_grid_config": "Nieprawidłowy grid_config: musi być listą",
-                    "invalid_grid_structure": "Nieprawidłowa struktura grid_config: {{error}}"
-                },
-                "warnings": {
-                    "grid_capacity_mismatch": "Liczba stwierdzeń ({{count}}) nie odpowiada pojemności siatki ({{capacity}})",
-                    "missing_consent_draft": "Brak tytułu lub opisu formularza zgody (badanie w szkicu)",
-                    "external_branding_logo": "Logo marki używa zewnętrznego URL: {{url}}",
-                    "external_partner_logo": "Logo partnera '{{name}}' używa zewnętrznego URL: {{url}}",
-                    "external_logo": "URL logo odwołuje się do zasobu zewnętrznego — może być niedostępny"
-                }
-            }
-        },
-        "dialogs": {
-            "create_study": {
-                "title": "Utwórz nowe badanie",
-                "description": "Rozpocznij nowe badanie metodologią Q. Stwierdzenia i ustawienia można skonfigurować później.",
-                "study_title": "Tytuł badania",
-                "study_title_placeholder": "Np. Perspektywy dotyczące AI",
-                "url_slug": "URL slug",
-                "url_slug_placeholder": "np. perspektywy-ai-2025",
-                "cancel": "Anuluj",
-                "create": "Utwórz badanie",
-                "success": "Badanie zostało pomyślnie utworzone",
-                "error": "Nie udało się utworzyć badania",
-                "languages": "Języki",
-                "languages_desc": "Wybierz języki do włączenia. Treść zostanie zainicjowana zlokalizowanymi wartościami domyślnymi."
-            }
-        },
+        "flexible": {
+          "label": "Elastyczny",
+          "tooltip": "Łączna liczba kart = rozmiar zbioru Q; pojemności kolumn są miękkimi wskazówkami (tylko ostrzeżenia)."
+        }
+      },
+      "rough_sort": {
+        "toggle_label": "Włącz wstępne sortowanie (triaż na 3 stosy)",
+        "lock_banner": "Przełącznik zablokowany. {{count}} uczestnik(-ów) rozpoczął(-ęło) ankietę; zarchiwizuj lub usuń te sesje przed zmianą tego ustawienia.",
+        "deck_mode_note": "Wyłączone. Uczestnicy widzą pełny zbiór Q jako przewijany poziomo talia kart."
+      }
+    },
+    "study": {
+      "activate_error": "Nie można aktywować badania. Sprawdź, czy projekt badania jest prawidłowy, i spróbuj ponownie.",
+      "save": {
+        "success": "Zmiany zapisane pomyślnie",
+        "save_success": "Zapisano pomyślnie",
+        "synced_warnings": "Zsynchronizowano z serwerem. Zachowano zmiany w: {{fields}}",
+        "synced_concurrent": "Zsynchronizowano ze zmianami wprowadzonymi przez innego użytkownika",
+        "conflict": "Wykryto konflikt. Niektórych zmian nie można było scalić.",
+        "error": "Nie udało się zapisać zmian"
+      },
+      "postsort": {
+        "missing": {
+          "title": "Brakujące stwierdzenia",
+          "desc": "Czy w zestawie stwierdzeń brakowało jakichś idei lub perspektyw?"
+        }
+      },
+      "state": {
+        "manage": "Zarządzaj przebiegiem badania"
+      }
+    },
+    "components": {
+      "markdown": {
+        "label": "Markdown",
+        "tooltip": "Obsługuje Markdown do bogatego formatowania",
+        "bold": "Pogrubienie",
+        "italic": "Kursywa",
+        "list": "Lista",
+        "link": "Link",
+        "edit": "Edytuj",
+        "preview": "Podgląd",
+        "empty": "Brak treści do podglądu"
+      },
+      "icon_picker": {
+        "icons": {
+          "User": "Osoba",
+          "Zap": "Błyskawica",
+          "Scale": "Waga",
+          "MessageSquareText": "Wiadomość",
+          "ClipboardList": "Schowek",
+          "CheckCircle": "Znacznik wyboru",
+          "Flag": "Flaga",
+          "Info": "Informacja",
+          "HelpCircle": "Pomoc",
+          "FileText": "Dokument",
+          "LayoutGrid": "Siatka",
+          "Rocket": "Rakieta",
+          "Target": "Cel",
+          "Brain": "Mózg",
+          "Lightbulb": "Pomysł",
+          "ListChecks": "Lista kontrolna"
+        }
+      },
+      "click_to_edit": "Kliknij, aby edytować",
+      "audio_player": {
+        "play": "Odtwórz audio",
+        "pause": "Wstrzymaj audio"
+      }
+    },
+    "layout": {
+      "title": "Admin",
+      "back_home": "Wróć do strony głównej",
+      "beta": "Wersja badawcza beta",
+      "logout": "Wyloguj",
+      "account": "Ustawienia konta",
+      "admin_user": "Użytkownik administracyjny",
+      "platform_settings": "Ustawienia platformy"
+    },
+    "account": {
+      "title": "Ustawienia konta",
+      "description": "Zarządzaj danymi osobowymi i bezpieczeństwem konta.",
+      "personal": {
+        "title": "Dane osobowe",
+        "email": "Adres e-mail",
+        "email_locked": "Twój adres e-mail nie może być jeszcze zmieniony tutaj. Skontaktuj się z administratorem, aby go zaktualizować.",
+        "name": "Imię i nazwisko",
+        "save": "Zapisz",
+        "saving": "Zapisywanie...",
+        "success": "Profil zaktualizowany pomyślnie",
+        "error": "Nie udało się zaktualizować profilu",
+        "cannot_remove_self": "Nie można usunąć samego siebie",
+        "name_required": "Imię i nazwisko jest wymagane"
+      },
+      "security": {
+        "title": "Bezpieczeństwo",
+        "description": "Zarządzaj weryfikacją dwuetapową i hasłem.",
+        "tfa_subtitle": "Weryfikacja dwuetapowa",
+        "password_subtitle": "Hasło",
+        "enabled": "Włączone",
+        "setup_cta": "Skonfiguruj weryfikację dwuetapową",
+        "configure_title": "Konfiguruj aplikację uwierzytelniającą",
+        "scan_desc": "Zeskanuj ten kod QR aplikacją uwierzytelniającą (Google Authenticator, Authy itp.)",
+        "enter_code": "Wpisz 6-cyfrowy kod",
+        "enable_btn": "Włącz weryfikację dwuetapową",
+        "disable_btn": "Wyłącz weryfikację dwuetapową",
+        "confirm_disable": "Potwierdź wyłączenie",
+        "confirm_password_label": "Potwierdź hasłem",
+        "verifying": "Weryfikowanie...",
+        "cancel": "Anuluj",
+        "enabled_success": "Weryfikacja dwuetapowa włączona",
+        "disabled_success": "Weryfikacja dwuetapowa wyłączona",
+        "secret_copied": "Sekret skopiowany",
+        "invalid_token": "Nieprawidłowy kod weryfikacyjny",
+        "disable_error": "Nie udało się wyłączyć weryfikacji dwuetapowej"
+      },
+      "password": {
+        "title": "Zarządzanie hasłem",
+        "current": "Aktualne hasło",
+        "new": "Nowe hasło",
+        "change_btn": "Zmień hasło",
+        "updating": "Aktualizowanie...",
+        "success": "Hasło zmienione pomyślnie",
+        "error": "Nie udało się zmienić hasła. Sprawdź aktualne hasło.",
         "validation": {
-            "required": "Wymagane",
-            "slug_min": "Slug musi mieć co najmniej 3 znaki",
-            "slug_regex": "Slug może zawierać tylko małe litery, cyfry i myślniki"
+          "required": "Wymagane",
+          "min_length": "Min. 8 znaków"
+        }
+      }
+    },
+    "sidebar": {
+      "home": "Panel",
+      "add_study": "Dodaj badanie",
+      "create_project": "UTWÓRZ NOWY PROJEKT",
+      "dashboard": "Panel",
+      "overview": "Przegląd",
+      "design": "Projekt",
+      "recruit": "Dostęp",
+      "data": "Dane",
+      "analysis": "Analiza",
+      "privacy": "Prywatność danych",
+      "team": "Zespół",
+      "settings": "Ustawienia badania",
+      "project_settings": "Ustawienia projektu",
+      "study_tools": "Narzędzia badania",
+      "project": "Projekt",
+      "documentation": "Dokumentacja",
+      "support": "Wsparcie",
+      "study_management": "Zarządzanie badaniem",
+      "search": "Szukaj...",
+      "studies": "Badania",
+      "select_study": "Wybierz badanie",
+      "select_study_msg": "Wybierz lub utwórz badanie, aby rozpocząć.",
+      "view_all_studies": "Wszystkie badania",
+      "study": "Badanie",
+      "select_project": "Wybierz projekt",
+      "concourses": "Konkursy",
+      "concourse": "Konkurs",
+      "members": "Członkowie zespołu"
+    },
+    "concourse": {
+      "title": "Konkurs",
+      "description": "Zarządzaj stwierdzeniami kandydatów do badania metodologią Q",
+      "default_title": "Konkurs",
+      "default_title_for_project": "Konkurs {{project}}",
+      "create": "Nowy konkurs",
+      "create_success": "Konkurs utworzony",
+      "create_error": "Nie udało się utworzyć konkursu",
+      "create_dialog_title": "Utwórz konkurs",
+      "create_dialog_desc": "Konkurs to zbiór stwierdzień kandydatów, spośród których zostanie wybrany zbiór Q.",
+      "field_title": "Tytuł",
+      "field_title_placeholder": "np. Postawy wobec zmian klimatu",
+      "field_description": "Opis",
+      "field_description_placeholder": "Krótki opis tego konkursu...",
+      "field_code": "Kod",
+      "field_text": "Tekst stwierdzenia",
+      "field_text_placeholder": "Wpisz tekst stwierdzenia...",
+      "field_source": "Źródło",
+      "items_label": "elementów",
+      "updated": "Zaktualizowano",
+      "empty_title": "Brak konkursów",
+      "empty_desc": "Utwórz konkurs, aby zacząć zbierać i porządkować stwierdzenia kandydatów do badań metodologią Q.",
+      "add_item": "Dodaj element",
+      "bulk_import": "Import zbiorczy",
+      "import_desc": "Wklej stwierdzenia oddzielone nową linią. Każda linia staje się jednym elementem.",
+      "import_prefix": "Prefiks kodu",
+      "import_statements": "Stwierdzenia",
+      "import_placeholder": "Jedno stwierdzenie na wiersz...",
+      "items_to_import": "stwierdzeń do importu",
+      "import_button": "Importuj",
+      "import_success": "Zaimportowano {{count}} elementów",
+      "import_error": "Import nie powiódł się",
+      "item_created": "Element dodany",
+      "item_create_error": "Nie udało się dodać elementu",
+      "item_updated": "Element zaktualizowany",
+      "item_update_error": "Nie udało się zaktualizować elementu",
+      "item_deleted": "Element usunięty",
+      "item_delete_error": "Nie udało się usunąć elementu",
+      "status_error": "Nie udało się zmienić statusu",
+      "search_placeholder": "Szukaj elementów...",
+      "source_placeholder": "np. Wywiad nr 3, Przegląd literatury",
+      "no_items": "Brak elementów. Dodaj pierwsze stwierdzenie.",
+      "no_matches": "Żaden element nie pasuje do filtrów.",
+      "danger_zone": "Strefa zagrożenia",
+      "delete": "Usuń konkurs",
+      "delete_confirm": "Czy na pewno chcesz usunąć ten konkurs i wszystkie jego elementy?",
+      "deleted": "Konkurs usunięty",
+      "delete_error": "Nie udało się usunąć konkursu",
+      "delete_item_title": "Usuń element",
+      "delete_item_confirm": "Usunąć ten element? Tego działania nie można cofnąć.",
+      "status": {
+        "proposed": "Proponowane",
+        "accepted": "Zaakceptowane",
+        "rejected": "Odrzucone"
+      },
+      "change_note_placeholder": "Uwaga do zmiany (opcjonalnie)",
+      "history": "Historia",
+      "comments": "Komentarze",
+      "no_history": "Brak historii edycji.",
+      "no_comments": "Brak komentarzy.",
+      "add_comment": "Napisz komentarz...",
+      "send_comment": "Wyślij",
+      "comment_added": "Komentarz dodany",
+      "comment_error": "Nie udało się dodać komentarza. Proszę spróbować ponownie.",
+      "version_label": "v{{n}}",
+      "item_detail_desc": "Historia i komentarze dla tego elementu",
+      "manage_tags": "Tagi",
+      "tag_name_placeholder": "Nazwa tagu",
+      "tag_color": "Kolor tagu",
+      "tag_created": "Tag utworzony",
+      "tag_create_error": "Nie udało się utworzyć tagu",
+      "tag_deleted": "Tag usunięty",
+      "tag_delete_error": "Nie udało się usunąć tagu",
+      "no_tags": "Brak tagów. Utwórz pierwszy tag powyżej.",
+      "field_tags": "Tagi",
+      "export_csv": "Eksportuj CSV",
+      "select_language": "Język",
+      "add_language": "Dodaj język",
+      "add_language_desc": "Wpisz kod języka (np. en, fr, fi).",
+      "add_language_desc_v2": "Wybierz język tłumaczeń stwierdzeń.",
+      "add_language_tooltip": "Dodaj język tłumaczenia",
+      "field_language": "Język",
+      "import_language": "Język",
+      "select_all": "Zaznacz wszystko",
+      "select_item": "Zaznacz {{code}}",
+      "bulk_selected": "Zaznaczono {{count}}",
+      "bulk_set_status": "Ustaw status:",
+      "bulk_clear": "Wyczyść",
+      "bulk_status_success": "Zaktualizowano {{count}} elementów",
+      "bulk_status_error": "Nie udało się zaktualizować niektórych elementów",
+      "qset_title": "Kuracja",
+      "qset_reviewed_of": "{{total}} elementów przejrzanych",
+      "qset_accepted": "{{count}} zaakceptowanych",
+      "qset_pending": "{{count}} elementów do przejrzenia",
+      "qset_complete": "Wszystkie elementy przejrzane",
+      "show_pending": "Do przejrzenia",
+      "bulk_confirm_title": "Potwierdź zmianę statusu",
+      "bulk_confirm_desc": "Ustawić {{count}} elementów na \"{{status}}\"?",
+      "no_translation": "Brak tekstu",
+      "language_tooltip": "Język tekstów stwierdzeń",
+      "loading": "Konfigurowanie konkursu...",
+      "diff_code": "kod",
+      "diff_status": "status",
+      "diff_text": "tekst",
+      "diff_tags": "tagi",
+      "diff_changed": "Zmieniono:",
+      "methodological_context": {
+        "title": "Kontekst metodologiczny",
+        "subtitle": "Opcjonalne pola dokumentacyjne. Wypełnij to, co istotne dla projektu; pozostałe pozostaw puste."
+      },
+      "import_from_csv": "Importuj CSV/TSV…",
+      "import_csv_hint": "CSV/TSV wymaga kolumn: code, language, text.",
+      "import_csv_no_match": "Żaden wiersz nie pasuje do wybranego języka ({{lang}}).",
+      "import_csv_skipped": "Pominięto {{count}} wiersz(-y) w innych językach: {{langs}}.",
+      "import_csv_more_errors": "{{count}} więcej problemów"
+    },
+    "concourse_import": {
+      "title": "Importuj z konkursu",
+      "desc": "Wybierz elementy z konkursu, aby zaimportować je jako stwierdzenia badania. Elementy są kopiowane; zmiany w konkursie nie wpłyną na badanie.",
+      "button_label": "Importuj z konkursu",
+      "select_concourse": "Konkurs",
+      "select_placeholder": "Wybierz konkurs...",
+      "code_prefix": "Prefiks kodu",
+      "code_prefix_placeholder": "np. S",
+      "only_accepted": "Tylko zaakceptowane",
+      "replace_existing": "Zastąp istniejące stwierdzenia",
+      "replace_warning": "Wszystkie istniejące stwierdzenia zostaną trwale usunięte i zastąpione wybranymi elementami.",
+      "selected": "Wybrano: {{count}}",
+      "select_all": "Zaznacz wszystkie",
+      "import_button": "Importuj {{count}} stwierdzenia(-n)",
+      "success": "Zaimportowano {{count}} stwierdzenia(-n)",
+      "error": "Nie można zaimportować elementów z konkursu. Spróbuj ponownie.",
+      "no_accepted": "Brak zaakceptowanych elementów w tym konkursie. Odznacz opcję \"Tylko zaakceptowane\", aby zobaczyć wszystkie.",
+      "no_items": "Ten konkurs nie ma żadnych elementów.",
+      "no_concourses": "Brak konkursów w tym projekcie. Najpierw utwórz konkurs."
+    },
+    "concourse_sync": {
+      "update_available": "Aktualizacja",
+      "source_deleted": "Źródło usunięte",
+      "source_deleted_tip": "Element źródłowy konkursu został usunięty.",
+      "new_version": "Nowa wersja w konkursie:",
+      "synced": "Stwierdzenie zaktualizowane z konkursu",
+      "error": "Nie można zsynchronizować z konkursem. Spróbuj ponownie.",
+      "stale_banner": "{{count}} stwierdzenie(-n) ma dostępne aktualizacje z konkursu."
+    },
+    "analysis": {
+      "title": "Analiza",
+      "description": "Analiza czynnikowa danych z sortowania Q: wyodrębnianie punktów widzenia z odpowiedzi uczestników",
+      "configuration": "Konfiguracja",
+      "configuration_description": "Wybierz metodę ekstrakcji, liczbę czynników i rotację",
+      "extraction_method": "Ekstrakcja",
+      "centroid": "Centroid",
+      "n_factors": "Czynniki",
+      "rotation_method": "Rotacja",
+      "none": "Brak",
+      "run": "Uruchom analizę",
+      "run_will_replace": "Ponowne uruchomienie zastąpi bieżący widok wyników. Użyj panelu historii, aby porównać przebiegi.",
+      "running": "Analizowanie...",
+      "reanalyzing": "Ponowne analizowanie...",
+      "success": "Analiza zakończona. Wyodrębniono {{n}} czynników.",
+      "error": "Analiza nie powiodła się: {{message}}",
+      "scree_hint": "Każdy słupek pokazuje, ile wariancji wyjaśnia dany czynnik (jego wartość własna). Przerywana linia oznacza wartość własną = 1 (kryterium Kaisera). Kliknij słupek, aby wybrać liczbę czynników do wyodrębnienia.",
+      "kaiser_suggestion": "{{n}} czynnik(-ów) ma wartości własne powyżej 1 (kryterium Kaisera)",
+      "factor": "Czynnik",
+      "factor_n": "Czynnik {{n}}",
+      "eigenvalue": "Wartość własna",
+      "too_few_participants": "Do uruchomienia analizy potrzebne są co najmniej 2 ukończone sortowania.",
+      "eigenvalue_error": "Nie udało się wczytać danych analizy. Proszę spróbować ponownie.",
+      "scree_plot_label": "Wykres osypiska pokazujący wartości własne dla {{n}} czynników",
+      "loading_eigenvalues": "Wczytywanie wartości własnych...",
+      "empty_state": "Ustaw parametry i uruchom analizę.",
+      "empty": {
+        "contract_title": "Za mało danych z sortowania Q",
+        "contract_body": "Analiza czynnikowa metodologii Q wymaga co najmniej 2 uczestników, którzy ukończyli sortowanie. Opcje konfiguracji (ekstrakcja, czynniki, rotacja, oznaczanie) nabierają znaczenia po zgromadzeniu danych. Udostępnij link do badania z widoku ogólnego, aby zacząć zbierać odpowiedzi.",
+        "contract_cta": "Otwórz widok ogólny badania"
+      },
+      "advanced": {
+        "title": "Ustawienia zaawansowane",
+        "summary": "Rotacja: {{rotation}} · Oznaczanie: {{flagging}} · Bootstrap: {{bootstrap}}",
+        "bootstrap_off": "wyłączony",
+        "bootstrap_on": "{{n}} iteracji"
+      },
+      "tab_loadings": "Ładunki",
+      "tab_factor_arrays": "Tablice czynnikowe",
+      "tab_statements": "Stwierdzenia",
+      "tab_summary": "Podsumowanie",
+      "participant": "Uczestnik",
+      "flagged": "Oznaczony",
+      "significance_threshold": "Próg istotności (p<0,05): ±{{threshold}}",
+      "sorts": "sortowania",
+      "distinguishing_legend": "Stwierdzenie różnicujące",
+      "code": "Kod",
+      "statement": "Stwierdzenie",
+      "type": "Typ",
+      "distinguishing": "Różnicujące",
+      "consensus": "Konsensusowe",
+      "variance_explained": "Wyjaśniona wariancja (%)",
+      "cumulative_variance": "Skumulowana wariancja (%)",
+      "n_flagged": "Liczba oznaczonych sortowań",
+      "composite_reliability": "Rzetelność złożona",
+      "se_factor_scores": "Błąd standardowy wyników czynnikowych",
+      "factor_correlations": "Korelacje czynników",
+      "high_correlation": "Wysoka korelacja",
+      "total_variance": "Łączna wyjaśniona wariancja",
+      "method_used": "Metoda",
+      "statements_label": "stwierdzenia",
+      "pca": "PCA",
+      "varimax": "Varimax",
+      "metric": "Metryka",
+      "caption_loadings": "Ładunki czynnikowe na uczestnika",
+      "caption_statements": "Wyniki z i tablice czynnikowe na czynnik",
+      "caption_characteristics": "Charakterystyki czynników i statystyki rzetelności",
+      "caption_correlations": "Macierz korelacji między czynnikami",
+      "retry": "Spróbuj ponownie",
+      "flagging_method": "Oznaczanie",
+      "auto": "Auto",
+      "manual": "Ręczny",
+      "manual_flag_hint": "Kliknij komórkę ładunku, aby oznaczyć/odznaczyć uczestnika dla danego czynnika. Uruchom ponownie analizę, aby zaktualizować wyniki.",
+      "no_flagged_participants": "Żaden uczestnik nie jest oznaczony dla żadnego czynnika. Spróbuj dostosować liczbę czynników lub metodę oznaczania.",
+      "no_statement_scores": "Brak dostępnych wyników stwierdzeń. Upewnij się, że uczestnicy są oznaczeni dla co najmniej jednego czynnika.",
+      "no_characteristics": "Brak dostępnych charakterystyk czynników.",
+      "export": "Eksportuj",
+      "export_loadings": "Ładunki czynnikowe (CSV)",
+      "export_scores": "Wyniki stwierdzeń (CSV)",
+      "export_xlsx": "Pełna analiza (XLSX)",
+      "export_error": "Nie udało się wygenerować eksportu XLSX.",
+      "select_factors": "Wybierz liczbę czynników",
+      "loadings_help": "Ładunki czynnikowe pokazują, jak silnie sortowanie każdego uczestnika koreluje z każdym czynnikiem. Wyróżnione komórki przekraczają próg istotności podany powyżej.",
+      "factor_array_help": "Złożone sortowanie Q pokazujące wyidealizowany wzorzec sortowania dla tego czynnika. Stwierdzenia są rozmieszczone w rozkładzie na podstawie ważonych wyników z.",
+      "factor_array_label": "Złożone sortowanie czynnika {{n}}",
+      "factor_arrays": {
+        "toggle_narratives": "Pokaż interpretacje czynników",
+        "toggle_narratives_aria": "Przełącz interpretacje poszczególnych czynników"
+      },
+      "statements_help": "Wyniki z pokazują standardową pozycję każdego czynnika na każdym stwierdzeniu. D = różnicujące (istotnie różne między czynnikami), C = konsensusowe (brak istotnych różnic).",
+      "z_scores_description": "Wyniki z i pozycje tablicy czynnikowej na stwierdzenie",
+      "factor_statistics": "Statystyki czynników",
+      "characteristics_help": "Wartości własne odzwierciedlają ilość wyjaśnionej wariancji. Rzetelność złożona odzwierciedla wewnętrzną spójność oznaczonych sortowań. Błąd standardowy wyników czynnikowych odzwierciedla precyzję estymacji złożonej.",
+      "help_extraction": "PCA maksymalizuje wyjaśnianą wariancję. Centroid jest mniej ograniczony matematycznie.",
+      "help_n_factors": "Każdy czynnik reprezentuje odrębny punkt widzenia.",
+      "help_rotation": "Varimax rozdziela czynniki dla prostszej struktury.",
+      "help_flagging": "Auto: oznaczaj uczestników ładujących się na dokładnie jeden czynnik. Ręczny: nadpisuj ręcznie dla każdego uczestnika.",
+      "guide_loadings_title": "Odczytywanie ładunków czynnikowych",
+      "guide_loadings_1": "Każdy ładunek to korelacja (od −1 do +1) między uczestnikiem a czynnikiem (wspólnym punktem widzenia).",
+      "guide_loadings_2": "Wyróżnione wartości przekraczają próg istotności pokazany powyżej tabeli.",
+      "guide_arrays_title": "Interpretacja tablic czynnikowych",
+      "guide_arrays_1": "Każda tablica czynnikowa to złożone sortowanie Q reprezentujące jeden wspólny punkt widzenia.",
+      "guide_arrays_2": "Czytaj od lewej do prawej: od największego braku zgody do największej zgody. Pozycje skrajne niosą najsilniejszy sygnał interpretacyjny.",
+      "guide_statements_title": "Rozumienie wyników stwierdzeń",
+      "guide_statements_1": "Wyniki z pokazują, jak silnie każdy czynnik zgadza się lub nie zgadza z każdym stwierdzeniem (0 = neutralnie).",
+      "guide_statements_2": "D = różnicujące (umieszczone istotnie różnie między czynnikami). Gwiazdki wskazują poziom istotności.",
+      "guide_summary_title": "Ocena rozwiązania",
+      "guide_summary_1": "Wartości własne mierzą, ile wariancji wyjaśnia dany czynnik. Kryterium Kaisera (wartość własna > 1) to jedna z popularnych heurystyk decydowania o liczbie czynników do zachowania.",
+      "guide_summary_2": "Rzetelność złożona odzwierciedla, jak spójnie oznaczone sortowania definiują dany czynnik. Wyższe wartości oznaczają, że estymacja czynnika opiera się na większej zgodności sortowań go definiujących.",
+      "benchmark_above": "Powyżej progu",
+      "benchmark_below": "Poniżej progu",
+      "history": {
+        "title": "Historia analiz",
+        "loading": "Wczytywanie historii…",
+        "fetch_error": "Nie udało się wczytać historii analiz.",
+        "empty": "Brak poprzednich analiz dla tego badania. Uruchom jedną, aby rozpocząć ślad audytu.",
+        "empty_explainer": "Każde uruchomienie jest tutaj rejestrowane, aby można było dokumentować i ponownie przeglądać każdą decyzję.",
+        "load_error": "Nie udało się wczytać tego przebiegu analizy. Odśwież stronę, aby spróbować ponownie.",
+        "load_run_aria": "Wczytaj przebieg analizy z {{date}}",
+        "loading_run": "Wczytywanie…",
+        "current_tag": "bieżący",
+        "n_factors_label": "{{n}}C",
+        "edit_notes": "Edytuj notatki",
+        "edit_notes_aria": "Edytuj notatki dla tego przebiegu",
+        "notes_placeholder": "Dodaj notatkę o tym przebiegu…",
+        "notes_aria": "Edytuj notatki dla tego przebiegu",
+        "save_notes_aria": "Zapisz notatki",
+        "cancel_edit_aria": "Anuluj edycję",
+        "notes_saved": "Notatki zapisane.",
+        "notes_error": "Nie udało się zapisać notatek. Sprawdź połączenie i spróbuj ponownie.",
+        "delete_run": "Usuń przebieg",
+        "delete_run_aria": "Usuń ten przebieg analizy",
+        "delete_dialog_title": "Usunąć przebieg analizy?",
+        "delete_dialog_description": "Usunięcie przebiegu analizy usuwa dowód analitycznego wyboru ze śladu audytu. Czy na pewno?",
+        "cancel": "Anuluj",
+        "delete_confirm": "Usuń",
+        "deleted": "Przebieg analizy usunięty.",
+        "delete_error": "Nie udało się usunąć przebiegu.",
+        "viewing_banner": "Podgląd przebiegu z {{date}}: {{extraction}} · {{n}}C · {{rotation}}",
+        "back_to_current": "Wróć do bieżącego"
+      },
+      "factor_voices": {
+        "title": "Głosy przy czynniku {{n}}",
+        "no_audio": "Brak nagrań audio po sortowaniu od uczestników oznaczonych dla tego czynnika.",
+        "no_material": "Brak nagrań audio po sortowaniu ani pisemnych komentarzy od uczestników oznaczonych dla tego czynnika.",
+        "loading": "Wczytywanie nagrań…",
+        "error": "Nie udało się wczytać nagrań audio. Proszę spróbować ponownie.",
+        "context": "Osadź interpretację czynnika we własnych słowach uczestników: ich uzasadnieniach audio i pisemnych komentarzach do kart.",
+        "context_aria": "O tym panelu",
+        "audio_label": "Nagranie: {{key}} — {{participant}}",
+        "url_unavailable": "URL audio niedostępny.",
+        "comments_label": "Komentarze do kart",
+        "question_default": "Komentarz głosowy"
+      },
+      "factor_note": {
+        "label": "Interpretacja czynnika",
+        "placeholder": "Napisz interpretację tego czynnika: dyskurs, głosy i napięcia, które eksponuje.",
+        "empty_hint": "Dodaj interpretację dla tego czynnika",
+        "char_count": "{{n}}/{{max}}",
+        "edit_aria": "Edytuj interpretację czynnika {{n}}",
+        "save_aria": "Zapisz interpretację czynnika",
+        "cancel_aria": "Anuluj edycję",
+        "aria": "Edytuj interpretację czynnika {{n}}",
+        "saved": "Interpretacja czynnika zapisana.",
+        "error": "Nie udało się zapisać interpretacji czynnika."
+      },
+      "rotation": {
+        "judgmental": {
+          "label": "Ekspercka (ręczna)",
+          "short": "Ekspercka",
+          "tooltip": "Ręcznie obracaj pary czynników o wybrane kąty, aby ustawić je w merytorycznie sensownych pozycjach."
+        }
+      },
+      "manual_rotations": {
+        "title": "Rotacje ręczne",
+        "helper": "Podaj rotacje w formie: 'obróć czynnik F o Δ° wokół czynnika G'. Rotacje są stosowane w kolejności.",
+        "add": "Dodaj rotację",
+        "remove_aria": "Usuń rotację",
+        "empty": "Dodaj co najmniej jedną rotację, aby uruchomić analizę.",
+        "factor_a_label": "Obróć czynnik",
+        "angle_label": "o",
+        "factor_b_label": "wokół czynnika"
+      },
+      "bootstrap": {
+        "toggle_label": "Uruchom bootstrap stabilności",
+        "iterations_label": "Iteracje (B)",
+        "helper": "Opcjonalnie. Próbkuje sortowania Q B razy, aby oszacować przedziały ufności dla wyników czynnikowych.",
+        "running": "Trwa bootstrap…",
+        "se_column": "Średni błąd standardowy (z)",
+        "tooltip": "Nieparametryczny bootstrap sortowań Q (próbkowanie ze zwracaniem); analiza jest powtarzana B razy, aby oszacować 95% przedziały ufności dla wyników z."
+      },
+      "explore": {
+        "diagnostics_title": "Diagnostyka",
+        "kaiser": "Kaiser",
+        "parallel": "Analiza równoległa",
+        "map": "MAP Velicera",
+        "advisory": "Wyłącznie orientacyjne. Decyzja o liczbie czynników w metodologii Q zależy też od interpretowalności i stabilności (Watts i Stenner 2012).",
+        "preview_range_title": "Podgląd zakresu",
+        "preview_range_disabled": "Podgląd zakresu obsługuje tylko PCA + varimax. Ekstrakcja centroidów i rotacja ekspercka są zależne od ścieżki; zatwierdź rzeczywisty przebieg, aby sprawdzić.",
+        "select_k": "{{k}} czynników",
+        "empty_factor": "Pusty czynnik (nadmierna faktoryzacja)",
+        "cumvar": "skum. war. %",
+        "pct_flagged": "% oznaczonych",
+        "n_distinguishing": "# różnicujące",
+        "n_cross_loaders": "# wieloczynnikowe",
+        "min_def_sorts": "min. sortowań def.",
+        "advanced_title": "Konfiguracja zaawansowana",
+        "commit_cta": "Zatwierdź i interpretuj"
+      },
+      "interpret": {
+        "def_sorts": "Sortowania definiujące: {{n}}",
+        "statements_title": "Stwierdzenia",
+        "narrative_title": "Interpretacja C{{n}}",
+        "insert_comment_quote": "Wstaw komentarz jako cytat",
+        "focus_mode": "Fokus na czynnik",
+        "overview_mode": "Widok ogólny",
+        "mode_toggle": "Tryb widoku"
+      },
+      "compare": {
+        "pin_cta": "Przypnij do porównania",
+        "no_other_runs": "Brak innych dostępnych przebiegów",
+        "run_label": "Przebieg #{{id}} ({{n}} czynników)",
+        "pinned": "Porównanie z przebiegiem #{{id}}",
+        "phi": "φ = {{phi}}",
+        "ambiguous": "niejednoznaczne dopasowanie (interpretuj różnice ostrożnie)",
+        "unpin": "Odepnij",
+        "delta_z_aria": "Δz {{delta}} vs przebieg porównawczy",
+        "delta_loading_aria": "Δładunek {{delta}} vs przebieg porównawczy"
+      },
+      "quote_insert_format": "> {{text}}\n> {{p}}, o stwierdzeniu {{code}}: \"{{stmt}}\""
+    },
+    "project": {
+      "remove_member": "Usuń członka",
+      "table_caption": "Członkowie projektu",
+      "switcher": {
+        "settings": "Ustawienia projektu",
+        "settings_desc": "Członkowie i profile",
+        "new_project": "Nowy projekt",
+        "new_project_desc": "Utwórz nowy projekt"
+      },
+      "roles": {
+        "owner": "Właściciel",
+        "admin": "Administrator",
+        "viewer": "Obserwator",
+        "member": "Członek"
+      },
+      "study_states": {
+        "active": "Aktywne",
+        "draft": "Szkic",
+        "paused": "Wstrzymane",
+        "closed": "Zamknięte"
+      },
+      "create": {
+        "title": "Utwórz projekt",
+        "card_title": "Szczegóły projektu",
+        "name_label": "Nazwa projektu",
+        "name_placeholder": "Badanie Q postaw wobec klimatu",
+        "url_label": "URL projektu",
+        "url_placeholder": "badanie-q-postawy-klimat",
+        "url_description": "To staje sie sciezka projektu pod /app/.",
+        "cancel": "Anuluj",
+        "create_button": "Utwórz projekt",
+        "creating": "Tworzenie...",
+        "success": "Projekt został pomyślnie utworzony",
+        "error": "Nie udało się utworzyć projektu"
+      }
+    },
+    "recruitment": {
+      "title": "Dostęp",
+      "description": "Skonfiguruj URL badania, zarządzaj dostępem uczestników i śledź efektywność rekrutacji.",
+      "study_url": {
+        "title": "URL badania",
+        "description": "Publiczny adres, pod którym uczestnicy mają dostęp do badania.",
+        "full_url_label": "Pełny URL",
+        "slug_label": "URL slug",
+        "slug_description": "Unikalny identyfikator używany w URL badania. Tylko małe litery, cyfry i myślniki.",
+        "slug_locked": "Slug URL można zmieniać tylko w trybie szkicu."
+      },
+      "state_draft": "Tryb szkicu. Linki będą działać po aktywowaniu badania.",
+      "state_closed": "To badanie jest zamknięte. Istniejące linki pozostają widoczne, ale nowi uczestnicy nie mogą rozpocząć.",
+      "state_archived": "To badanie jest zarchiwizowane. Wszystkie dane rekrutacji są tylko do odczytu.",
+      "empty_title": "Brak linków rekrutacyjnych",
+      "empty_description": "Utwórz pierwszy link, aby zacząć zapraszać uczestników.",
+      "empty_cta": "Utwórz link dostępu",
+      "stats_summary": {
+        "links": "linków",
+        "started": "rozpoczętych",
+        "submitted": "przesłanych"
+      },
+      "access_rules": {
+        "title": "Reguły dostępu",
+        "description": "Kontroluj, kiedy i jak uczestnicy mają dostęp do badania.",
+        "password_toggle": "Wymagaj hasła",
+        "password_toggle_desc": "Uczestnicy muszą wpisać hasło przed rozpoczęciem badania.",
+        "password_label": "Hasło dostępu",
+        "password_placeholder": "Wpisz hasło dostępu",
+        "password_locked": "Ochrona hasłem może być zmieniana tylko w trybie szkicu.",
+        "password_set": "Hasło jest aktualnie ustawione. Wpisz nową wartość, aby je zmienić, lub wyłącz przełącznik, aby je usunąć.",
+        "collection_window": "Okno zbierania danych",
+        "window_toggle": "Ogranicz okno zbierania danych",
+        "window_toggle_help": "Ogranicz dostęp uczestników do określonego zakresu czasu.",
+        "start_date_label": "Otwiera się o",
+        "end_date_label": "Zamyka się o",
+        "date_hint": "Pozostaw puste, aby nie ograniczać czasu.",
+        "clear_date": "Wyczyść datę",
+        "save_button": "Zapisz reguły dostępu",
+        "save_success": "Reguły dostępu zaktualizowane",
+        "save_error": "Nie udało się zaktualizować reguł dostępu",
+        "non_draft_notice": "Poza trybem szkicu można edytować tylko okno zbierania danych. Przełącz badanie z powrotem na szkic, aby zmienić inne reguły dostępu.",
+        "archived_notice": "To badanie jest zarchiwizowane. Reguły dostępu są tylko do odczytu."
+      },
+      "new_link": "Nowy link dostępu",
+      "create_title": "Utwórz linki dostępu",
+      "link_type": "Strategia dostępu",
+      "select_type": "Wybierz typ rekrutacji...",
+      "campaign_name": "Kanał / nazwa kampanii",
+      "name_placeholder": "Np. LinkedIn, e-mail partia a, lista studentów...",
+      "link_count": "Rozmiar partii",
+      "capacity_label": "Maks. zgłoszeń",
+      "generate_links": "Generuj linki",
+      "no_links": "Nie wygenerowano jeszcze żadnych linków rekrutacyjnych.",
+      "unnamed": "Kanał bez nazwy",
+      "revoked": "Dostęp odwołany",
+      "qr_title": "Udostępnij przez QR",
+      "copy_link": "Kopiuj URL",
+      "table_title": "Linki rekrutacyjne",
+      "share_title": "Udostępnij badanie",
+      "share_desc": "Rozprowadź URL badania, aby zaprosić uczestników.",
+      "public_url_label": "Publiczny URL uczestnictwa",
+      "hide_qr": "Ukryj QR",
+      "show_qr": "Pokaż kod QR",
+      "delete_link": "Usuń link",
+      "qr_alt": "Kod QR dla {{url}}",
+      "table_caption": "Linki rekrutacyjne",
+      "progress_label": "{{count}} z {{max}} odpowiedzi",
+      "usage": {
+        "started": "rozpoczęte",
+        "submitted": "przesłane",
+        "completed": "Ukończone",
+        "in_progress": "W toku",
+        "unused": "Nieużyte"
+      },
+      "live_study": "Badanie na żywo",
+      "download_qr": "Pobierz obraz",
+      "qr_print_hint": "Zeskanuj lub wydrukuj ten kod do fizycznych materiałów rekrutacyjnych (ulotki, plakaty).",
+      "analytics_title": "Analityka kampanii",
+      "analytics_desc": "Bezpośrednie linki i skany QR są automatycznie śledzone w panelu zdrowia powyżej.",
+      "copy_success": "Link do badania skopiowany do schowka",
+      "types": {
+        "public": "Dostęp otwarty (publiczny)",
+        "individual": "Jednorazowy kod dostępu",
+        "limited": "Ograniczone uczestnictwo"
+      },
+      "guidance": {
+        "public": "Najlepszy do rekrutacji na dużą skalę. Jeden URL dla wszystkich uczestników.",
+        "individual": "Maksymalne bezpieczeństwo. Generuje unikalne linki wygasające po jednym pomyślnym ukończeniu.",
+        "limited": "Kontrolowany dostęp. Jeden link, który przestaje działać po określonej liczbie zgłoszeń."
+      },
+      "stats": {
+        "total_links": "Łącznie kanałów",
+        "active_channels": "Aktywne partie rekrutacyjne",
+        "started": "Łącznie sesji",
+        "engagements": "Uczestnicy, którzy rozpoczęli",
+        "submitted": "Prawidłowe dane",
+        "completions": "Ukończone zgłoszenia",
+        "conversion": "Wskaźnik przechwycenia",
+        "efficiency": "Ostateczny wynik danych"
+      },
+      "table": {
+        "name": "Kampania / partia",
+        "type": "Typ wejścia",
+        "token": "Token bezpieczeństwa",
+        "usage": "Pojemność",
+        "status": "Stan",
+        "actions": "Zarządzaj",
+        "type_help": "Publiczny, jednorazowy lub z ograniczoną pojemnością. Patrz opisy strategii w oknie dialogowym 'Nowy link dostępu'."
+      },
+      "status": {
+        "public": "Publiczny",
+        "individual": "Indywidualny",
+        "limited": "Ograniczony"
+      },
+      "toasts": {
+        "created": "Linki rekrutacyjne utworzone pomyślnie",
+        "failed": "Nie udało się utworzyć linków rekrutacyjnych. Sprawdź dane wejściowe i spróbuj ponownie.",
+        "revoked": "Link odwołany",
+        "revoke_failed": "Nie udało się odwołać tego linku. Możliwe, że jest już w użyciu.",
+        "copied": "Skopiowano do schowka"
+      }
+    },
+    "analytics": {
+      "charts": {
+        "recruitment_funnel": {
+          "title": "Lejek rekrutacyjny",
+          "subtitle": "Łączna wydajność konwersji",
+          "initial_contact": "Pierwszy kontakt",
+          "completion": "Ukończenie",
+          "started_study": "Rozpoczęto badanie",
+          "submitted": "Przesłano",
+          "yield": "Wynik",
+          "success_rate": "Wskaźnik sukcesu",
+          "completion_rate": "{{rate}}% uczestników ukończyło badanie"
         },
-        "study_overview": {
-            "title": "Przegląd",
-            "back_to_overview": "Wróć do przeglądu",
-            "sample_size": "Liczba uczestników (P-Set)",
-            "valid": "prawidłowe",
-            "completion_rate": "Wskaźnik ukończenia",
-            "active": "aktywne",
-            "mobile": "mobilne",
-            "median_duration": "Mediana czasu trwania",
-            "suspect": "Podejrzane",
-            "recent_activity": "Ostatnia aktywność",
-            "latest_participants": "Ostatni uczestnicy ({{count}} z {{total}})",
-            "recently_completed": "Ostatnio ukończone",
-            "in_progress": "W toku",
-            "discarded": "Odrzucone",
-            "started": "Rozpoczęto",
-            "view_all": "Zobacz wszystkich uczestników i szczegóły danych",
-            "no_participants": "Brak uczestników.",
-            "view_data": "Pokaż",
-            "submitted": "Przesłano",
-            "edit_design": "Edytuj projekt",
-            "export_csv": "Pobierz CSV",
-            "export_json": "Pobierz JSON",
-            "steps": {
-                "welcome": "Powitanie",
-                "consent": "Zgoda",
-                "rough_sort": "Sortowanie zgrubne",
-                "fine_sort": "Sortowanie Q",
-                "final": "Ostatnie kroki"
-            }
+        "link_performance": {
+          "title": "Śledzenie skuteczności linków",
+          "subtitle": "Monitorowanie efektywności poszczególnych kanałów rekrutacyjnych",
+          "volume": "Wolumen",
+          "yield": "Wynik",
+          "conversion_rate": "Wskaźnik konwersji",
+          "total_responses": "odpowiedzi"
+        }
+      }
+    },
+    "breadcrumbs": {
+      "admin": "Admin",
+      "dashboard": "Dashboard",
+      "study_dashboard": "Overview",
+      "design": "Design",
+      "participants": "Participants",
+      "team": "Team",
+      "recruitment": "Access",
+      "exports": "Data",
+      "data": "Data",
+      "privacy": "Data privacy",
+      "account": "Account settings",
+      "participant_n": "Participant {{code}}",
+      "analysis": "Analysis",
+      "settings": "Settings",
+      "concourse": "Concourse",
+      "members": "Team members"
+    },
+    "command_menu": {
+      "title": "Globalne menu poleceń",
+      "placeholder": "Wpisz polecenie lub wyszukaj...",
+      "no_results": "Brak wyników.",
+      "switch_project": "Przełącz projekt",
+      "switch_study": "Przełącz badanie",
+      "study_actions": "Akcje badania",
+      "system": "System",
+      "no_studies": "Brak badań w tym projekcie.",
+      "open_dashboard": "Otwórz panel",
+      "design_study": "Projekt badania",
+      "collaborators": "Współpracownicy",
+      "copy_link": "Kopiuj publiczny link",
+      "toggle_theme": "Przełącz motyw",
+      "logout": "Wyloguj",
+      "search_label": "Szukaj lub uruchom polecenia",
+      "to_open": "Otwórz",
+      "active": "Aktywne",
+      "link_copied": "Link do badania skopiowany!",
+      "logged_out": "Wylogowano pomyślnie",
+      "switched_project": "Przełączono na {{name}}"
+    },
+    "dashboard": {
+      "title": "Panel projektu",
+      "welcome": "Witamy z powrotem,",
+      "snapshot": "Oto migawka aktywności badawczej.",
+      "create_study": "Utwórz badanie",
+      "total_studies": "Łącznie badań",
+      "across_statuses": "Wszystkich statusów",
+      "active_data_collection": "Aktywne zbieranie danych",
+      "receiving_responses": "Badania przyjmujące odpowiedzi",
+      "total_participants": "Łącznie uczestników",
+      "all_studies": "Wszystkie badania",
+      "all_studies_description": "Wszystkie badania w tym projekcie.",
+      "languages_count_one": "{{count}} język",
+      "languages_count_other": "{{count}} języków",
+      "n_participants_one": "{{count}} uczestnik",
+      "n_participants_other": "{{count}} uczestników",
+      "n_studies_one": "{{count}} badanie",
+      "n_studies_other": "{{count}} badań",
+      "n_active_one": "{{count}} aktywne",
+      "n_active_other": "{{count}} aktywnych",
+      "n_participants_total_one": "{{count}} uczestnik",
+      "n_participants_total_other": "{{count}} uczestników",
+      "concourse_n_items_one": "{{count}} stwierdzenie",
+      "concourse_n_items_other": "{{count}} stwierdzeń",
+      "concourse_open_hint": "Kuracja stwierdzeń kandydatów",
+      "created": "Utworzono",
+      "no_studies": "Nie znaleziono badań. Utwórz pierwsze badanie, aby zacząć!",
+      "import_study": "Importuj badanie",
+      "get_started": "Zacznij swój projekt badawczy",
+      "onboarding_title": "Pierwsze kroki",
+      "step_create_project": "Utwórz projekt",
+      "step_create_project_desc": "Projekt jest gotowy.",
+      "step_concourse": "Zbierz stwierdzenia w konkursie",
+      "step_concourse_desc": "Dodaj stwierdzenia kandydatów z przeglądu literatury.",
+      "step_qset": "Wybierz zbiór Q",
+      "step_qset_desc": "Przejrzyj i zaakceptuj elementy tworzące zbiór Q.",
+      "step_study": "Utwórz badanie",
+      "step_study_desc": "Zdefiniuj siatkę sortowania Q.",
+      "step_import": "Zaimportuj zbiór Q do badania",
+      "step_import_desc": "Zaimportuj zaakceptowane elementy konkursu jako stwierdzenia badania.",
+      "step_configure": "Skonfiguruj przepływ uczestnika",
+      "step_configure_desc": "Skonfiguruj instrukcje, wstępne sortowanie i pytania końcowe.",
+      "step_launch": "Uruchom rekrutację",
+      "step_launch_desc": "Generuj linki uczestnictwa i udostępniaj je.",
+      "go_to_concourse": "Otwórz konkurs",
+      "go_to_qset": "Otwórz zbiór Q",
+      "concourse": "Konkurs",
+      "concourse_empty": "Brak elementów. Zacznij budować kolekcję stwierdzeń.",
+      "team": "Zespół",
+      "team_loading": "Ładowanie...",
+      "studies": "Badania",
+      "active_studies": "Aktywne",
+      "paused_studies": "Wstrzymane",
+      "draft_studies": "Szkice",
+      "closed_studies": "Ukończone",
+      "attention": "Wymaga uwagi",
+      "alert_deadline": "{{study}}: zamknięcie za {{days}} dni, {{count}} uczestników",
+      "view": "Pokaż",
+      "open_study": "Otwórz badanie",
+      "add_study": "Dodaj badanie",
+      "closes": "Zamknięcie",
+      "timeline": {
+        "title": "Oś czasu zgłoszeń",
+        "subtitle": "Dzienne trendy uczestnictwa",
+        "started": "Rozpoczęto",
+        "completed": "Ukończono"
+      },
+      "devices": {
+        "title": "Rozkład urządzeń",
+        "subtitle": "Jak uczestnicy korzystają z badania",
+        "types": {
+          "desktop": "Komputer",
+          "mobile": "Telefon",
+          "tablet": "Tablet",
+          "unknown": "Nieznane"
+        }
+      },
+      "n_studies_help": "Łączna liczba badań w tym projekcie, w tym szkice i zamknięte.",
+      "n_active_help": "Badania aktualnie przyjmujące zgłoszenia uczestników (stan = aktywne).",
+      "n_participants_total_help": "Suma ukończonych uczestników we wszystkich badaniach tego projektu.",
+      "tool_help": {
+        "design": "Konfiguruj badanie: siatka rozkładu, warunki instrukcji, stwierdzenia, zgoda.",
+        "recruit": "Linki rekrutacyjne, reguły dostępu i ustawienia URL badania.",
+        "data": "Odpowiedzi uczestników i eksporty (CSV, zrzuty sortowania Q).",
+        "analysis": "Konfiguracja analizy czynnikowej i historia przebiegów."
+      }
+    },
+    "export": {
+      "config": "Eksportuj konfigurację",
+      "exporting": "Eksportowanie...",
+      "config_success": "Konfiguracja wyeksportowana pomyślnie",
+      "config_error": "Nie można wyeksportować konfiguracji. Spróbuj ponownie.",
+      "label": "Eksportuj dane",
+      "success": "Eksport zakończony pomyślnie",
+      "error": "Eksport nie powiódł się. Spróbuj ponownie.",
+      "csv": "Eksportuj CSV",
+      "json": "Eksportuj JSON",
+      "audio": "Eksportuj nagrania audio (ZIP)",
+      "formats": {
+        "csv": "CSV",
+        "pqmethod": "PQMethod (ZIP)",
+        "rkit": "R-Kit (ZIP)",
+        "package": "Pakiet badawczy (ZIP)",
+        "json": "Zrzut JSON"
+      },
+      "download": "Pobierz",
+      "package_dialog": {
+        "title": "Pobierz pakiet badawczy",
+        "description": "Łączy wszystkie dane badania w jeden plik ZIP do OSF lub rejestracji wstępnej.",
+        "discussion_hint": "Dodaje plik memo/memo-discussion.md ze wszystkimi wątkami komentarzy (podpisanymi i opatrzonymi datą). Domyślnie wyłączone; zachowaj czysty eksport, chyba że potrzebna jest ścieżka deliberacji."
+      }
+    },
+    "import": {
+      "title": "Importuj konfigurację badania",
+      "config": "Importuj konfigurację",
+      "upload_desc": "Prześlij wcześniej wyeksportowany plik konfiguracji badania",
+      "validate_desc": "Przejrzyj konfigurację i podaj unikalny slug",
+      "creating_desc": "Tworzenie badania...",
+      "file_upload": "Prześlij plik",
+      "paste_json": "Wklej JSON",
+      "drop_here": "Upuść plik tutaj",
+      "drag_drop": "Przeciągnij i upuść plik JSON lub kliknij, aby przeglądać",
+      "supported": "Obsługiwany format: .json",
+      "paste_label": "Wklej konfigurację JSON",
+      "validate": "Sprawdź poprawność i kontynuuj",
+      "valid": "Konfiguracja jest prawidłowa",
+      "invalid": "Konfiguracja zawiera błędy",
+      "errors": "Błędy",
+      "warnings": "Ostrzeżenia",
+      "summary": "Podsumowanie badania",
+      "title_field": "Tytuł",
+      "languages": "Języki",
+      "statements": "Stwierdzenia",
+      "grid": "Zakres siatki",
+      "new_slug": "Nowy slug badania",
+      "slug_help": "Musi być unikalny, 3–100 znaków, tylko małe litery, cyfry i myślniki",
+      "creating": "Tworzenie badania z konfiguracji...",
+      "create_study": "Utwórz badanie",
+      "invalid_json": "Nieprawidłowy plik JSON",
+      "validation_failed": "Konfiguracja jest nieprawidłowa",
+      "success": "Badanie zaimportowane pomyślnie",
+      "redirecting": "Otwieranie projektanta badania...",
+      "failed": "Nie udało się zaimportować badania. Zapoznaj się ze szczegółami poniżej i spróbuj ponownie.",
+      "validation": {
+        "errors": {
+          "missing_version": "Brak pola wersji",
+          "unsupported_version": "Nieobsługiwana wersja: {{version}}",
+          "missing_field": "Brak wymaganego pola: {{field}}",
+          "no_translations": "Wymagane jest co najmniej jedno tłumaczenie",
+          "missing_translation_field": "Tłumaczeniu {{index}} brakuje wymaganego pola: {{field}}",
+          "invalid_lang_code": "Nieprawidłowy kod języka: {{lang}}",
+          "no_statements": "Wymagane jest co najmniej jedno stwierdzenie",
+          "duplicate_codes": "Zduplikowane kody stwierdzeń: {{codes}}",
+          "missing_stmt_translations": "Stwierdzeniu {{index}} brakuje tłumaczeń",
+          "invalid_grid_config": "Nieprawidłowy grid_config: musi być listą",
+          "invalid_grid_structure": "Nieprawidłowa struktura grid_config: {{error}}"
         },
-        "overview": {
-            "copy_id": "Copy participant ID"
+        "warnings": {
+          "grid_capacity_mismatch": "Liczba stwierdzeń ({{count}}) nie odpowiada pojemności siatki ({{capacity}})",
+          "missing_consent_draft": "Brak tytułu lub opisu formularza zgody (badanie w szkicu)",
+          "external_branding_logo": "Logo marki używa zewnętrznego URL: {{url}}",
+          "external_partner_logo": "Logo partnera '{{name}}' używa zewnętrznego URL: {{url}}",
+          "external_logo": "URL logo odwołuje się do zasobu zewnętrznego — może być niedostępny"
+        }
+      }
+    },
+    "dialogs": {
+      "create_study": {
+        "title": "Utwórz nowe badanie",
+        "description": "Rozpocznij nowe badanie metodologią Q. Stwierdzenia i ustawienia można skonfigurować później.",
+        "study_title": "Tytuł badania",
+        "study_title_placeholder": "Np. Perspektywy dotyczące AI",
+        "url_slug": "URL slug",
+        "url_slug_placeholder": "np. perspektywy-ai-2025",
+        "cancel": "Anuluj",
+        "create": "Utwórz badanie",
+        "success": "Badanie zostało pomyślnie utworzone",
+        "error": "Nie udało się utworzyć badania",
+        "languages": "Języki",
+        "languages_desc": "Wybierz języki do włączenia. Treść zostanie zainicjowana zlokalizowanymi wartościami domyślnymi."
+      }
+    },
+    "validation": {
+      "required": "Wymagane",
+      "slug_min": "Slug musi mieć co najmniej 3 znaki",
+      "slug_regex": "Slug może zawierać tylko małe litery, cyfry i myślniki"
+    },
+    "study_overview": {
+      "title": "Przegląd",
+      "back_to_overview": "Wróć do przeglądu",
+      "sample_size": "Liczba uczestników (P-Set)",
+      "valid": "prawidłowe",
+      "completion_rate": "Wskaźnik ukończenia",
+      "active": "aktywne",
+      "mobile": "mobilne",
+      "median_duration": "Mediana czasu trwania",
+      "suspect": "Podejrzane",
+      "recent_activity": "Ostatnia aktywność",
+      "latest_participants": "Ostatni uczestnicy ({{count}} z {{total}})",
+      "recently_completed": "Ostatnio ukończone",
+      "in_progress": "W toku",
+      "discarded": "Odrzucone",
+      "started": "Rozpoczęto",
+      "view_all": "Zobacz wszystkich uczestników i szczegóły danych",
+      "no_participants": "Brak uczestników.",
+      "view_data": "Pokaż",
+      "submitted": "Przesłano",
+      "edit_design": "Edytuj projekt",
+      "export_csv": "Pobierz CSV",
+      "export_json": "Pobierz JSON",
+      "steps": {
+        "welcome": "Powitanie",
+        "consent": "Zgoda",
+        "rough_sort": "Sortowanie zgrubne",
+        "fine_sort": "Sortowanie Q",
+        "final": "Ostatnie kroki"
+      }
+    },
+    "overview": {
+      "copy_id": "Copy participant ID"
+    },
+    "study_status": {
+      "dialog": {
+        "draft": {
+          "title": "Przywrócić do szkicu?",
+          "desc": "Spowoduje to zatrzymanie zbierania danych, ale umożliwi modyfikację projektu badania. Istniejące dane zostaną zachowane.",
+          "action": "Przywróć do szkicu"
         },
-        "study_status": {
-            "dialog": {
-                "draft": {
-                    "title": "Przywrócić do szkicu?",
-                    "desc": "Spowoduje to zatrzymanie zbierania danych, ale umożliwi modyfikację projektu badania. Istniejące dane zostaną zachowane.",
-                    "action": "Przywróć do szkicu"
-                },
-                "active": {
-                    "title": "Uruchomić badanie?",
-                    "desc": "Aktywowanie badania otworzy je dla uczestników.",
-                    "action": "Ustaw jako aktywne"
-                },
-                "paused": {
-                    "title": "Wstrzymać badanie?",
-                    "desc": "Uczestnicy nie będą mogli wziąć udziału w badaniu, gdy jest ono wstrzymane. Można je wznowić później.",
-                    "action": "Wstrzymaj badanie"
-                },
-                "closed": {
-                    "title": "Zamknąć badanie?",
-                    "desc": "Uniemożliwi to nowym uczestnikom wejście do badania. Trwające sesje mogą zostać ukończone. Można je ponownie otworzyć później.",
-                    "action": "Zamknij badanie"
-                }
-            },
-            "steps": {
-                "draft": {
-                    "label": "Szkic",
-                    "description": "Konfiguracja i projekt"
-                },
-                "active": {
-                    "label": "Aktywne",
-                    "description": "Zbieranie odpowiedzi"
-                },
-                "paused": {
-                    "label": "Wstrzymane",
-                    "description": "Wstrzymano"
-                },
-                "closed": {
-                    "label": "Zamknięte",
-                    "description": "Analiza i eksport"
-                }
-            },
-            "state": {
-                "activate": "Aktywuj badanie",
-                "switch_to_draft": "Tryb szkicu",
-                "manage": "Zarządzaj statusem"
-            },
-            "notifications": {
-                "success": {
-                    "draft": "Badanie pomyślnie przywrócono do szkicu",
-                    "active": "Badanie zostało pomyślnie uruchomione",
-                    "paused": "Badanie zostało pomyślnie wstrzymane",
-                    "closed": "Badanie zostało pomyślnie zamknięte"
-                },
-                "error": "Nie można zmienić stanu badania. Sprawdź swoje uprawnienia i spróbuj ponownie.",
-                "state_changed_active": "Badanie jest teraz aktywne!"
-            }
+        "active": {
+          "title": "Uruchomić badanie?",
+          "desc": "Aktywowanie badania otworzy je dla uczestników.",
+          "action": "Ustaw jako aktywne"
         },
-        "design": {
-            "title": "Projekt badania",
-            "translation_needed": "Wymaga weryfikacji (kopia)",
-            "reset_defaults": "Przywróć wartości domyślne",
-            "editing_language_banner": "Edytowanie wersji {{language}}. Aby przełączyć, użyj selektora języka na pasku narzędzi.",
-            "multilang": {
-                "view_others": "Pokaż w innych językach",
-                "other_formulations": "Inne sformułowania"
-            },
-            "guidance": {
-                "title": "Wskazówki projektowe",
-                "intro_title": "Witamy w studiu",
-                "intro_desc": "Zacznij od określenia celu badania. Informacje te będą widoczne dla uczestników przed rozpoczęciem sortowania.",
-                "qsort_title": "Równowaga stwierdzeń i siatki",
-                "qsort_desc": "Upewnij się, że pojemność siatki dokładnie odpowiada liczbie stwierdzeń. Wyważony zbiór Q zwykle podąża za rozkładem quasi-normalnym (w kształcie krzywej dzwonowej)."
-            },
-            "checklist": {
-                "title": "Lista kontrolna",
-                "statements": "Stwierdzenia",
-                "grid_balance": "Siatka wyważona",
-                "branding": "Logo i kolory",
-                "instructions": "Instrukcje",
-                "ready": "Wszystkie niezbędne elementy są gotowe. Możesz teraz uruchomić badanie!",
-                "pending": "Wykonaj wymagane kroki powyżej, aby umożliwić aktywację badania.",
-                "study_title": "Tytuł badania",
-                "consent_defined": "Formularz zgody",
-                "progress": "Postęp",
-                "languages": "Języki",
-                "status_ready": "Gotowe",
-                "status_pending": "Oczekuje",
-                "required": "Wymagane",
-                "reset_defaults": "Przywróć wartości domyślne"
-            },
-            "unsaved_changes": {
-                "title": "Niezapisane zmiany",
-                "description": "W projekcie badania są niezapisane zmiany. Opuszczenie strony spowoduje ich utratę.",
-                "confirm": "Opuść bez zapisywania",
-                "cancel": "Kontynuuj edycję"
-            },
-            "tips": {
-                "title": "Szybka wskazówka",
-                "pilot": "Zawsze przeprowadź testowe sortowanie samodzielnie przed udostępnieniem linku uczestnikom."
-            },
-            "toolbar": {
-                "title": "Projekt",
-                "back": "Wstecz",
-                "preview": "Pokaż podgląd",
-                "hide_preview": "Ukryj podgląd",
-                "popout": "Otwórz podgląd w oknie",
-                "discard": "Odrzuć niezapisane zmiany",
-                "test_run": "Uruchomienie testowe",
-                "save": "Zapisz",
-                "saved": "Zapisano",
-                "closed": "Zamknięte",
-                "back_to_study": "Wróć do badania",
-                "editing_language": "Edytowany język",
-                "manage_langs": "Zarządzaj językami",
-                "select_lang": "Wybierz język",
-                "test_run_help": "Podgląd z perspektywy uczestnika. Te sesje nie są uwzględniane w danych.",
-                "more_actions": "Więcej działań"
-            },
-            "sync": {
-                "saving": "Zapisywanie...",
-                "error": "Błąd zapisu",
-                "modified": "Niezapisane zmiany",
-                "synced": "Zmiany zapisane",
-                "wait_save": "Trwa zapisywanie... Proszę chwilę poczekać.",
-                "recovered": "Szkic przywrócony z lokalnej kopii zapasowej!",
-                "recovery_title": "Znaleziono niezapisane zmiany",
-                "recovery_desc": "Znaleziono lokalną wersję tego badania nowszą niż wersja na serwerze. Czy chcesz ją przywrócić?",
-                "recovery_restore": "Przywróć wersję lokalną",
-                "recovery_discard": "Odrzuć wersję lokalną"
-            },
-            "validation": {
-                "failed_title": "Konfiguracja niekompletna",
-                "failed_desc": "Proszę poprawić te problemy, aby aktywować:",
-                "errors": {
-                    "no_statements": "Badanie musi zawierać co najmniej jedno stwierdzenie.",
-                    "no_grid": "Brak konfiguracji siatki.",
-                    "capacity_mismatch": "Pojemność siatki ({{total}}) nie odpowiada liczbie stwierdzeń ({{count}}).",
-                    "no_translations": "Badanie musi mieć co najmniej jedno tłumaczenie językowe.",
-                    "missing_default_lang": "Brak tłumaczenia dla języka domyślnego ({{lang}}).",
-                    "missing_title": "Brak tytułu dla języka '{{lang}}'.",
-                    "missing_consent_title": "Brak tytułu formularza zgody dla języka '{{lang}}'.",
-                    "missing_consent_description": "Brak opisu formularza zgody dla języka '{{lang}}'.",
-                    "missing_grid_instructions": "Brak instrukcji sortowania Q dla języka '{{lang}}'.",
-                    "missing_step_title": "Brak tytułu kroku {{index}} dla języka '{{lang}}'.",
-                    "missing_statement_translation": "Stwierdzenie '{{code}}' nie ma tłumaczeń dla: {{missing}}.",
-                    "empty_statement_text": "Stwierdzenie '{{code}}' ma pusty tekst dla języka '{{lang}}'.",
-                    "missing_question_label": "Pytanie '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}}).",
-                    "missing_option_label": "Opcja {{index}} pytania '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}})."
-                }
-            },
-            "languages": {
-                "manage_title": "Zarządzaj językami",
-                "manage_desc": "Włącz lub wyłącz języki dostępne dla uczestników w tym badaniu.",
-                "auto_translate": "Automatyczne tłumaczenie",
-                "auto_translate_desc": "Wkrótce będzie można używać AI do automatycznego tłumaczenia badania na ponad 30 języków.",
-                "activate_title": "Aktywuj język",
-                "activate_desc": "Wybierz język źródłowy, z którego zostaną skopiowane tłumaczenia. Zapobiega to pustym polom widocznym dla uczestników.",
-                "source_label": "Język źródłowy",
-                "copy_notice": "Wszystkie pola zostaną skopiowane. Pola wymagające tłumaczenia będą oznaczone wizualnie.",
-                "confirm_activate": "Aktywuj i skopiuj"
-            },
-            "tabs": {
-                "welcome": "Ogólne",
-                "presort": "Wstępne sortowanie",
-                "condition": "Warunek",
-                "qsort": "Sortowanie Q",
-                "postsort": "Sortowanie końcowe",
-                "interface": "Interfejs",
-                "theme": "Motyw",
-                "general": "Ogólne",
-                "statements": "Stwierdzenia",
-                "grid": "Siatka",
-                "survey": "Ankieta",
-                "branding": "Identyfikacja wizualna"
-            },
-            "view_mode": {
-                "mobile": "Widok mobilny",
-                "desktop": "Widok komputerowy"
-            },
-            "intro": {
-                "general_settings": "Ustawienia ogólne",
-                "welcome_title": "Wiadomość powitalna",
-                "process_title": "Przegląd kroków badania",
-                "process_steps": {
-                    "title": "Przegląd kroków badania",
-                    "desc": "Zdefiniuj etapy wyświetlane uczestnikom na stronie powitalnej. Jeśli pozostawione puste, zostaną użyte domyślne kroki.",
-                    "add_step": "Dodaj krok",
-                    "empty": {
-                        "title": "Brak niestandardowych kroków",
-                        "desc": "Badanie użyje standardowego przepływu metodologii Q (poznajmy się, pierwsze wrażenia, perspektywa, dlaczego)."
-                    },
-                    "fields": {
-                        "title": "Tytuł kroku",
-                        "description": "Krótki opis",
-                        "icon": "Ikona",
-                        "toggle": "Przełącznik"
-                    },
-                    "defaults": {
-                        "new_step": "Nowy krok badania",
-                        "new_desc": "Wyjaśnij, co uczestnik będzie robił na tym etapie."
-                    },
-                    "reset": {
-                        "instructions": "Przywróć instrukcje",
-                        "consent_title": "Przywróć tytuł zgody",
-                        "consent_description": "Przywróć opis zgody",
-                        "process_steps": "Przywróć kroki procesu",
-                        "process_steps_confirm": "Czy na pewno chcesz przywrócić wszystkie kroki procesu do wartości domyślnych? Zastąpi to niestandardowe kroki."
-                    },
-                    "inconsistent": {
-                        "banner_title": "Niespójne kroki procesu",
-                        "rough_disabled": "Krok 'Pierwsze wrażenia' (sortowanie zgrubne) jest na tej liście, ale sortowanie zgrubne jest w badaniu wyłączone. Uczestnicy go nie zobaczą.",
-                        "presort_disabled": "Krok 'Poznajmy się' (ankieta wstępna) jest na tej liście, ale ankieta wstępna jest wyłączona. Uczestnicy go nie zobaczą.",
-                        "remove_action": "Usuń"
-                    }
-                },
-                "consent_title": "Formularz zgody",
-                "reset": "Przywróć instrukcję",
-                "consent_details": "Szczegóły formularza zgody",
-                "fields": {
-                    "default_lang": "Język domyślny",
-                    "default_lang_help": "Ten język będzie domyślnie wyświetlany uczestnikom, jeśli język przeglądarki nie jest obsługiwany.",
-                    "title": "Tytuł badania",
-                    "title_placeholder": "Wpisz tytuł publiczny...",
-                    "subtitle": "Podtytuł (opcjonalnie)",
-                    "subtitle_placeholder": "Krótkie hasło...",
-                    "objective": "Cel badania",
-                    "objective_placeholder": "Jakie jest pytanie badawcze lub cel tego badania?",
-                    "task_overview": "Wprowadzenie",
-                    "task_placeholder": "Opisz tutaj przebieg badania (liczba kroków, szacowany czas itp.). To pole jest opcjonalne, jeśli używasz niestandardowych kroków powyżej.",
-                    "consent_title_label": "Tytuł zgody",
-                    "legal_text": "Tekst prawny / umowa",
-                    "legal_placeholder": "Wpisz pełny tekst umowy prawnej..."
-                },
-                "consent_desc": "Uczestnicy muszą zaakceptować te warunki przed rozpoczęciem."
-            },
-            "condition": {
-                "title": "Warunek instrukcji",
-                "label": "Zdefiniuj warunek instrukcji",
-                "desc": "To jest główna instrukcja, która prowadzi uczestników przez cały proces sortowania.",
-                "field_label": "Treść instrukcji",
-                "placeholder": "Np. Proszę uszeregować poniższe stwierdzenia od tych, z którymi najbardziej się Pan/Pani zgadza, do tych, z którymi najbardziej się nie zgadza",
-                "grid_title": "Instrukcja sortowania Q",
-                "grid_desc": "To jest główna instrukcja prowadząca uczestników podczas procesu sortowania Q.",
-                "pre_title": "Instrukcja wstępnego sortowania",
-                "pre_desc": "Instrukcja podawana uczestnikom podczas wstępnego sortowania zgrubnego.",
-                "pre_field_label": "Treść instrukcji",
-                "pre_placeholder": "Np. Na podstawie własnego punktu widzenia podziel karty na trzy stosy...",
-                "enable_pre": "Włącz etap wstępnej instrukcji",
-                "pre_label": "Treść wstępnej instrukcji",
-                "tips": {
-                    "title": "Dlaczego to ważne?",
-                    "desc": "W metodologii Q 'warunek instrukcji' określa punkt widzenia, z którego uczestnik sortuje stwierdzenia. Powinien być jasny i spójny we wszystkich fazach sortowania."
-                }
-            },
-            "questions": {
-                "enable_presort": "Włącz ankietę wstępną",
-                "enable_presort_desc": "Zbierz dane demograficzne lub inne informacje przed zadaniem sortowania.",
-                "add_field": "Dodaj nowe pole",
-                "basic_fields": "Pola podstawowe",
-                "choice_fields": "Pola wyboru",
-                "scale_fields": "Pola skali",
-                "labels": {
-                    "question": "Etykieta pytania",
-                    "required": "Pole wymagane",
-                    "options": "Opcje",
-                    "option_ordinal": "Opcja {{number}}",
-                    "multiple": "(Dozwolony wielokrotny wybór)",
-                    "single": "(Pojedynczy wybór)",
-                    "placeholder": "Wpisz tutaj swoje pytanie...",
-                    "scale": "Skala ocen",
-                    "scale_points": "Liczba punktów",
-                    "scale_left": "Etykieta lewego krańca",
-                    "scale_right": "Etykieta prawego krańca"
-                },
-                "types": {
-                    "text": "Tekst",
-                    "long_text": "Tekst długi",
-                    "number": "Liczba",
-                    "date": "Data",
-                    "email": "E-mail",
-                    "dropdown": "Lista rozwijana",
-                    "radio": "Przycisk radiowy",
-                    "checkboxes": "Pola wyboru",
-                    "text_audio": "Tekst + audio",
-                    "rating": "Skala ocen"
-                },
-                "empty": {
-                    "title": "Brak pytań",
-                    "desc": "Kliknij powyżej, aby dodać pierwsze pytanie"
-                },
-                "defaults": {
-                    "new_question": "Nowe pytanie",
-                    "option": "Opcja",
-                    "enter_answer": "Wpisz swoją odpowiedź...",
-                    "untitled": "Pytanie bez tytułu",
-                    "scale_left": "Zdecydowanie się nie zgadzam",
-                    "scale_right": "Zdecydowanie się zgadzam"
-                },
-                "actions": {
-                    "add_option": "Dodaj opcję",
-                    "copy_from": "Importuj z języka",
-                    "copy_success": "Zaimportowano"
-                },
-                "logic": {
-                    "title": "Logika widoczności",
-                    "enable": "Dodaj warunek widoczności",
-                    "depends_on": "Pokaż to pytanie tylko jeśli...",
-                    "select_placeholder": "Wybierz pytanie nadrzędne",
-                    "operator": "Operator",
-                    "value": "Wartość porównania",
-                    "operators": {
-                        "equals": "Równa się",
-                        "not_equals": "Nie równa się",
-                        "contains": "Zawiera",
-                        "greater_than": "Większe niż",
-                        "less_than": "Mniejsze niż"
-                    }
-                }
-            },
-            "qsort": {
-                "tabs": {
-                    "statements": "Stwierdzenia",
-                    "distribution": "Rozkład"
-                },
-                "bulk": {
-                    "title": "Edytor zbiorczy (szybkie wklejanie)",
-                    "desc": "Jedno stwierdzenie w każdym wierszu. Obsługuje format 'kod: tekst' i kopiowanie z Excela (wielojęzyczne).",
-                    "replace_all": "Zastąp wszystko",
-                    "append": "Dołącz do listy",
-                    "sync_by_code": "Synchronizuj/scal wg kodu",
-                    "placeholder": "Proste: Moje stwierdzenie",
-                    "detected": "Wykryto {{count}} stwierdzeń",
-                    "process_replace": "Przetwórz i zastąp stwierdzenia",
-                    "process_append": "Przetwórz i dołącz stwierdzenia",
-                    "process_sync": "Przetwórz i synchronizuj tłumaczenia",
-                    "detected_format": {
-                        "excel": "Wykryto format Excel (tabulatory)",
-                        "list": "Wykryto format listy (kod: tekst)",
-                        "simple": "Wykryto prostą listę (jeden wiersz = jedno stwierdzenie)",
-                        "multi_lang": "Wielojęzyczne: {{langs}}",
-                        "with_codes": "Z niestandardowymi kodami"
-                    }
-                },
-                "set": {
-                    "title": "Zbiór Q",
-                    "clear": "Wyczyść wszystko",
-                    "confirm_clear": "Czy na pewno chcesz usunąć WSZYSTKIE stwierdzenia? Tego działania nie można cofnąć.",
-                    "updated": "Stwierdzenie zaktualizowane",
-                    "cleared": "Wszystkie stwierdzenia wyczyszczone",
-                    "imported": "Pomyślnie zaimportowano {{count}} stwierdzeń",
-                    "reset_codes": "Resetuj kody",
-                    "confirm_reset_codes": "Czy na pewno chcesz ponownie nadać numery wszystkim kodom stwierdzeń (s1, s2, s3...)?",
-                    "codes_reset": "Kody stwierdzeń ponownie ponumerowane"
-                },
-                "settings": {
-                    "title": "Ustawienia badawcze",
-                    "desc": "Skonfiguruj sposób prezentacji stwierdzeń uczestnikom",
-                    "show_codes": "Pokaż kody stwierdzeń",
-                    "show_codes_desc": "Wyświetlaj kody stwierdzeń (np. 'S1', 'S2') obok tekstu.",
-                    "randomize": "Losuj kolejność stwierdzeń",
-                    "randomize_desc": "Prezentuj stwierdzenia w losowej kolejności każdemu uczestnikowi (spójnie w ramach sesji)"
-                },
-                "grid": {
-                    "title": "Siatka rozkładu sortowania Q",
-                    "desc": "Kształt siatki zmusza uczestników do różnicowania stwierdzeń, przybliżając rozkład normalny.",
-                    "slot_count": "Przydzielono {{count}} miejsc",
-                    "stat_count": "{{count}} stwierdzeń",
-                    "perfect": "Idealna równowaga",
-                    "too_many": "{{count}} stwierdzeń za dużo",
-                    "too_few": "Brakuje {{count}} stwierdzeń",
-                    "min_reached": "Osiągnięto minimalny zakres (±2)",
-                    "max_reached": "Osiągnięto maksymalny zakres (±6)",
-                    "remove_extreme_columns": "Usuń skrajne kolumny",
-                    "add_extreme_columns": "Dodaj skrajne kolumny",
-                    "symmetry_lock": "Blokada symetrii",
-                    "symmetry_lock_desc": "Automatycznie stosuj zmiany do kolumn przeciwnych, aby zachować wyważony rozkład.",
-                    "auto_balance": "Auto-wyważenie",
-                    "auto_balance_desc": "Przekształć siatkę w wyważony rozkład półnormalny",
-                    "reshaped": "Siatka przekształcona do wyważonego rozkładu",
-                    "balanced": "Siatka wyważona do standardowego rozkładu",
-                    "no_statements": "Najpierw dodaj stwierdzenia, aby automatycznie ukształtować siatkę",
-                    "statements": "stwierdzenia",
-                    "ideal_shape": "Idealny kształt",
-                    "symmetric": "Symetryczna",
-                    "asymmetric": "Asymetryczna",
-                    "tooltip_title": "Dlaczego rozkład wymuszony?",
-                    "tooltip_desc": "Metodologia Q używa rozkładu quasi-normalnego (kurtoza > 0), aby zapewnić, że uczestnicy dokonują znaczących rozróżnień. Kształt piramidy zapobiega błędowi tendencji centralnej.",
-                    "locked": "Projekt zablokowany",
-                    "locked_desc": "Zmiany strukturalne (kody stwierdzeń, siatka) są wyłączone, ponieważ badanie zebrało dane lub nie jest już w trybie szkicu. Nadal można edytować tłumaczenia tekstowe.",
-                    "locked_active": "To badanie jest aktywne. Przełącz na tryb szkicu, aby edytować.",
-                    "locked_paused": "To badanie jest wstrzymane. Przełącz na tryb szkicu, aby edytować.",
-                    "locked_closed": "To badanie jest zamknięte. Projekt jest zarchiwizowany.",
-                    "view_read_only": "Podgląd tylko do odczytu",
-                    "locked_dialog_desc": "Edycja jest zablokowana, gdy badanie jest w tym stanie. Zamknij to powiadomienie, aby przeczytać konfigurację bez wprowadzania zmian.",
-                    "mismatch_title": "Niezgodność pojemności siatki",
-                    "mismatch_desc": "Masz {{statements}} stwierdzeń, ale siatka ma tylko miejsca dla {{slots}} elementów. Dostosuj kolumny poniżej.",
-                    "unlock_hint": "Przejdź do eksploratora danych, aby wyczyścić sesje i odblokować strukturę"
-                }
-            },
-            "postsort": {
-                "extreme": {
-                    "title": "Kolumny docelowe",
-                    "desc": "Wybierz kolumny, które wyzwalają pytania uzupełniające.",
-                    "no_columns": "Nie wybrano żadnych kolumn.",
-                    "add_label": "Dodaj kolumnę:",
-                    "prompt_label": "Pytanie o stwierdzenia",
-                    "prompt_placeholder": "Dlaczego umieścił/a Pan/Pani to stwierdzenie w tym miejscu?",
-                    "add": "Dodaj",
-                    "add_defaults": "Dodaj domyślne skrajności",
-                    "select_placeholder": "Wybierz..."
-                },
-                "random_comments": {
-                    "title": "Zezwalaj na swobodne komentarze",
-                    "desc": "Pozwól uczestnikom dodawać komentarze do dowolnego stwierdzenia na siatce."
-                },
-                "custom": {
-                    "title": "Pytania niestandardowe",
-                    "desc": "Dodaj niestandardowe pytania do ankiety po sortowaniu."
-                },
-                "missing": {
-                    "title": "Pytaj o brakujące stwierdzenia",
-                    "desc": "Jeśli tak, proszę opisać je krótko.",
-                    "prompt_label": "Treść pytania",
-                    "prompt_placeholder": "Proszę śmiało sugerować i wyjaśniać."
-                },
-                "steps": {
-                    "step1": "Krok 1: informacja zwrotna",
-                    "step2": "Krok 2: pytania"
-                },
-                "email": {
-                    "title": "Kontakt uzupełniający z uczestnikiem",
-                    "desc": "Zbieraj adresy e-mail do celów kontaktu uzupełniającego lub przekazania wyników badania.",
-                    "interview": "Zaproponuj kontakt uzupełniający",
-                    "results": "Zaproponuj zapis na listę mailingową z wynikami badania",
-                    "interview_warning": "Uwaga: zgoda na kontakt znosi anonimowość wobec badacza.",
-                    "results_hint": "E-mail wyłącznie do celów przekazania wyników, anonimowość zachowana."
-                },
-                "audio": {
-                    "title": "Nagranie audio",
-                    "desc": "Pozwól uczestnikom nagrywać odpowiedzi audio zamiast tekstu.",
-                    "max_duration": "Maksymalny czas trwania",
-                    "seconds": "sekund",
-                    "max_duration_help": "Maksymalny czas nagrywania na pytanie (30–600 sekund).",
-                    "participant_choice_info": "Uczestnicy mogą odpowiadać tekstem, nagraniem audio lub obydwoma sposobami na każde pytanie.",
-                    "storage_unavailable_body": "Magazyn obiektów nie jest skonfigurowany, więc nie można zbierać odpowiedzi audio. Nadal możesz włączyć audio, ale uczestnicy będą odpowiadać wyłącznie tekstem i żadne nagranie nie zostanie wykonane. Skonfiguruj magazyn obiektów i uruchom ponownie serwer, aby włączyć przechwytywanie audio.",
-                    "storage_unavailable_title": "Przechwytywanie audio jest niedostępne na tym serwerze"
-                }
-            },
-            "interface": {
-                "title": "Dostosowanie interfejsu",
-                "desc": "Dostosuj przyciski i etykiety interfejsu do tonu badania (np. zastępując 'zgadzam się/nie zgadzam się' słowami 'lubię/nie lubię').",
-                "nav": {
-                    "title": "Przyciski nawigacyjne",
-                    "start": "Przycisk start",
-                    "next": "Przycisk następnego kroku",
-                    "submit": "Przycisk wyślij",
-                    "confirm": "Przycisk potwierdzenia sortowania",
-                    "tooltips": {
-                        "start": "Przycisk rozpoczynający badanie",
-                        "next": "Przejście do następnego kroku",
-                        "submit": "Wyślij wyniki na końcu",
-                        "confirm": "Ogólny przycisk zatwierdzania"
-                    }
-                },
-                "terms": {
-                    "title": "Terminologia sortowania",
-                    "desc": "Zdefiniuj etykiety dla sortowania spontanicznego i spektrum siatki.",
-                    "rough": "Etykiety sortowania zgrubnego",
-                    "agree": "Zgadzam się",
-                    "neutral": "Neutralnie",
-                    "disagree": "Nie zgadzam się",
-                    "grid": "Legendy siatki (skrajności)",
-                    "most_agree": "Najbardziej zgadzam się",
-                    "most_disagree": "Najbardziej nie zgadzam się"
-                },
-                "hints": {
-                    "title": "Wskazówki metodologiczne",
-                    "desc": "Dodaj lub zmodyfikuj pływające wskazówki pomagające uczestnikom podczas fazy sortowania na siatce.",
-                    "placeholder": "Wpisz wskazówkę metodologiczną...",
-                    "add": "Dodaj wskazówkę",
-                    "reset": "Przywróć wartości domyślne"
-                },
-                "help": {
-                    "title": "Wskazówki dla kroków (co/dlaczego)",
-                    "desc": "Dostosuj kontekstową pomoc dostępną dla uczestników na każdym kroku przez nakładkę '?'.",
-                    "step_disabled": "(krok wyłączony)"
-                }
-            },
-            "theme": {
-                "title": "Identyfikacja wizualna",
-                "accent": {
-                    "title": "Kolor akcentu",
-                    "desc": "Ten kolor będzie używany dla przycisków, linków i wyróżnień w całym badaniu.",
-                    "pick": "Wybierz kolor",
-                    "reset": "Przywróć domyślny"
-                },
-                "logo": {
-                    "title": "Logo badania",
-                    "desc": "Prześlij niestandardowe logo zastępujące domyślną markę Qualis.",
-                    "label": "URL logo",
-                    "hint": "Zalecany rozmiar: 200×50 px. Obsługiwane formaty: PNG, SVG, JPG.",
-                    "preview": "Podgląd logo",
-                    "help_title": "Gdzie pojawia się to logo?",
-                    "help_desc": "Logo jest wyświetlane na górze każdej strony badania (pasek nawigacyjny) i na stronie powitalnej. Wzmacnia identyfikację wizualną projektu."
-                },
-                "partners": {
-                    "title": "Partnerzy instytucjonalni",
-                    "desc": "Dodaj logo wspierających instytucji lub partnerów.",
-                    "add": "Dodaj partnera",
-                    "name_label": "Nazwa partnera",
-                    "name_placeholder": "Nazwa instytucji",
-                    "logo_label": "URL logo",
-                    "url_label": "Strona internetowa (opcjonalnie)",
-                    "url_placeholder": "https://...",
-                    "help_title": "Wyświetlanie logo",
-                    "help_desc": "Logo partnerów są wyświetlane na stronie startowej oraz w nagłówku badania, obok głównego logo."
-                },
-                "upload": {
-                    "upload": "Prześlij",
-                    "recommended": "Zalecane",
-                    "invalid_type": "Nieprawidłowy typ pliku. Użyj PNG, JPG lub SVG.",
-                    "file_too_large": "Plik jest za duży. Maksymalny rozmiar: {{size}} kB.",
-                    "conversion_error": "Nie udało się przetworzyć obrazu.",
-                    "processing": "Przetwarzanie obrazu...",
-                    "drag_drop": "Przeciągnij i upuść lub kliknij, aby przesłać",
-                    "max": "Maks."
-                }
-            },
-            "activate_dialog": {
-                "title": "Aktywować to badanie?",
-                "description": "Aktywacja otwiera rekrutację i odblokowuje publiczne linki. Prawdziwi uczestnicy będą mogli zacząć przesyłać odpowiedzi.",
-                "checklist_title": "Kontrola przed startem",
-                "languages_title": "Języki",
-                "lang_ready": "Gotowe",
-                "lang_incomplete": "Niekompletne",
-                "required": "(wymagane)",
-                "attestation": "Zapoznałem/am się z tekstem zgody i polityką przechowywania danych i potwierdzam, że badanie jest gotowe do przyjęcia prawdziwych uczestników.",
-                "confirm": "Aktywuj badanie"
-            }
+        "paused": {
+          "title": "Wstrzymać badanie?",
+          "desc": "Uczestnicy nie będą mogli wziąć udziału w badaniu, gdy jest ono wstrzymane. Można je wznowić później.",
+          "action": "Wstrzymaj badanie"
         },
-        "data": {
-            "title": "Dane",
-            "description": "Monitoruj uczestnictwo w czasie rzeczywistym, analizuj jakość danych i zarządzaj sesjami badawczymi.",
-            "sections": {
-                "key_indicators": "Kluczowe wskaźniki",
-                "responses": "Odpowiedzi",
-                "key_statistics": "Kluczowe statystyki"
-            },
-            "stats": {
-                "email_collection": "Zbieranie e-maili",
-                "participants": "łącznie",
-                "newsletter": "Chce wyniki",
-                "opt_in": "Wskaźnik odpowiedzi",
-                "follow_up": "Potencjał kontaktu uzupełniającego",
-                "interested": "zainteresowanych",
-                "click_to_filter": "Kliknij, aby filtrować",
-                "click_to_export": "Kliknij, aby eksportować listę",
-                "completed": "Ukończone",
-                "in_progress": "W toku",
-                "abandoned_count": "{{count}} porzuconych",
-                "interview_interested": "Akceptuje kontakt uzupełniający",
-                "interview": "Akceptuje kontakt uzupełniający",
-                "email": "E-maile"
-            },
-            "tabs": {
-                "live": "Uczestnicy na żywo",
-                "test": "Sesje testowe",
-                "browse": "Widok interaktywny",
-                "export": "Centrum eksportu"
-            },
-            "status": {
-                "started": "rozpoczęte",
-                "completed": "Ukończone",
-                "in_progress": "W toku",
-                "abandoned": "Porzucone",
-                "discarded": "odrzucone"
-            },
-            "step": {
-                "consent": "Zgoda",
-                "presort": "Ankieta wstępna",
-                "rough": "Sortowanie zgrubne",
-                "fine": "Sortowanie Q",
-                "post": "Ankieta końcowa"
-            },
-            "actions": {
-                "discard": "Odrzuć",
-                "restore": "Przywróć",
-                "export": "Eksportuj",
-                "clear_all": "Resetuj wszystkie dane",
-                "clear_all_confirm": "UWAGA: Spowoduje to trwałe usunięcie WSZYSTKICH danych uczestników dla tego badania. Tego działania nie można cofnąć.",
-                "clear_all_success": "Wszystkie dane wyczyszczone",
-                "clear_all_error": "Nie udało się wyczyścić danych. Sprawdź uprawnienia i spróbuj ponownie."
-            },
-            "confirm_discard": {
-                "title": "Odrzucić uczestnika?",
-                "description": "Ten uczestnik zostanie wykluczony z eksportów i analiz. Można go przywrócić później.",
-                "reason_label": "Powód (opcjonalnie)",
-                "reason_placeholder": "Dlaczego ten uczestnik jest odrzucany?"
-            },
-            "confirm_restore": {
-                "title": "Przywrócić uczestnika?",
-                "description": "Ten uczestnik zostanie ponownie uwzględniony w eksportach i analizach."
-            },
-            "guide": {
-                "title": "Przewodnik formatów",
-                "csv": {
-                    "title": "Uniwersalny CSV",
-                    "desc": "Surowe dane prostokątne. Najlepsze do analizy w R, Pythonie, SPSS lub Excelu. Zawiera wszystkie metadane."
-                },
-                "json": {
-                    "title": "KenQ JSON",
-                    "desc": "Zoptymalizowane dla narzędzia web-kenq. Zawiera definicję badania i sortowania."
-                },
-                "zip": {
-                    "title": "Pakiet PQMethod (ZIP)",
-                    "desc": "Zawiera starsze pliki .DAT i .STA do analizy DOS PQMethod."
-                }
-            },
-            "table": {
-                "participant": "Uczestnik",
-                "lang": "Język",
-                "status": "Status",
-                "consent": "Zgoda",
-                "flags": "Oznaczenia",
-                "duration": "Czas trwania",
-                "submitted": "Przesłano",
-                "last_step": "Ostatni krok",
-                "current_step": "Aktualny krok",
-                "view": "Pokaż",
-                "actions": "Szczegóły",
-                "duplicate_ip": "Duplikat IP",
-                "duplicate_ip_hint": "Współdzieli hash IP z innymi uczestnikami"
-            },
-            "tooltips": {
-                "suspect": "Potencjalnie podejrzane: czas trwania sesji < 2 minuty",
-                "has_comments": "Zawiera komentarze uczestnika do kart",
-                "has_audio": "Ma odpowiedzi audio",
-                "email_provided": "Podano e-mail",
-                "newsletter_consent": "Chce wyniki",
-                "interview_consent": "Akceptuje kontakt uzupełniający"
-            },
-            "toast": {
-                "discarded": "Uczestnik odrzucony",
-                "restored": "Uczestnik przywrócony",
-                "error": "Nie udało się zaktualizować uczestnika. Sprawdź połączenie i spróbuj ponownie."
-            },
-            "detail": {
-                "participant": "Uczestnik",
-                "participant_n": "Uczestnik {{code}}",
-                "not_found": "Uczestnik nie znaleziony",
-                "title": "Profil uczestnika",
-                "session": "Sesja",
-                "discarded_badge": "Odrzucony",
-                "description": "Pełne wyniki sortowania Q i metadane.",
-                "stats": {
-                    "duration": "Łączny czas trwania",
-                    "language": "Użyty język"
-                },
-                "actions": {
-                    "discard": "Odrzuć uczestnika",
-                    "restore": "Przywróć uczestnika"
-                },
-                "sort_config": "Konfiguracja sortowania",
-                "survey": {
-                    "title": "Odpowiedzi ankietowe",
-                    "csv_note": "Pełne odpowiedzi dostępne w eksporcie CSV."
-                }
-            },
-            "filter": {
-                "show_discarded": "Uwzględnij odrzucone rekordy",
-                "all_states": "Wszystkie stany",
-                "only_active": "Tylko aktywne",
-                "only_flagged": "Oznaczona jakość"
-            },
-            "filters": {
-                "active": "Aktywne filtry",
-                "has_email": "Podano e-mail",
-                "newsletter": "Chce wyniki",
-                "interview": "Akceptuje kontakt uzupełniający",
-                "flagged": "Tylko oznaczone",
-                "clear_all": "Wyczyść filtry",
-                "remove_filter": "Usuń filtr",
-                "all_statuses": "Wszystkie statusy",
-                "all_consents": "Wszystkie",
-                "all_indicators": "Wszystkie",
-                "all_steps": "Wszystkie kroki",
-                "has_comments": "Ma komentarze",
-                "has_audio": "Ma audio",
-                "has_recruitment": "Ma link rekrutacyjny"
-            },
-            "charts": {
-                "section_title": "Rozkłady odpowiedzi",
-                "distribution_label": "Rozkład dla {{question}}",
-                "multi_select_note": "Dozwolony wielokrotny wybór",
-                "responses_count": "{{count}} odpowiedzi",
-                "no_answer": "Brak odpowiedzi",
-                "option": "Opcja",
-                "count": "Liczba"
-            },
-            "search": {
-                "placeholder": "Szukaj po ID lub tokenie rekrutacyjnym...",
-                "records_found": "Wykryte rekordy",
-                "no_results": "Żaden rekord nie pasuje do zapytania"
-            },
-            "errors": {
-                "load_failed": "Synchronizacja z chmurą przerwana. Proszę sprawdzić połączenie."
-            },
-            "export_emails_success": "E-maile wyeksportowane pomyślnie",
-            "empty": {
-                "no_participants_title": "Brak uczestników",
-                "no_participants_desc": "Udostępnij link do badania, aby zacząć zbierać odpowiedzi.",
-                "contract_title": "Brak zgłoszeń",
-                "contract_body": "Zgłoszenia i eksporty pojawią się tutaj. Udostępnij link do badania, aby zacząć zbierać dane.",
-                "contract_cta": "Otwórz widok ogólny badania"
-            },
-            "pagination": {
-                "showing": "Pokazuję {{from}}–{{to}} z {{total}}"
-            }
+        "closed": {
+          "title": "Zamknąć badanie?",
+          "desc": "Uniemożliwi to nowym uczestnikom wejście do badania. Trwające sesje mogą zostać ukończone. Można je ponownie otworzyć później.",
+          "action": "Zamknij badanie"
+        }
+      },
+      "steps": {
+        "draft": {
+          "label": "Szkic",
+          "description": "Konfiguracja i projekt"
         },
-        "team": {
-            "title": "Zespół badania",
-            "description": "Zarządzaj współpracownikami i kontrolą dostępu na poziomie badania.",
-            "invite_title": "Zaproś współpracownika",
-            "invite_description": "Wygeneruj bezpieczny link, aby zaprosić nowego członka do tego badania.",
-            "email_label": "Adres e-mail",
-            "role_label": "Rola",
-            "select_role": "Wybierz rolę",
-            "generate_link": "Generuj link",
-            "invite_success": "Link zaproszenia wygenerowany!",
-            "invite_error": "Nie udało się wygenerować zaproszenia",
-            "copy_success": "Link skopiowany do schowka",
-            "share_label": "Udostępnij ten link zaproszonej osobie:",
-            "collab_overview": "Przegląd współpracy",
-            "active_members": "Aktywni członkowie",
-            "permissions_info": "Informacje o uprawnieniach",
-            "list_title": "Zespół badawczy",
-            "list_description": "Zarządzaj dostępem dla istniejących współpracowników.",
-            "added_on": "Dodano",
-            "headers": {
-                "collaborator": "Współpracownik",
-                "role": "Rola",
-                "actions": "Akcje"
-            },
-            "roles": {
-                "owner": "Właściciel (pełna kontrola)",
-                "editor": "Redaktor (projekt i analiza)",
-                "viewer": "Obserwator (tylko odczyt)",
-                "owner_badge": "WŁAŚCICIEL",
-                "editor_badge": "REDAKTOR",
-                "viewer_badge": "OBSERWATOR"
-            },
-            "permissions": {
-                "owner": "Może usunąć badanie i zarządzać zespołem.",
-                "editor": "Może modyfikować projekt i przeglądać wyniki.",
-                "viewer": "Dostęp tylko do odczytu do wszystkich modułów."
-            }
+        "active": {
+          "label": "Aktywne",
+          "description": "Zbieranie odpowiedzi"
         },
-        "empty_states": {
-            "participants": {
-                "title": "Gotowe do uruchomienia?",
-                "desc": "Udostępnij link do badania, aby rozpocząć zbieranie odpowiedzi. Pierwszy uczestnik jest o jedno kliknięcie.",
-                "action": "Kopiuj link do badania",
-                "hint": "Lub zeskanuj kod QR",
-                "copy_success": "Link do badania skopiowany do schowka!"
-            },
-            "team": {
-                "title": "Działasz samodzielnie",
-                "desc": "Zaproś współpracowników, aby pomogli zarządzać tym badaniem. Mogą przeglądać dane, edytować projekt lub jedynie obserwować.",
-                "action": "Zaproś pierwszego współpracownika"
-            },
-            "designer": {
-                "title": "Tabula rasa",
-                "desc": "To badanie nie ma jeszcze żadnych stwierdzeń. Dodaj elementy zbioru Q, aby rozpocząć projektowanie sortowania.",
-                "action": "Wczytaj przykładowy zbiór Q"
-            }
+        "paused": {
+          "label": "Wstrzymane",
+          "description": "Wstrzymano"
         },
-        "status": {
-            "active": "Active",
-            "paused": "Paused",
-            "closed": "Closed",
-            "draft": "Draft"
+        "closed": {
+          "label": "Zamknięte",
+          "description": "Analiza i eksport"
+        }
+      },
+      "state": {
+        "activate": "Aktywuj badanie",
+        "switch_to_draft": "Tryb szkicu",
+        "manage": "Zarządzaj statusem"
+      },
+      "notifications": {
+        "success": {
+          "draft": "Badanie pomyślnie przywrócono do szkicu",
+          "active": "Badanie zostało pomyślnie uruchomione",
+          "paused": "Badanie zostało pomyślnie wstrzymane",
+          "closed": "Badanie zostało pomyślnie zamknięte"
+        },
+        "error": "Nie można zmienić stanu badania. Sprawdź swoje uprawnienia i spróbuj ponownie.",
+        "state_changed_active": "Badanie jest teraz aktywne!"
+      }
+    },
+    "design": {
+      "title": "Projekt badania",
+      "translation_needed": "Wymaga weryfikacji (kopia)",
+      "reset_defaults": "Przywróć wartości domyślne",
+      "editing_language_banner": "Edytowanie wersji {{language}}. Aby przełączyć, użyj selektora języka na pasku narzędzi.",
+      "multilang": {
+        "view_others": "Pokaż w innych językach",
+        "other_formulations": "Inne sformułowania"
+      },
+      "guidance": {
+        "title": "Wskazówki projektowe",
+        "intro_title": "Witamy w studiu",
+        "intro_desc": "Zacznij od określenia celu badania. Informacje te będą widoczne dla uczestników przed rozpoczęciem sortowania.",
+        "qsort_title": "Równowaga stwierdzeń i siatki",
+        "qsort_desc": "Upewnij się, że pojemność siatki dokładnie odpowiada liczbie stwierdzeń. Wyważony zbiór Q zwykle podąża za rozkładem quasi-normalnym (w kształcie krzywej dzwonowej)."
+      },
+      "checklist": {
+        "title": "Lista kontrolna",
+        "statements": "Stwierdzenia",
+        "grid_balance": "Siatka wyważona",
+        "branding": "Logo i kolory",
+        "instructions": "Instrukcje",
+        "ready": "Wszystkie niezbędne elementy są gotowe. Możesz teraz uruchomić badanie!",
+        "pending": "Wykonaj wymagane kroki powyżej, aby umożliwić aktywację badania.",
+        "study_title": "Tytuł badania",
+        "consent_defined": "Formularz zgody",
+        "progress": "Postęp",
+        "languages": "Języki",
+        "status_ready": "Gotowe",
+        "status_pending": "Oczekuje",
+        "required": "Wymagane",
+        "reset_defaults": "Przywróć wartości domyślne"
+      },
+      "unsaved_changes": {
+        "title": "Niezapisane zmiany",
+        "description": "W projekcie badania są niezapisane zmiany. Opuszczenie strony spowoduje ich utratę.",
+        "confirm": "Opuść bez zapisywania",
+        "cancel": "Kontynuuj edycję"
+      },
+      "tips": {
+        "title": "Szybka wskazówka",
+        "pilot": "Zawsze przeprowadź testowe sortowanie samodzielnie przed udostępnieniem linku uczestnikom."
+      },
+      "toolbar": {
+        "title": "Projekt",
+        "back": "Wstecz",
+        "preview": "Pokaż podgląd",
+        "hide_preview": "Ukryj podgląd",
+        "popout": "Otwórz podgląd w oknie",
+        "discard": "Odrzuć niezapisane zmiany",
+        "test_run": "Uruchomienie testowe",
+        "save": "Zapisz",
+        "saved": "Zapisano",
+        "closed": "Zamknięte",
+        "back_to_study": "Wróć do badania",
+        "editing_language": "Edytowany język",
+        "manage_langs": "Zarządzaj językami",
+        "select_lang": "Wybierz język",
+        "test_run_help": "Podgląd z perspektywy uczestnika. Te sesje nie są uwzględniane w danych.",
+        "more_actions": "Więcej działań"
+      },
+      "sync": {
+        "saving": "Zapisywanie...",
+        "error": "Błąd zapisu",
+        "modified": "Niezapisane zmiany",
+        "synced": "Zmiany zapisane",
+        "wait_save": "Trwa zapisywanie... Proszę chwilę poczekać.",
+        "recovered": "Szkic przywrócony z lokalnej kopii zapasowej!",
+        "recovery_title": "Znaleziono niezapisane zmiany",
+        "recovery_desc": "Znaleziono lokalną wersję tego badania nowszą niż wersja na serwerze. Czy chcesz ją przywrócić?",
+        "recovery_restore": "Przywróć wersję lokalną",
+        "recovery_discard": "Odrzuć wersję lokalną"
+      },
+      "validation": {
+        "failed_title": "Konfiguracja niekompletna",
+        "failed_desc": "Proszę poprawić te problemy, aby aktywować:",
+        "errors": {
+          "no_statements": "Badanie musi zawierać co najmniej jedno stwierdzenie.",
+          "no_grid": "Brak konfiguracji siatki.",
+          "capacity_mismatch": "Pojemność siatki ({{total}}) nie odpowiada liczbie stwierdzeń ({{count}}).",
+          "no_translations": "Badanie musi mieć co najmniej jedno tłumaczenie językowe.",
+          "missing_default_lang": "Brak tłumaczenia dla języka domyślnego ({{lang}}).",
+          "missing_title": "Brak tytułu dla języka '{{lang}}'.",
+          "missing_consent_title": "Brak tytułu formularza zgody dla języka '{{lang}}'.",
+          "missing_consent_description": "Brak opisu formularza zgody dla języka '{{lang}}'.",
+          "missing_grid_instructions": "Brak instrukcji sortowania Q dla języka '{{lang}}'.",
+          "missing_step_title": "Brak tytułu kroku {{index}} dla języka '{{lang}}'.",
+          "missing_statement_translation": "Stwierdzenie '{{code}}' nie ma tłumaczeń dla: {{missing}}.",
+          "empty_statement_text": "Stwierdzenie '{{code}}' ma pusty tekst dla języka '{{lang}}'.",
+          "missing_question_label": "Pytanie '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}}).",
+          "missing_option_label": "Opcja {{index}} pytania '{{id}}' nie ma etykiety dla języka '{{lang}}' ({{section}})."
+        }
+      },
+      "languages": {
+        "manage_title": "Zarządzaj językami",
+        "manage_desc": "Włącz lub wyłącz języki dostępne dla uczestników w tym badaniu.",
+        "auto_translate": "Automatyczne tłumaczenie",
+        "auto_translate_desc": "Wkrótce będzie można używać AI do automatycznego tłumaczenia badania na ponad 30 języków.",
+        "activate_title": "Aktywuj język",
+        "activate_desc": "Wybierz język źródłowy, z którego zostaną skopiowane tłumaczenia. Zapobiega to pustym polom widocznym dla uczestników.",
+        "source_label": "Język źródłowy",
+        "copy_notice": "Wszystkie pola zostaną skopiowane. Pola wymagające tłumaczenia będą oznaczone wizualnie.",
+        "confirm_activate": "Aktywuj i skopiuj"
+      },
+      "tabs": {
+        "welcome": "Ogólne",
+        "presort": "Wstępne sortowanie",
+        "condition": "Warunek",
+        "qsort": "Sortowanie Q",
+        "postsort": "Sortowanie końcowe",
+        "interface": "Interfejs",
+        "theme": "Motyw",
+        "general": "Ogólne",
+        "statements": "Stwierdzenia",
+        "grid": "Siatka",
+        "survey": "Ankieta",
+        "branding": "Identyfikacja wizualna"
+      },
+      "view_mode": {
+        "mobile": "Widok mobilny",
+        "desktop": "Widok komputerowy"
+      },
+      "intro": {
+        "general_settings": "Ustawienia ogólne",
+        "welcome_title": "Wiadomość powitalna",
+        "process_title": "Przegląd kroków badania",
+        "process_steps": {
+          "title": "Przegląd kroków badania",
+          "desc": "Zdefiniuj etapy wyświetlane uczestnikom na stronie powitalnej. Jeśli pozostawione puste, zostaną użyte domyślne kroki.",
+          "add_step": "Dodaj krok",
+          "empty": {
+            "title": "Brak niestandardowych kroków",
+            "desc": "Badanie użyje standardowego przepływu metodologii Q (poznajmy się, pierwsze wrażenia, perspektywa, dlaczego)."
+          },
+          "fields": {
+            "title": "Tytuł kroku",
+            "description": "Krótki opis",
+            "icon": "Ikona",
+            "toggle": "Przełącznik"
+          },
+          "defaults": {
+            "new_step": "Nowy krok badania",
+            "new_desc": "Wyjaśnij, co uczestnik będzie robił na tym etapie."
+          },
+          "reset": {
+            "instructions": "Przywróć instrukcje",
+            "consent_title": "Przywróć tytuł zgody",
+            "consent_description": "Przywróć opis zgody",
+            "process_steps": "Przywróć kroki procesu",
+            "process_steps_confirm": "Czy na pewno chcesz przywrócić wszystkie kroki procesu do wartości domyślnych? Zastąpi to niestandardowe kroki."
+          },
+          "inconsistent": {
+            "banner_title": "Niespójne kroki procesu",
+            "rough_disabled": "Krok 'Pierwsze wrażenia' (sortowanie zgrubne) jest na tej liście, ale sortowanie zgrubne jest w badaniu wyłączone. Uczestnicy go nie zobaczą.",
+            "presort_disabled": "Krok 'Poznajmy się' (ankieta wstępna) jest na tej liście, ale ankieta wstępna jest wyłączona. Uczestnicy go nie zobaczą.",
+            "remove_action": "Usuń"
+          }
+        },
+        "consent_title": "Formularz zgody",
+        "reset": "Przywróć instrukcję",
+        "consent_details": "Szczegóły formularza zgody",
+        "fields": {
+          "default_lang": "Język domyślny",
+          "default_lang_help": "Ten język będzie domyślnie wyświetlany uczestnikom, jeśli język przeglądarki nie jest obsługiwany.",
+          "title": "Tytuł badania",
+          "title_placeholder": "Wpisz tytuł publiczny...",
+          "subtitle": "Podtytuł (opcjonalnie)",
+          "subtitle_placeholder": "Krótkie hasło...",
+          "objective": "Cel badania",
+          "objective_placeholder": "Jakie jest pytanie badawcze lub cel tego badania?",
+          "task_overview": "Wprowadzenie",
+          "task_placeholder": "Opisz tutaj przebieg badania (liczba kroków, szacowany czas itp.). To pole jest opcjonalne, jeśli używasz niestandardowych kroków powyżej.",
+          "consent_title_label": "Tytuł zgody",
+          "legal_text": "Tekst prawny / umowa",
+          "legal_placeholder": "Wpisz pełny tekst umowy prawnej..."
+        },
+        "consent_desc": "Uczestnicy muszą zaakceptować te warunki przed rozpoczęciem."
+      },
+      "condition": {
+        "title": "Warunek instrukcji",
+        "label": "Zdefiniuj warunek instrukcji",
+        "desc": "To jest główna instrukcja, która prowadzi uczestników przez cały proces sortowania.",
+        "field_label": "Treść instrukcji",
+        "placeholder": "Np. Proszę uszeregować poniższe stwierdzenia od tych, z którymi najbardziej się Pan/Pani zgadza, do tych, z którymi najbardziej się nie zgadza",
+        "grid_title": "Instrukcja sortowania Q",
+        "grid_desc": "To jest główna instrukcja prowadząca uczestników podczas procesu sortowania Q.",
+        "pre_title": "Instrukcja wstępnego sortowania",
+        "pre_desc": "Instrukcja podawana uczestnikom podczas wstępnego sortowania zgrubnego.",
+        "pre_field_label": "Treść instrukcji",
+        "pre_placeholder": "Np. Na podstawie własnego punktu widzenia podziel karty na trzy stosy...",
+        "enable_pre": "Włącz etap wstępnej instrukcji",
+        "pre_label": "Treść wstępnej instrukcji",
+        "tips": {
+          "title": "Dlaczego to ważne?",
+          "desc": "W metodologii Q 'warunek instrukcji' określa punkt widzenia, z którego uczestnik sortuje stwierdzenia. Powinien być jasny i spójny we wszystkich fazach sortowania."
+        }
+      },
+      "questions": {
+        "enable_presort": "Włącz ankietę wstępną",
+        "enable_presort_desc": "Zbierz dane demograficzne lub inne informacje przed zadaniem sortowania.",
+        "add_field": "Dodaj nowe pole",
+        "basic_fields": "Pola podstawowe",
+        "choice_fields": "Pola wyboru",
+        "scale_fields": "Pola skali",
+        "labels": {
+          "question": "Etykieta pytania",
+          "required": "Pole wymagane",
+          "options": "Opcje",
+          "option_ordinal": "Opcja {{number}}",
+          "multiple": "(Dozwolony wielokrotny wybór)",
+          "single": "(Pojedynczy wybór)",
+          "placeholder": "Wpisz tutaj swoje pytanie...",
+          "scale": "Skala ocen",
+          "scale_points": "Liczba punktów",
+          "scale_left": "Etykieta lewego krańca",
+          "scale_right": "Etykieta prawego krańca"
+        },
+        "types": {
+          "text": "Tekst",
+          "long_text": "Tekst długi",
+          "number": "Liczba",
+          "date": "Data",
+          "email": "E-mail",
+          "dropdown": "Lista rozwijana",
+          "radio": "Przycisk radiowy",
+          "checkboxes": "Pola wyboru",
+          "text_audio": "Tekst + audio",
+          "rating": "Skala ocen"
+        },
+        "empty": {
+          "title": "Brak pytań",
+          "desc": "Kliknij powyżej, aby dodać pierwsze pytanie"
+        },
+        "defaults": {
+          "new_question": "Nowe pytanie",
+          "option": "Opcja",
+          "enter_answer": "Wpisz swoją odpowiedź...",
+          "untitled": "Pytanie bez tytułu",
+          "scale_left": "Zdecydowanie się nie zgadzam",
+          "scale_right": "Zdecydowanie się zgadzam"
+        },
+        "actions": {
+          "add_option": "Dodaj opcję",
+          "copy_from": "Importuj z języka",
+          "copy_success": "Zaimportowano"
+        },
+        "logic": {
+          "title": "Logika widoczności",
+          "enable": "Dodaj warunek widoczności",
+          "depends_on": "Pokaż to pytanie tylko jeśli...",
+          "select_placeholder": "Wybierz pytanie nadrzędne",
+          "operator": "Operator",
+          "value": "Wartość porównania",
+          "operators": {
+            "equals": "Równa się",
+            "not_equals": "Nie równa się",
+            "contains": "Zawiera",
+            "greater_than": "Większe niż",
+            "less_than": "Mniejsze niż"
+          }
+        }
+      },
+      "qsort": {
+        "tabs": {
+          "statements": "Stwierdzenia",
+          "distribution": "Rozkład"
+        },
+        "bulk": {
+          "title": "Edytor zbiorczy (szybkie wklejanie)",
+          "desc": "Jedno stwierdzenie w każdym wierszu. Obsługuje format 'kod: tekst' i kopiowanie z Excela (wielojęzyczne).",
+          "replace_all": "Zastąp wszystko",
+          "append": "Dołącz do listy",
+          "sync_by_code": "Synchronizuj/scal wg kodu",
+          "placeholder": "Proste: Moje stwierdzenie",
+          "detected": "Wykryto {{count}} stwierdzeń",
+          "process_replace": "Przetwórz i zastąp stwierdzenia",
+          "process_append": "Przetwórz i dołącz stwierdzenia",
+          "process_sync": "Przetwórz i synchronizuj tłumaczenia",
+          "detected_format": {
+            "excel": "Wykryto format Excel (tabulatory)",
+            "list": "Wykryto format listy (kod: tekst)",
+            "simple": "Wykryto prostą listę (jeden wiersz = jedno stwierdzenie)",
+            "multi_lang": "Wielojęzyczne: {{langs}}",
+            "with_codes": "Z niestandardowymi kodami"
+          }
+        },
+        "set": {
+          "title": "Zbiór Q",
+          "clear": "Wyczyść wszystko",
+          "confirm_clear": "Czy na pewno chcesz usunąć WSZYSTKIE stwierdzenia? Tego działania nie można cofnąć.",
+          "updated": "Stwierdzenie zaktualizowane",
+          "cleared": "Wszystkie stwierdzenia wyczyszczone",
+          "imported": "Pomyślnie zaimportowano {{count}} stwierdzeń",
+          "reset_codes": "Resetuj kody",
+          "confirm_reset_codes": "Czy na pewno chcesz ponownie nadać numery wszystkim kodom stwierdzeń (s1, s2, s3...)?",
+          "codes_reset": "Kody stwierdzeń ponownie ponumerowane"
         },
         "settings": {
-            "title": "Ustawienia",
-            "description": "Przechowywanie danych, archiwizacja i usuwanie badania.",
-            "lifecycle": {
-                "title": "Archiwizacja",
-                "description": "Zarchiwizuj badanie, aby uczynić je tylko do odczytu dla wszystkich.",
-                "notice": "Aby zarchiwizować badanie, należy je najpierw zamknąć. Po archiwizacji nie można wprowadzać żadnych zmian.",
-                "archived_status": "Badanie jest zarchiwizowane",
-                "archive_button": "Archiwizuj badanie",
-                "current_state": "Aktualny stan"
-            },
-            "danger": {
-                "title": "Strefa zagrożenia",
-                "description": "Działania tutaj są nieodwracalne.",
-                "notice": "Usunięcie badania trwale usuwa WSZYSTKIE dane (uczestników, odpowiedzi, konfigurację). Badanie musi być zarchiwizowane przed usunięciem.",
-                "delete_button": "Usuń badanie",
-                "delete_confirm": "Czy na pewno? To działanie jest NIEODWRACALNE.",
-                "delete_dialog_title": "Usunąć to badanie?",
-                "delete_dialog_intro": "Trwale usuwa sortowania, nagrania audio i przebiegi analiz.",
-                "delete_dialog_typed_label": "Wpisz slug badania, aby potwierdzić",
-                "delete_dialog_action": "Usuń trwale"
-            },
-            "save_button": "Zapisz",
-            "save_success": "Ustawienia zaktualizowane",
-            "save_success_desc": "Ustawienia badania zostały zapisane.",
-            "save_error": "Nie udało się zapisać ustawień. Sprawdź wartości i spróbuj ponownie.",
-            "save_error_desc": "Nie udało się zaktualizować ustawień. Możliwe, że slug jest już zajęty.",
-            "archive_success": "Badanie zarchiwizowane",
-            "archive_success_desc": "Badanie jest teraz zarchiwizowane i tylko do odczytu.",
-            "archive_error": "Błąd archiwizacji badania",
-            "archive_error_desc": "Nie udało się zarchiwizować badania. Czy zostało zamknięte?",
-            "delete_success": "Badanie usunięte",
-            "delete_success_desc": "Badanie zostało trwale usunięte.",
-            "delete_error": "Nie udało się usunąć badania. Upewnij się, że wszystkie dane zostały wcześniej wyczyszczone.",
-            "delete_error_desc": "Nie udało się usunąć badania.",
-            "storage": {
-                "title": "Użycie pamięci audio",
-                "used": "Używana pamięć",
-                "quota": "Limit",
-                "quota_label": "Limit pamięci",
-                "quota_help": "Maksymalna łączna pamięć audio dla tego badania (10–1000 MB).",
-                "error": "Nie udało się wczytać informacji o użyciu pamięci.",
-                "warning_high_usage": "Użycie pamięci jest wysokie. Rozważ zwiększenie limitu lub usunięcie starych nagrań.",
-                "save_success": "Limit pamięci zaktualizowany",
-                "save_error": "Nie udało się zaktualizować limitu pamięci. Proszę spróbować ponownie."
-            },
-            "retention": {
-                "title": "Przechowywanie danych",
-                "months_label": "Okres przechowywania (miesiące)",
-                "help": "Typowe wartości: 6, 12, 24, 60 miesięcy. Pozostaw puste, aby użyć wartości domyślnej systemu (12).",
-                "save_success": "Polityka przechowywania danych zaktualizowana",
-                "save_error": "Nie udało się zaktualizować polityki przechowywania danych",
-                "range_error": "Okres przechowywania musi być liczbą całkowitą od 1 do 240 miesięcy."
-            }
+          "title": "Ustawienia badawcze",
+          "desc": "Skonfiguruj sposób prezentacji stwierdzeń uczestnikom",
+          "show_codes": "Pokaż kody stwierdzeń",
+          "show_codes_desc": "Wyświetlaj kody stwierdzeń (np. 'S1', 'S2') obok tekstu.",
+          "randomize": "Losuj kolejność stwierdzeń",
+          "randomize_desc": "Prezentuj stwierdzenia w losowej kolejności każdemu uczestnikowi (spójnie w ramach sesji)"
         },
-        "privacy": {
-            "title": "Ochrona danych",
-            "header_desc": "Zgoda, inwentarz i anonimizacja",
-            "load_error": "Nie udało się wczytać inwentarza danych.",
-            "participants_title": "Migawka uczestników",
-            "stat_started": "Rozpoczętych",
-            "stat_completed": "Ukończonych",
-            "stat_discarded": "Odrzuconych",
-            "stat_anonymised": "Zanonimizowanych",
-            "older_1y": "Starsze niż 1 rok (niezanonimizowane)",
-            "older_2y": "Starsze niż 2 lata (niezanonimizowane)",
-            "audio_title": "Pamięć audio",
-            "audio_count": "Nagrania",
-            "audio_mb": "Łączny rozmiar",
-            "locale_title": "Podział według języka",
-            "locale_col": "Język",
-            "locale_count_col": "Uczestnicy",
-            "locale_empty": "Brak danych językowych.",
-            "timeline_title": "Oś czasu",
-            "tl_first": "Pierwsze zgłoszenie",
-            "tl_last": "Ostatnie zgłoszenie",
-            "tl_anon": "Ostatnia anonimizacja",
-            "bulk_title": "Anonimizacja zbiorcza",
-            "bulk_desc": "Usuń dane osobowe ukończonych uczestników, którzy przesłali zgłoszenia przed datą graniczną. Ranking sortowania Q jest zachowany.",
-            "cutoff_label": "Data graniczna",
-            "cutoff_help": "Zanonimizowani zostaną tylko ukończeni uczestnicy, którzy przesłali zgłoszenia ściśle przed tą datą.",
-            "preview_label": "Kandydaci:",
-            "preview_zero": "Żaden uczestnik nie kwalifikuje się do tej daty granicznej. Spróbuj wcześniejszej daty.",
-            "anonymise_button": "Anonimizuj",
-            "anonymise_success": "Anonimizacja zakończona",
-            "anonymise_success_desc": "Zanonimizowano {{n}} uczestnika(-ów), {{s}} już anonimowych.",
-            "anonymise_error": "Anonimizacja nie powiodła się",
-            "confirm_title": "Zanonimizować dane uczestników?",
-            "confirm_candidates": "Zostanie zanonimizowanych {{count}} ukończony(-ch) uczestnik(-ów), którzy przesłali zgłoszenia przed {{date}}.",
-            "confirm_preserved": "Ranking sortowania Q jest zachowany; tożsamość jest usuwana.",
-            "confirm_irreversible": "To działanie jest natychmiastowe i nie można go cofnąć.",
-            "confirm_in_progress": "Anonimizowanie…",
-            "confirm_action": "Tak, zanonimizuj",
-            "cutoff_from_policy": "Wartość domyślna wynikająca z polityki przechowywania badania ({{months}} miesięcy).",
-            "empty": {
-                "title": "Brak danych uczestników",
-                "body": "Ta strona aktywuje się po przesłaniu zgłoszeń przez uczestników. Najpierw udostępnij link do badania.",
-                "cta": "Otwórz widok ogólny badania"
-            },
-            "consent": {
-                "title": "Formularz zgody",
-                "description": "To, co uczestnicy widzą przed wejściem do badania. Edytowane w projekcie badania.",
-                "no_text": "Brak tekstu zgody.",
-                "no_title": "(brak tytułu)",
-                "no_body": "(puste)",
-                "edit_in_design": "Edytuj w projekcie badania",
-                "view": "Pokaż"
-            }
-        },
-        "projects": {
-            "title": "Projekty",
-            "settings": {
-                "title": "Ustawienia projektu",
-                "identity_desc": "Zarządzaj tożsamością projektu.",
-                "general": {
-                    "title": "Ustawienia ogólne",
-                    "desc": "Tożsamość i podstawowa identyfikacja projektu.",
-                    "label_title": "Tytuł projektu",
-                    "placeholder_title": "Moje świetne laboratorium",
-                    "label_slug": "URL slug",
-                    "placeholder_slug": "moje-laboratorium",
-                    "slug_hint": "Zmiana slugu zaktualizuje wszystkie linki do panelu badawczego.",
-                    "save": "Zapisz",
-                    "save_success": "Projekt zaktualizowany pomyślnie",
-                    "save_error": "Nie udało się zaktualizować projektu."
-                },
-                "team_growth_title": "Zarządzanie zespołem",
-                "team_growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
-                "team": {
-                    "title": "Członkowie zespołu",
-                    "desc": "Lista użytkowników mających dostęp do tego projektu.",
-                    "col_user": "Użytkownik",
-                    "col_role": "Rola",
-                    "col_joined": "Dołączył/a",
-                    "col_actions": "Działania",
-                    "remove_confirm": "Czy na pewno chcesz usunąć tego członka?",
-                    "remove_dialog_title": "Usunąć członka zespołu?",
-                    "remove_dialog_body": "{{name}} straci dostęp do tego projektu. Można go zaprosić ponownie później.",
-                    "remove_dialog_action": "Usuń",
-                    "remove_member_aria": "Usuń {{name}}",
-                    "remove_success": "Członek usunięty pomyślnie",
-                    "remove_error": "Nie udało się usunąć członka",
-                    "growth_title": "Rozwój zespołu",
-                    "growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
-                    "invite_button": "Zaproś współpracownika",
-                    "permissions_matrix": {
-                        "title": "Macierz uprawnień",
-                        "admin": {
-                            "label": "Administrator",
-                            "desc": "Może zarządzać ustawieniami projektu, członkami i wszystkimi badaniami."
-                        },
-                        "owner": {
-                            "label": "Właściciel",
-                            "desc": "Pełna kontrola nad projektem, członkami i badaniami."
-                        },
-                        "member": {
-                            "label": "Członek",
-                            "desc": "Może tworzyć i zarządzać wszystkimi badaniami. Brak dostępu do ustawień projektu."
-                        },
-                        "viewer": {
-                            "label": "Obserwator",
-                            "desc": "Dostęp tylko do odczytu do wszystkich badań i danych w projekcie."
-                        }
-                    },
-                    "coming_soon": "Wkrótce",
-                    "invite_modal": {
-                        "title": "Zaproś współpracownika",
-                        "email_label": "E-mail współpracownika",
-                        "role_label": "Przypisana rola",
-                        "success": "Link zaproszenia wygenerowany!",
-                        "error": "Nie udało się utworzyć zaproszenia.",
-                        "send": "Utwórz i wyślij zaproszenie",
-                        "copy_success": "Link skopiowany do schowka!"
-                    }
-                }
-            }
-        },
-        "members": {
-            "title": "Członkowie zespołu",
-            "description": "Zarządzaj dostępem do projektu i uprawnieniami."
-        },
-        "participants": {
-            "title": "Uczestnicy",
-            "description": "Zarządzaj uczestnikami i przeglądaj przesłane dane.",
-            "table": {
-                "id": "ID",
-                "status": "Status",
-                "started": "Rozpoczęto o",
-                "completed": "Ukończono o",
-                "duration": "Czas trwania",
-                "actions": "Akcje"
-            }
-        },
-        "participant": {
-            "tabs": {
-                "session": "Metadane",
-                "presort": "Wstępne sortowanie",
-                "grid": "Siatka sortowania Q",
-                "postsort": "Sortowanie końcowe"
-            },
-            "grid": {
-                "detail_view": "Szczegóły karty",
-                "no_comment": "Brak komentarza.",
-                "select_instruction": "Wybierz kartę na siatce, aby zobaczyć szczegóły.",
-                "read_only_mode": "Tryb obserwatora",
-                "score": "Wynik"
-            },
-            "metadata": {
-                "title": "Metadane sesji",
-                "technology": "Technologia",
-                "browser": "Przeglądarka",
-                "session": "Szczegóły sesji",
-                "duration": "Łączny czas",
-                "started": "Rozpoczęto",
-                "submitted": "Przesłano",
-                "id": "Wewnętrzny identyfikator",
-                "ip_hash": "Hash IP",
-                "recruitment_token": "Token rekrutacyjny",
-                "device": {
-                    "mobile": "Telefon",
-                    "tablet": "Tablet",
-                    "desktop": "Komputer"
-                }
-            },
-            "status": {
-                "started": "Rozpoczęto",
-                "completed": "Ukończone",
-                "discarded": "Odrzucone",
-                "in_progress": "W toku"
-            },
-            "survey": {
-                "presort": "Pytania wstępne",
-                "postsort": "Pytania końcowe",
-                "no_answers": "Brak zapisanych odpowiedzi dla tej sekcji.",
-                "question_default": "Odpowiedź głosowa",
-                "answer_default": "Odpowiedź",
-                "categories": {
-                    "identity": "Tożsamość i kontakt",
-                    "questions": "Odpowiedzi na pytania",
-                    "comments": "Komentarze do kart",
-                    "feedback": "Opinie ogólne"
-                }
-            }
-        },
-        "users": {
-            "title": "Użytkownicy",
-            "subtitle": "Zarządzaj kontami platformy i sprawdzaj higienę dostępów.",
-            "error_title": "Akcja nie powiodła się",
-            "generic_error": "Coś poszło nie tak. Spróbuj ponownie.",
-            "search_placeholder": "Szukaj według e-mail lub nazwy",
-            "empty": "Brak pasujących użytkowników.",
-            "inactive": "Nieaktywny",
-            "no_name": "Brak nazwy",
-            "last_seen": "Ostatnio widziany {{when}}",
-            "never_logged_in": "Nigdy się nie logował",
-            "actions_aria": "Akcje dla {{email}}",
-            "menu_label": "Zarządzaj kontem",
-            "filter": {
-                "all": "Wszyscy użytkownicy",
-                "superusers": "Superużytkownicy",
-                "no_2fa": "Bez 2FA",
-                "unverified": "E-mail niezweryfikowany",
-                "dormant": "Nieaktywny"
-            },
-            "risk": {
-                "superuser_no_2fa": "Superużytkownik bez 2FA",
-                "email_unverified": "E-mail niezweryfikowany",
-                "password_stale": "Hasło starsze niż rok",
-                "email_change_pending": "Zmiana e-mail w toku",
-                "dormant": "Nieaktywny (90+ dni)"
-            },
-            "role": {
-                "superuser": "Superużytkownik",
-                "user": "Użytkownik"
-            },
-            "action": {
-                "demote": "Odbierz uprawnienia superużytkownika",
-                "promote": "Nadaj uprawnienia superużytkownika",
-                "deactivate": "Dezaktywuj konto",
-                "reactivate": "Reaktywuj konto",
-                "force_password_reset": "Wymuś reset hasła",
-                "reset_totp": "Zresetuj 2FA",
-                "delete": "Usuń użytkownika",
-                "generate_reset_link": "Wygeneruj link resetujący hasło",
-                "set_email": "Ustaw e-mail"
-            },
-            "confirm": {
-                "cancel": "Anuluj",
-                "confirm": "Potwierdź",
-                "delete_title": "Usunąć tego użytkownika?",
-                "delete_body": "Trwale usuń {{email}}. Tej operacji nie można cofnąć.",
-                "reset-totp_title": "Zresetować uwierzytelnianie dwuskładnikowe?",
-                "reset-totp_body": "Wyłącz 2FA dla {{email}}. Użytkownik będzie musiał je skonfigurować ponownie.",
-                "force-password-reset_title": "Wymusić reset hasła?",
-                "force-password-reset_body": "Unieważnij hasło {{email}} i zażądaj jego zmiany przy następnym logowaniu.",
-                "deactivate_title": "Dezaktywować to konto?",
-                "deactivate_body": "Natychmiast wyloguj {{email}} i zablokuj logowanie do czasu reaktywacji.",
-                "demote_title": "Odebrać dostęp superużytkownika?",
-                "demote_body": "Usuń uprawnienia superużytkownika od {{email}}.",
-                "promote_title": "Przyznać dostęp superużytkownika?",
-                "promote_body": "Przyznaj {{email}} pełne uprawnienia superużytkownika na platformie."
-            },
-            "email_manual_note": "Wysyłka e-maili nie jest skonfigurowana. Do odzyskania konta użyj poniższego linku resetującego hasło oraz akcji ustawienia adresu e-mail — żaden e-mail nie jest wysyłany.",
-            "load_error_body": "Nie udało się pobrać listy użytkowników. Odśwież stronę lub spróbuj ponownie później.",
-            "load_error_title": "Nie można załadować użytkowników",
-            "recovery_link": {
-                "copy": "Kopiuj link",
-                "help": "Udostępnij ten jednorazowy link użytkownikowi innym kanałem. Wygasa zgodnie z oknem resetowania hasła.",
-                "title": "Link resetujący hasło"
-            },
-            "set_email_dialog": {
-                "current": "Bieżący",
-                "description": "Spowoduje to wylogowanie {{email}}; użytkownik musi zalogować się ponownie przy użyciu nowego adresu. Żaden e-mail potwierdzający nie jest wysyłany.",
-                "error": "Nie można ustawić adresu e-mail.",
-                "label": "Nowy adres e-mail",
-                "submit": "Ustaw e-mail",
-                "success": "Zaktualizowano e-mail.",
-                "title": "Ustaw e-mail użytkownika"
-            }
+        "grid": {
+          "title": "Siatka rozkładu sortowania Q",
+          "desc": "Kształt siatki zmusza uczestników do różnicowania stwierdzeń, przybliżając rozkład normalny.",
+          "slot_count": "Przydzielono {{count}} miejsc",
+          "stat_count": "{{count}} stwierdzeń",
+          "perfect": "Idealna równowaga",
+          "too_many": "{{count}} stwierdzeń za dużo",
+          "too_few": "Brakuje {{count}} stwierdzeń",
+          "min_reached": "Osiągnięto minimalny zakres (±2)",
+          "max_reached": "Osiągnięto maksymalny zakres (±6)",
+          "remove_extreme_columns": "Usuń skrajne kolumny",
+          "add_extreme_columns": "Dodaj skrajne kolumny",
+          "symmetry_lock": "Blokada symetrii",
+          "symmetry_lock_desc": "Automatycznie stosuj zmiany do kolumn przeciwnych, aby zachować wyważony rozkład.",
+          "auto_balance": "Auto-wyważenie",
+          "auto_balance_desc": "Przekształć siatkę w wyważony rozkład półnormalny",
+          "reshaped": "Siatka przekształcona do wyważonego rozkładu",
+          "balanced": "Siatka wyważona do standardowego rozkładu",
+          "no_statements": "Najpierw dodaj stwierdzenia, aby automatycznie ukształtować siatkę",
+          "statements": "stwierdzenia",
+          "ideal_shape": "Idealny kształt",
+          "symmetric": "Symetryczna",
+          "asymmetric": "Asymetryczna",
+          "tooltip_title": "Dlaczego rozkład wymuszony?",
+          "tooltip_desc": "Metodologia Q używa rozkładu quasi-normalnego (kurtoza > 0), aby zapewnić, że uczestnicy dokonują znaczących rozróżnień. Kształt piramidy zapobiega błędowi tendencji centralnej.",
+          "locked": "Projekt zablokowany",
+          "locked_desc": "Zmiany strukturalne (kody stwierdzeń, siatka) są wyłączone, ponieważ badanie zebrało dane lub nie jest już w trybie szkicu. Nadal można edytować tłumaczenia tekstowe.",
+          "locked_active": "To badanie jest aktywne. Przełącz na tryb szkicu, aby edytować.",
+          "locked_paused": "To badanie jest wstrzymane. Przełącz na tryb szkicu, aby edytować.",
+          "locked_closed": "To badanie jest zamknięte. Projekt jest zarchiwizowany.",
+          "view_read_only": "Podgląd tylko do odczytu",
+          "locked_dialog_desc": "Edycja jest zablokowana, gdy badanie jest w tym stanie. Zamknij to powiadomienie, aby przeczytać konfigurację bez wprowadzania zmian.",
+          "mismatch_title": "Niezgodność pojemności siatki",
+          "mismatch_desc": "Masz {{statements}} stwierdzeń, ale siatka ma tylko miejsca dla {{slots}} elementów. Dostosuj kolumny poniżej.",
+          "unlock_hint": "Przejdź do eksploratora danych, aby wyczyścić sesje i odblokować strukturę"
         }
+      },
+      "postsort": {
+        "extreme": {
+          "title": "Kolumny docelowe",
+          "desc": "Wybierz kolumny, które wyzwalają pytania uzupełniające.",
+          "no_columns": "Nie wybrano żadnych kolumn.",
+          "add_label": "Dodaj kolumnę:",
+          "prompt_label": "Pytanie o stwierdzenia",
+          "prompt_placeholder": "Dlaczego umieścił/a Pan/Pani to stwierdzenie w tym miejscu?",
+          "add": "Dodaj",
+          "add_defaults": "Dodaj domyślne skrajności",
+          "select_placeholder": "Wybierz..."
+        },
+        "random_comments": {
+          "title": "Zezwalaj na swobodne komentarze",
+          "desc": "Pozwól uczestnikom dodawać komentarze do dowolnego stwierdzenia na siatce."
+        },
+        "custom": {
+          "title": "Pytania niestandardowe",
+          "desc": "Dodaj niestandardowe pytania do ankiety po sortowaniu."
+        },
+        "missing": {
+          "title": "Pytaj o brakujące stwierdzenia",
+          "desc": "Jeśli tak, proszę opisać je krótko.",
+          "prompt_label": "Treść pytania",
+          "prompt_placeholder": "Proszę śmiało sugerować i wyjaśniać."
+        },
+        "steps": {
+          "step1": "Krok 1: informacja zwrotna",
+          "step2": "Krok 2: pytania"
+        },
+        "email": {
+          "title": "Kontakt uzupełniający z uczestnikiem",
+          "desc": "Zbieraj adresy e-mail do celów kontaktu uzupełniającego lub przekazania wyników badania.",
+          "interview": "Zaproponuj kontakt uzupełniający",
+          "results": "Zaproponuj zapis na listę mailingową z wynikami badania",
+          "interview_warning": "Uwaga: zgoda na kontakt znosi anonimowość wobec badacza.",
+          "results_hint": "E-mail wyłącznie do celów przekazania wyników, anonimowość zachowana."
+        },
+        "audio": {
+          "title": "Nagranie audio",
+          "desc": "Pozwól uczestnikom nagrywać odpowiedzi audio zamiast tekstu.",
+          "max_duration": "Maksymalny czas trwania",
+          "seconds": "sekund",
+          "max_duration_help": "Maksymalny czas nagrywania na pytanie (30–600 sekund).",
+          "participant_choice_info": "Uczestnicy mogą odpowiadać tekstem, nagraniem audio lub obydwoma sposobami na każde pytanie.",
+          "storage_unavailable_body": "Magazyn obiektów nie jest skonfigurowany, więc nie można zbierać odpowiedzi audio. Nadal możesz włączyć audio, ale uczestnicy będą odpowiadać wyłącznie tekstem i żadne nagranie nie zostanie wykonane. Skonfiguruj magazyn obiektów i uruchom ponownie serwer, aby włączyć przechwytywanie audio.",
+          "storage_unavailable_title": "Przechwytywanie audio jest niedostępne na tym serwerze"
+        }
+      },
+      "interface": {
+        "title": "Dostosowanie interfejsu",
+        "desc": "Dostosuj przyciski i etykiety interfejsu do tonu badania (np. zastępując 'zgadzam się/nie zgadzam się' słowami 'lubię/nie lubię').",
+        "nav": {
+          "title": "Przyciski nawigacyjne",
+          "start": "Przycisk start",
+          "next": "Przycisk następnego kroku",
+          "submit": "Przycisk wyślij",
+          "confirm": "Przycisk potwierdzenia sortowania",
+          "tooltips": {
+            "start": "Przycisk rozpoczynający badanie",
+            "next": "Przejście do następnego kroku",
+            "submit": "Wyślij wyniki na końcu",
+            "confirm": "Ogólny przycisk zatwierdzania"
+          }
+        },
+        "terms": {
+          "title": "Terminologia sortowania",
+          "desc": "Zdefiniuj etykiety dla sortowania spontanicznego i spektrum siatki.",
+          "rough": "Etykiety sortowania zgrubnego",
+          "agree": "Zgadzam się",
+          "neutral": "Neutralnie",
+          "disagree": "Nie zgadzam się",
+          "grid": "Legendy siatki (skrajności)",
+          "most_agree": "Najbardziej zgadzam się",
+          "most_disagree": "Najbardziej nie zgadzam się"
+        },
+        "hints": {
+          "title": "Wskazówki metodologiczne",
+          "desc": "Dodaj lub zmodyfikuj pływające wskazówki pomagające uczestnikom podczas fazy sortowania na siatce.",
+          "placeholder": "Wpisz wskazówkę metodologiczną...",
+          "add": "Dodaj wskazówkę",
+          "reset": "Przywróć wartości domyślne"
+        },
+        "help": {
+          "title": "Wskazówki dla kroków (co/dlaczego)",
+          "desc": "Dostosuj kontekstową pomoc dostępną dla uczestników na każdym kroku przez nakładkę '?'.",
+          "step_disabled": "(krok wyłączony)"
+        }
+      },
+      "theme": {
+        "title": "Identyfikacja wizualna",
+        "accent": {
+          "title": "Kolor akcentu",
+          "desc": "Ten kolor będzie używany dla przycisków, linków i wyróżnień w całym badaniu.",
+          "pick": "Wybierz kolor",
+          "reset": "Przywróć domyślny"
+        },
+        "logo": {
+          "title": "Logo badania",
+          "desc": "Prześlij niestandardowe logo zastępujące domyślną markę Qualis.",
+          "label": "URL logo",
+          "hint": "Zalecany rozmiar: 200×50 px. Obsługiwane formaty: PNG, SVG, JPG.",
+          "preview": "Podgląd logo",
+          "help_title": "Gdzie pojawia się to logo?",
+          "help_desc": "Logo jest wyświetlane na górze każdej strony badania (pasek nawigacyjny) i na stronie powitalnej. Wzmacnia identyfikację wizualną projektu."
+        },
+        "partners": {
+          "title": "Partnerzy instytucjonalni",
+          "desc": "Dodaj logo wspierających instytucji lub partnerów.",
+          "add": "Dodaj partnera",
+          "name_label": "Nazwa partnera",
+          "name_placeholder": "Nazwa instytucji",
+          "logo_label": "URL logo",
+          "url_label": "Strona internetowa (opcjonalnie)",
+          "url_placeholder": "https://...",
+          "help_title": "Wyświetlanie logo",
+          "help_desc": "Logo partnerów są wyświetlane na stronie startowej oraz w nagłówku badania, obok głównego logo."
+        },
+        "upload": {
+          "upload": "Prześlij",
+          "recommended": "Zalecane",
+          "invalid_type": "Nieprawidłowy typ pliku. Użyj PNG, JPG lub SVG.",
+          "file_too_large": "Plik jest za duży. Maksymalny rozmiar: {{size}} kB.",
+          "conversion_error": "Nie udało się przetworzyć obrazu.",
+          "processing": "Przetwarzanie obrazu...",
+          "drag_drop": "Przeciągnij i upuść lub kliknij, aby przesłać",
+          "max": "Maks."
+        }
+      },
+      "activate_dialog": {
+        "title": "Aktywować to badanie?",
+        "description": "Aktywacja otwiera rekrutację i odblokowuje publiczne linki. Prawdziwi uczestnicy będą mogli zacząć przesyłać odpowiedzi.",
+        "checklist_title": "Kontrola przed startem",
+        "languages_title": "Języki",
+        "lang_ready": "Gotowe",
+        "lang_incomplete": "Niekompletne",
+        "required": "(wymagane)",
+        "attestation": "Zapoznałem/am się z tekstem zgody i polityką przechowywania danych i potwierdzam, że badanie jest gotowe do przyjęcia prawdziwych uczestników.",
+        "confirm": "Aktywuj badanie"
+      }
+    },
+    "data": {
+      "title": "Dane",
+      "description": "Monitoruj uczestnictwo w czasie rzeczywistym, analizuj jakość danych i zarządzaj sesjami badawczymi.",
+      "sections": {
+        "key_indicators": "Kluczowe wskaźniki",
+        "responses": "Odpowiedzi",
+        "key_statistics": "Kluczowe statystyki"
+      },
+      "stats": {
+        "email_collection": "Zbieranie e-maili",
+        "participants": "łącznie",
+        "newsletter": "Chce wyniki",
+        "opt_in": "Wskaźnik odpowiedzi",
+        "follow_up": "Potencjał kontaktu uzupełniającego",
+        "interested": "zainteresowanych",
+        "click_to_filter": "Kliknij, aby filtrować",
+        "click_to_export": "Kliknij, aby eksportować listę",
+        "completed": "Ukończone",
+        "in_progress": "W toku",
+        "abandoned_count": "{{count}} porzuconych",
+        "interview_interested": "Akceptuje kontakt uzupełniający",
+        "interview": "Akceptuje kontakt uzupełniający",
+        "email": "E-maile"
+      },
+      "tabs": {
+        "live": "Uczestnicy na żywo",
+        "test": "Sesje testowe",
+        "browse": "Widok interaktywny",
+        "export": "Centrum eksportu"
+      },
+      "status": {
+        "started": "rozpoczęte",
+        "completed": "Ukończone",
+        "in_progress": "W toku",
+        "abandoned": "Porzucone",
+        "discarded": "odrzucone"
+      },
+      "step": {
+        "consent": "Zgoda",
+        "presort": "Ankieta wstępna",
+        "rough": "Sortowanie zgrubne",
+        "fine": "Sortowanie Q",
+        "post": "Ankieta końcowa"
+      },
+      "actions": {
+        "discard": "Odrzuć",
+        "restore": "Przywróć",
+        "export": "Eksportuj",
+        "clear_all": "Resetuj wszystkie dane",
+        "clear_all_confirm": "UWAGA: Spowoduje to trwałe usunięcie WSZYSTKICH danych uczestników dla tego badania. Tego działania nie można cofnąć.",
+        "clear_all_success": "Wszystkie dane wyczyszczone",
+        "clear_all_error": "Nie udało się wyczyścić danych. Sprawdź uprawnienia i spróbuj ponownie."
+      },
+      "confirm_discard": {
+        "title": "Odrzucić uczestnika?",
+        "description": "Ten uczestnik zostanie wykluczony z eksportów i analiz. Można go przywrócić później.",
+        "reason_label": "Powód (opcjonalnie)",
+        "reason_placeholder": "Dlaczego ten uczestnik jest odrzucany?"
+      },
+      "confirm_restore": {
+        "title": "Przywrócić uczestnika?",
+        "description": "Ten uczestnik zostanie ponownie uwzględniony w eksportach i analizach."
+      },
+      "guide": {
+        "title": "Przewodnik formatów",
+        "csv": {
+          "title": "Uniwersalny CSV",
+          "desc": "Surowe dane prostokątne. Najlepsze do analizy w R, Pythonie, SPSS lub Excelu. Zawiera wszystkie metadane."
+        },
+        "json": {
+          "title": "KenQ JSON",
+          "desc": "Zoptymalizowane dla narzędzia web-kenq. Zawiera definicję badania i sortowania."
+        },
+        "zip": {
+          "title": "Pakiet PQMethod (ZIP)",
+          "desc": "Zawiera starsze pliki .DAT i .STA do analizy DOS PQMethod."
+        }
+      },
+      "table": {
+        "participant": "Uczestnik",
+        "lang": "Język",
+        "status": "Status",
+        "consent": "Zgoda",
+        "flags": "Oznaczenia",
+        "duration": "Czas trwania",
+        "submitted": "Przesłano",
+        "last_step": "Ostatni krok",
+        "current_step": "Aktualny krok",
+        "view": "Pokaż",
+        "actions": "Szczegóły",
+        "duplicate_ip": "Duplikat IP",
+        "duplicate_ip_hint": "Współdzieli hash IP z innymi uczestnikami"
+      },
+      "tooltips": {
+        "suspect": "Potencjalnie podejrzane: czas trwania sesji < 2 minuty",
+        "has_comments": "Zawiera komentarze uczestnika do kart",
+        "has_audio": "Ma odpowiedzi audio",
+        "email_provided": "Podano e-mail",
+        "newsletter_consent": "Chce wyniki",
+        "interview_consent": "Akceptuje kontakt uzupełniający"
+      },
+      "toast": {
+        "discarded": "Uczestnik odrzucony",
+        "restored": "Uczestnik przywrócony",
+        "error": "Nie udało się zaktualizować uczestnika. Sprawdź połączenie i spróbuj ponownie."
+      },
+      "detail": {
+        "participant": "Uczestnik",
+        "participant_n": "Uczestnik {{code}}",
+        "not_found": "Uczestnik nie znaleziony",
+        "title": "Profil uczestnika",
+        "session": "Sesja",
+        "discarded_badge": "Odrzucony",
+        "description": "Pełne wyniki sortowania Q i metadane.",
+        "stats": {
+          "duration": "Łączny czas trwania",
+          "language": "Użyty język"
+        },
+        "actions": {
+          "discard": "Odrzuć uczestnika",
+          "restore": "Przywróć uczestnika"
+        },
+        "sort_config": "Konfiguracja sortowania",
+        "survey": {
+          "title": "Odpowiedzi ankietowe",
+          "csv_note": "Pełne odpowiedzi dostępne w eksporcie CSV."
+        }
+      },
+      "filter": {
+        "show_discarded": "Uwzględnij odrzucone rekordy",
+        "all_states": "Wszystkie stany",
+        "only_active": "Tylko aktywne",
+        "only_flagged": "Oznaczona jakość"
+      },
+      "filters": {
+        "active": "Aktywne filtry",
+        "has_email": "Podano e-mail",
+        "newsletter": "Chce wyniki",
+        "interview": "Akceptuje kontakt uzupełniający",
+        "flagged": "Tylko oznaczone",
+        "clear_all": "Wyczyść filtry",
+        "remove_filter": "Usuń filtr",
+        "all_statuses": "Wszystkie statusy",
+        "all_consents": "Wszystkie",
+        "all_indicators": "Wszystkie",
+        "all_steps": "Wszystkie kroki",
+        "has_comments": "Ma komentarze",
+        "has_audio": "Ma audio",
+        "has_recruitment": "Ma link rekrutacyjny"
+      },
+      "charts": {
+        "section_title": "Rozkłady odpowiedzi",
+        "distribution_label": "Rozkład dla {{question}}",
+        "multi_select_note": "Dozwolony wielokrotny wybór",
+        "responses_count": "{{count}} odpowiedzi",
+        "no_answer": "Brak odpowiedzi",
+        "option": "Opcja",
+        "count": "Liczba"
+      },
+      "search": {
+        "placeholder": "Szukaj po ID lub tokenie rekrutacyjnym...",
+        "records_found": "Wykryte rekordy",
+        "no_results": "Żaden rekord nie pasuje do zapytania"
+      },
+      "errors": {
+        "load_failed": "Synchronizacja z chmurą przerwana. Proszę sprawdzić połączenie."
+      },
+      "export_emails_success": "E-maile wyeksportowane pomyślnie",
+      "empty": {
+        "no_participants_title": "Brak uczestników",
+        "no_participants_desc": "Udostępnij link do badania, aby zacząć zbierać odpowiedzi.",
+        "contract_title": "Brak zgłoszeń",
+        "contract_body": "Zgłoszenia i eksporty pojawią się tutaj. Udostępnij link do badania, aby zacząć zbierać dane.",
+        "contract_cta": "Otwórz widok ogólny badania"
+      },
+      "pagination": {
+        "showing": "Pokazuję {{from}}–{{to}} z {{total}}"
+      }
+    },
+    "team": {
+      "title": "Zespół badania",
+      "description": "Zarządzaj współpracownikami i kontrolą dostępu na poziomie badania.",
+      "invite_title": "Zaproś współpracownika",
+      "invite_description": "Wygeneruj bezpieczny link, aby zaprosić nowego członka do tego badania.",
+      "email_label": "Adres e-mail",
+      "role_label": "Rola",
+      "select_role": "Wybierz rolę",
+      "generate_link": "Generuj link",
+      "invite_success": "Link zaproszenia wygenerowany!",
+      "invite_error": "Nie udało się wygenerować zaproszenia",
+      "copy_success": "Link skopiowany do schowka",
+      "share_label": "Udostępnij ten link zaproszonej osobie:",
+      "collab_overview": "Przegląd współpracy",
+      "active_members": "Aktywni członkowie",
+      "permissions_info": "Informacje o uprawnieniach",
+      "list_title": "Zespół badawczy",
+      "list_description": "Zarządzaj dostępem dla istniejących współpracowników.",
+      "added_on": "Dodano",
+      "headers": {
+        "collaborator": "Współpracownik",
+        "role": "Rola",
+        "actions": "Akcje"
+      },
+      "roles": {
+        "owner": "Właściciel (pełna kontrola)",
+        "editor": "Redaktor (projekt i analiza)",
+        "viewer": "Obserwator (tylko odczyt)",
+        "owner_badge": "WŁAŚCICIEL",
+        "editor_badge": "REDAKTOR",
+        "viewer_badge": "OBSERWATOR"
+      },
+      "permissions": {
+        "owner": "Może usunąć badanie i zarządzać zespołem.",
+        "editor": "Może modyfikować projekt i przeglądać wyniki.",
+        "viewer": "Dostęp tylko do odczytu do wszystkich modułów."
+      }
+    },
+    "empty_states": {
+      "participants": {
+        "title": "Gotowe do uruchomienia?",
+        "desc": "Udostępnij link do badania, aby rozpocząć zbieranie odpowiedzi. Pierwszy uczestnik jest o jedno kliknięcie.",
+        "action": "Kopiuj link do badania",
+        "hint": "Lub zeskanuj kod QR",
+        "copy_success": "Link do badania skopiowany do schowka!"
+      },
+      "team": {
+        "title": "Działasz samodzielnie",
+        "desc": "Zaproś współpracowników, aby pomogli zarządzać tym badaniem. Mogą przeglądać dane, edytować projekt lub jedynie obserwować.",
+        "action": "Zaproś pierwszego współpracownika"
+      },
+      "designer": {
+        "title": "Tabula rasa",
+        "desc": "To badanie nie ma jeszcze żadnych stwierdzeń. Dodaj elementy zbioru Q, aby rozpocząć projektowanie sortowania.",
+        "action": "Wczytaj przykładowy zbiór Q"
+      }
+    },
+    "status": {
+      "active": "Active",
+      "paused": "Paused",
+      "closed": "Closed",
+      "draft": "Draft"
+    },
+    "settings": {
+      "title": "Ustawienia",
+      "description": "Przechowywanie danych, archiwizacja i usuwanie badania.",
+      "lifecycle": {
+        "title": "Archiwizacja",
+        "description": "Zarchiwizuj badanie, aby uczynić je tylko do odczytu dla wszystkich.",
+        "notice": "Aby zarchiwizować badanie, należy je najpierw zamknąć. Po archiwizacji nie można wprowadzać żadnych zmian.",
+        "archived_status": "Badanie jest zarchiwizowane",
+        "archive_button": "Archiwizuj badanie",
+        "current_state": "Aktualny stan"
+      },
+      "danger": {
+        "title": "Strefa zagrożenia",
+        "description": "Działania tutaj są nieodwracalne.",
+        "notice": "Usunięcie badania trwale usuwa WSZYSTKIE dane (uczestników, odpowiedzi, konfigurację). Badanie musi być zarchiwizowane przed usunięciem.",
+        "delete_button": "Usuń badanie",
+        "delete_confirm": "Czy na pewno? To działanie jest NIEODWRACALNE.",
+        "delete_dialog_title": "Usunąć to badanie?",
+        "delete_dialog_intro": "Trwale usuwa sortowania, nagrania audio i przebiegi analiz.",
+        "delete_dialog_typed_label": "Wpisz slug badania, aby potwierdzić",
+        "delete_dialog_action": "Usuń trwale"
+      },
+      "save_button": "Zapisz",
+      "save_success": "Ustawienia zaktualizowane",
+      "save_success_desc": "Ustawienia badania zostały zapisane.",
+      "save_error": "Nie udało się zapisać ustawień. Sprawdź wartości i spróbuj ponownie.",
+      "save_error_desc": "Nie udało się zaktualizować ustawień. Możliwe, że slug jest już zajęty.",
+      "archive_success": "Badanie zarchiwizowane",
+      "archive_success_desc": "Badanie jest teraz zarchiwizowane i tylko do odczytu.",
+      "archive_error": "Błąd archiwizacji badania",
+      "archive_error_desc": "Nie udało się zarchiwizować badania. Czy zostało zamknięte?",
+      "delete_success": "Badanie usunięte",
+      "delete_success_desc": "Badanie zostało trwale usunięte.",
+      "delete_error": "Nie udało się usunąć badania. Upewnij się, że wszystkie dane zostały wcześniej wyczyszczone.",
+      "delete_error_desc": "Nie udało się usunąć badania.",
+      "storage": {
+        "title": "Użycie pamięci audio",
+        "used": "Używana pamięć",
+        "quota": "Limit",
+        "quota_label": "Limit pamięci",
+        "quota_help": "Maksymalna łączna pamięć audio dla tego badania (10–1000 MB).",
+        "error": "Nie udało się wczytać informacji o użyciu pamięci.",
+        "warning_high_usage": "Użycie pamięci jest wysokie. Rozważ zwiększenie limitu lub usunięcie starych nagrań.",
+        "save_success": "Limit pamięci zaktualizowany",
+        "save_error": "Nie udało się zaktualizować limitu pamięci. Proszę spróbować ponownie."
+      },
+      "retention": {
+        "title": "Przechowywanie danych",
+        "months_label": "Okres przechowywania (miesiące)",
+        "help": "Typowe wartości: 6, 12, 24, 60 miesięcy. Pozostaw puste, aby użyć wartości domyślnej systemu (12).",
+        "save_success": "Polityka przechowywania danych zaktualizowana",
+        "save_error": "Nie udało się zaktualizować polityki przechowywania danych",
+        "range_error": "Okres przechowywania musi być liczbą całkowitą od 1 do 240 miesięcy."
+      }
+    },
+    "privacy": {
+      "title": "Ochrona danych",
+      "header_desc": "Zgoda, inwentarz i anonimizacja",
+      "load_error": "Nie udało się wczytać inwentarza danych.",
+      "participants_title": "Migawka uczestników",
+      "stat_started": "Rozpoczętych",
+      "stat_completed": "Ukończonych",
+      "stat_discarded": "Odrzuconych",
+      "stat_anonymised": "Zanonimizowanych",
+      "older_1y": "Starsze niż 1 rok (niezanonimizowane)",
+      "older_2y": "Starsze niż 2 lata (niezanonimizowane)",
+      "audio_title": "Pamięć audio",
+      "audio_count": "Nagrania",
+      "audio_mb": "Łączny rozmiar",
+      "locale_title": "Podział według języka",
+      "locale_col": "Język",
+      "locale_count_col": "Uczestnicy",
+      "locale_empty": "Brak danych językowych.",
+      "timeline_title": "Oś czasu",
+      "tl_first": "Pierwsze zgłoszenie",
+      "tl_last": "Ostatnie zgłoszenie",
+      "tl_anon": "Ostatnia anonimizacja",
+      "bulk_title": "Anonimizacja zbiorcza",
+      "bulk_desc": "Usuń dane osobowe ukończonych uczestników, którzy przesłali zgłoszenia przed datą graniczną. Ranking sortowania Q jest zachowany.",
+      "cutoff_label": "Data graniczna",
+      "cutoff_help": "Zanonimizowani zostaną tylko ukończeni uczestnicy, którzy przesłali zgłoszenia ściśle przed tą datą.",
+      "preview_label": "Kandydaci:",
+      "preview_zero": "Żaden uczestnik nie kwalifikuje się do tej daty granicznej. Spróbuj wcześniejszej daty.",
+      "anonymise_button": "Anonimizuj",
+      "anonymise_success": "Anonimizacja zakończona",
+      "anonymise_success_desc": "Zanonimizowano {{n}} uczestnika(-ów), {{s}} już anonimowych.",
+      "anonymise_error": "Anonimizacja nie powiodła się",
+      "confirm_title": "Zanonimizować dane uczestników?",
+      "confirm_candidates": "Zostanie zanonimizowanych {{count}} ukończony(-ch) uczestnik(-ów), którzy przesłali zgłoszenia przed {{date}}.",
+      "confirm_preserved": "Ranking sortowania Q jest zachowany; tożsamość jest usuwana.",
+      "confirm_irreversible": "To działanie jest natychmiastowe i nie można go cofnąć.",
+      "confirm_in_progress": "Anonimizowanie…",
+      "confirm_action": "Tak, zanonimizuj",
+      "cutoff_from_policy": "Wartość domyślna wynikająca z polityki przechowywania badania ({{months}} miesięcy).",
+      "empty": {
+        "title": "Brak danych uczestników",
+        "body": "Ta strona aktywuje się po przesłaniu zgłoszeń przez uczestników. Najpierw udostępnij link do badania.",
+        "cta": "Otwórz widok ogólny badania"
+      },
+      "consent": {
+        "title": "Formularz zgody",
+        "description": "To, co uczestnicy widzą przed wejściem do badania. Edytowane w projekcie badania.",
+        "no_text": "Brak tekstu zgody.",
+        "no_title": "(brak tytułu)",
+        "no_body": "(puste)",
+        "edit_in_design": "Edytuj w projekcie badania",
+        "view": "Pokaż"
+      }
+    },
+    "projects": {
+      "title": "Projekty",
+      "settings": {
+        "title": "Ustawienia projektu",
+        "identity_desc": "Zarządzaj tożsamością projektu.",
+        "general": {
+          "title": "Ustawienia ogólne",
+          "desc": "Tożsamość i podstawowa identyfikacja projektu.",
+          "label_title": "Tytuł projektu",
+          "placeholder_title": "Moje świetne laboratorium",
+          "label_slug": "URL slug",
+          "placeholder_slug": "moje-laboratorium",
+          "slug_hint": "Zmiana slugu zaktualizuje wszystkie linki do panelu badawczego.",
+          "save": "Zapisz",
+          "save_success": "Projekt zaktualizowany pomyślnie",
+          "save_error": "Nie udało się zaktualizować projektu."
+        },
+        "team_growth_title": "Zarządzanie zespołem",
+        "team_growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
+        "team": {
+          "title": "Członkowie zespołu",
+          "desc": "Lista użytkowników mających dostęp do tego projektu.",
+          "col_user": "Użytkownik",
+          "col_role": "Rola",
+          "col_joined": "Dołączył/a",
+          "col_actions": "Działania",
+          "remove_confirm": "Czy na pewno chcesz usunąć tego członka?",
+          "remove_dialog_title": "Usunąć członka zespołu?",
+          "remove_dialog_body": "{{name}} straci dostęp do tego projektu. Można go zaprosić ponownie później.",
+          "remove_dialog_action": "Usuń",
+          "remove_member_aria": "Usuń {{name}}",
+          "remove_success": "Członek usunięty pomyślnie",
+          "remove_error": "Nie udało się usunąć członka",
+          "growth_title": "Rozwój zespołu",
+          "growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
+          "invite_button": "Zaproś współpracownika",
+          "permissions_matrix": {
+            "title": "Macierz uprawnień",
+            "admin": {
+              "label": "Administrator",
+              "desc": "Może zarządzać ustawieniami projektu, członkami i wszystkimi badaniami."
+            },
+            "owner": {
+              "label": "Właściciel",
+              "desc": "Pełna kontrola nad projektem, członkami i badaniami."
+            },
+            "member": {
+              "label": "Członek",
+              "desc": "Może tworzyć i zarządzać wszystkimi badaniami. Brak dostępu do ustawień projektu."
+            },
+            "viewer": {
+              "label": "Obserwator",
+              "desc": "Dostęp tylko do odczytu do wszystkich badań i danych w projekcie."
+            }
+          },
+          "coming_soon": "Wkrótce",
+          "invite_modal": {
+            "title": "Zaproś współpracownika",
+            "email_label": "E-mail współpracownika",
+            "role_label": "Przypisana rola",
+            "success": "Link zaproszenia wygenerowany!",
+            "error": "Nie udało się utworzyć zaproszenia.",
+            "send": "Utwórz i wyślij zaproszenie",
+            "copy_success": "Link skopiowany do schowka!"
+          }
+        }
+      }
+    },
+    "members": {
+      "title": "Członkowie zespołu",
+      "description": "Zarządzaj dostępem do projektu i uprawnieniami."
+    },
+    "participants": {
+      "title": "Uczestnicy",
+      "description": "Zarządzaj uczestnikami i przeglądaj przesłane dane.",
+      "table": {
+        "id": "ID",
+        "status": "Status",
+        "started": "Rozpoczęto o",
+        "completed": "Ukończono o",
+        "duration": "Czas trwania",
+        "actions": "Akcje"
+      }
+    },
+    "participant": {
+      "tabs": {
+        "session": "Metadane",
+        "presort": "Wstępne sortowanie",
+        "grid": "Siatka sortowania Q",
+        "postsort": "Sortowanie końcowe"
+      },
+      "grid": {
+        "detail_view": "Szczegóły karty",
+        "no_comment": "Brak komentarza.",
+        "select_instruction": "Wybierz kartę na siatce, aby zobaczyć szczegóły.",
+        "read_only_mode": "Tryb obserwatora",
+        "score": "Wynik"
+      },
+      "metadata": {
+        "title": "Metadane sesji",
+        "technology": "Technologia",
+        "browser": "Przeglądarka",
+        "session": "Szczegóły sesji",
+        "duration": "Łączny czas",
+        "started": "Rozpoczęto",
+        "submitted": "Przesłano",
+        "id": "Wewnętrzny identyfikator",
+        "ip_hash": "Hash IP",
+        "recruitment_token": "Token rekrutacyjny",
+        "device": {
+          "mobile": "Telefon",
+          "tablet": "Tablet",
+          "desktop": "Komputer"
+        }
+      },
+      "status": {
+        "started": "Rozpoczęto",
+        "completed": "Ukończone",
+        "discarded": "Odrzucone",
+        "in_progress": "W toku"
+      },
+      "survey": {
+        "presort": "Pytania wstępne",
+        "postsort": "Pytania końcowe",
+        "no_answers": "Brak zapisanych odpowiedzi dla tej sekcji.",
+        "question_default": "Odpowiedź głosowa",
+        "answer_default": "Odpowiedź",
+        "categories": {
+          "identity": "Tożsamość i kontakt",
+          "questions": "Odpowiedzi na pytania",
+          "comments": "Komentarze do kart",
+          "feedback": "Opinie ogólne"
+        }
+      }
+    },
+    "users": {
+      "title": "Użytkownicy",
+      "subtitle": "Zarządzaj kontami platformy i sprawdzaj higienę dostępów.",
+      "error_title": "Akcja nie powiodła się",
+      "generic_error": "Coś poszło nie tak. Spróbuj ponownie.",
+      "search_placeholder": "Szukaj według e-mail lub nazwy",
+      "empty": "Brak pasujących użytkowników.",
+      "inactive": "Nieaktywny",
+      "no_name": "Brak nazwy",
+      "last_seen": "Ostatnio widziany {{when}}",
+      "never_logged_in": "Nigdy się nie logował",
+      "actions_aria": "Akcje dla {{email}}",
+      "menu_label": "Zarządzaj kontem",
+      "filter": {
+        "all": "Wszyscy użytkownicy",
+        "superusers": "Superużytkownicy",
+        "no_2fa": "Bez 2FA",
+        "unverified": "E-mail niezweryfikowany",
+        "dormant": "Nieaktywny"
+      },
+      "risk": {
+        "superuser_no_2fa": "Superużytkownik bez 2FA",
+        "email_unverified": "E-mail niezweryfikowany",
+        "password_stale": "Hasło starsze niż rok",
+        "email_change_pending": "Zmiana e-mail w toku",
+        "dormant": "Nieaktywny (90+ dni)"
+      },
+      "role": {
+        "superuser": "Superużytkownik",
+        "user": "Użytkownik"
+      },
+      "action": {
+        "demote": "Odbierz uprawnienia superużytkownika",
+        "promote": "Nadaj uprawnienia superużytkownika",
+        "deactivate": "Dezaktywuj konto",
+        "reactivate": "Reaktywuj konto",
+        "force_password_reset": "Wymuś reset hasła",
+        "reset_totp": "Zresetuj 2FA",
+        "delete": "Usuń użytkownika",
+        "generate_reset_link": "Wygeneruj link resetujący hasło",
+        "set_email": "Ustaw e-mail"
+      },
+      "confirm": {
+        "cancel": "Anuluj",
+        "confirm": "Potwierdź",
+        "delete_title": "Usunąć tego użytkownika?",
+        "delete_body": "Trwale usuń {{email}}. Tej operacji nie można cofnąć.",
+        "reset-totp_title": "Zresetować uwierzytelnianie dwuskładnikowe?",
+        "reset-totp_body": "Wyłącz 2FA dla {{email}}. Użytkownik będzie musiał je skonfigurować ponownie.",
+        "force-password-reset_title": "Wymusić reset hasła?",
+        "force-password-reset_body": "Unieważnij hasło {{email}} i zażądaj jego zmiany przy następnym logowaniu.",
+        "deactivate_title": "Dezaktywować to konto?",
+        "deactivate_body": "Natychmiast wyloguj {{email}} i zablokuj logowanie do czasu reaktywacji.",
+        "demote_title": "Odebrać dostęp superużytkownika?",
+        "demote_body": "Usuń uprawnienia superużytkownika od {{email}}.",
+        "promote_title": "Przyznać dostęp superużytkownika?",
+        "promote_body": "Przyznaj {{email}} pełne uprawnienia superużytkownika na platformie."
+      },
+      "email_manual_note": "Wysyłka e-maili nie jest skonfigurowana. Do odzyskania konta użyj poniższego linku resetującego hasło oraz akcji ustawienia adresu e-mail — żaden e-mail nie jest wysyłany.",
+      "load_error_body": "Nie udało się pobrać listy użytkowników. Odśwież stronę lub spróbuj ponownie później.",
+      "load_error_title": "Nie można załadować użytkowników",
+      "recovery_link": {
+        "copy": "Kopiuj link",
+        "help": "Udostępnij ten jednorazowy link użytkownikowi innym kanałem. Wygasa zgodnie z oknem resetowania hasła.",
+        "title": "Link resetujący hasło"
+      },
+      "set_email_dialog": {
+        "current": "Bieżący",
+        "description": "Spowoduje to wylogowanie {{email}}; użytkownik musi zalogować się ponownie przy użyciu nowego adresu. Żaden e-mail potwierdzający nie jest wysyłany.",
+        "error": "Nie można ustawić adresu e-mail.",
+        "label": "Nowy adres e-mail",
+        "submit": "Ustaw e-mail",
+        "success": "Zaktualizowano e-mail.",
+        "title": "Ustaw e-mail użytkownika"
+      }
     }
+  }
 }

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1914,7 +1914,9 @@
         "contract_cta": "Otwórz widok ogólny badania"
       },
       "pagination": {
-        "showing": "Pokazuję {{from}}–{{to}} z {{total}}"
+        "showing": "Pokazuję {{from}}–{{to}} z {{total}}",
+        "previous": "Poprzednia strona",
+        "next": "Następna strona"
       }
     },
     "team": {

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1535,7 +1535,9 @@
           "imported": "Pomyślnie zaimportowano {{count}} stwierdzeń",
           "reset_codes": "Resetuj kody",
           "confirm_reset_codes": "Czy na pewno chcesz ponownie nadać numery wszystkim kodom stwierdzeń (s1, s2, s3...)?",
-          "codes_reset": "Kody stwierdzeń ponownie ponumerowane"
+          "codes_reset": "Kody stwierdzeń ponownie ponumerowane",
+          "save_item": "Zapisz {{code}}",
+          "cancel_edit": "Anuluj edycję {{code}}"
         },
         "settings": {
           "title": "Ustawienia badawcze",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -314,7 +314,8 @@
         "disabled_success": "Weryfikacja dwuetapowa wyłączona",
         "secret_copied": "Sekret skopiowany",
         "invalid_token": "Nieprawidłowy kod weryfikacyjny",
-        "disable_error": "Nie udało się wyłączyć weryfikacji dwuetapowej"
+        "disable_error": "Nie udało się wyłączyć weryfikacji dwuetapowej",
+        "copy_secret": "Kopiuj sekret"
       },
       "password": {
         "title": "Zarządzanie hasłem",
@@ -1392,6 +1393,9 @@
             "rough_disabled": "Krok 'Pierwsze wrażenia' (sortowanie zgrubne) jest na tej liście, ale sortowanie zgrubne jest w badaniu wyłączone. Uczestnicy go nie zobaczą.",
             "presort_disabled": "Krok 'Poznajmy się' (ankieta wstępna) jest na tej liście, ale ankieta wstępna jest wyłączona. Uczestnicy go nie zobaczą.",
             "remove_action": "Usuń"
+          },
+          "actions": {
+            "delete": "Usuń {{title}}"
           }
         },
         "consent_title": "Formularz zgody",
@@ -1588,7 +1592,8 @@
           "prompt_placeholder": "Dlaczego umieścił/a Pan/Pani to stwierdzenie w tym miejscu?",
           "add": "Dodaj",
           "add_defaults": "Dodaj domyślne skrajności",
-          "select_placeholder": "Wybierz..."
+          "select_placeholder": "Wybierz...",
+          "remove": "Usuń {{score}}"
         },
         "random_comments": {
           "title": "Zezwalaj na swobodne komentarze",
@@ -1673,7 +1678,9 @@
           "title": "Kolor akcentu",
           "desc": "Ten kolor będzie używany dla przycisków, linków i wyróżnień w całym badaniu.",
           "pick": "Wybierz kolor",
-          "reset": "Przywróć domyślny"
+          "reset": "Przywróć domyślny",
+          "info_label": "O kolorze akcentu",
+          "swatch": "Ustaw kolor akcentu na {{color}}"
         },
         "logo": {
           "title": "Logo badania",
@@ -1682,7 +1689,9 @@
           "hint": "Zalecany rozmiar: 200×50 px. Obsługiwane formaty: PNG, SVG, JPG.",
           "preview": "Podgląd logo",
           "help_title": "Gdzie pojawia się to logo?",
-          "help_desc": "Logo jest wyświetlane na górze każdej strony badania (pasek nawigacyjny) i na stronie powitalnej. Wzmacnia identyfikację wizualną projektu."
+          "help_desc": "Logo jest wyświetlane na górze każdej strony badania (pasek nawigacyjny) i na stronie powitalnej. Wzmacnia identyfikację wizualną projektu.",
+          "info_label": "O logo badania",
+          "remove": "Usuń logo"
         },
         "partners": {
           "title": "Partnerzy instytucjonalni",
@@ -1694,7 +1703,11 @@
           "url_label": "Strona internetowa (opcjonalnie)",
           "url_placeholder": "https://...",
           "help_title": "Wyświetlanie logo",
-          "help_desc": "Logo partnerów są wyświetlane na stronie startowej oraz w nagłówku badania, obok głównego logo."
+          "help_desc": "Logo partnerów są wyświetlane na stronie startowej oraz w nagłówku badania, obok głównego logo.",
+          "info_label": "O partnerach instytucjonalnych",
+          "remove_logo": "Usuń logo dla {{name}}",
+          "remove": "Usuń {{name}}",
+          "unnamed": "Partner {{number}}"
         },
         "upload": {
           "upload": "Prześlij",
@@ -1704,7 +1717,8 @@
           "conversion_error": "Nie udało się przetworzyć obrazu.",
           "processing": "Przetwarzanie obrazu...",
           "drag_drop": "Przeciągnij i upuść lub kliknij, aby przesłać",
-          "max": "Maks."
+          "max": "Maks.",
+          "remove_default": "Usuń obraz"
         }
       },
       "activate_dialog": {

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -264,7 +264,11 @@
                     "ListChecks": "Lista de verificação"
                 }
             },
-            "click_to_edit": "Clique para editar"
+            "click_to_edit": "Clique para editar",
+            "audio_player": {
+                "play": "Reproduzir áudio",
+                "pause": "Pausar áudio"
+            }
         },
         "layout": {
             "title": "Administração",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1848,7 +1848,8 @@
                 "has_audio": "Tem respostas em áudio",
                 "email_provided": "Email fornecido",
                 "newsletter_consent": "Quer resultados",
-                "interview_consent": "Aceita acompanhamento"
+                "interview_consent": "Aceita acompanhamento",
+                "recruitment_link": "Link de recrutamento"
             },
             "toast": {
                 "discarded": "Participante descartado",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1535,7 +1535,9 @@
                     "imported": "{{count}} afirmações importadas com sucesso",
                     "reset_codes": "Repor códigos",
                     "confirm_reset_codes": "Tem a certeza de que pretende resequenciar todos os códigos de afirmações (s1, s2, s3...)?",
-                    "codes_reset": "Códigos das afirmações resequenciados"
+                    "codes_reset": "Códigos das afirmações resequenciados",
+                    "save_item": "Guardar {{code}}",
+                    "cancel_edit": "Cancelar edição de {{code}}"
                 },
                 "settings": {
                     "title": "Definições de investigação",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -475,7 +475,15 @@
             "import_csv_hint": "O CSV/TSV precisa das colunas: code, language, text.",
             "import_csv_no_match": "Nenhuma linha corresponde ao idioma selecionado ({{lang}}).",
             "import_csv_skipped": "Ignoradas {{count}} linha(s) noutros idiomas: {{langs}}.",
-            "import_csv_more_errors": "{{count}} mais problemas"
+            "import_csv_more_errors": "{{count}} mais problemas",
+            "filters": {
+                "status": "Filtrar por estado",
+                "tag": "Filtrar por etiqueta"
+            },
+            "status_for": "Estado de {{code}}",
+            "create_tag": "Criar etiqueta",
+            "delete_tag": "Eliminar {{tag}}",
+            "cancel_delete_tag": "Cancelar eliminação de {{tag}}"
         },
         "concourse_import": {
             "title": "Importar do concurso",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -264,11 +264,7 @@
                     "ListChecks": "Lista de verificação"
                 }
             },
-            "click_to_edit": "Clique para editar",
-            "audio_player": {
-                "play": "Reproduzir áudio",
-                "pause": "Pausar áudio"
-            }
+            "click_to_edit": "Clique para editar"
         },
         "layout": {
             "title": "Administração",
@@ -2316,6 +2312,13 @@
                 "success": "E-mail atualizado.",
                 "title": "Definir o e-mail do utilizador"
             }
+        },
+        "audio": {
+            "download": "Descarregar áudio",
+            "recording": "Gravação áudio",
+            "play": "Reproduzir áudio",
+            "pause": "Pausar áudio",
+            "seek": "Posição de reprodução"
         }
     }
 }

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1484,7 +1484,10 @@
                 "actions": {
                     "add_option": "Adicionar opção",
                     "copy_from": "Importar de idioma",
-                    "copy_success": "Importado"
+                    "copy_success": "Importado",
+                    "copy_from_aria": "Importar {{label}} de outro idioma",
+                    "delete": "Eliminar {{label}}",
+                    "remove_option": "Remover {{option}}"
                 },
                 "logic": {
                     "title": "Lógica de visibilidade",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1646,7 +1646,8 @@
                         "next": "Avançar para o passo seguinte",
                         "submit": "Submeter resultados no final",
                         "confirm": "Botão de validação genérico"
-                    }
+                    },
+                    "info_label": "Sobre {{label}}"
                 },
                 "terms": {
                     "title": "Terminologia de classificação",
@@ -1664,7 +1665,9 @@
                     "desc": "Adicione ou modifique dicas flutuantes para ajudar os participantes durante a fase de classificação na grelha.",
                     "placeholder": "Introduza uma dica metodológica...",
                     "add": "Adicionar dica",
-                    "reset": "Repor valores predefinidos"
+                    "reset": "Repor valores predefinidos",
+                    "remove": "Remover {{tip}}",
+                    "unnamed": "Dica {{number}}"
                 },
                 "help": {
                     "title": "Orientação por passo (o quê/porquê)",
@@ -2147,8 +2150,11 @@
                         "success": "Link de convite gerado!",
                         "error": "Falha ao criar o convite.",
                         "send": "Criar e enviar convite",
-                        "copy_success": "Link copiado para a área de transferência!"
-                    }
+                        "copy_success": "Link copiado para a área de transferência!",
+                        "copy_link": "Copiar link",
+                        "copied": "Copiado"
+                    },
+                    "role_for": "Função de {{name}}"
                 }
             }
         },

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1914,7 +1914,9 @@
                 "contract_cta": "Abrir visão geral do estudo"
             },
             "pagination": {
-                "showing": "A mostrar {{from}}–{{to}} de {{total}}"
+                "showing": "A mostrar {{from}}–{{to}} de {{total}}",
+                "previous": "Página anterior",
+                "next": "Página seguinte"
             }
         },
         "team": {

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -314,7 +314,8 @@
                 "disabled_success": "Autenticação de dois fatores desativada",
                 "secret_copied": "Segredo copiado",
                 "invalid_token": "Código de verificação inválido",
-                "disable_error": "Falha ao desativar a 2FA"
+                "disable_error": "Falha ao desativar a 2FA",
+                "copy_secret": "Copiar segredo"
             },
             "password": {
                 "title": "Gestão de palavra-passe",
@@ -1392,6 +1393,9 @@
                         "rough_disabled": "O passo «Primeiras impressões» (classificação inicial) está nesta lista, mas a classificação inicial está desativada no estudo. Os participantes não o verão.",
                         "presort_disabled": "O passo «Vamos conhecer-nos» (questionário de pré-classificação) está nesta lista, mas o questionário de pré-classificação está desativado. Os participantes não o verão.",
                         "remove_action": "Remover"
+                    },
+                    "actions": {
+                        "delete": "Eliminar {{title}}"
                     }
                 },
                 "consent_title": "Formulário de consentimento",
@@ -1588,7 +1592,8 @@
                     "prompt_placeholder": "Porque colocou esta afirmação aqui?",
                     "add": "Adicionar",
                     "add_defaults": "Adicionar extremos predefinidos",
-                    "select_placeholder": "Selecionar..."
+                    "select_placeholder": "Selecionar...",
+                    "remove": "Remover {{score}}"
                 },
                 "random_comments": {
                     "title": "Permitir comentários livres",
@@ -1673,7 +1678,9 @@
                     "title": "Cor de destaque",
                     "desc": "Esta cor será usada nos botões, ligações e destaques em todo o estudo.",
                     "pick": "Escolher uma cor",
-                    "reset": "Repor valor predefinido"
+                    "reset": "Repor valor predefinido",
+                    "info_label": "Sobre a cor de destaque",
+                    "swatch": "Definir a cor de destaque para {{color}}"
                 },
                 "logo": {
                     "title": "Logótipo do estudo",
@@ -1682,7 +1689,9 @@
                     "hint": "Tamanho recomendado: 200x50px. Suporta PNG, SVG, JPG.",
                     "preview": "Pré-visualização do logótipo",
                     "help_title": "Onde aparece este logótipo?",
-                    "help_desc": "O logótipo é exibido no topo de cada página do estudo (barra de navegação) e na página de boas-vindas. Reforça a identidade visual do seu projeto."
+                    "help_desc": "O logótipo é exibido no topo de cada página do estudo (barra de navegação) e na página de boas-vindas. Reforça a identidade visual do seu projeto.",
+                    "info_label": "Sobre o logótipo do estudo",
+                    "remove": "Remover logótipo"
                 },
                 "partners": {
                     "title": "Parceiros institucionais",
@@ -1694,7 +1703,11 @@
                     "url_label": "Website (opcional)",
                     "url_placeholder": "Https://...",
                     "help_title": "Apresentação dos logótipos",
-                    "help_desc": "Os logótipos dos parceiros são exibidos na página de entrada e no cabeçalho do estudo, junto ao logótipo principal."
+                    "help_desc": "Os logótipos dos parceiros são exibidos na página de entrada e no cabeçalho do estudo, junto ao logótipo principal.",
+                    "info_label": "Sobre os parceiros institucionais",
+                    "remove_logo": "Remover logótipo de {{name}}",
+                    "remove": "Remover {{name}}",
+                    "unnamed": "Parceiro {{number}}"
                 },
                 "upload": {
                     "upload": "Carregar",
@@ -1704,7 +1717,8 @@
                     "conversion_error": "Falha ao processar a imagem.",
                     "processing": "A processar imagem...",
                     "drag_drop": "Arraste e largue ou clique para carregar",
-                    "max": "Máx"
+                    "max": "Máx",
+                    "remove_default": "Remover imagem"
                 }
             },
             "activate_dialog": {

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,8 +1,5 @@
 {
     "unnamedControls": {
-        "src/components/admin/AudioPlayer.tsx": {
-            "Button#9eaa609dff": 1
-        },
         "src/components/admin/dashboard/InteractiveDataView.columns.tsx": {
             "TooltipTrigger#07b7bb5f30": 1,
             "TooltipTrigger#64528336d1": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,15 +1,5 @@
 {
-    "unnamedControls": {
-        "src/components/admin/dashboard/InteractiveDataView.columns.tsx": {
-            "TooltipTrigger#07b7bb5f30": 1,
-            "TooltipTrigger#64528336d1": 1,
-            "TooltipTrigger#66bd021c8d": 1,
-            "TooltipTrigger#991c394724": 1,
-            "TooltipTrigger#d1a4ff6af5": 1,
-            "TooltipTrigger#ef4eaf74a9": 1,
-            "TooltipTrigger#f738eb0490": 1
-        }
-    },
+    "unnamedControls": {},
     "lowContrastControls": {
         "src/components/admin/analysis/AnalysisHistoryPanel.tsx": {
             "button#74bf5e335c": 1

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -9,11 +9,6 @@
             "TooltipTrigger#ef4eaf74a9": 1,
             "TooltipTrigger#f738eb0490": 1
         },
-        "src/components/admin/dashboard/InteractiveDataView.tsx": {
-            "Button#0bacf4658c": 1,
-            "Button#e38e166000": 1,
-            "Button#f08923f571": 1
-        },
         "src/components/admin/designer/QuestionBuilder.tsx": {
             "Button#81017c5def": 2,
             "Button#83b5f464b1": 1

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -9,10 +9,6 @@
             "TooltipTrigger#ef4eaf74a9": 1,
             "TooltipTrigger#f738eb0490": 1
         },
-        "src/components/admin/designer/QuestionBuilder.tsx": {
-            "Button#81017c5def": 2,
-            "Button#83b5f464b1": 1
-        },
         "src/pages/admin/ConcourseDetailPage.tsx": {
             "Button#1dd7a5d308": 1,
             "Button#81017c5def": 1,
@@ -44,8 +40,9 @@
             "Button#cfd0f92c60": 1
         },
         "src/components/admin/designer/QuestionBuilder.tsx": {
-            "Button#81017c5def": 2,
-            "DropdownMenuTrigger#f0edeb0f8a": 1
+            "Button#b8299f38ab": 1,
+            "Button#ed2885af3a": 1,
+            "DropdownMenuTrigger#f1cda76386": 1
         },
         "src/layouts/StudyLayout.tsx": {
             "button#543c37a641": 1

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -14,11 +14,6 @@
             "Button#e38e166000": 1,
             "Button#f08923f571": 1
         },
-        "src/components/admin/designer/QSortEditor.tsx": {
-            "Button#afbf633168": 1,
-            "Button#b1a1a82138": 1,
-            "Button#e81d9b56d8": 1
-        },
         "src/components/admin/designer/QuestionBuilder.tsx": {
             "Button#81017c5def": 2,
             "Button#83b5f464b1": 1

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -14,10 +14,6 @@
             "Button#e38e166000": 1,
             "Button#f08923f571": 1
         },
-        "src/components/admin/designer/InterfaceEditor.tsx": {
-            "Button#5a9712977a": 1,
-            "TooltipTrigger#ee8b70d151": 1
-        },
         "src/components/admin/designer/QSortEditor.tsx": {
             "Button#afbf633168": 1,
             "Button#b1a1a82138": 1,
@@ -33,10 +29,6 @@
             "Button#a1f3efb8f5": 1,
             "SelectTrigger#872cdad358": 3,
             "SelectTrigger#bb89cca4e9": 1
-        },
-        "src/pages/admin/ProjectMembersPage.tsx": {
-            "Button#d8507040f1": 1,
-            "SelectTrigger#872cdad358": 1
         }
     },
     "lowContrastControls": {
@@ -53,7 +45,7 @@
             "button#9fdeea95db": 1
         },
         "src/components/admin/designer/InterfaceEditor.tsx": {
-            "Button#5a9712977a": 1
+            "Button#5417b42698": 1
         },
         "src/components/admin/designer/ProcessStepEditor.tsx": {
             "Button#08fe1834a8": 1

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -8,13 +8,6 @@
             "TooltipTrigger#d1a4ff6af5": 1,
             "TooltipTrigger#ef4eaf74a9": 1,
             "TooltipTrigger#f738eb0490": 1
-        },
-        "src/pages/admin/ConcourseDetailPage.tsx": {
-            "Button#1dd7a5d308": 1,
-            "Button#81017c5def": 1,
-            "Button#a1f3efb8f5": 1,
-            "SelectTrigger#872cdad358": 3,
-            "SelectTrigger#bb89cca4e9": 1
         }
     },
     "lowContrastControls": {

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -14,23 +14,9 @@
             "Button#e38e166000": 1,
             "Button#f08923f571": 1
         },
-        "src/components/admin/designer/BrandingEditor.tsx": {
-            "button#aa40493fca": 1,
-            "button#acb2a0d0e8": 1,
-            "TooltipTrigger#ee8b70d151": 3
-        },
-        "src/components/admin/designer/ImageUploadInput.tsx": {
-            "button#c142fb7ba6": 1
-        },
         "src/components/admin/designer/InterfaceEditor.tsx": {
             "Button#5a9712977a": 1,
             "TooltipTrigger#ee8b70d151": 1
-        },
-        "src/components/admin/designer/PostSortConfigEditor.tsx": {
-            "button#c142fb7ba6": 1
-        },
-        "src/components/admin/designer/ProcessStepEditor.tsx": {
-            "Button#81017c5def": 1
         },
         "src/components/admin/designer/QSortEditor.tsx": {
             "Button#afbf633168": 1,
@@ -40,9 +26,6 @@
         "src/components/admin/designer/QuestionBuilder.tsx": {
             "Button#81017c5def": 2,
             "Button#83b5f464b1": 1
-        },
-        "src/pages/admin/AccountSettingsPage.tsx": {
-            "button#3ddd1d5369": 1
         },
         "src/pages/admin/ConcourseDetailPage.tsx": {
             "Button#1dd7a5d308": 1,
@@ -67,13 +50,13 @@
             "Button#ff3d58c3b9": 1
         },
         "src/components/admin/designer/BrandingEditor.tsx": {
-            "button#acb2a0d0e8": 1
+            "button#9fdeea95db": 1
         },
         "src/components/admin/designer/InterfaceEditor.tsx": {
             "Button#5a9712977a": 1
         },
         "src/components/admin/designer/ProcessStepEditor.tsx": {
-            "Button#81017c5def": 1
+            "Button#08fe1834a8": 1
         },
         "src/components/admin/designer/QSortEditor.tsx": {
             "Button#cfd0f92c60": 1

--- a/frontend/src/components/admin/AudioPlayer.test.tsx
+++ b/frontend/src/components/admin/AudioPlayer.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, beforeAll, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { AudioPlayer } from './AudioPlayer';
+import { renderWithProviders, screen } from '@/test-utils/test-utils';
+
+// jsdom does not implement HTMLMediaElement playback; stub just enough for the
+// toggle handler to run without throwing "not implemented".
+beforeAll(() => {
+    window.HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    window.HTMLMediaElement.prototype.pause = vi.fn();
+});
+
+describe('AudioPlayer', () => {
+    it('names the play/pause toggle and flips the name when toggled', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AudioPlayer url="https://example.com/audio.webm" />);
+
+        const toggle = screen.getByRole('button', { name: 'Play audio' });
+        expect(screen.queryByRole('button', { name: 'Pause audio' })).not.toBeInTheDocument();
+
+        await user.click(toggle);
+
+        expect(screen.getByRole('button', { name: 'Pause audio' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Play audio' })).not.toBeInTheDocument();
+    });
+
+    it('names the download control', () => {
+        renderWithProviders(<AudioPlayer url="https://example.com/audio.webm" />);
+
+        expect(screen.getByRole('button', { name: 'Download audio' })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/AudioPlayer.test.tsx
+++ b/frontend/src/components/admin/AudioPlayer.test.tsx
@@ -29,4 +29,13 @@ describe('AudioPlayer', () => {
 
         expect(screen.getByRole('button', { name: 'Download audio' })).toBeInTheDocument();
     });
+
+    it('names the seek slider (review fix round 1: <input> is invisible to the a11y gate)', () => {
+        renderWithProviders(<AudioPlayer url="https://example.com/audio.webm" />);
+
+        // <input type="range"> computes an implicit ARIA role of "slider" —
+        // getByRole resolves it the same way a screen reader would, not via
+        // an attribute check.
+        expect(screen.getByRole('slider', { name: 'Seek audio position' })).toBeInTheDocument();
+    });
 });

--- a/frontend/src/components/admin/AudioPlayer.tsx
+++ b/frontend/src/components/admin/AudioPlayer.tsx
@@ -108,6 +108,11 @@ export function AudioPlayer({ url, duration, fileName = 'audio.webm' }: AudioPla
                     size="sm"
                     variant="ghost"
                     className="h-10 w-10 rounded-full bg-indigo-100 hover:bg-indigo-200 text-indigo-700"
+                    aria-label={
+                        isPlaying
+                            ? t('admin.components.audio_player.pause', 'Pause audio')
+                            : t('admin.components.audio_player.play', 'Play audio')
+                    }
                 >
                     {isPlaying ? (
                         <Pause className="w-4 h-4" />

--- a/frontend/src/components/admin/AudioPlayer.tsx
+++ b/frontend/src/components/admin/AudioPlayer.tsx
@@ -110,8 +110,8 @@ export function AudioPlayer({ url, duration, fileName = 'audio.webm' }: AudioPla
                     className="h-10 w-10 rounded-full bg-indigo-100 hover:bg-indigo-200 text-indigo-700"
                     aria-label={
                         isPlaying
-                            ? t('admin.components.audio_player.pause', 'Pause audio')
-                            : t('admin.components.audio_player.play', 'Play audio')
+                            ? t('admin.audio.pause', 'Pause audio')
+                            : t('admin.audio.play', 'Play audio')
                     }
                 >
                     {isPlaying ? (
@@ -132,6 +132,7 @@ export function AudioPlayer({ url, duration, fileName = 'audio.webm' }: AudioPla
                         max={audioDuration || 0}
                         value={currentTime}
                         onChange={handleSeek}
+                        aria-label={t('admin.audio.seek', 'Seek audio position')}
                         className="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer accent-indigo-600"
                     />
                 </div>

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -501,7 +501,12 @@ export function buildColumns({
                         <div className="flex items-center gap-1.5">
                             {p.postsort.email && (
                                 <Tooltip>
-                                    <TooltipTrigger>
+                                    <TooltipTrigger
+                                        aria-label={t(
+                                            'admin.data.tooltips.email_provided',
+                                            'Email provided'
+                                        )}
+                                    >
                                         <div className="p-1 bg-indigo-50 rounded text-indigo-600 border border-indigo-100">
                                             <Mail className="h-3 w-3" />
                                         </div>
@@ -513,7 +518,12 @@ export function buildColumns({
                             )}
                             {p.postsort.newsletter_consent && (
                                 <Tooltip>
-                                    <TooltipTrigger>
+                                    <TooltipTrigger
+                                        aria-label={t(
+                                            'admin.data.tooltips.newsletter_consent',
+                                            'Wants results'
+                                        )}
+                                    >
                                         <div className="p-1 bg-emerald-50 rounded text-emerald-600 border border-emerald-100">
                                             <FileText className="h-3 w-3" />
                                         </div>
@@ -528,7 +538,12 @@ export function buildColumns({
                             )}
                             {p.postsort.interview_consent && (
                                 <Tooltip>
-                                    <TooltipTrigger>
+                                    <TooltipTrigger
+                                        aria-label={t(
+                                            'admin.data.tooltips.interview_consent',
+                                            'Accepts follow-up'
+                                        )}
+                                    >
                                         <div className="p-1 bg-amber-50 rounded text-amber-600 border border-amber-100">
                                             <MessagesSquare className="h-3 w-3" />
                                         </div>
@@ -633,7 +648,12 @@ export function buildColumns({
                         <TooltipProvider>
                             {hasRecruitmentLink && (
                                 <Tooltip>
-                                    <TooltipTrigger>
+                                    <TooltipTrigger
+                                        aria-label={`${t(
+                                            'admin.data.tooltips.recruitment_link',
+                                            'Recruitment link'
+                                        )}: ${p.recruitment_token}`}
+                                    >
                                         <div className="p-1 bg-slate-50 rounded text-slate-500 border border-slate-200">
                                             <Tag className="h-3 w-3" />
                                         </div>
@@ -649,7 +669,7 @@ export function buildColumns({
                             )}
                             {isSuspect && (
                                 <Tooltip>
-                                    <TooltipTrigger>
+                                    <TooltipTrigger aria-label={t('admin.data.tooltips.suspect')}>
                                         <div className="p-1 bg-amber-50 rounded text-amber-500 border border-amber-100">
                                             <AlertTriangle className="h-3 w-3" />
                                         </div>
@@ -661,7 +681,9 @@ export function buildColumns({
                             )}
                             {hasComments && (
                                 <Tooltip>
-                                    <TooltipTrigger>
+                                    <TooltipTrigger
+                                        aria-label={t('admin.data.tooltips.has_comments')}
+                                    >
                                         <div className="p-1 bg-blue-50 rounded text-blue-500 border border-blue-100">
                                             <MessageSquare className="h-3 w-3" />
                                         </div>
@@ -673,7 +695,12 @@ export function buildColumns({
                             )}
                             {hasAudio && (
                                 <Tooltip>
-                                    <TooltipTrigger>
+                                    <TooltipTrigger
+                                        aria-label={t(
+                                            'admin.data.tooltips.has_audio',
+                                            'Has audio responses'
+                                        )}
+                                    >
                                         <div className="p-1 bg-purple-50 rounded text-purple-500 border border-purple-100">
                                             <Mic className="h-3 w-3" />
                                         </div>

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -24,6 +24,7 @@
  * real `npm run dev` pipeline (React Compiler included).
  */
 
+import { computeAccessibleName } from 'dom-accessibility-api';
 import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { DumpParticipant, DumpResponse } from './types';
@@ -134,5 +135,68 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         expect(screen.getByRole('button', { name: 'Previous page' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Next page' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'More actions' })).toBeInTheDocument();
+    });
+
+    it('names the seven per-row indicator TooltipTriggers (InteractiveDataView.columns.tsx)', async () => {
+        // One participant that trips every flag the "Consent" and "Flags"
+        // columns render an icon-only tooltip chip for: up to seven
+        // previously-anonymous tab stops in a single row.
+        const participant = makeParticipant({
+            id: 'p1',
+            db_id: 1,
+            duration_seconds: 30, // < SUSPECT_DURATION_THRESHOLD (120)
+            recruitment_token: 'REF123',
+            postsort: {
+                email: 'ada@example.com',
+                newsletter_consent: true,
+                interview_consent: true,
+                card_comments: { s1: 'a comment' },
+            },
+            audio_recordings: { s1: {} },
+        });
+        mockDumpQuery.mockReturnValue({
+            data: {
+                ...dumpResponseWithTranslations(['en']),
+                participants: [participant],
+            },
+            isLoading: false,
+            error: null,
+        });
+
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        expect(screen.getByRole('button', { name: 'Email provided' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Wants results' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Accepts follow-up' })).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Recruitment link: REF123' })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', {
+                name: 'Potentially suspect: session duration < 2 minutes',
+            })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', {
+                name: 'Contains participant comments on cards',
+            })
+        ).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Has audio responses' })).toBeInTheDocument();
+
+        // The user-visible claim: this participant's row used to carry seven
+        // anonymous tab stops (a screen reader announcing only "button" x7)
+        // across the Consent and Flags columns. Scope to the row via the
+        // participant-id badge, then compute each button's *real* accessible
+        // name the way accname/browsers do (not an attribute-presence proxy)
+        // and assert none resolve to empty — not just the seven asserted
+        // above by exact text, which would miss a regression on an eighth,
+        // unasserted button.
+        const row = screen.getByText('p1').closest('tr');
+        if (!row) throw new Error('participant row not found');
+        const buttonNames = within(row)
+            .getAllByRole('button')
+            .map((button) => computeAccessibleName(button));
+        expect(buttonNames.every((name) => name.trim().length > 0)).toBe(true);
     });
 });

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -101,3 +101,38 @@ describe('InteractiveDataView — responses table header/body alignment', () => 
         expect(await screen.findByRole('columnheader', { name: /lang/i })).toBeInTheDocument();
     });
 });
+
+describe('InteractiveDataView — control names (Task 6.7c)', () => {
+    it('names the pagination and "more actions" controls', async () => {
+        // PAGE_SIZE is 25; 30 live (non-discarded) participants on a draft
+        // study exercises both the pagination buttons (page count > 1) and
+        // the kebab "more actions" menu (liveCount > 0 && state === 'draft').
+        const participants = Array.from({ length: 30 }, (_, i) =>
+            makeParticipant({ id: `p${i}`, db_id: i })
+        );
+        mockDumpQuery.mockReturnValue({
+            data: {
+                study: {
+                    slug: 'demo',
+                    statements: [],
+                    translations: [{ lang: 'en', title: 'Study' }],
+                    presort_config: {},
+                    postsort_config: {},
+                    state: 'draft',
+                    rough_sort_enabled: true,
+                },
+                participants,
+                statement_id_to_index: {},
+            } as unknown as DumpResponse,
+            isLoading: false,
+            error: null,
+        });
+
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        expect(screen.getByRole('button', { name: 'Previous page' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Next page' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'More actions' })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -749,6 +749,7 @@ export default function InteractiveDataView({
                                         variant="ghost"
                                         size="icon"
                                         className="h-9 w-9 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+                                        aria-label={t('admin.design.toolbar.more_actions')}
                                     >
                                         <MoreVertical className="h-4 w-4" />
                                     </Button>
@@ -935,6 +936,10 @@ export default function InteractiveDataView({
                                     onClick={() => table.previousPage()}
                                     disabled={!table.getCanPreviousPage()}
                                     className="h-8 w-8 p-0 rounded-lg"
+                                    aria-label={t(
+                                        'admin.data.pagination.previous',
+                                        'Previous page'
+                                    )}
                                 >
                                     <ChevronLeft className="h-4 w-4" />
                                 </Button>
@@ -947,6 +952,7 @@ export default function InteractiveDataView({
                                     onClick={() => table.nextPage()}
                                     disabled={!table.getCanNextPage()}
                                     className="h-8 w-8 p-0 rounded-lg"
+                                    aria-label={t('admin.data.pagination.next', 'Next page')}
                                 >
                                     <ChevronRight className="h-4 w-4" />
                                 </Button>

--- a/frontend/src/components/admin/designer/BrandingEditor.test.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.test.tsx
@@ -30,3 +30,57 @@ describe('BrandingEditor — partner name accessible name (Task 6.7b)', () => {
         expect(field).toHaveFocus();
     });
 });
+
+describe('BrandingEditor — control names (Task 6.7c)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: convenient partial mock
+    const mockDraft: any = {
+        slug: 'test-study',
+        state: 'draft',
+        branding: {
+            logo_url: 'https://example.com/logo.png',
+            accent_color: '#4f46e5',
+            partners: [
+                { id: 'partner-1', name: 'Acme University', logo_url: null },
+                { id: 'partner-2', name: '', logo_url: null },
+            ],
+        },
+    };
+
+    const renderEditor = () =>
+        renderWithStore(<BrandingEditor />, {
+            initialState: { draft: mockDraft, activeLocale: 'en' },
+        });
+
+    it('names the accent-color info tooltip trigger and swatch buttons', () => {
+        renderEditor();
+
+        expect(screen.getByRole('button', { name: 'About accent color' })).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Set accent color to #4f46e5' })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Set accent color to #dc2626' })
+        ).toBeInTheDocument();
+    });
+
+    it('names the logo info tooltip trigger and the remove-logo control', () => {
+        renderEditor();
+
+        expect(screen.getByRole('button', { name: 'About the study logo' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Remove logo' })).toBeInTheDocument();
+    });
+
+    it('names the partners info tooltip trigger and discriminates per-row controls by name', () => {
+        renderEditor();
+
+        expect(
+            screen.getByRole('button', { name: 'About institutional partners' })
+        ).toBeInTheDocument();
+
+        // Named partner: discriminated by its own name.
+        expect(screen.getByRole('button', { name: 'Remove Acme University' })).toBeInTheDocument();
+
+        // Unnamed partner (empty name): falls back to an ordinal, not a blank/duplicate name.
+        expect(screen.getByRole('button', { name: 'Remove Partner 2' })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/BrandingEditor.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.tsx
@@ -61,7 +61,12 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                 </CardTitle>
                                 <TooltipProvider>
                                     <Tooltip>
-                                        <TooltipTrigger>
+                                        <TooltipTrigger
+                                            aria-label={t(
+                                                'admin.design.theme.accent.info_label',
+                                                'About accent color'
+                                            )}
+                                        >
                                             <Info className="h-3.5 w-3.5 text-slate-400 hover:text-indigo-500 transition-colors" />
                                         </TooltipTrigger>
                                         <TooltipContent side="right" className="max-w-xs">
@@ -144,6 +149,12 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                         style={{ backgroundColor: color }}
                                         disabled={readOnly}
                                         onClick={() => updateBranding('accent_color', color)}
+                                        aria-label={t(
+                                            'admin.design.theme.accent.swatch',
+                                            'Set accent color to {{color}}',
+                                            { color }
+                                        )}
+                                        aria-pressed={branding.accent_color === color}
                                     >
                                         {branding.accent_color === color && (
                                             <div className="w-2 h-2 bg-white rounded-full shadow-inner" />
@@ -164,7 +175,12 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                 </CardTitle>
                                 <TooltipProvider>
                                     <Tooltip>
-                                        <TooltipTrigger>
+                                        <TooltipTrigger
+                                            aria-label={t(
+                                                'admin.design.theme.logo.info_label',
+                                                'About the study logo'
+                                            )}
+                                        >
                                             <Info className="h-3.5 w-3.5 text-slate-400" />
                                         </TooltipTrigger>
                                         <TooltipContent side="right">
@@ -185,6 +201,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                 label={t('admin.design.theme.logo.label')}
                                 recommendedSize="200x50px"
                                 maxFileSize={500 * 1024}
+                                removeAriaLabel={t('admin.design.theme.logo.remove', 'Remove logo')}
                             />
 
                             <div className="bg-blue-50/50 border border-blue-100 rounded-xl p-4 text-sm text-blue-900">
@@ -224,7 +241,12 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                 </CardTitle>
                                 <TooltipProvider>
                                     <Tooltip>
-                                        <TooltipTrigger>
+                                        <TooltipTrigger
+                                            aria-label={t(
+                                                'admin.design.theme.partners.info_label',
+                                                'About institutional partners'
+                                            )}
+                                        >
                                             <Info className="h-3.5 w-3.5 text-slate-400" />
                                         </TooltipTrigger>
                                         <TooltipContent side="right">
@@ -242,84 +264,106 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                         <CardContent className="space-y-6">
                             <div className="grid gap-4">
                                 {(branding.partners || []).map(
-                                    (partner: PartnerLogo, index: number) => (
-                                        <div
-                                            key={partner.id || index}
-                                            className="flex flex-col sm:flex-row gap-3 sm:gap-4 items-start p-3 sm:p-4 bg-slate-50/50 rounded-2xl border border-slate-200/60 group transition-all hover:bg-white hover:shadow-md"
-                                        >
-                                            <div className="w-14 h-14 bg-white rounded-xl flex items-center justify-center p-1.5 border border-slate-100 shrink-0 shadow-sm">
-                                                {partner.logo_url ? (
-                                                    <img
-                                                        src={partner.logo_url}
-                                                        alt={partner.name}
-                                                        className="max-w-full max-h-full object-contain"
-                                                    />
-                                                ) : (
-                                                    <ImageIcon className="text-slate-300 w-6 h-6" />
-                                                )}
-                                            </div>
-                                            <div className="flex-1 space-y-3">
-                                                <div className="grid gap-1.5">
-                                                    <Label
-                                                        htmlFor={`partner-name-${partner.id ?? index}`}
-                                                        className="text-2xs font-black text-slate-400"
-                                                    >
-                                                        {t(
-                                                            'admin.design.theme.partners.name_placeholder',
-                                                            'Name'
-                                                        )}
-                                                    </Label>
-                                                    <Input
-                                                        id={`partner-name-${partner.id ?? index}`}
-                                                        name="partnerName"
-                                                        value={partner.name}
-                                                        onChange={(e) => {
+                                    (partner: PartnerLogo, index: number) => {
+                                        const partnerDisplayName = partner.name?.trim()
+                                            ? partner.name
+                                            : t(
+                                                  'admin.design.theme.partners.unnamed',
+                                                  'Partner {{number}}',
+                                                  { number: index + 1 }
+                                              );
+                                        return (
+                                            <div
+                                                key={partner.id || index}
+                                                className="flex flex-col sm:flex-row gap-3 sm:gap-4 items-start p-3 sm:p-4 bg-slate-50/50 rounded-2xl border border-slate-200/60 group transition-all hover:bg-white hover:shadow-md"
+                                            >
+                                                <div className="w-14 h-14 bg-white rounded-xl flex items-center justify-center p-1.5 border border-slate-100 shrink-0 shadow-sm">
+                                                    {partner.logo_url ? (
+                                                        <img
+                                                            src={partner.logo_url}
+                                                            alt={partner.name}
+                                                            className="max-w-full max-h-full object-contain"
+                                                        />
+                                                    ) : (
+                                                        <ImageIcon className="text-slate-300 w-6 h-6" />
+                                                    )}
+                                                </div>
+                                                <div className="flex-1 space-y-3">
+                                                    <div className="grid gap-1.5">
+                                                        <Label
+                                                            htmlFor={`partner-name-${partner.id ?? index}`}
+                                                            className="text-2xs font-black text-slate-400"
+                                                        >
+                                                            {t(
+                                                                'admin.design.theme.partners.name_placeholder',
+                                                                'Name'
+                                                            )}
+                                                        </Label>
+                                                        <Input
+                                                            id={`partner-name-${partner.id ?? index}`}
+                                                            name="partnerName"
+                                                            value={partner.name}
+                                                            onChange={(e) => {
+                                                                const newPartners = [
+                                                                    ...(branding.partners || []),
+                                                                ];
+                                                                newPartners[index] = {
+                                                                    ...partner,
+                                                                    name: e.target.value,
+                                                                };
+                                                                updateBranding(
+                                                                    'partners',
+                                                                    newPartners
+                                                                );
+                                                            }}
+                                                            placeholder="Institution Name"
+                                                            disabled={readOnly}
+                                                            className="h-9 text-sm font-bold rounded-xl"
+                                                        />
+                                                    </div>
+                                                    <ImageUploadInput
+                                                        name="partnerLogoUrl"
+                                                        value={partner.logo_url}
+                                                        onChange={(value) => {
                                                             const newPartners = [
                                                                 ...(branding.partners || []),
                                                             ];
                                                             newPartners[index] = {
                                                                 ...partner,
-                                                                name: e.target.value,
+                                                                logo_url: value,
                                                             };
                                                             updateBranding('partners', newPartners);
                                                         }}
-                                                        placeholder="Institution Name"
-                                                        disabled={readOnly}
-                                                        className="h-9 text-sm font-bold rounded-xl"
+                                                        recommendedSize="120x40px"
+                                                        maxFileSize={300 * 1024}
+                                                        removeAriaLabel={t(
+                                                            'admin.design.theme.partners.remove_logo',
+                                                            'Remove logo for {{name}}',
+                                                            { name: partnerDisplayName }
+                                                        )}
                                                     />
                                                 </div>
-                                                <ImageUploadInput
-                                                    name="partnerLogoUrl"
-                                                    value={partner.logo_url}
-                                                    onChange={(value) => {
-                                                        const newPartners = [
-                                                            ...(branding.partners || []),
-                                                        ];
-                                                        newPartners[index] = {
-                                                            ...partner,
-                                                            logo_url: value,
-                                                        };
+                                                <button
+                                                    type="button"
+                                                    disabled={readOnly}
+                                                    onClick={() => {
+                                                        const newPartners = (
+                                                            branding.partners || []
+                                                        ).filter((_, i) => i !== index);
                                                         updateBranding('partners', newPartners);
                                                     }}
-                                                    recommendedSize="120x40px"
-                                                    maxFileSize={300 * 1024}
-                                                />
+                                                    className="text-slate-300 hover:text-red-500 p-2 transition-colors bg-white rounded-xl shadow-sm border border-slate-100 hover:border-red-100"
+                                                    aria-label={t(
+                                                        'admin.design.theme.partners.remove',
+                                                        'Remove {{name}}',
+                                                        { name: partnerDisplayName }
+                                                    )}
+                                                >
+                                                    <Trash2 className="size-4" />
+                                                </button>
                                             </div>
-                                            <button
-                                                type="button"
-                                                disabled={readOnly}
-                                                onClick={() => {
-                                                    const newPartners = (
-                                                        branding.partners || []
-                                                    ).filter((_, i) => i !== index);
-                                                    updateBranding('partners', newPartners);
-                                                }}
-                                                className="text-slate-300 hover:text-red-500 p-2 transition-colors bg-white rounded-xl shadow-sm border border-slate-100 hover:border-red-100"
-                                            >
-                                                <Trash2 className="size-4" />
-                                            </button>
-                                        </div>
-                                    )
+                                        );
+                                    }
                                 )}
 
                                 <button

--- a/frontend/src/components/admin/designer/ImageUploadInput.test.tsx
+++ b/frontend/src/components/admin/designer/ImageUploadInput.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import ImageUploadInput from './ImageUploadInput';
+import { renderWithProviders, screen } from '@/test-utils/test-utils';
+
+describe('ImageUploadInput — remove-image control name (Task 6.7c)', () => {
+    it('falls back to a generic name when the caller passes no discriminator', () => {
+        renderWithProviders(
+            <ImageUploadInput value="https://example.com/logo.png" onChange={() => {}} />
+        );
+
+        expect(screen.getByRole('button', { name: 'Remove image' })).toBeInTheDocument();
+    });
+
+    it('uses the caller-supplied discriminator when provided', () => {
+        renderWithProviders(
+            <ImageUploadInput
+                value="https://example.com/logo.png"
+                onChange={() => {}}
+                removeAriaLabel="Remove logo for Acme University"
+            />
+        );
+
+        expect(
+            screen.getByRole('button', { name: 'Remove logo for Acme University' })
+        ).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Remove image' })).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/ImageUploadInput.tsx
+++ b/frontend/src/components/admin/designer/ImageUploadInput.tsx
@@ -14,6 +14,13 @@ interface ImageUploadInputProps {
     maxFileSize?: number; // in bytes, default 500KB
     id?: string;
     name?: string;
+    /**
+     * Accessible name for the "remove image" button. Callers that render more
+     * than one ImageUploadInput side by side (e.g. one per partner logo) should
+     * pass a discriminator here — otherwise every instance reads identically to
+     * a screen reader. Falls back to a generic "Remove image".
+     */
+    removeAriaLabel?: string;
 }
 
 const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
@@ -24,6 +31,7 @@ const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
     maxFileSize = 500 * 1024, // 500KB default
     id,
     name,
+    removeAriaLabel,
 }) => {
     const { t } = useTranslation();
     const [mode, setMode] = useState<'url' | 'upload'>('url');
@@ -256,6 +264,10 @@ const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
                         type="button"
                         onClick={handleClear}
                         className="absolute top-2 right-2 p-1.5 bg-white rounded-full shadow-md text-slate-400 hover:text-red-500 hover:bg-red-50 transition-all"
+                        aria-label={
+                            removeAriaLabel ??
+                            t('admin.design.theme.upload.remove_default', 'Remove image')
+                        }
                     >
                         <X className="h-3.5 w-3.5" />
                     </button>

--- a/frontend/src/components/admin/designer/InterfaceEditor.test.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.test.tsx
@@ -132,4 +132,34 @@ describe('InterfaceEditor', () => {
             expect(whatFields).toHaveLength(whyFields.length);
         });
     });
+
+    describe('control names (Task 6.7c)', () => {
+        it('names the navigation-button info tooltip trigger per field', () => {
+            renderEditor();
+
+            expect(screen.getByRole('button', { name: 'About Start button' })).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'About Next step button' })
+            ).toBeInTheDocument();
+        });
+
+        it('discriminates the remove-tip button by the tip text, falling back to an ordinal when empty', () => {
+            renderEditor({
+                draft: {
+                    translations: [
+                        {
+                            language_code: 'en',
+                            ui_labels: {},
+                            methodology_tips: ['Sort intuitively first', ''],
+                        },
+                    ],
+                },
+            });
+
+            expect(
+                screen.getByRole('button', { name: 'Remove Sort intuitively first' })
+            ).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Remove Tip 2' })).toBeInTheDocument();
+        });
+    });
 });

--- a/frontend/src/components/admin/designer/InterfaceEditor.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.tsx
@@ -177,7 +177,17 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                             </Label>
                                             <TooltipProvider>
                                                 <Tooltip>
-                                                    <TooltipTrigger>
+                                                    <TooltipTrigger
+                                                        aria-label={t(
+                                                            'admin.design.interface.nav.info_label',
+                                                            'About {{label}}',
+                                                            {
+                                                                label: t(
+                                                                    `admin.design.interface.nav.${tipKey}`
+                                                                ),
+                                                            }
+                                                        )}
+                                                    >
                                                         <Info className="size-3 text-slate-400" />
                                                     </TooltipTrigger>
                                                     <TooltipContent className="text-2xs">
@@ -363,6 +373,19 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                         });
                                     }}
                                     className="text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-xl h-10 w-10 transition-all border border-transparent hover:border-red-100 shadow-none hover:shadow-sm"
+                                    aria-label={t(
+                                        'admin.design.interface.hints.remove',
+                                        'Remove {{tip}}',
+                                        {
+                                            tip:
+                                                tip.trim() ||
+                                                t(
+                                                    'admin.design.interface.hints.unnamed',
+                                                    'Tip {{number}}',
+                                                    { number: index + 1 }
+                                                ),
+                                        }
+                                    )}
                                 >
                                     <Trash2 className="h-4 w-4" />
                                 </Button>

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.test.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.test.tsx
@@ -213,6 +213,17 @@ describe('PostSortConfigEditor - Extreme Columns Prompts', () => {
         expect(negativeLabel).toBeInTheDocument();
     });
 
+    it('names each selected-column remove control by its own score (Task 6.7c)', () => {
+        renderEditor({
+            draft: {
+                postsort_config: { extreme_columns: [-2, 2] },
+            },
+        });
+
+        expect(screen.getByRole('button', { name: 'Remove +2' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Remove -2' })).toBeInTheDocument();
+    });
+
     it('updates specific prompt values in store', () => {
         renderEditor({
             draft: {

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -205,6 +205,11 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                                     type="button"
                                                     onClick={() => removeExtremeColumn(score)}
                                                     className="ml-1 text-slate-400 hover:text-red-500 transition-colors"
+                                                    aria-label={t(
+                                                        'admin.design.postsort.extreme.remove',
+                                                        'Remove {{score}}',
+                                                        { score: `${score > 0 ? '+' : ''}${score}` }
+                                                    )}
                                                 >
                                                     <X className="h-3.5 w-3.5" />
                                                 </button>

--- a/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
@@ -254,3 +254,27 @@ describe('ProcessStepEditor — step field accessible names (Task 6.7b)', () => 
         expect(screen.queryByRole('button', { name: 'User' })).not.toBeInTheDocument();
     });
 });
+
+describe('ProcessStepEditor — delete-step control name (Task 6.7c)', () => {
+    it('discriminates the delete button by each step’s own title', () => {
+        const draft = buildDraft([profileStep, roughStep]);
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        expect(screen.getByRole('button', { name: "Delete Let's meet" })).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Delete First impressions' })
+        ).toBeInTheDocument();
+    });
+
+    it('falls back to the step id when the step has no title yet', () => {
+        const untitledStep = { id: 'step_new_1', title: '', description: '', icon: 'Circle' };
+        const draft = buildDraft([untitledStep]);
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        expect(screen.getByRole('button', { name: 'Delete step_new_1' })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -126,6 +126,11 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                                 e.stopPropagation();
                                                 onDelete();
                                             }}
+                                            aria-label={t(
+                                                'admin.design.intro.process_steps.actions.delete',
+                                                'Delete {{title}}',
+                                                { title: step.title || step.id }
+                                            )}
                                         >
                                             <Trash2 className="h-4 w-4" />
                                         </Button>

--- a/frontend/src/components/admin/designer/QSortEditor.test.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.test.tsx
@@ -178,6 +178,16 @@ describe('QSortEditor', () => {
             expect(screen.queryByText('Existing Statement')).not.toBeInTheDocument();
         });
 
+        it('names the save/cancel controls by the statement code being edited (Task 6.7c)', async () => {
+            const user = userEvent.setup();
+            renderEditor();
+
+            await user.click(screen.getByText('Existing Statement'));
+
+            expect(screen.getByRole('button', { name: 'Save s1' })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Cancel editing s1' })).toBeInTheDocument();
+        });
+
         it('clears all statements with confirmation', async () => {
             const user = userEvent.setup();
             const confirmSpy = vi.spyOn(window, 'confirm').mockImplementation(() => true);
@@ -236,6 +246,13 @@ describe('QSortEditor', () => {
             expect(screen.getByText('Q-Sort distribution grid')).toBeInTheDocument();
             // Should see input fields for the grid
             // (Assuming grid editor renders inputs implies it's working)
+        });
+
+        it('names the "why forced distribution" help control (Task 6.7c)', () => {
+            renderEditor({ activeSubStep: 'grid' });
+            expect(
+                screen.getByRole('button', { name: 'Why forced distribution?' })
+            ).toBeInTheDocument();
         });
     });
 

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -181,6 +181,9 @@ function SortableStatementItem({
                             size="icon"
                             onClick={handleSaveStatement}
                             className="h-9 w-9 text-green-600 hover:bg-green-50 rounded-xl"
+                            aria-label={t('admin.design.qsort.set.save_item', 'Save {{code}}', {
+                                code: item.code,
+                            })}
                         >
                             <CheckCircle2 className="h-4 w-4" />
                         </Button>
@@ -189,6 +192,11 @@ function SortableStatementItem({
                             size="icon"
                             onClick={() => setEditingId(null)}
                             className="h-9 w-9 text-slate-400 hover:bg-slate-50 rounded-xl"
+                            aria-label={t(
+                                'admin.design.qsort.set.cancel_edit',
+                                'Cancel editing {{code}}',
+                                { code: item.code }
+                            )}
                         >
                             <AlertCircle className="h-4 w-4" />
                         </Button>
@@ -1124,6 +1132,9 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                                     variant="ghost"
                                                     size="icon"
                                                     className="h-10 w-10 text-slate-400 hover:text-indigo-600 rounded-xl hover:bg-indigo-50 transition-all"
+                                                    aria-label={t(
+                                                        'admin.design.qsort.grid.tooltip_title'
+                                                    )}
                                                 >
                                                     <HelpCircle className="h-5 w-5" />
                                                 </Button>

--- a/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
@@ -266,3 +266,94 @@ describe('QuestionBuilder — question field accessible names (Task 6.7b)', () =
         expect(screen.getByRole('textbox', { name: 'Option 2' })).toHaveValue('Beta');
     });
 });
+
+describe('QuestionBuilder — action-button accessible names (Task 6.7c)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: weak typing for test utility
+    const renderBuilder = (initialStateOverrides: any = {}) => {
+        const mergedDraft = {
+            slug: 'test',
+            state: 'draft',
+            postsort_config: { questions: {} },
+            ...(initialStateOverrides.draft || {}),
+        };
+
+        return renderWithStore(<QuestionBuilder type="post" />, {
+            initialState: {
+                ...initialStateOverrides,
+                draft: mergedDraft,
+                activeLocale: 'en',
+            },
+        });
+    };
+
+    it('discriminates the delete button by the question label', () => {
+        renderBuilder({
+            draft: {
+                postsort_config: {
+                    questions: {
+                        q1: { type: 'text', label: 'First question', required: false },
+                    },
+                },
+            },
+        });
+
+        expect(screen.getByRole('button', { name: 'Delete First question' })).toBeInTheDocument();
+    });
+
+    it('discriminates the "import from another language" trigger by the question label', () => {
+        renderBuilder({
+            draft: {
+                translations: [{ language_code: 'en' }, { language_code: 'fr' }],
+                postsort_config: {
+                    questions: {
+                        q1: { type: 'text', label: 'First question', required: false },
+                    },
+                },
+            },
+        });
+
+        expect(
+            screen.getByRole('button', {
+                name: 'Import First question from another language',
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('falls back to the item id when the question has no label yet', () => {
+        renderBuilder({
+            draft: {
+                postsort_config: {
+                    questions: {
+                        q1: { type: 'text', label: '', required: false },
+                    },
+                },
+            },
+        });
+
+        expect(screen.getByRole('button', { name: 'Delete q1' })).toBeInTheDocument();
+    });
+
+    it('discriminates the remove-option button by the option’s own ordinal', async () => {
+        const user = userEvent.setup();
+        renderBuilder({
+            draft: {
+                postsort_config: {
+                    questions: {
+                        q1: {
+                            type: 'select',
+                            label: 'Pick one',
+                            required: false,
+                            options: ['Alpha', 'Beta'],
+                        },
+                    },
+                },
+            },
+        });
+
+        const trigger = await screen.findByTestId('question-accordion-trigger');
+        await user.click(trigger);
+
+        expect(screen.getByRole('button', { name: 'Remove Option 1' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Remove Option 2' })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -150,6 +150,10 @@ const QuestionItem = (props: QuestionItemProps) => {
         typeof question.label === 'string'
             ? question.label
             : question.label?.[activeLocale] || question.label?.en || '';
+    // Discriminator for this question's action buttons (delete, copy-from-
+    // language) — falls back to the stable item id when the question has no
+    // label yet, same convention as ProcessStepEditor's step.title || step.id.
+    const questionLabel = label || id;
 
     const handleLabelChange = (val: string) => {
         if (readOnly) return;
@@ -272,6 +276,11 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                         size="icon"
                                                         className="h-9 w-9 text-slate-300 hover:text-indigo-600 hover:bg-indigo-50 rounded-xl transition-all"
                                                         onClick={(e) => e.stopPropagation()}
+                                                        aria-label={t(
+                                                            'admin.design.questions.actions.copy_from_aria',
+                                                            'Import {{label}} from another language',
+                                                            { label: questionLabel }
+                                                        )}
                                                     >
                                                         <Languages className="h-4 w-4" />
                                                     </Button>
@@ -305,6 +314,11 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                 e.stopPropagation();
                                                 onDelete();
                                             }}
+                                            aria-label={t(
+                                                'admin.design.questions.actions.delete',
+                                                'Delete {{label}}',
+                                                { label: questionLabel }
+                                            )}
                                         >
                                             <Trash2 className="h-4 w-4" />
                                         </Button>
@@ -876,6 +890,17 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                             variant="ghost"
                                                             size="icon"
                                                             className="h-10 w-10 text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all border border-transparent hover:border-red-100"
+                                                            aria-label={t(
+                                                                'admin.design.questions.actions.remove_option',
+                                                                'Remove {{option}}',
+                                                                {
+                                                                    option: t(
+                                                                        'admin.design.questions.labels.option_ordinal',
+                                                                        'Option {{number}}',
+                                                                        { number: idx + 1 }
+                                                                    ),
+                                                                }
+                                                            )}
                                                             onClick={() => {
                                                                 const newOpts =
                                                                     question.options?.filter(

--- a/frontend/src/pages/admin/AccountSettingsPage.test.tsx
+++ b/frontend/src/pages/admin/AccountSettingsPage.test.tsx
@@ -70,4 +70,19 @@ describe('AccountSettingsPage 2FA (authenticator app)', () => {
 
         expect(enableMutate).toHaveBeenCalledWith({ data: { token: '123456' } });
     });
+
+    it('names the copy-secret control and copies the TOTP secret (Task 6.7c)', async () => {
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText: vi.fn().mockResolvedValue(undefined) },
+            writable: true,
+            configurable: true,
+        });
+        renderWithProviders(<AccountSettingsPage />);
+        fireEvent.click(screen.getByRole('button', { name: /setup 2fa now/i }));
+
+        const copyButton = await screen.findByRole('button', { name: 'Copy secret' });
+        fireEvent.click(copyButton);
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('XYZ123');
+    });
 });

--- a/frontend/src/pages/admin/AccountSettingsPage.tsx
+++ b/frontend/src/pages/admin/AccountSettingsPage.tsx
@@ -349,6 +349,10 @@ const AccountSettingsPage = () => {
                                                             )
                                                         );
                                                     }}
+                                                    aria-label={t(
+                                                        'admin.account.security.copy_secret',
+                                                        'Copy secret'
+                                                    )}
                                                 >
                                                     <Copy size={14} className="text-slate-500" />
                                                 </button>

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -12,11 +12,20 @@ import type { ConcourseDetailPageApi } from '@/hooks/admin/useConcourseDetailPag
 import type { ConcourseDetailRead, ConcourseItemRead, ConcourseItemStatus } from '@/api/model';
 
 // Radix Select triggers a compose-refs loop in React 19 + happy-dom — stub it
-// (same approach as ProjectMembersPage.remove-member-dialog.test.tsx).
+// (same approach as ProjectMembersPage.remove-member-dialog.test.tsx). The
+// stub forwards the rest of the props (aria-label, className, ...) rather
+// than only `children` — a stub that drops aria-label would make every
+// accessible-name assertion against a SelectTrigger pass vacuously, whether
+// the real component carries the label or not (Task 6.7c).
 vi.mock('@/components/ui/select', () => ({
     Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
-        <button type="button">{children}</button>
+    SelectTrigger: ({
+        children,
+        ...props
+    }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children: React.ReactNode }) => (
+        <button type="button" {...props}>
+            {children}
+        </button>
     ),
     SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
@@ -420,5 +429,83 @@ describe('ConcourseDetailPage — Add Item / Bulk Import label accessible names 
         // association, not from the heading merely sitting nearby.
         expect(within(dialog).getByRole('group', { name: /^Tags/ })).toBeInTheDocument();
         expect(within(dialog).getByRole('checkbox', { name: /vision/i })).toBeInTheDocument();
+    });
+});
+
+describe('ConcourseDetailPage — control accessible names (Task 6.7c)', () => {
+    it('names the status and tag filter-bar selects', () => {
+        const concourse = concourseWith(1, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            filteredItems: concourse.items ?? [],
+            tags: [{ id: 1, name: 'Vision', color: '#6366f1', project_id: 1 }],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expect(screen.getByRole('button', { name: 'Filter by status' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Filter by tag' })).toBeInTheDocument();
+    });
+
+    it("discriminates each row's status select by the item code, not a shared generic name", () => {
+        const concourse = concourseWith(2, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            filteredItems: concourse.items ?? [],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        const codes = (concourse.items ?? []).map((item) => item.code);
+        expect(codes).toHaveLength(2);
+        for (const code of codes) {
+            // Both a mobile and a desktop copy of the row render simultaneously
+            // (CSS toggles visibility) — getAllByRole confirms at least one
+            // resolves under this exact name rather than none at all.
+            expect(
+                screen.getAllByRole('button', { name: `Status for ${code}` }).length
+            ).toBeGreaterThan(0);
+        }
+    });
+
+    it('names the create-tag control in the Tag Manager dialog', () => {
+        const concourse = concourseWith(0, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            tagManagerOpen: true,
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expect(screen.getByRole('button', { name: 'Create tag' })).toBeInTheDocument();
+    });
+
+    it('names the per-tag delete control by the tag name', () => {
+        const concourse = concourseWith(0, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            tagManagerOpen: true,
+            tags: [{ id: 1, name: 'Vision', color: '#6366f1', project_id: 1 }],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expect(screen.getByRole('button', { name: 'Delete Vision' })).toBeInTheDocument();
+    });
+
+    it('names the per-tag cancel-delete control by the tag name, once delete is armed', () => {
+        const concourse = concourseWith(0, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            tagManagerOpen: true,
+            tags: [{ id: 1, name: 'Vision', color: '#6366f1', project_id: 1 }],
+            // Mirrors the post-click state (setDeleteTagId(tag.id)) directly,
+            // since setDeleteTagId is a mock and won't re-render the hook.
+            deleteTagId: 1,
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expect(screen.getByRole('button', { name: 'Cancel deleting Vision' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Delete Vision' })).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -347,7 +347,10 @@ export default function ConcourseDetailPage() {
                         className="h-9 rounded-xl w-full sm:w-64 bg-white"
                     />
                     <Select value={filterStatus} onValueChange={setFilterStatus}>
-                        <SelectTrigger className="h-9 w-full sm:w-36 rounded-xl bg-white text-xs font-bold">
+                        <SelectTrigger
+                            className="h-9 w-full sm:w-36 rounded-xl bg-white text-xs font-bold"
+                            aria-label={t('admin.concourse.filters.status', 'Filter by status')}
+                        >
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent className="rounded-xl">
@@ -365,7 +368,10 @@ export default function ConcourseDetailPage() {
                     </Select>
                     {tags && tags.length > 0 && (
                         <Select value={filterTag} onValueChange={setFilterTag}>
-                            <SelectTrigger className="h-9 w-full sm:w-36 rounded-xl bg-white text-xs font-bold">
+                            <SelectTrigger
+                                className="h-9 w-full sm:w-36 rounded-xl bg-white text-xs font-bold"
+                                aria-label={t('admin.concourse.filters.tag', 'Filter by tag')}
+                            >
                                 <Tag className="size-3 mr-1" />
                                 <SelectValue />
                             </SelectTrigger>
@@ -747,6 +753,11 @@ export default function ConcourseDetailPage() {
                                                                 'h-7 w-[100px] rounded-lg text-2xs font-bold border',
                                                                 STATUS_COLORS[item.status] ?? ''
                                                             )}
+                                                            aria-label={t(
+                                                                'admin.concourse.status_for',
+                                                                'Status for {{code}}',
+                                                                { code: item.code }
+                                                            )}
                                                         >
                                                             <SelectValue />
                                                         </SelectTrigger>
@@ -1045,6 +1056,11 @@ export default function ConcourseDetailPage() {
                                                         className={cn(
                                                             'h-7 w-[100px] rounded-lg text-2xs font-bold border',
                                                             STATUS_COLORS[item.status] ?? ''
+                                                        )}
+                                                        aria-label={t(
+                                                            'admin.concourse.status_for',
+                                                            'Status for {{code}}',
+                                                            { code: item.code }
                                                         )}
                                                     >
                                                         <SelectValue />
@@ -1628,6 +1644,7 @@ export default function ConcourseDetailPage() {
                                 className="h-9 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white"
                                 disabled={!newTagName.trim() || isCreatingTag}
                                 onClick={handleCreateTag}
+                                aria-label={t('admin.concourse.create_tag', 'Create tag')}
                             >
                                 {isCreatingTag ? (
                                     <Loader2 className="size-3.5 animate-spin" />
@@ -1672,6 +1689,11 @@ export default function ConcourseDetailPage() {
                                                     size="sm"
                                                     className="h-7 px-2 text-slate-400 text-xs"
                                                     onClick={() => setDeleteTagId(null)}
+                                                    aria-label={t(
+                                                        'admin.concourse.cancel_delete_tag',
+                                                        'Cancel deleting {{tag}}',
+                                                        { tag: tag.name }
+                                                    )}
                                                 >
                                                     <X className="size-3" />
                                                 </Button>
@@ -1682,6 +1704,11 @@ export default function ConcourseDetailPage() {
                                                 size="sm"
                                                 className="h-7 w-7 p-0 text-slate-400 hover:text-red-500 hover:bg-red-50"
                                                 onClick={() => setDeleteTagId(tag.id)}
+                                                aria-label={t(
+                                                    'admin.concourse.delete_tag',
+                                                    'Delete {{tag}}',
+                                                    { tag: tag.name }
+                                                )}
                                             >
                                                 <Trash2 className="size-3.5" />
                                             </Button>

--- a/frontend/src/pages/admin/ProjectMembersPage.test.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.test.tsx
@@ -18,9 +18,10 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 // this test needs to exercise. It has been verified stable in this
 // React 19 + happy-dom environment for this page.
 
-const { removeMember, refetchMembers } = vi.hoisted(() => ({
+const { removeMember, refetchMembers, createInvitation } = vi.hoisted(() => ({
     removeMember: vi.fn().mockResolvedValue({}),
     refetchMembers: vi.fn(),
+    createInvitation: vi.fn().mockResolvedValue({ invite_url: 'https://example.com/join/abc' }),
 }));
 
 vi.mock('@/api/generated', () => ({
@@ -63,7 +64,7 @@ vi.mock('@/api/generated', () => ({
         isPending: false,
     }),
     useCreateInvitationApiAdminProjectsSlugInvitationsPost: () => ({
-        mutateAsync: vi.fn(),
+        mutateAsync: createInvitation,
         isPending: false,
     }),
 }));
@@ -126,6 +127,19 @@ describe('ProjectMembersPage role select', () => {
         // instead of just presence.
         expect(within(row).getAllByText('nn@example.com')).toHaveLength(1);
     });
+
+    it('names each row role select by that member, not a shared generic name (Task 6.7c)', async () => {
+        renderWithProviders(<ProjectMembersPage />);
+
+        expect(
+            await screen.findByRole('combobox', { name: 'Role for Ada Lovelace' })
+        ).toBeInTheDocument();
+        // The no-name member falls back to the email, matching the visible
+        // display-name cell one column over.
+        expect(
+            screen.getByRole('combobox', { name: 'Role for nn@example.com' })
+        ).toBeInTheDocument();
+    });
 });
 
 describe('ProjectMembersPage invite modal accessible names (Task 6.7b)', () => {
@@ -163,5 +177,26 @@ describe('ProjectMembersPage invite modal accessible names (Task 6.7b)', () => {
 
         await user.click(screen.getByText('Assigned role'));
         expect(roleTrigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('names the copy-invite-link control and flips the name once copied (Task 6.7c)', async () => {
+        const user = userEvent.setup();
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText: vi.fn() },
+            writable: true,
+            configurable: true,
+        });
+        renderWithProviders(<ProjectMembersPage />);
+
+        await user.click(await screen.findByRole('button', { name: /invite collaborator/i }));
+        await user.type(screen.getByRole('textbox', { name: /collaborator email/i }), 'x@y.io');
+        await user.click(screen.getByRole('button', { name: /create & send invitation/i }));
+
+        const copyButton = await screen.findByRole('button', { name: 'Copy link' });
+        await user.click(copyButton);
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('https://example.com/join/abc');
+        expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Copy link' })).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -260,6 +260,15 @@ export default function ProjectMembersPage() {
                                                                     ? 'bg-emerald-50 text-emerald-700'
                                                                     : 'bg-slate-100 text-slate-600'
                                                             )}
+                                                            aria-label={t(
+                                                                'admin.projects.settings.team.role_for',
+                                                                'Role for {{name}}',
+                                                                {
+                                                                    name:
+                                                                        member.user.full_name ||
+                                                                        member.user.email,
+                                                                }
+                                                            )}
                                                         >
                                                             <SelectValue />
                                                         </SelectTrigger>
@@ -584,6 +593,17 @@ function InviteMemberModal({ slug, isOwner }: { slug: string; isOwner: boolean }
                                         variant="ghost"
                                         className="absolute right-1 top-1/2 -translate-y-1/2 size-8 p-0"
                                         onClick={copyToClipboard}
+                                        aria-label={
+                                            copied
+                                                ? t(
+                                                      'admin.projects.settings.team.invite_modal.copied',
+                                                      'Copied'
+                                                  )
+                                                : t(
+                                                      'admin.projects.settings.team.invite_modal.copy_link',
+                                                      'Copy link'
+                                                  )
+                                        }
                                     >
                                         {copied ? (
                                             <Check className="size-3 text-emerald-600" />


### PR DESCRIPTION
## Summary

Task 6.7c — the second burn-down against the gate from [#326](https://github.com/jvastenaekels/qualis/pull/326). **Stacked on [#327](https://github.com/jvastenaekels/qualis/pull/327); merge that first.**

37 controls had no accessible name. A researcher reaching them by keyboard heard only the role — "button", "combobox" — with nothing identifying what they do. Several are destructive.

**Result: 37 → 0.** The `unnamedControls` bucket that motivated the gate is empty.

## Changes

Eight commits, one per file or small group, so each can be checked independently: `ConcourseDetailPage` 7, `InteractiveDataView.columns` 7, `BrandingEditor` 5, `QuestionBuilder` 3, `QSortEditor` 3, `InteractiveDataView` 3, `ProjectMembersPage` 2, `InterfaceEditor` 2, and one each in `AccountSettingsPage`, `ProcessStepEditor`, `PostSortConfigEditor`, `ImageUploadInput`, `AudioPlayer`.

Names say what the control does and carry a discriminator where instances differ only by row: `Delete First question`, `Remove +2`, `Recruitment link: REF123`, `Potentially suspect: session duration < 2 minutes`, `Status for C1`, `Role for Ada Lovelace`. 33 new keys across all nine admin locales.

The largest cluster was the Data table: seven `TooltipTrigger`s per participant row, each a focusable Radix button whose only content was a `<div>` and an icon, with the descriptive text reachable only while the tooltip was open.

## The brief was wrong, and the implementer was right to refuse it

The task brief pushed `asChild` as the preferred fix for that cluster, on the theory that it collapses the extra focusable button rather than naming a wrapper.

**Radix injects no `tabIndex` under `asChild`** — verified by grep in the package — and the gate exempts `asChild` unconditionally. Following the brief would have taken the cluster from 7 to 0 **while deleting keyboard access entirely**: the counter would have read zero, and keyboard users would have lost the controls. That is the exact failure mode the previous task had just taught us, reintroduced by the instruction written to prevent it.

`aria-label` on the existing triggers was used instead.

## A gap the counter could not ask for

`AudioPlayer`'s seek slider — the only control that navigates a recording — was left anonymous, because `<input>` is not in the checker's tracked set. Two of three controls in that file were named and the third was not, purely because nothing measured it. Fixed, along with two keys (`admin.audio.download`, `admin.audio.recording`) that were referenced in code but present in **zero** locale files, so the Download button announced English to every non-English researcher.

## Checklist

- [ ] `make ci` passes locally — **frontend green (191 files / 1653 tests, biome + tsc clean, gate at 0 unnamed); backend `pytest` fails on a local Postgres credential issue reproducing identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — every assertion uses `getByRole(role, { name })`, which computes the real accessible name. `InteractiveDataView.test.tsx` adds a `computeAccessibleName` sweep asserting no button in a participant row resolves empty — testing the claim, not the strings.
- [x] Translation keys added to all locales — 33 keys in all nine, register per the repo's glossaries.
- [x] API client regenerated if backend schemas changed — not applicable.

## How the burn-down was verified

Review imported the gate's own analysis function and re-ran it against every `.tsx` at all ten commits: `37 → 36 → 27 → 23 → 20 → 17 → 14 → 7 → 0`, every drop confined to files that commit touched, low-contrast count steady at 13 throughout, nothing suppressed. Chrome's accessibility tree was read via CDP to confirm the five `SelectTrigger`s were genuinely nameless before — not a false positive like the one this chain retracted earlier — and that adding `aria-label` does not clobber the announced value.

## Recorded, not fixed

Naming the seven status chips is a strict improvement but the wrong end state: they are indicators, activating them does nothing, and seven tab stops × 25 rows is up to **175 phantom stops per page**. Neither axe (a named button is axe-clean) nor the static gate can find this — only a human reading the tab order. It is written into the plan as Task 6.7g, with the `asChild` trap documented so it is not relearned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)