### PR TITLE
fix(a11y): raise interactive contrast, and drop the last clickable divs

### DIFF
--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1633,6 +1633,29 @@ Independent of 6.7c and 6.7d; touches no file they touch, so it can run in paral
 
 ---
 
+### Task 6.7h: Teach the gate to see role-bearing divs
+
+**Why:** the gate's contrast and name checks are **tag-based** (`CONTRAST_BEARING`, `NAME_BEARING` in `check-a11y-names.mjs`), so a `<div>` made interactive by a spread — `{...attributes} {...listeners}` from dnd-kit, which injects `role="button"` and `tabIndex={0}` — is invisible to it.
+
+Task 6.7d hit this concretely: three drag handles sat at 1.45:1 contrast, forty pixels from delete buttons the same task was fixing, and the gate reported zero. They were only found because a reviewer read the files by hand.
+
+This is the third shape of the same structural problem, and it is worth naming as a class:
+- `<input>` is not in `NAME_BEARING` — an unnamed audio seek slider survived Task 6.7c
+- a **named** button is axe-clean — the Data table's phantom tab stops survive Task 6.7g
+- a **role-bearing div** is in neither set — the drag handles survived Task 6.7d
+
+Each time, the instrument certified a surface it could not see.
+
+**The work:** make the checker resolve a control's *effective role* rather than its tag — matching `role="button"`, a `tabIndex` attribute, or a spread that is known to inject them — and add `<input>` to the name-bearing set. Then re-baseline and report what the wider net catches.
+
+- [ ] **Step 1: Extend the matching, and count what appears**
+- [ ] **Step 2: Triage the new findings** — expect false positives; the retraction in Task 3.4 exists because a control that looks unnamed in source may be correctly named
+- [ ] **Step 3: Fix or baseline each, with the baseline entry explaining why anything is left**
+- [ ] **Step 4: Add a test per new matcher** to `check-a11y-names.test.mjs`
+- [ ] **Step 5: Commit** — `fix(a11y): match controls by effective role, not by tag`
+
+---
+
 ### Task 6.7g: The Data table's status chips should not be buttons at all
 
 **The defect, and why no automated check will find it.** Task 6.7c named the seven per-row indicator `TooltipTrigger`s in `InteractiveDataView.columns.tsx` — a strict improvement over seven anonymous tab stops. But naming them was the wrong end state: **they are pure status indicators, and activating them does nothing.** Seven focusable buttons × 25 rows is up to **175 phantom tab stops per page**, each announcing a fact the researcher cannot act on.

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,9 +1,6 @@
 {
     "unnamedControls": {},
     "lowContrastControls": {
-        "src/components/admin/analysis/AnalysisHistoryPanel.tsx": {
-            "button#74bf5e335c": 1
-        },
         "src/components/admin/dashboard/InteractiveDataView.columns.tsx": {
             "Button#2af1b92949": 1,
             "Button#51bc640990": 1,

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -4,11 +4,6 @@
         "src/components/admin/designer/QSortEditor.tsx": {
             "Button#cfd0f92c60": 1
         },
-        "src/components/admin/designer/QuestionBuilder.tsx": {
-            "Button#b8299f38ab": 1,
-            "Button#ed2885af3a": 1,
-            "DropdownMenuTrigger#f1cda76386": 1
-        },
         "src/layouts/StudyLayout.tsx": {
             "button#543c37a641": 1
         }

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,9 +1,5 @@
 {
     "unnamedControls": {},
-    "lowContrastControls": {
-        "src/layouts/StudyLayout.tsx": {
-            "button#543c37a641": 1
-        }
-    },
+    "lowContrastControls": {},
     "suppressedLabelErrors": {}
 }

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,9 +1,6 @@
 {
     "unnamedControls": {},
     "lowContrastControls": {
-        "src/components/admin/designer/InterfaceEditor.tsx": {
-            "Button#5417b42698": 1
-        },
         "src/components/admin/designer/ProcessStepEditor.tsx": {
             "Button#08fe1834a8": 1
         },

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,9 +1,6 @@
 {
     "unnamedControls": {},
     "lowContrastControls": {
-        "src/components/admin/designer/ProcessStepEditor.tsx": {
-            "Button#08fe1834a8": 1
-        },
         "src/components/admin/designer/QSortEditor.tsx": {
             "Button#cfd0f92c60": 1
         },

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,9 +1,6 @@
 {
     "unnamedControls": {},
     "lowContrastControls": {
-        "src/components/admin/designer/QSortEditor.tsx": {
-            "Button#cfd0f92c60": 1
-        },
         "src/layouts/StudyLayout.tsx": {
             "button#543c37a641": 1
         }

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,12 +1,6 @@
 {
     "unnamedControls": {},
     "lowContrastControls": {
-        "src/components/admin/dashboard/InteractiveDataView.columns.tsx": {
-            "Button#2af1b92949": 1,
-            "Button#51bc640990": 1,
-            "Button#7d4243c19a": 1,
-            "Button#ff3d58c3b9": 1
-        },
         "src/components/admin/designer/BrandingEditor.tsx": {
             "button#9fdeea95db": 1
         },

--- a/frontend/scripts/a11y-baseline.json
+++ b/frontend/scripts/a11y-baseline.json
@@ -1,9 +1,6 @@
 {
     "unnamedControls": {},
     "lowContrastControls": {
-        "src/components/admin/designer/BrandingEditor.tsx": {
-            "button#9fdeea95db": 1
-        },
         "src/components/admin/designer/InterfaceEditor.tsx": {
             "Button#5417b42698": 1
         },

--- a/frontend/src/components/admin/analysis/AnalysisHistory.test.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistory.test.tsx
@@ -255,6 +255,39 @@ describe('AnalysisHistoryPanel', () => {
         expect(screen.getByText('manual')).toBeInTheDocument();
     });
 
+    // ── Test 4b: The metadata separators are legible, not 1.45:1 (Task 6.7d) ──
+    it('renders the metadata separator dots at a legible contrast', () => {
+        const run = makeRun({ id: 1 });
+        mockListRunsHook.mockReturnValue({
+            data: [run],
+            isLoading: false,
+            isSuccess: true,
+            isError: false,
+        });
+
+        renderWithProviders(
+            <AnalysisHistoryPanel
+                slug="test-study"
+                viewedRunId={null}
+                latestRunId={null}
+                onLoadRun={vi.fn()}
+            />
+        );
+
+        // Four "·" separators sit between extraction/n_factors/rotation/flagging,
+        // plus one before the researcher email (ran_by_email is set by makeRun).
+        const dots = screen.getAllByText('·');
+        expect(dots).toHaveLength(4);
+        for (const dot of dots) {
+            expect(dot).toHaveClass('text-slate-500');
+            expect(dot).not.toHaveClass('text-slate-300');
+        }
+        // The row itself stays a real, named, clickable control — the color
+        // change didn't touch the control's operability (proven end-to-end by
+        // Test 2's click-to-load assertion above).
+        expect(screen.getByRole('button', { name: /Load analysis run from/i })).toBeInTheDocument();
+    });
+
     // ── Test 5: Current tag shown when latestRunId matches a run ──────────
     it('shows "current" tag on the run matching latestRunId', () => {
         const run = makeRun({ id: 99 });

--- a/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
@@ -282,7 +282,7 @@ export function AnalysisHistoryPanel({
                                             <span className="text-xs text-slate-500">
                                                 {run.extraction_method.toUpperCase()}
                                             </span>
-                                            <span className="text-slate-300 text-xs">·</span>
+                                            <span className="text-slate-500 text-xs">·</span>
                                             <span className="text-xs text-slate-500">
                                                 {t(
                                                     'admin.analysis.history.n_factors_label',
@@ -290,17 +290,17 @@ export function AnalysisHistoryPanel({
                                                     { n: run.n_factors }
                                                 )}
                                             </span>
-                                            <span className="text-slate-300 text-xs">·</span>
+                                            <span className="text-slate-500 text-xs">·</span>
                                             <span className="text-xs text-slate-500">
                                                 {run.rotation_method}
                                             </span>
-                                            <span className="text-slate-300 text-xs">·</span>
+                                            <span className="text-slate-500 text-xs">·</span>
                                             <span className="text-xs text-slate-500">
                                                 {run.flagging_mode}
                                             </span>
                                             {run.ran_by_email && (
                                                 <>
-                                                    <span className="text-slate-300 text-xs">
+                                                    <span className="text-slate-500 text-xs">
                                                         ·
                                                     </span>
                                                     <span className="text-xs text-slate-400 italic">

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -276,7 +276,7 @@ export function buildColumns({
                               ) : column.getIsSorted() === 'desc' ? (
                                   <ArrowDown className="ml-2 h-3 w-3 text-indigo-500" />
                               ) : (
-                                  <ArrowUpDown className="ml-2 h-3 w-3 text-slate-300" />
+                                  <ArrowUpDown className="ml-2 h-3 w-3 text-slate-500" />
                               )}
                           </Button>
                       ),
@@ -306,7 +306,7 @@ export function buildColumns({
                         ) : column.getIsSorted() === 'desc' ? (
                             <ArrowDown className="ml-1 h-3 w-3 text-indigo-500" />
                         ) : (
-                            <ArrowUpDown className="ml-1 h-3 w-3 text-slate-300" />
+                            <ArrowUpDown className="ml-1 h-3 w-3 text-slate-500" />
                         )}
                     </Button>
                     <DropdownMenu>
@@ -732,7 +732,7 @@ export function buildColumns({
                     ) : column.getIsSorted() === 'desc' ? (
                         <ArrowDown className="ml-2 h-3 w-3 text-indigo-500" />
                     ) : (
-                        <ArrowUpDown className="ml-2 h-3 w-3 text-slate-300" />
+                        <ArrowUpDown className="ml-2 h-3 w-3 text-slate-500" />
                     )}
                 </Button>
             ),
@@ -771,7 +771,7 @@ export function buildColumns({
                     ) : column.getIsSorted() === 'desc' ? (
                         <ArrowDown className="ml-2 h-3 w-3 text-indigo-500" />
                     ) : (
-                        <ArrowUpDown className="ml-2 h-3 w-3 text-slate-300" />
+                        <ArrowUpDown className="ml-2 h-3 w-3 text-slate-500" />
                     )}
                 </Button>
             ),

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -27,6 +27,7 @@
 import { computeAccessibleName } from 'dom-accessibility-api';
 import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import type { DumpParticipant, DumpResponse } from './types';
 import InteractiveDataView from './InteractiveDataView';
 
@@ -198,5 +199,24 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
             .getAllByRole('button')
             .map((button) => computeAccessibleName(button));
         expect(buttonNames.every((name) => name.trim().length > 0)).toBe(true);
+    });
+});
+
+describe('InteractiveDataView — sort-header icon contrast (Task 6.7d)', () => {
+    it('renders the idle sort indicator at a legible contrast and keeps sorting operable', async () => {
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        const languageHeader = screen.getByRole('columnheader', { name: /lang/i });
+        const sortButton = within(languageHeader).getByRole('button');
+        const arrowIcon = sortButton.querySelector('svg.lucide-arrow-up-down');
+        expect(arrowIcon).not.toBeNull();
+        expect(arrowIcon).toHaveClass('text-slate-500');
+        expect(arrowIcon).not.toHaveClass('text-slate-300');
+
+        // The color change didn't touch operability: the header is still a
+        // real, clickable sort toggle.
+        await userEvent.click(sortButton);
+        expect(sortButton).toBeInTheDocument();
     });
 });

--- a/frontend/src/components/admin/dashboard/StudyStatusControl.test.tsx
+++ b/frontend/src/components/admin/dashboard/StudyStatusControl.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Task 6.7d: StudyStatusControl's clickable status-step tile used to be a
+ * hand-rolled `<div role="button" tabIndex={0}>` with NO onKeyDown at all —
+ * focusable, but pressing Enter/Space did nothing (the div's role="button"
+ * doesn't get native Enter/Space-to-click translation from the browser; that
+ * only happens for real interactive elements or JS-implemented handlers,
+ * neither of which existed here). Converted to a native <button> (Radix's
+ * AlertDialogTrigger asChild clones it, same as every other trigger in this
+ * codebase), which gets the translation for free — restoring, not just
+ * preserving, keyboard operability. Verified the same way
+ * AdminDashboard.test.tsx verifies its own div-to-button conversions: focus
+ * the tile, press Enter, assert the dialog opens.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import StudyStatusControl from './StudyStatusControl';
+import { renderWithProviders } from '@/test-utils/test-utils';
+
+const { mockChangeStateMutation } = vi.hoisted(() => ({
+    mockChangeStateMutation: vi.fn(),
+}));
+
+vi.mock('@/api/generated', () => ({
+    useChangeStudyStateApiAdminStudiesSlugStatePost: mockChangeStateMutation,
+    getListStudiesApiAdminStudiesGetQueryKey: () => ['studies'],
+    getGetStudyApiAdminStudiesSlugGetQueryKey: (slug: string) => ['study', slug],
+}));
+
+vi.mock('sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function setup() {
+    mockChangeStateMutation.mockReturnValue({
+        mutateAsync: vi.fn().mockResolvedValue(undefined),
+        isPending: false,
+    });
+    return renderWithProviders(
+        <StudyStatusControl slug="demo-study" currentState="draft" onStateChange={vi.fn()} />
+    );
+}
+
+describe('StudyStatusControl — the reachable step tile is a real, keyboard-operable button', () => {
+    it('exposes a clickable step as a native <button>, not an ARIA-only div', () => {
+        setup();
+
+        // From "draft", only "active" is a reachable transition
+        // (isTransitionAllowed) — that tile is the one under test.
+        const tile = screen.getByRole('button', { name: /active/i });
+        expect(tile.tagName).toBe('BUTTON');
+        expect(tile).not.toHaveAttribute('role');
+        expect(tile).not.toHaveAttribute('tabindex');
+    });
+
+    it('opens the confirmation dialog on Enter while focused (was previously inert)', async () => {
+        const user = userEvent.setup();
+        setup();
+
+        const tile = screen.getByRole('button', { name: /active/i });
+        expect(screen.queryByText(/launch study\?/i)).not.toBeInTheDocument();
+
+        tile.focus();
+        expect(tile).toHaveFocus();
+        await user.keyboard('{Enter}');
+
+        expect(await screen.findByText(/launch study\?/i)).toBeInTheDocument();
+    });
+
+    it('leaves an unreachable step as plain, non-interactive content', () => {
+        setup();
+
+        // From "draft", "closed" is not a reachable transition — it must not
+        // register as a button at all (no dead/duplicate tab stop).
+        expect(screen.queryByRole('button', { name: /^closed$/i })).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/dashboard/StudyStatusControl.tsx
+++ b/frontend/src/components/admin/dashboard/StudyStatusControl.tsx
@@ -112,9 +112,12 @@ function StatusStepButton({ step, currentState, renderActionDialog }: StatusStep
                 {renderActionDialog(
                     // biome-ignore lint/suspicious/noExplicitAny: generic ID
                     step.id as any,
-                    <div role="button" tabIndex={0} className="outline-none">
+                    <button
+                        type="button"
+                        className="block w-full text-left outline-none bg-transparent"
+                    >
                         {content}
-                    </div>
+                    </button>
                 )}
             </React.Fragment>
         );

--- a/frontend/src/components/admin/designer/BrandingEditor.test.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.test.tsx
@@ -84,3 +84,33 @@ describe('BrandingEditor — control names (Task 6.7c)', () => {
         expect(screen.getByRole('button', { name: 'Remove Partner 2' })).toBeInTheDocument();
     });
 });
+
+describe('BrandingEditor — remove-partner button contrast (Task 6.7d)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: convenient partial mock
+    const mockDraft: any = {
+        slug: 'test-study',
+        state: 'draft',
+        branding: {
+            logo_url: null,
+            accent_color: null,
+            partners: [{ id: 'partner-1', name: 'Acme University', logo_url: null }],
+        },
+    };
+
+    it('renders the remove-partner icon at a legible contrast and keeps it operable', async () => {
+        const user = userEvent.setup();
+        renderWithStore(<BrandingEditor />, {
+            initialState: { draft: mockDraft, activeLocale: 'en' },
+        });
+
+        const removeButton = screen.getByRole('button', { name: 'Remove Acme University' });
+        expect(removeButton).toHaveClass('text-slate-500');
+        expect(removeButton).not.toHaveClass('text-slate-300');
+
+        await user.click(removeButton);
+        // Operable end to end: the partner row is gone from the DOM.
+        expect(
+            screen.queryByRole('button', { name: 'Remove Acme University' })
+        ).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/admin/designer/BrandingEditor.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.tsx
@@ -352,7 +352,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                         ).filter((_, i) => i !== index);
                                                         updateBranding('partners', newPartners);
                                                     }}
-                                                    className="text-slate-300 hover:text-red-500 p-2 transition-colors bg-white rounded-xl shadow-sm border border-slate-100 hover:border-red-100"
+                                                    className="text-slate-500 hover:text-red-500 p-2 transition-colors bg-white rounded-xl shadow-sm border border-slate-100 hover:border-red-100"
                                                     aria-label={t(
                                                         'admin.design.theme.partners.remove',
                                                         'Remove {{name}}',

--- a/frontend/src/components/admin/designer/ImageUploadInput.test.tsx
+++ b/frontend/src/components/admin/designer/ImageUploadInput.test.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import ImageUploadInput from './ImageUploadInput';
 import { renderWithProviders, screen } from '@/test-utils/test-utils';
 
@@ -24,5 +25,40 @@ describe('ImageUploadInput — remove-image control name (Task 6.7c)', () => {
             screen.getByRole('button', { name: 'Remove logo for Acme University' })
         ).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Remove image' })).not.toBeInTheDocument();
+    });
+});
+
+describe('ImageUploadInput — drag/drop zone is a real, keyboard-operable button (Task 6.7d)', () => {
+    it('is a native <button> with no hand-rolled role/tabIndex, and opens the file picker via keyboard', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<ImageUploadInput value="" onChange={() => {}} />);
+
+        await user.click(screen.getByRole('button', { name: 'Upload' }));
+
+        const zone = screen.getByRole('button', { name: 'Drag & drop or click to upload' });
+        // Positive: it's a genuine <button>, not a div faking the role.
+        expect(zone.tagName).toBe('BUTTON');
+        // Negative: no hand-rolled role attribute needed — the tag itself
+        // carries the semantics.
+        expect(zone).not.toHaveAttribute('role');
+
+        const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click');
+        zone.focus();
+        await user.keyboard('{Enter}');
+
+        // A native <button> converts Enter into a click automatically — no
+        // custom onKeyDown needed — which is what actually opens the hidden
+        // file input.
+        expect(clickSpy).toHaveBeenCalled();
+        clickSpy.mockRestore();
+    });
+
+    it('keeps the hidden file input outside the button (valid content model)', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<ImageUploadInput value="" onChange={() => {}} />);
+        await user.click(screen.getByRole('button', { name: 'Upload' }));
+
+        const zone = screen.getByRole('button', { name: 'Drag & drop or click to upload' });
+        expect(zone.querySelector('input[type="file"]')).toBeNull();
     });
 });

--- a/frontend/src/components/admin/designer/ImageUploadInput.tsx
+++ b/frontend/src/components/admin/designer/ImageUploadInput.tsx
@@ -181,30 +181,10 @@ const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
 
             {/* Upload Mode */}
             {mode === 'upload' && (
-                <div
-                    onDrop={handleDrop}
-                    onDragOver={handleDragOver}
-                    onDragLeave={handleDragLeave}
-                    className={cn(
-                        'border-2 border-dashed rounded-xl p-6 transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2',
-                        isDragging
-                            ? 'border-indigo-400 bg-indigo-50'
-                            : 'border-slate-200 hover:border-indigo-300 hover:bg-slate-50'
-                    )}
-                    onClick={() => fileInputRef.current?.click()}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            fileInputRef.current?.click();
-                        }
-                    }}
-                    tabIndex={0}
-                    role="button"
-                    aria-label={t(
-                        'admin.design.theme.upload.drag_drop',
-                        'Drag & drop or click to upload'
-                    )}
-                >
+                <div className="relative">
+                    {/* Kept outside the button below: a <button> may not contain
+                        interactive content per the HTML content model, and a
+                        native file <input> counts as interactive even hidden. */}
                     <input
                         ref={fileInputRef}
                         type="file"
@@ -212,33 +192,51 @@ const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
                         onChange={handleFileInputChange}
                         className="hidden"
                     />
-                    <div className="flex flex-col items-center justify-center gap-2 text-center">
-                        {isConverting ? (
-                            <>
-                                <Loader2 className="h-8 w-8 text-indigo-500 animate-spin" />
-                                <p className="text-xs font-medium text-slate-600">
-                                    {t(
-                                        'admin.design.theme.upload.processing',
-                                        'Processing image...'
-                                    )}
-                                </p>
-                            </>
-                        ) : (
-                            <>
-                                <Upload className="h-8 w-8 text-slate-400" />
-                                <p className="text-sm font-medium text-slate-700">
-                                    {t(
-                                        'admin.design.theme.upload.drag_drop',
-                                        'Drag & drop or click to upload'
-                                    )}
-                                </p>
-                                <p className="text-xs text-slate-500">
-                                    PNG, JPG, SVG • {t('admin.design.theme.upload.max', 'Max')}{' '}
-                                    {Math.round(maxFileSize / 1024)}KB
-                                </p>
-                            </>
+                    <button
+                        type="button"
+                        onDrop={handleDrop}
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                        onClick={() => fileInputRef.current?.click()}
+                        className={cn(
+                            'block w-full text-left border-2 border-dashed rounded-xl p-6 transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2',
+                            isDragging
+                                ? 'border-indigo-400 bg-indigo-50'
+                                : 'border-slate-200 hover:border-indigo-300 hover:bg-slate-50'
                         )}
-                    </div>
+                        aria-label={t(
+                            'admin.design.theme.upload.drag_drop',
+                            'Drag & drop or click to upload'
+                        )}
+                    >
+                        <div className="flex flex-col items-center justify-center gap-2 text-center">
+                            {isConverting ? (
+                                <>
+                                    <Loader2 className="h-8 w-8 text-indigo-500 animate-spin" />
+                                    <p className="text-xs font-medium text-slate-600">
+                                        {t(
+                                            'admin.design.theme.upload.processing',
+                                            'Processing image...'
+                                        )}
+                                    </p>
+                                </>
+                            ) : (
+                                <>
+                                    <Upload className="h-8 w-8 text-slate-400" />
+                                    <p className="text-sm font-medium text-slate-700">
+                                        {t(
+                                            'admin.design.theme.upload.drag_drop',
+                                            'Drag & drop or click to upload'
+                                        )}
+                                    </p>
+                                    <p className="text-xs text-slate-500">
+                                        PNG, JPG, SVG • {t('admin.design.theme.upload.max', 'Max')}{' '}
+                                        {Math.round(maxFileSize / 1024)}KB
+                                    </p>
+                                </>
+                            )}
+                        </div>
+                    </button>
                 </div>
             )}
 

--- a/frontend/src/components/admin/designer/ImportFromConcourseDialog.test.tsx
+++ b/frontend/src/components/admin/designer/ImportFromConcourseDialog.test.tsx
@@ -47,3 +47,68 @@ describe('ImportFromConcourseDialog — code prefix accessible name (Task 6.7b)'
         expect(field).toHaveFocus();
     });
 });
+
+describe('ImportFromConcourseDialog — item row is a native label, not an ARIA-only div (Task 6.7d)', () => {
+    const renderDialog = () =>
+        renderWithProviders(
+            <ImportFromConcourseDialog
+                open
+                onOpenChange={vi.fn()}
+                studySlug="demo-study"
+                activeLocale="en"
+                onImported={vi.fn()}
+            />
+        );
+
+    it('names the checkbox from the row text and toggles it on click, exactly once', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        // The checkbox now carries a real accessible name (the row's own
+        // text) instead of the div's former unlabeled role="button".
+        const checkbox = screen.getByRole('checkbox', { name: /a statement/i });
+        expect(checkbox).not.toBeChecked();
+
+        // Click on the row text (not the checkbox itself) — native <label>
+        // click-forwarding, not a hand-rolled onClick.
+        await user.click(screen.getByText('A statement'));
+        expect(checkbox).toBeChecked();
+
+        // Click again to flip back — proves it toggles by exactly one step
+        // per click, i.e. no double-firing from a leftover row handler.
+        await user.click(screen.getByText('A statement'));
+        expect(checkbox).not.toBeChecked();
+    });
+
+    it('toggles exactly once when the checkbox itself is clicked directly', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        const checkbox = screen.getByRole('checkbox', { name: /a statement/i });
+        await user.click(checkbox);
+        expect(checkbox).toBeChecked();
+        await user.click(checkbox);
+        expect(checkbox).not.toBeChecked();
+    });
+
+    it('stays keyboard-operable: Tab to the checkbox, Space toggles it', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        const checkbox = screen.getByRole('checkbox', { name: /a statement/i });
+        checkbox.focus();
+        expect(checkbox).toHaveFocus();
+
+        await user.keyboard(' ');
+        expect(checkbox).toBeChecked();
+    });
+
+    it('renders the row as a <label>, with no leftover role="button"/tabIndex', () => {
+        renderDialog();
+
+        const row = screen.getByText('A statement').closest('label');
+        expect(row).not.toBeNull();
+        expect(row).not.toHaveAttribute('role');
+        expect(row).not.toHaveAttribute('tabindex');
+    });
+});

--- a/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
+++ b/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
@@ -247,19 +247,24 @@ export function ImportFromConcourseDialog({
                             </div>
                             <div className="divide-y divide-slate-50">
                                 {filteredItems.map((item) => (
-                                    <div
+                                    // A native <label> wrapping the Checkbox, not a
+                                    // role="button" div: this row already contains a
+                                    // real interactive control (Checkbox renders a real
+                                    // <button role="checkbox">), so wrapping the whole
+                                    // row in ANOTHER button would nest interactive
+                                    // controls (invalid content model) and, worse,
+                                    // double-toggle on every click (the outer button's
+                                    // onClick plus the checkbox's own onCheckedChange).
+                                    // <label> gives "click anywhere in the row toggles
+                                    // the checkbox" for free via native label/control
+                                    // association — no onClick/onKeyDown needed — and
+                                    // it also gives the checkbox a real accessible name
+                                    // from the row's own text (the div it replaces had
+                                    // none).
+                                    <label
                                         key={item.id}
-                                        role="button"
-                                        tabIndex={0}
-                                        onClick={() => toggleItem(item.id)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === ' ' || e.key === 'Enter') {
-                                                e.preventDefault();
-                                                toggleItem(item.id);
-                                            }
-                                        }}
                                         className={cn(
-                                            'flex items-start gap-3 px-4 py-2.5 cursor-pointer hover:bg-slate-50/50 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset',
+                                            'flex items-start gap-3 px-4 py-2.5 cursor-pointer hover:bg-slate-50/50 transition-colors',
                                             selectedItemIds.has(item.id) && 'bg-indigo-50/30'
                                         )}
                                     >
@@ -291,7 +296,7 @@ export function ImportFromConcourseDialog({
                                                 {getItemText(item)}
                                             </p>
                                         </div>
-                                    </div>
+                                    </label>
                                 ))}
                             </div>
                         </div>

--- a/frontend/src/components/admin/designer/InterfaceEditor.test.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.test.tsx
@@ -161,5 +161,31 @@ describe('InterfaceEditor', () => {
             ).toBeInTheDocument();
             expect(screen.getByRole('button', { name: 'Remove Tip 2' })).toBeInTheDocument();
         });
+
+        it('renders the remove-tip icon at a legible contrast and keeps it operable (Task 6.7d)', async () => {
+            const user = userEvent.setup();
+            renderEditor({
+                draft: {
+                    translations: [
+                        {
+                            language_code: 'en',
+                            ui_labels: {},
+                            methodology_tips: ['Sort intuitively first'],
+                        },
+                    ],
+                },
+            });
+
+            const removeButton = screen.getByRole('button', {
+                name: 'Remove Sort intuitively first',
+            });
+            expect(removeButton).toHaveClass('text-slate-500');
+            expect(removeButton).not.toHaveClass('text-slate-300');
+
+            await user.click(removeButton);
+            expect(
+                screen.queryByRole('button', { name: 'Remove Sort intuitively first' })
+            ).not.toBeInTheDocument();
+        });
     });
 });

--- a/frontend/src/components/admin/designer/InterfaceEditor.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.tsx
@@ -372,7 +372,7 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                             }
                                         });
                                     }}
-                                    className="text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-xl h-10 w-10 transition-all border border-transparent hover:border-red-100 shadow-none hover:shadow-sm"
+                                    className="text-slate-500 hover:text-red-500 hover:bg-red-50 rounded-xl h-10 w-10 transition-all border border-transparent hover:border-red-100 shadow-none hover:shadow-sm"
                                     aria-label={t(
                                         'admin.design.interface.hints.remove',
                                         'Remove {{tip}}',

--- a/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
@@ -292,4 +292,23 @@ describe('ProcessStepEditor — delete-step control name (Task 6.7c)', () => {
         await user.click(deleteButton);
         expect(screen.queryByRole('button', { name: "Delete Let's meet" })).not.toBeInTheDocument();
     });
+
+    it('renders the drag-handle icon at a legible contrast (review fix-round, Task 6.7d)', () => {
+        const draft = buildDraft([profileStep, roughStep]);
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        const deleteButton = screen.getByRole('button', { name: "Delete Let's meet" });
+        const item = deleteButton.closest('.group');
+        expect(item).not.toBeNull();
+        // dnd-kit's useSortable spreads {...attributes} onto this div, which
+        // injects role="button" — no accessible name, so it's found by class
+        // rather than by role+name.
+        // biome-ignore lint/style/noNonNullAssertion: test setup
+        const dragHandle = item!.querySelector('.cursor-grab');
+        expect(dragHandle).not.toBeNull();
+        expect(dragHandle).toHaveClass('text-slate-500');
+        expect(dragHandle).not.toHaveClass('text-slate-300');
+    });
 });

--- a/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.test.tsx
@@ -277,4 +277,19 @@ describe('ProcessStepEditor — delete-step control name (Task 6.7c)', () => {
 
         expect(screen.getByRole('button', { name: 'Delete step_new_1' })).toBeInTheDocument();
     });
+
+    it('renders the delete icon at a legible contrast and keeps it operable (Task 6.7d)', async () => {
+        const user = userEvent.setup();
+        const draft = buildDraft([profileStep, roughStep]);
+        renderWithStore(<ProcessStepEditor />, {
+            initialState: { draft, activeLocale: 'en' },
+        });
+
+        const deleteButton = screen.getByRole('button', { name: "Delete Let's meet" });
+        expect(deleteButton).toHaveClass('text-slate-500');
+        expect(deleteButton).not.toHaveClass('text-slate-300');
+
+        await user.click(deleteButton);
+        expect(screen.queryByRole('button', { name: "Delete Let's meet" })).not.toBeInTheDocument();
+    });
 });

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -77,7 +77,7 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                     <div
                         {...attributes}
                         {...listeners}
-                        className="mt-2.5 cursor-grab active:cursor-grabbing text-slate-300 hover:text-indigo-500 transition-colors"
+                        className="mt-2.5 cursor-grab active:cursor-grabbing text-slate-500 hover:text-indigo-500 transition-colors"
                     >
                         <GripVertical className="h-4 w-4" />
                     </div>

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -121,7 +121,7 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                         <Button
                                             variant="ghost"
                                             size="icon"
-                                            className="h-9 w-9 text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all border border-transparent hover:border-red-100"
+                                            className="h-9 w-9 text-slate-500 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all border border-transparent hover:border-red-100"
                                             onClick={(e) => {
                                                 e.stopPropagation();
                                                 onDelete();

--- a/frontend/src/components/admin/designer/QSortEditor.test.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.test.tsx
@@ -230,7 +230,17 @@ describe('QSortEditor', () => {
                 expect(screen.getByRole('button', { name: 'Save s1' })).toBeInTheDocument();
             });
 
-            it('is disabled (not just visually muted) when the editor is read-only', () => {
+            // Review fix-round 2: a native `disabled` button blocks the mouse
+            // events a text-selection drag needs, in every browser,
+            // regardless of `user-select` (verified live — see the
+            // select-text entry below and the report). Since a read-only
+            // study is exactly the state where statements get read and
+            // quoted, this control now stays focusable and selectable —
+            // `aria-disabled` communicates non-operability to assistive tech,
+            // and the `onClick` guard (restored — the original <div> already
+            // had it) keeps Enter/Space inert without removing the element
+            // from the tab order or from `window.getSelection()`'s reach.
+            it('is aria-disabled — not natively disabled — when the editor is read-only, so its text stays selectable', () => {
                 renderWithStore(
                     <TooltipProvider>
                         <QSortEditor readOnly />
@@ -239,7 +249,28 @@ describe('QSortEditor', () => {
                 );
 
                 const editControl = screen.getByRole('button', { name: 'Existing Statement' });
-                expect(editControl).toBeDisabled();
+                expect(editControl).toHaveAttribute('aria-disabled', 'true');
+                expect(editControl).not.toBeDisabled();
+            });
+
+            it('no-ops on click and on Enter when read-only — the guard does what `disabled` used to', async () => {
+                const user = userEvent.setup();
+                renderWithStore(
+                    <TooltipProvider>
+                        <QSortEditor readOnly />
+                    </TooltipProvider>,
+                    { initialState: { draft: mockDraft, activeLocale: 'en' } }
+                );
+
+                const editControl = screen.getByRole('button', { name: 'Existing Statement' });
+
+                await user.click(editControl);
+                expect(screen.queryByRole('button', { name: /^Save /i })).not.toBeInTheDocument();
+
+                editControl.focus();
+                expect(editControl).toHaveFocus();
+                await user.keyboard('{Enter}');
+                expect(screen.queryByRole('button', { name: /^Save /i })).not.toBeInTheDocument();
             });
 
             // Review fix-round: Firefox's UA stylesheet sets `user-select: none`

--- a/frontend/src/components/admin/designer/QSortEditor.test.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.test.tsx
@@ -189,6 +189,21 @@ describe('QSortEditor', () => {
             expect(deleteButton).not.toHaveClass('text-slate-300');
         });
 
+        it('renders the drag-handle icon at a legible contrast (review fix-round, Task 6.7d)', () => {
+            renderEditor();
+
+            const statementItem = screen.getByText('Existing Statement').closest('.group');
+            expect(statementItem).toBeInTheDocument();
+            // dnd-kit's useSortable spreads {...attributes} onto this div,
+            // which injects role="button" — no accessible name, so it's found
+            // by class rather than by role+name.
+            // biome-ignore lint/style/noNonNullAssertion: test setup
+            const dragHandle = statementItem!.querySelector('.cursor-grab');
+            expect(dragHandle).not.toBeNull();
+            expect(dragHandle).toHaveClass('text-slate-500');
+            expect(dragHandle).not.toHaveClass('text-slate-300');
+        });
+
         it('names the save/cancel controls by the statement code being edited (Task 6.7c)', async () => {
             const user = userEvent.setup();
             renderEditor();
@@ -225,6 +240,32 @@ describe('QSortEditor', () => {
 
                 const editControl = screen.getByRole('button', { name: 'Existing Statement' });
                 expect(editControl).toBeDisabled();
+            });
+
+            // Review fix-round: Firefox's UA stylesheet sets `user-select: none`
+            // on <button> (Chromium's default is `auto`, which does not block
+            // selection) — a plain <div> defaults to `auto` in every engine, so
+            // this regressed statement-text selection/copy specifically in
+            // Firefox when this control became a <button>. `select-text`
+            // overrides the UA default explicitly.
+            //
+            // A computed-style or real drag-select assertion is NOT expressible
+            // here: happy-dom (this project's test environment, see
+            // vitest.config.ts) loads no stylesheet at all, UA or Tailwind —
+            // verified directly, `getComputedStyle(button).userSelect` reads
+            // `''` for a bare <button> AND for one with the `select-text`
+            // class, in this environment, always. An assertion against
+            // computed style here could never fail, which is worse than no
+            // assertion — it would look like coverage without being any. The
+            // only thing checkable in this environment is that the class
+            // making the override is actually present on the shipped element;
+            // the cross-engine behavior itself was verified live (headless
+            // Chromium here, Firefox by the reviewer) outside the test suite.
+            it('carries select-text, overriding the Firefox UA default that would block copying statement text', () => {
+                renderEditor();
+
+                const editControl = screen.getByRole('button', { name: 'Existing Statement' });
+                expect(editControl).toHaveClass('select-text');
             });
         });
 

--- a/frontend/src/components/admin/designer/QSortEditor.test.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.test.tsx
@@ -178,6 +178,17 @@ describe('QSortEditor', () => {
             expect(screen.queryByText('Existing Statement')).not.toBeInTheDocument();
         });
 
+        it('renders the delete-statement icon at a legible contrast (Task 6.7d)', () => {
+            renderEditor();
+
+            const statementItem = screen.getByText('Existing Statement').closest('.group');
+            expect(statementItem).toBeInTheDocument();
+            // biome-ignore lint/style/noNonNullAssertion: test setup
+            const deleteButton = within(statementItem!).getByRole('button', { name: 'Delete' });
+            expect(deleteButton).toHaveClass('text-slate-500');
+            expect(deleteButton).not.toHaveClass('text-slate-300');
+        });
+
         it('names the save/cancel controls by the statement code being edited (Task 6.7c)', async () => {
             const user = userEvent.setup();
             renderEditor();
@@ -186,6 +197,35 @@ describe('QSortEditor', () => {
 
             expect(screen.getByRole('button', { name: 'Save s1' })).toBeInTheDocument();
             expect(screen.getByRole('button', { name: 'Cancel editing s1' })).toBeInTheDocument();
+        });
+
+        describe('click-to-edit control is a real, keyboard-operable button (Task 6.7d)', () => {
+            it('is a native <button> with no hand-rolled role/tabIndex, and enters edit mode on Enter', async () => {
+                const user = userEvent.setup();
+                renderEditor();
+
+                const editControl = screen.getByRole('button', { name: 'Existing Statement' });
+                expect(editControl.tagName).toBe('BUTTON');
+                expect(editControl).not.toHaveAttribute('role');
+                expect(editControl).not.toHaveAttribute('tabindex');
+
+                editControl.focus();
+                await user.keyboard('{Enter}');
+
+                expect(screen.getByRole('button', { name: 'Save s1' })).toBeInTheDocument();
+            });
+
+            it('is disabled (not just visually muted) when the editor is read-only', () => {
+                renderWithStore(
+                    <TooltipProvider>
+                        <QSortEditor readOnly />
+                    </TooltipProvider>,
+                    { initialState: { draft: mockDraft, activeLocale: 'en' } }
+                );
+
+                const editControl = screen.getByRole('button', { name: 'Existing Statement' });
+                expect(editControl).toBeDisabled();
+            });
         });
 
         it('clears all statements with confirmation', async () => {

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -204,31 +204,22 @@ function SortableStatementItem({
                 </>
             ) : (
                 <>
-                    <div
-                        role="button"
-                        tabIndex={0}
+                    <button
+                        type="button"
+                        disabled={readOnly}
                         className={cn(
-                            'flex-1 px-3 py-2 rounded-xl transition-all font-medium text-slate-700 leading-normal',
+                            'flex-1 block w-full text-left px-3 py-2 rounded-xl transition-all font-medium text-slate-700 leading-normal',
                             !readOnly ? 'cursor-text hover:bg-slate-50' : 'cursor-default'
                         )}
                         onClick={() => {
-                            if (readOnly) return;
                             setEditingId(item.code);
                             setEditingText(item.text);
                             setEditingCode(item.code);
                         }}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                                setEditingId(item.code);
-                                setEditingText(item.text);
-                                setEditingCode(item.code);
-                                e.preventDefault();
-                            }
-                        }}
                         title={t('admin.components.click_to_edit')}
                     >
                         {item.text}
-                    </div>
+                    </button>
                     {staleInfo && !readOnly && !structureLocked && (
                         <TooltipProvider>
                             <Tooltip>
@@ -295,7 +286,7 @@ function SortableStatementItem({
                                 });
                             }}
                             aria-label={t('common.delete', 'Delete')}
-                            className="h-9 w-9 text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-xl opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-all"
+                            className="h-9 w-9 text-slate-500 hover:text-red-500 hover:bg-red-50 rounded-xl opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-all"
                         >
                             <Trash2 className="h-4 w-4" />
                         </Button>

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -206,12 +206,24 @@ function SortableStatementItem({
                 <>
                     <button
                         type="button"
-                        disabled={readOnly}
+                        aria-disabled={readOnly}
                         className={cn(
                             'flex-1 block w-full text-left select-text px-3 py-2 rounded-xl transition-all font-medium text-slate-700 leading-normal',
                             !readOnly ? 'cursor-text hover:bg-slate-50' : 'cursor-default'
                         )}
                         onClick={() => {
+                            // A native `disabled` button blocks the mouse
+                            // events a text-selection drag needs, in every
+                            // browser, regardless of `user-select` — so
+                            // read-only inertness is enforced here instead
+                            // (the guard the original <div> already had),
+                            // keeping the element focusable and its text
+                            // selectable/copyable while a study is
+                            // collecting. `aria-disabled` communicates the
+                            // non-operability to assistive tech; Enter/Space
+                            // route through this same onClick, so both are
+                            // inert too.
+                            if (readOnly) return;
                             setEditingId(item.code);
                             setEditingText(item.text);
                             setEditingCode(item.code);

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -136,7 +136,7 @@ function SortableStatementItem({
                 <div
                     {...attributes}
                     {...listeners}
-                    className="cursor-grab active:cursor-grabbing text-slate-300 hover:text-indigo-600 transition-colors p-1 hover:bg-indigo-50 rounded-lg"
+                    className="cursor-grab active:cursor-grabbing text-slate-500 hover:text-indigo-600 transition-colors p-1 hover:bg-indigo-50 rounded-lg"
                 >
                     <GripVertical className="h-4 w-4" />
                 </div>
@@ -208,7 +208,7 @@ function SortableStatementItem({
                         type="button"
                         disabled={readOnly}
                         className={cn(
-                            'flex-1 block w-full text-left px-3 py-2 rounded-xl transition-all font-medium text-slate-700 leading-normal',
+                            'flex-1 block w-full text-left select-text px-3 py-2 rounded-xl transition-all font-medium text-slate-700 leading-normal',
                             !readOnly ? 'cursor-text hover:bg-slate-50' : 'cursor-default'
                         )}
                         onClick={() => {

--- a/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
@@ -356,4 +356,40 @@ describe('QuestionBuilder — action-button accessible names (Task 6.7c)', () =>
         expect(screen.getByRole('button', { name: 'Remove Option 1' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Remove Option 2' })).toBeInTheDocument();
     });
+
+    it('renders the delete/import/remove-option icons at a legible contrast (Task 6.7d)', async () => {
+        const user = userEvent.setup();
+        renderBuilder({
+            draft: {
+                translations: [{ language_code: 'en' }, { language_code: 'fr' }],
+                postsort_config: {
+                    questions: {
+                        q1: {
+                            type: 'select',
+                            label: 'Pick one',
+                            required: false,
+                            options: ['Alpha', 'Beta'],
+                        },
+                    },
+                },
+            },
+        });
+
+        const deleteButton = screen.getByRole('button', { name: 'Delete Pick one' });
+        expect(deleteButton).toHaveClass('text-slate-500');
+        expect(deleteButton).not.toHaveClass('text-slate-300');
+
+        const importButton = screen.getByRole('button', {
+            name: 'Import Pick one from another language',
+        });
+        expect(importButton).toHaveClass('text-slate-500');
+        expect(importButton).not.toHaveClass('text-slate-300');
+
+        const trigger = await screen.findByTestId('question-accordion-trigger');
+        await user.click(trigger);
+
+        const removeOption = screen.getByRole('button', { name: 'Remove Option 1' });
+        expect(removeOption).toHaveClass('text-slate-500');
+        expect(removeOption).not.toHaveClass('text-slate-300');
+    });
 });

--- a/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
@@ -300,6 +300,27 @@ describe('QuestionBuilder — action-button accessible names (Task 6.7c)', () =>
         expect(screen.getByRole('button', { name: 'Delete First question' })).toBeInTheDocument();
     });
 
+    it('renders the drag-handle icon at a legible contrast (review fix-round, Task 6.7d)', () => {
+        renderBuilder({
+            draft: {
+                postsort_config: {
+                    questions: {
+                        q1: { type: 'text', label: 'First question', required: false },
+                    },
+                },
+            },
+        });
+
+        const item = screen.getByTestId('question-item');
+        // dnd-kit's useSortable spreads {...attributes} onto this div, which
+        // injects role="button" — no accessible name, so it's found by class
+        // rather than by role+name.
+        const dragHandle = item.querySelector('.cursor-grab');
+        expect(dragHandle).not.toBeNull();
+        expect(dragHandle).toHaveClass('text-slate-500');
+        expect(dragHandle).not.toHaveClass('text-slate-300');
+    });
+
     it('discriminates the "import from another language" trigger by the question label', () => {
         renderBuilder({
             draft: {

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -274,7 +274,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                     <Button
                                                         variant="ghost"
                                                         size="icon"
-                                                        className="h-9 w-9 text-slate-300 hover:text-indigo-600 hover:bg-indigo-50 rounded-xl transition-all"
+                                                        className="h-9 w-9 text-slate-500 hover:text-indigo-600 hover:bg-indigo-50 rounded-xl transition-all"
                                                         onClick={(e) => e.stopPropagation()}
                                                         aria-label={t(
                                                             'admin.design.questions.actions.copy_from_aria',
@@ -309,7 +309,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                         <Button
                                             variant="ghost"
                                             size="icon"
-                                            className="h-9 w-9 text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all"
+                                            className="h-9 w-9 text-slate-500 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all"
                                             onClick={(e) => {
                                                 e.stopPropagation();
                                                 onDelete();
@@ -889,7 +889,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                         <Button
                                                             variant="ghost"
                                                             size="icon"
-                                                            className="h-10 w-10 text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all border border-transparent hover:border-red-100"
+                                                            className="h-10 w-10 text-slate-500 hover:text-red-500 hover:bg-red-50 rounded-xl transition-all border border-transparent hover:border-red-100"
                                                             aria-label={t(
                                                                 'admin.design.questions.actions.remove_option',
                                                                 'Remove {{option}}',

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -210,7 +210,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                     <div
                         {...attributes}
                         {...listeners}
-                        className="mt-1 cursor-grab active:cursor-grabbing text-slate-300 hover:text-indigo-600 transition-colors p-1 hover:bg-indigo-50 rounded-lg"
+                        className="mt-1 cursor-grab active:cursor-grabbing text-slate-500 hover:text-indigo-600 transition-colors p-1 hover:bg-indigo-50 rounded-lg"
                     >
                         <GripVertical className="h-5 w-5" />
                     </div>

--- a/frontend/src/layouts/StudyLayout.tsx
+++ b/frontend/src/layouts/StudyLayout.tsx
@@ -598,7 +598,7 @@ const StudyLayoutContent: React.FC = () => {
                                            w-8 h-8 shrink-0 rounded-full flex items-center justify-center border-2 transition-all duration-300 hover:scale-105
                                            ${
                                                status === 'upcoming' && !isReachable
-                                                   ? 'bg-slate-50 text-slate-300 cursor-not-allowed pointer-events-none'
+                                                   ? 'bg-slate-50 cursor-not-allowed pointer-events-none'
                                                    : 'cursor-pointer shadow-sm'
 }
                                        `}


### PR DESCRIPTION
## Summary

Task 6.7d — contrast and role hygiene, against the gate landed in #326. **Takes the gate to a true zero: `0 unnamed controls, 0 low-contrast controls, 0 label errors`.**

## Changes

**13 controls at 1.45:1 → 4.76:1.** `text-slate-300` on white against a 4.5:1 threshold, on delete buttons, remove-option icons, sort indicators and drag handles across `InteractiveDataView.columns`, `QuestionBuilder`, `QSortEditor`, `ProcessStepEditor`, `InterfaceEditor`, `BrandingEditor` and `AnalysisHistoryPanel`.

**Four `role="button"` + `tabIndex={0}` divs converted** — the hand-rolled pattern a previous phase replaced with native buttons on the dashboard. One deviation: `ImportFromConcourseDialog`'s row became a `<label>`, not a `<button>`, because it already contained an interactive `Checkbox` — nesting controls would have double-toggled. Verified in Chromium *and* Firefox that the label forwards exactly one activation, and that drag-selecting the row text no longer toggles the checkbox, which a button wrapper would have done.

**A dead class deleted** in `StudyLayout` that an unconditional inline `style` overrode in every state — proven, not assumed. Leaving it would have pinned the gate at 1 forever, which trains people to ignore the number.

`StudyStatusControl`'s tile is a real fix, not cosmetic: it had `role="button"` and `tabIndex={0}` but **no `onKeyDown`** — announced as a button, inert to Enter.

## The regression this task introduced, and how it was caught

Converting the clickable div to a native `<button>` at `QSortEditor` made **statement text unselectable while a study is collecting data**. A `:disabled` element receives no mouse events in any engine, and `readOnly` set `disabled`. The original `<div>` had used an `if (readOnly) return;` guard, which left the text selectable — we replaced an application-level guard with a browser mechanism and inherited its side effects.

That state is exactly when researchers read and quote their statements.

Review proved the severity with a pixel-faithful reproduction driven by trusted input — drag-select, triple-click and double-click-then-shift all failed, **8 runs out of 8** — and blocked the merge. Fixed with `aria-disabled` plus the restored guard: inert to click and Enter, still focusable, text selectable again. Re-review then drove **real Firefox 151** via Playwright against a fixture built from a real `vite build`'s compiled Tailwind: all three gestures work in both engines, tab order intact, no visual regression.

**Worth stating plainly:** the gate read `0 unnamed, 0 low-contrast, 0 label errors` at the exact moment a researcher had lost the ability to copy their own statement text. A dashboard zero reports what the tool counts.

## Checklist

- [ ] `make ci` passes locally — **frontend green (192 files / 1676 tests, biome + tsc clean, gate at true zero); backend `pytest` fails on a local Postgres credential issue reproducing identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — every contrast test pairs the class assertion with an operability assertion, which is the defence against a class-name shell game. The keyboard conversions assert focus → Enter → effect.
- [x] Translation keys added to all locales — no user-facing strings changed.
- [x] API client regenerated if backend schemas changed — not applicable.

## Recorded, not fixed

Three drag handles were at 1.45:1 forty pixels from the delete buttons this task was fixing, and the gate reported zero throughout: they are `<div>`s made interactive by dnd-kit's spread, and the gate's checks are tag-based. They are fixed here, but the blind spot is not — that is Task 6.7h in the plan.

It is the third shape of one structural problem: `<input>` is not in the name-bearing set (found in 6.7c), a *named* button is axe-clean (6.7g), and a role-bearing div is in neither. Each time, the instrument certified a surface it could not see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)