### PR TITLE
test(a11y): run axe against the admin at both breakpoints

### DIFF
--- a/frontend/e2e/accessibility/admin-pages.spec.ts
+++ b/frontend/e2e/accessibility/admin-pages.spec.ts
@@ -1,0 +1,224 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/db-setup';
+import { gridConfig23, testDataBuilders } from '../fixtures/test-data';
+import { expectNoA11yViolations } from './rules';
+
+/**
+ * E2E: admin accessibility smoke (task 6.7e)
+ *
+ * `public-pages.spec.ts` covers two pages that never carried an unnamed control or a
+ * `text-slate-300` on white. The admin is where every defect in the 6.7 remediation
+ * chain actually lived, and until this file it carried no axe coverage at all — task
+ * 6.7a measured the backlog and named the gap; 6.7b-d and 6.7f cleared what the
+ * static gate (`npm run lint:a11y`) can see. This file adds the runtime check that
+ * sees the rest: axe computes the rendered accessible name, so it sees through Radix
+ * `asChild`, resolves `<SelectValue>`, honours `display:none`, and computes real
+ * contrast ratios instead of matching one banned class string.
+ *
+ * Run at two widths, not one. Task 6.7a found a control — the study designer's
+ * language switcher — whose only visible text sits in a `hidden sm:inline` span:
+ * named above the `sm` breakpoint (640px), nameless below it. A desktop-only axe run
+ * cannot see that; `display:none` is a rendering fact axe evaluates live. That defect
+ * is fixed in the same commit as this spec (StudyDesignPage.tsx) — this file is what
+ * caught it.
+ *
+ * Coverage boundary — what a green run here does and does not prove:
+ *   - Seven routes, matching the brief exactly: project dashboard, the concourse (its
+ *     detail page — `ConcourseListPage` only ever auto-creates one and redirects to
+ *     it, so there is nothing else to visit), and five study-scoped pages: design,
+ *     access (recruitment), data, analysis, settings.
+ *   - NOT covered: study overview (the study-scope landing page), data privacy,
+ *     project settings, project members, account settings, the superuser admin-users
+ *     page, create-project, participant detail, or any dialog/sheet/modal opened by
+ *     interacting with these pages — axe only sees the DOM as first loaded.
+ *   - Study design is audited in **draft** state, deliberately. An active, paused, or
+ *     closed study opens a blocking `Dialog` on load (`isFullyReadOnly`); axe would
+ *     then see only the dialog's own content, because Radix marks the rest of the
+ *     page `aria-hidden` while a dialog is open. The QuestionBuilder /
+ *     IntroductionEditor / BrandingEditor tree — where most of the 6.7a-c backlog
+ *     lived — would go entirely unscanned in any other state.
+ *   - Analysis is audited in its default **Explore** phase (scree plot + run button),
+ *     the same state `analysis-workflow.spec.ts`'s smoke test renders. The Interpret
+ *     phase (loadings/arrays/statements tabs) only exists after a run is committed;
+ *     that spec exercises it functionally, but no axe pass covers it.
+ *   - axe cannot see everything even on the pages it does visit. It will not flag a
+ *     *named* control that should not be a tab stop at all — the Data table's seven
+ *     status chips per row are exactly that case (task 6.7g): correctly named,
+ *     axe-clean, and still up to 175 phantom tab stops on a full page. A rule that
+ *     checks names cannot fail on a control that already has one.
+ */
+
+test.setTimeout(120_000);
+
+const MOBILE_VIEWPORT = { width: 375, height: 800 };
+
+/**
+ * Runs the smoke rule set at the project's default desktop viewport, then again at
+ * 375px. `waitReady` is re-run after the resize (rather than a fixed sleep) because
+ * the defect this spec exists to catch — a name that only exists above `sm` — only
+ * disappears once the browser has actually reflowed at the new width; a locator wait
+ * is the honest way to wait for that, a timeout would just be hoping it's enough.
+ */
+async function auditAtBothWidths(page: Page, waitReady: () => Promise<unknown>) {
+    await waitReady();
+    await expectNoA11yViolations(page);
+
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await waitReady();
+    await expectNoA11yViolations(page);
+}
+
+test.describe('Admin accessibility', () => {
+    test('project dashboard', async ({ page, testDb, authToken }) => {
+        await testDb.createStudy(
+            authToken,
+            testDataBuilders.study({ slug: `a11y-dash-${Date.now()}`, state: 'active' })
+        );
+
+        // loginToAdminUI navigates to /app/{slug}/dashboard itself.
+        await testDb.loginToAdminUI(page);
+
+        await auditAtBothWidths(page, async () => {
+            await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+            // The project title resolves before the studies list query does — wait
+            // for the seeded study's own card (its default title, per
+            // testDataBuilders.study) rather than just the page header, so the
+            // scan covers the card content — where the study-state badge and
+            // metadata row live — instead of racing ahead of it.
+            await expect(page.getByText('Test Study')).toBeVisible();
+        });
+    });
+
+    test('concourse detail', async ({ page, testDb, authToken }) => {
+        // ConcourseListPage (the sidebar's "Concourse" link) has no content of its
+        // own — it auto-creates the project's one concourse and redirects to its
+        // detail page. Seeding it directly gives a deterministic URL instead of
+        // depending on that client-side redirect's timing.
+        const concourse = await testDb.createConcourse(authToken);
+        await testDb.loginToAdminUI(page);
+        const projectSlug = testDb.getWorkspaceSlug();
+        await page.goto(`/app/${projectSlug}/concourses/${concourse.id}`);
+
+        await auditAtBothWidths(page, () =>
+            expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+        );
+    });
+
+    test('study design (draft)', async ({ page, testDb, authToken }) => {
+        // Draft, deliberately — see the file header. A non-draft study replaces the
+        // whole editor with a blocking lock dialog on load, which would leave the
+        // designer panels this suite most needs to reach entirely unscanned.
+        const study = (await testDb.createStudy(
+            authToken,
+            testDataBuilders.study({ slug: `a11y-design-${Date.now()}` })
+        )) as { slug: string };
+        await testDb.loginToAdminUI(page);
+        const projectSlug = testDb.getWorkspaceSlug();
+        await page.goto(`/app/${projectSlug}/studies/${study.slug}/design`);
+
+        await auditAtBothWidths(page, async () => {
+            await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+            // The control task 6.7a found nameless below `sm` — waiting on it also
+            // means the toolbar (and not just the loading skeleton) is on screen.
+            await expect(page.getByRole('button', { name: 'Select language' })).toBeVisible();
+        });
+    });
+
+    test('access (recruitment)', async ({ page, testDb, authToken }) => {
+        const study = (await testDb.createStudy(
+            authToken,
+            testDataBuilders.study({
+                slug: `a11y-access-${Date.now()}`,
+                statements: testDataBuilders.statements(23),
+                grid_config: gridConfig23,
+                state: 'active',
+            })
+        )) as { slug: string };
+        await testDb.loginToAdminUI(page);
+        const projectSlug = testDb.getWorkspaceSlug();
+        await page.goto(`/app/${projectSlug}/studies/${study.slug}/recruitment`);
+
+        await auditAtBothWidths(page, () =>
+            expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+        );
+    });
+
+    test('data', async ({ page, testDb, authToken }) => {
+        const study = (await testDb.createStudy(
+            authToken,
+            testDataBuilders.study({
+                slug: `a11y-data-${Date.now()}`,
+                statements: testDataBuilders.statements(23),
+                grid_config: gridConfig23,
+                state: 'active',
+            })
+        )) as { slug: string };
+        // A couple of real rows — the empty state and the populated table are
+        // different DOM shapes, and the populated one is where the Data table's
+        // status-chip cells (task 6.7g's target, not this task's) actually render.
+        await Promise.all(
+            Array.from({ length: 2 }, () =>
+                testDb.createParticipant(
+                    authToken,
+                    study.slug,
+                    testDataBuilders.participantResult({})
+                )
+            )
+        );
+        await testDb.loginToAdminUI(page);
+        const projectSlug = testDb.getWorkspaceSlug();
+        await page.goto(`/app/${projectSlug}/studies/${study.slug}/data`);
+
+        await auditAtBothWidths(page, async () => {
+            await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+            await expect(page.locator('table')).toBeVisible();
+        });
+    });
+
+    test('analysis', async ({ page, testDb, authToken }) => {
+        const study = (await testDb.createStudy(
+            authToken,
+            testDataBuilders.study({
+                slug: `a11y-analysis-${Date.now()}`,
+                statements: testDataBuilders.statements(23),
+                grid_config: gridConfig23,
+                state: 'active',
+            })
+        )) as { slug: string };
+        // Enough completed sorts for eigenvalues to compute — matches the fixture
+        // count analysis-workflow.spec.ts's own smoke test uses for the same reason.
+        await Promise.all(
+            Array.from({ length: 5 }, () =>
+                testDb.createParticipant(
+                    authToken,
+                    study.slug,
+                    testDataBuilders.participantResult({})
+                )
+            )
+        );
+        await testDb.loginToAdminUI(page);
+        const projectSlug = testDb.getWorkspaceSlug();
+        await page.goto(`/app/${projectSlug}/studies/${study.slug}/analysis`);
+
+        await auditAtBothWidths(page, async () => {
+            await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+            await expect(page.locator('[aria-label*="Scree plot"]')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+    });
+
+    test('study settings', async ({ page, testDb, authToken }) => {
+        const study = (await testDb.createStudy(
+            authToken,
+            testDataBuilders.study({ slug: `a11y-settings-${Date.now()}` })
+        )) as { slug: string };
+        await testDb.loginToAdminUI(page);
+        const projectSlug = testDb.getWorkspaceSlug();
+        await page.goto(`/app/${projectSlug}/studies/${study.slug}/settings`);
+
+        await auditAtBothWidths(page, () =>
+            expect(page.getByRole('heading', { level: 1 })).toBeVisible()
+        );
+    });
+});

--- a/frontend/e2e/accessibility/admin-pages.spec.ts
+++ b/frontend/e2e/accessibility/admin-pages.spec.ts
@@ -53,6 +53,30 @@ test.setTimeout(120_000);
 const MOBILE_VIEWPORT = { width: 375, height: 800 };
 
 /**
+ * Every one of these pages wraps its content in Tailwind's `animate-in fade-in`
+ * (`tailwindcss-animate`), typically `duration-500`/`duration-700`, sometimes nested
+ * (a card inside the page's own fade-in animating a second time on top). Playwright's
+ * `toBeVisible()` does not wait out a CSS transition — an element mid-fade already has
+ * a bounding box and non-zero opacity, so it satisfies "visible" well before the
+ * animation settles. axe's `color-contrast`, in contrast, reads the *actual* computed
+ * opacity at scan time, so scanning mid-fade measures a foreground blended toward the
+ * background and reports a spuriously low ratio for a color that is fine once settled
+ * — confirmed by reproducing it: the same route audited with a generous fixed wait
+ * instead of `waitReady()` alone comes back clean. `public-pages.spec.ts` already hits
+ * this on the login page's fade-in and waits it out with a single
+ * `toHaveCSS('opacity', '1')` on the one container that animates there; the admin
+ * pages routinely animate several independent elements (the page shell, individual
+ * `GuidanceCard`s, dashboard cards), so this waits out every `.animate-in` element
+ * still short of full opacity instead of hardcoding one selector per route.
+ */
+async function waitForAnimationsToSettle(page: Page) {
+    await page.waitForFunction(() => {
+        const animating = document.querySelectorAll('.animate-in');
+        return Array.from(animating).every((el) => getComputedStyle(el).opacity === '1');
+    });
+}
+
+/**
  * Runs the smoke rule set at the project's default desktop viewport, then again at
  * 375px. `waitReady` is re-run after the resize (rather than a fixed sleep) because
  * the defect this spec exists to catch — a name that only exists above `sm` — only
@@ -61,10 +85,12 @@ const MOBILE_VIEWPORT = { width: 375, height: 800 };
  */
 async function auditAtBothWidths(page: Page, waitReady: () => Promise<unknown>) {
     await waitReady();
+    await waitForAnimationsToSettle(page);
     await expectNoA11yViolations(page);
 
     await page.setViewportSize(MOBILE_VIEWPORT);
     await waitReady();
+    await waitForAnimationsToSettle(page);
     await expectNoA11yViolations(page);
 }
 
@@ -169,10 +195,15 @@ test.describe('Admin accessibility', () => {
         const projectSlug = testDb.getWorkspaceSlug();
         await page.goto(`/app/${projectSlug}/studies/${study.slug}/data`);
 
-        await auditAtBothWidths(page, async () => {
-            await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
-            await expect(page.locator('table')).toBeVisible();
-        });
+        // Anchored on the table, not a heading: DataExportsPage renders
+        // StudyPageHeader's <h1> only in its zero-participant branch, so with
+        // participants seeded (as here) a heading-based wait would time out
+        // before axe ever runs — the table is the one thing guaranteed to exist
+        // in this seeded state. (page-has-heading-one is still checked — by axe
+        // itself, against the <h1> InteractiveDataView now provides; a locator
+        // wait on it here would just be re-asserting what the scan below
+        // already verifies.)
+        await auditAtBothWidths(page, () => expect(page.locator('table')).toBeVisible());
     });
 
     test('analysis', async ({ page, testDb, authToken }) => {

--- a/frontend/e2e/accessibility/admin-pages.spec.ts
+++ b/frontend/e2e/accessibility/admin-pages.spec.ts
@@ -70,9 +70,38 @@ const MOBILE_VIEWPORT = { width: 375, height: 800 };
  * still short of full opacity instead of hardcoding one selector per route.
  */
 async function waitForAnimationsToSettle(page: Page) {
+    type SettleState = { __a11yLastAnimateInCount?: number; __a11yStableTicks?: number };
+
+    // Reset the stability counters below before each call — this helper runs twice
+    // per test (once at desktop, once after the mobile resize) and each pass needs
+    // its own count, not one carried over from the previous viewport.
+    await page.evaluate(() => {
+        const state = window as unknown as SettleState;
+        state.__a11yLastAnimateInCount = -1;
+        state.__a11yStableTicks = 0;
+    });
+
     await page.waitForFunction(() => {
+        const state = window as unknown as SettleState;
         const animating = document.querySelectorAll('.animate-in');
-        return Array.from(animating).every((el) => getComputedStyle(el).opacity === '1');
+        const allSettled = Array.from(animating).every(
+            (el) => getComputedStyle(el).opacity === '1'
+        );
+
+        // `Array.every` on an empty NodeList returns `true` — a poll landing before
+        // any `.animate-in` element has mounted would otherwise resolve immediately
+        // and wait for nothing (the investigation named this hazard explicitly:
+        // `.animate-in` count was 0 at scan time on 4 of 7 routes it measured).
+        // Require the element count to be unchanged across two consecutive polls
+        // before trusting an empty-or-settled result: that rules out "polled before
+        // mount" while still resolving normally on routes that never render an
+        // `.animate-in` element at all (the count stabilises at 0 there too).
+        const count = animating.length;
+        state.__a11yStableTicks =
+            count === state.__a11yLastAnimateInCount ? (state.__a11yStableTicks ?? 0) + 1 : 0;
+        state.__a11yLastAnimateInCount = count;
+
+        return allSettled && state.__a11yStableTicks >= 2;
     });
 }
 

--- a/frontend/e2e/accessibility/public-pages.spec.ts
+++ b/frontend/e2e/accessibility/public-pages.spec.ts
@@ -1,51 +1,5 @@
-import AxeBuilder from '@axe-core/playwright';
-import { expect, test, type Page } from '@playwright/test';
-
-/**
- * Structure and contrast. `color-contrast` computes real ratios, which is what the
- * static gate (`npm run lint:a11y`) cannot do — it only bans one literal class.
- */
-const STRUCTURE_RULES = [
-    'color-contrast',
-    'heading-order',
-    'landmark-no-duplicate-main',
-    'landmark-one-main',
-    'page-has-heading-one',
-    'region',
-];
-
-/**
- * Accessible names, computed from the rendered DOM.
- *
- * This is the half of the accessible-name problem no static checker reaches: axe sees
- * through Radix `asChild`, resolves `<SelectValue>` to the text actually rendered,
- * honours the `title` fallback, and respects `display:none` — so a name that only
- * exists above the `sm` breakpoint fails here and nowhere else.
- *
- * Admin pages are not covered yet: they still carry the backlog measured by task 6.7a
- * (see scripts/a11y-baseline.json). Extending these rules to the admin is task 6.7e,
- * once 6.7b–d have cleared it.
- */
-const NAME_RULES = [
-    'aria-command-name',
-    'aria-input-field-name',
-    'aria-toggle-field-name',
-    'button-name',
-    'image-alt',
-    'input-button-name',
-    'input-image-alt',
-    'label',
-    'link-name',
-    'select-name',
-];
-
-const PUBLIC_PAGE_RULES = [...STRUCTURE_RULES, ...NAME_RULES];
-
-async function expectNoPublicPageA11yViolations(page: Page) {
-    const results = await new AxeBuilder({ page }).withRules(PUBLIC_PAGE_RULES).analyze();
-
-    expect(results.violations).toEqual([]);
-}
+import { expect, test } from '@playwright/test';
+import { expectNoA11yViolations } from './rules';
 
 test.describe('Public page accessibility', () => {
     test('landing page has no public Axe smoke violations', async ({ page }) => {
@@ -55,7 +9,7 @@ test.describe('Public page accessibility', () => {
         await expect(page.locator('#study-code')).toBeVisible();
         await expect(page.getByRole('button')).toBeVisible();
 
-        await expectNoPublicPageA11yViolations(page);
+        await expectNoA11yViolations(page);
     });
 
     test('login page has no public Axe smoke violations', async ({ page }) => {
@@ -68,6 +22,6 @@ test.describe('Public page accessibility', () => {
         await page.locator('#email').fill('researcher@example.com');
         await page.locator('#password').fill('correct horse battery staple');
 
-        await expectNoPublicPageA11yViolations(page);
+        await expectNoA11yViolations(page);
     });
 });

--- a/frontend/e2e/accessibility/rules.ts
+++ b/frontend/e2e/accessibility/rules.ts
@@ -41,5 +41,11 @@ export const SMOKE_RULES = [...STRUCTURE_RULES, ...NAME_RULES];
 export async function expectNoA11yViolations(page: Page) {
     const results = await new AxeBuilder({ page }).withRules(SMOKE_RULES).analyze();
 
+    // Only `violations` is asserted. `results.incomplete` — checks axe could not decide
+    // automatically (e.g. `color-contrast` over a background gradient or an image, where
+    // it cannot compute a single foreground/background pair) — is silently dropped, so
+    // this spec would pass over such a case rather than flag it for manual review. None
+    // of the routes audited here are known to have one today, but it's a real gap in
+    // what a green run proves, not a hypothetical one.
     expect(results.violations).toEqual([]);
 }

--- a/frontend/e2e/accessibility/rules.ts
+++ b/frontend/e2e/accessibility/rules.ts
@@ -1,0 +1,45 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Structure and contrast. `color-contrast` computes real ratios, which is what the
+ * static gate (`npm run lint:a11y`) cannot do — it only bans one literal class.
+ */
+export const STRUCTURE_RULES = [
+    'color-contrast',
+    'heading-order',
+    'landmark-no-duplicate-main',
+    'landmark-one-main',
+    'page-has-heading-one',
+    'region',
+];
+
+/**
+ * Accessible names, computed from the rendered DOM.
+ *
+ * This is the half of the accessible-name problem no static checker reaches: axe sees
+ * through Radix `asChild`, resolves `<SelectValue>` to the text actually rendered,
+ * honours the `title` fallback, and respects `display:none` — so a name that only
+ * exists above the `sm` breakpoint fails here and nowhere else.
+ */
+export const NAME_RULES = [
+    'aria-command-name',
+    'aria-input-field-name',
+    'aria-toggle-field-name',
+    'button-name',
+    'image-alt',
+    'input-button-name',
+    'input-image-alt',
+    'label',
+    'link-name',
+    'select-name',
+];
+
+/** The rule set every page in this suite is checked against. */
+export const SMOKE_RULES = [...STRUCTURE_RULES, ...NAME_RULES];
+
+export async function expectNoA11yViolations(page: Page) {
+    const results = await new AxeBuilder({ page }).withRules(SMOKE_RULES).analyze();
+
+    expect(results.violations).toEqual([]);
+}

--- a/frontend/e2e/accessibility/rules.ts
+++ b/frontend/e2e/accessibility/rules.ts
@@ -44,8 +44,13 @@ export async function expectNoA11yViolations(page: Page) {
     // Only `violations` is asserted. `results.incomplete` — checks axe could not decide
     // automatically (e.g. `color-contrast` over a background gradient or an image, where
     // it cannot compute a single foreground/background pair) — is silently dropped, so
-    // this spec would pass over such a case rather than flag it for manual review. None
-    // of the routes audited here are known to have one today, but it's a real gap in
-    // what a green run proves, not a hypothetical one.
+    // this spec would pass over such a case rather than flag it for manual review. This
+    // is not hypothetical: instrumenting `results.incomplete` shows every route in this
+    // suite reports `color-contrast` incompletes (13 nodes on analysis desktop, 12
+    // mobile, 10 on data). Most are benign, but on the two chart routes (dashboard,
+    // analysis) recharts renders axis/legend text ("Factor", "Eigenvalue", date labels)
+    // as SVG text nodes axe reports as "background color could not be determined
+    // because element contains an image node" — so chart text contrast is never
+    // actually checked by a green run here.
     expect(results.violations).toEqual([]);
 }

--- a/frontend/e2e/fixtures/db-setup.ts
+++ b/frontend/e2e/fixtures/db-setup.ts
@@ -275,6 +275,38 @@ export class TestDatabase {
     }
 
     /**
+     * Create a concourse via API. `ConcourseListPage` auto-creates one and
+     * redirects to its detail page on first visit, so tests that want a
+     * deterministic URL (rather than waiting on that client-side redirect)
+     * seed it directly the same way `roles.spec.ts` does.
+     */
+    async createConcourse(token: string, title?: string) {
+        if (!this.workspaceId) {
+            throw new Error('Workspace ID not initialized. Did setup() run?');
+        }
+        const cleanBaseUrl = this.baseUrl.replace(/\/$/, '');
+        const response = await this.fetchWithRetry(`${cleanBaseUrl}/api/admin/concourses`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+                'X-Project-ID': this.workspaceId.toString(),
+            },
+            body: JSON.stringify({
+                title: title || `Test Concourse ${Date.now()}`,
+                description: null,
+            }),
+        });
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`Failed to create concourse: ${error}`);
+        }
+
+        return response.json() as Promise<{ id: number; title: string }>;
+    }
+
+    /**
      * Activate a study
      */
     async activateStudy(token: string, slug: string) {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -94,7 +94,29 @@ export default defineConfig({
         {
             name: 'Accessibility Smoke',
             testMatch: /accessibility\/.*\.spec\.ts/,
-            use: { ...devices['Desktop Chrome'] },
+            use: {
+                ...devices['Desktop Chrome'],
+                /*
+                 * Audit as a reduced-motion user sees the page (task 6.7e). Every admin
+                 * route wraps its content in a `tailwindcss-animate` entry fade
+                 * (`animate-in fade-in …`); axe's `color-contrast` reads the actual
+                 * computed opacity at scan time, so a scan that lands mid-fade measures a
+                 * foreground blended toward the background and reports a spuriously low
+                 * ratio for a color that is fine once settled. Investigation
+                 * (task-6.7e-animation-investigation.md) measured this directly: on the
+                 * worst route (study design, desktop) the committed spec's own
+                 * `waitForAnimationsToSettle()` still let axe run at ancestor opacity
+                 * 0.00, reporting 24 `color-contrast` violations; `reducedMotion: 'reduce'`
+                 * collapses that to 1 (the one real failure), matching the settled ground
+                 * truth exactly — deterministic (no polling race) and faster than waiting.
+                 * `src/index.css:209` already honours `prefers-reduced-motion`, so this
+                 * does not hide anything a real user with that OS preference would not
+                 * also see; it does not conceal a defect (no palette survives opacity 0 —
+                 * `text-slate-900` measures 4.35:1 mid-fade — so no color change could fix
+                 * this, confirming the artifact is in the scan timing, not the tokens).
+                 */
+                reducedMotion: 'reduce',
+            },
         },
     ],
 

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -67,7 +67,7 @@ const CARD_TITLE_BUTTON =
 function getStateColor(state: string | undefined): string {
     switch (state) {
         case 'active':
-            return 'bg-emerald-100 text-emerald-800 border-emerald-200';
+            return 'bg-emerald-100 text-emerald-700 border-emerald-200';
         case 'draft':
             return 'bg-slate-100 text-slate-700 border-slate-200';
         case 'paused':
@@ -572,7 +572,7 @@ function SingleStudyCard({
                                 </Badge>
                             </div>
                             {/* text-slate-600, not text-muted-foreground — see ConcourseCard above. */}
-                            <div className="flex items-center gap-3 mt-1.5 text-xs text-slate-600">
+                            <div className="flex items-center gap-3 mt-1.5 text-xs text-muted-foreground">
                                 {languageCodes && <span>{languageCodes}</span>}
                                 <span className="inline-flex items-center gap-1">
                                     <Users className="h-3 w-3" />

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -55,15 +55,17 @@ const CARD_SHELL =
 const CARD_TITLE_BUTTON =
     'block max-w-full truncate text-left cursor-pointer outline-none transition-colors group-hover:text-indigo-600 after:absolute after:inset-0 after:rounded-xl';
 
-// text-*-800 (text-*-700 for slate, which already clears the threshold with
-// margin to spare), not the original -700/-500 tier: axe (task 6.7e) measured
-// the rendered "Active" badge (bg-emerald-100/text-emerald-700) at 3.92:1 on
-// its own pastel background — below WCAG AA's 4.5:1 despite the nominal
-// Tailwind palette values computing closer to 4.8:1, so a thin margin here
-// reliably fails once rendered. Only 'active' was directly observed failing,
-// but all five branches share the same pastel-bg/700-text shape, so all five
-// get the same one-step-darker treatment rather than leaving four unverified
-// siblings on a shade already shown to be too light.
+// 'active' is back at emerald-100/text-emerald-700 (reverted — see the revert
+// commit). Task 6.7e originally darkened all five branches to -800 on the
+// strength of axe measuring the "Active" badge at 3.92:1 — below WCAG AA's
+// 4.5:1. A later investigation (task-6.7e-animation-investigation.md) found
+// that reading was an animation-scan artifact: axe ran while the dashboard's
+// entry fade was mid-transition. Settled, emerald-100/700 measures 4.83:1, a
+// clean pass. 'paused' and 'closed' are still one shade darker (-800) from
+// that same now-refuted fix; both would also pass at -700 (amber-100/700 =
+// 4.51, thin but passing; blue-100/700 = 5.49) but were left as-is rather
+// than churned in this pass. The palette is inconsistent across branches,
+// not incorrect — worth reverting for consistency in a follow-up.
 function getStateColor(state: string | undefined): string {
     switch (state) {
         case 'active':
@@ -420,14 +422,17 @@ function ConcourseCard({
                             </button>
                         </h2>
                         {/*
-                         * text-slate-600, not text-muted-foreground: axe (task 6.7e) measured the
-                         * theme's --muted-foreground token at 3.79-3.91:1 on white at this text-xs
-                         * size — below WCAG AA's 4.5:1 for normal text. The token itself is used
-                         * too widely across the admin (dozens of files) to retune here without a
-                         * dedicated visual-QA pass, so this fix is scoped to the instances of it
-                         * axe actually flagged on this page; see task 6.7e's report for the rest
-                         * of that finding. Same swap below, on the "Add study" button and the
-                         * study card's metadata row.
+                         * text-slate-600 here (not text-muted-foreground). Task 6.7e originally
+                         * swapped this because axe measured --muted-foreground at 3.79-3.91:1 on
+                         * white at this text-xs size during that run — below WCAG AA's 4.5:1. A
+                         * later investigation (task-6.7e-animation-investigation.md) found that
+                         * reading was an animation-scan artifact: axe ran while this page's entry
+                         * fade was mid-transition. Settled, text-muted-foreground on white measures
+                         * ~4.75:1 — a pass. The study card's metadata row below was reverted back
+                         * to text-muted-foreground for that reason; this hint text and the "Add
+                         * study" button below were left at text-slate-600 rather than churned back
+                         * — functionally equivalent (settled ~7.6:1), just not worth a second edit
+                         * for a token that already passes either way.
                          */}
                         <p className="text-xs text-slate-600 mt-0.5">
                             {concourse
@@ -571,7 +576,12 @@ function SingleStudyCard({
                                     )}
                                 </Badge>
                             </div>
-                            {/* text-slate-600, not text-muted-foreground — see ConcourseCard above. */}
+                            {/*
+                             * text-muted-foreground, not text-slate-600 (reverted — see the
+                             * ConcourseCard comment above). Settled measurement: ~4.75:1 on white,
+                             * a pass; the 3.79-3.91:1 that justified darkening this was an
+                             * animation-scan artifact, not a real defect.
+                             */}
                             <div className="flex items-center gap-3 mt-1.5 text-xs text-muted-foreground">
                                 {languageCodes && <span>{languageCodes}</span>}
                                 <span className="inline-flex items-center gap-1">

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -55,20 +55,29 @@ const CARD_SHELL =
 const CARD_TITLE_BUTTON =
     'block max-w-full truncate text-left cursor-pointer outline-none transition-colors group-hover:text-indigo-600 after:absolute after:inset-0 after:rounded-xl';
 
+// text-*-800 (text-*-700 for slate, which already clears the threshold with
+// margin to spare), not the original -700/-500 tier: axe (task 6.7e) measured
+// the rendered "Active" badge (bg-emerald-100/text-emerald-700) at 3.92:1 on
+// its own pastel background — below WCAG AA's 4.5:1 despite the nominal
+// Tailwind palette values computing closer to 4.8:1, so a thin margin here
+// reliably fails once rendered. Only 'active' was directly observed failing,
+// but all five branches share the same pastel-bg/700-text shape, so all five
+// get the same one-step-darker treatment rather than leaving four unverified
+// siblings on a shade already shown to be too light.
 function getStateColor(state: string | undefined): string {
     switch (state) {
         case 'active':
-            return 'bg-emerald-100 text-emerald-700 border-emerald-200';
+            return 'bg-emerald-100 text-emerald-800 border-emerald-200';
         case 'draft':
-            return 'bg-slate-100 text-slate-600 border-slate-200';
+            return 'bg-slate-100 text-slate-700 border-slate-200';
         case 'paused':
-            return 'bg-amber-100 text-amber-700 border-amber-200';
+            return 'bg-amber-100 text-amber-800 border-amber-200';
         case 'closed':
-            return 'bg-blue-100 text-blue-700 border-blue-200';
+            return 'bg-blue-100 text-blue-800 border-blue-200';
         case 'archived':
-            return 'bg-gray-100 text-gray-500 border-gray-200';
+            return 'bg-gray-100 text-gray-700 border-gray-200';
         default:
-            return 'bg-slate-100 text-slate-600 border-slate-200';
+            return 'bg-slate-100 text-slate-700 border-slate-200';
     }
 }
 
@@ -410,7 +419,17 @@ function ConcourseCard({
                                 {t('admin.concourse.title', 'Concourse')}
                             </button>
                         </h2>
-                        <p className="text-xs text-muted-foreground mt-0.5">
+                        {/*
+                         * text-slate-600, not text-muted-foreground: axe (task 6.7e) measured the
+                         * theme's --muted-foreground token at 3.79-3.91:1 on white at this text-xs
+                         * size — below WCAG AA's 4.5:1 for normal text. The token itself is used
+                         * too widely across the admin (dozens of files) to retune here without a
+                         * dedicated visual-QA pass, so this fix is scoped to the instances of it
+                         * axe actually flagged on this page; see task 6.7e's report for the rest
+                         * of that finding. Same swap below, on the "Add study" button and the
+                         * study card's metadata row.
+                         */}
+                        <p className="text-xs text-slate-600 mt-0.5">
                             {concourse
                                 ? t('admin.dashboard.concourse_n_items', {
                                       count: itemCount,
@@ -511,10 +530,11 @@ function SingleStudyCard({
                     </h2>
                 </div>
                 {onCreateStudy && (
+                    // text-slate-600, not text-muted-foreground — see ConcourseCard above.
                     <Button
                         variant="ghost"
                         size="sm"
-                        className="text-xs text-muted-foreground"
+                        className="text-xs text-slate-600"
                         onClick={onCreateStudy}
                     >
                         <Plus className="h-3 w-3 mr-1" />
@@ -551,7 +571,8 @@ function SingleStudyCard({
                                     )}
                                 </Badge>
                             </div>
-                            <div className="flex items-center gap-3 mt-1.5 text-xs text-muted-foreground">
+                            {/* text-slate-600, not text-muted-foreground — see ConcourseCard above. */}
+                            <div className="flex items-center gap-3 mt-1.5 text-xs text-slate-600">
                                 {languageCodes && <span>{languageCodes}</span>}
                                 <span className="inline-flex items-center gap-1">
                                     <Users className="h-3 w-3" />

--- a/frontend/src/components/admin/GuidanceCard.tsx
+++ b/frontend/src/components/admin/GuidanceCard.tsx
@@ -99,7 +99,16 @@ export const GuidanceCard: React.FC<GuidanceCardProps> = ({
                     {icons[type]}
                 </div>
                 <div className="space-y-1.5">
-                    <h4 className="text-base font-bold tracking-tight">{title}</h4>
+                    {/*
+                     * Not a real <h#> (task 6.7e). GuidanceCard is a decorative tip/info
+                     * callout, not document-outline content, and it is used at arbitrary
+                     * nesting depths across many pages — a hardcoded level (this was
+                     * `<h4>`) reliably skips a level wherever the surrounding page has no
+                     * heading between its own <h1>/<h2> and this card (axe: heading-order).
+                     * A plain paragraph with the same styling carries the same visual
+                     * weight without asserting a place in the outline.
+                     */}
+                    <p className="text-base font-bold tracking-tight">{title}</p>
                     {body}
                 </div>
             </div>

--- a/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
@@ -207,7 +207,11 @@ export function AnalysisHistoryPanel({
             {!collapsed && (
                 <div className="px-5 pb-5">
                     {runsQuery.isLoading && (
-                        <p className="text-xs text-slate-400 py-3">
+                        // text-slate-600, not -400 — axe (task 6.7e) measured text-slate-400
+                        // on white at 2.56:1. Same defect as AnalysisPage's loading states,
+                        // missed there because the check was scoped to the page file rather
+                        // than the whole component tree the analysis route mounts.
+                        <p className="text-xs text-slate-600 py-3">
                             {t('admin.analysis.history.loading', 'Loading history…')}
                         </p>
                     )}

--- a/frontend/src/components/admin/analysis/ExplorerPanel.tsx
+++ b/frontend/src/components/admin/analysis/ExplorerPanel.tsx
@@ -77,7 +77,15 @@ export function ExplorerPanel({ explore, advancedContent }: Props) {
                 <div className="lg:col-span-2">
                     <Accordion type="single" collapsible>
                         <AccordionItem value="advanced">
-                            <AccordionTrigger>
+                            {/*
+                             * The page's only other heading is StudyPageHeader's <h1> —
+                             * Radix's default <h3> here would skip <h2> entirely (axe:
+                             * heading-order, task 6.7e). This is the Accordion axe actually
+                             * flagged; AnalysisPage.tsx also declares one with the same
+                             * "advanced" value/title that turned out to be dead code — see
+                             * the task 6.7e report.
+                             */}
+                            <AccordionTrigger headingLevel={2}>
                                 {t(
                                     'admin.analysis.explore.advanced_title',
                                     'Advanced configuration'

--- a/frontend/src/components/admin/analysis/ScreePlot.tsx
+++ b/frontend/src/components/admin/analysis/ScreePlot.tsx
@@ -121,7 +121,8 @@ export function ScreePlot({
                 ))}
             </div>
 
-            <p className="text-xs text-slate-400 text-center">
+            {/* text-slate-600, not -400 — axe (task 6.7e) measured 2.56:1. */}
+            <p className="text-xs text-slate-600 text-center">
                 {t(
                     'admin.analysis.kaiser_suggestion',
                     '{{n}} factor(s) have eigenvalues above 1 (Kaiser criterion)',

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -183,9 +183,10 @@ export function ParticipantCell({
                 <TooltipProvider>
                     <Tooltip>
                         <TooltipTrigger>
+                            {/* text-amber-800, not -600 — axe (task 6.7e) measured 3.07:1. */}
                             <Badge
                                 variant="outline"
-                                className="h-4 text-2xs px-1.5 font-semibold bg-amber-50 text-amber-600 border-amber-200"
+                                className="h-4 text-2xs px-1.5 font-semibold bg-amber-50 text-amber-800 border-amber-200"
                             >
                                 {t('admin.data.table.duplicate_ip', 'Duplicate IP')} #
                                 {duplicateIpGroups.get(p.ip_address)}
@@ -413,11 +414,13 @@ export function buildColumns({
                             variant="outline"
                             className={cn(
                                 'h-5 text-2xs px-2 font-semibold border-none',
+                                // text-*-800, not -600/-500: axe (task 6.7e) measured
+                                // 3.07-3.84:1 on these -50 backgrounds, below 4.5:1.
                                 displayStatus === 'completed'
-                                    ? 'bg-emerald-50 text-emerald-600'
+                                    ? 'bg-emerald-50 text-emerald-800'
                                     : displayStatus === 'abandoned'
-                                      ? 'bg-rose-50 text-rose-500'
-                                      : 'bg-sky-50 text-sky-600'
+                                      ? 'bg-rose-50 text-rose-800'
+                                      : 'bg-sky-50 text-sky-800'
                             )}
                         >
                             {t(`admin.data.status.${displayStatus}`, displayStatus)}

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -247,6 +247,15 @@ export default function InteractiveDataView({
 
     return (
         <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-700">
+            {/*
+             * Sole page heading (task 6.7e). DataExportsPage renders StudyPageHeader's
+             * <h1> only in its zero-participant branch; once participants exist it
+             * renders this component instead, which had no <h1> of its own — the page
+             * has zero <h1>s once real data arrives (axe: page-has-heading-one). Same
+             * title as the empty-state StudyPageHeader, same sr-only-h1 pattern already
+             * used on StudyDesignPage for the identical reason.
+             */}
+            <h1 className="sr-only">{t('admin.data.title', 'Data')}</h1>
             {/* Section 1: Key indicators */}
             <CollapsibleSection
                 title={t('admin.data.sections.key_indicators', 'Key indicators')}

--- a/frontend/src/components/admin/dashboard/charts/DeviceBreakdownChart.tsx
+++ b/frontend/src/components/admin/dashboard/charts/DeviceBreakdownChart.tsx
@@ -120,7 +120,8 @@ export const DeviceBreakdownChart = ({ deviceBreakdown, className }: DeviceBreak
                                             <span className="text-sm font-bold text-slate-900">
                                                 {item.value}
                                             </span>
-                                            <span className="text-xs font-medium text-slate-400">
+                                            {/* text-slate-600, not -400 — axe (task 6.7e) measured 2.56:1. */}
+                                            <span className="text-xs font-medium text-slate-600">
                                                 {percentage}%
                                             </span>
                                         </div>

--- a/frontend/src/components/admin/dashboard/charts/SubmissionsTimelineChart.tsx
+++ b/frontend/src/components/admin/dashboard/charts/SubmissionsTimelineChart.tsx
@@ -108,11 +108,13 @@ export const SubmissionsTimelineChart = ({
                     {/*
                      * data-[state=inactive]:text-slate-600, not the inherited
                      * text-muted-foreground (task 6.7e): TabsList's own base class sets
-                     * text-muted-foreground, which axe measured at 3.79-3.91:1 on white
-                     * elsewhere in the admin — below WCAG AA's 4.5:1. Scoped to the
-                     * inactive state (rather than an unconditional text-slate-600) so it
-                     * cannot out-specificity TabsTrigger's own
-                     * data-[state=active]:text-foreground.
+                     * text-muted-foreground, which here sits on this card's bg-muted tab
+                     * strip, not white — axe measured that pairing (text-muted-foreground
+                     * on bg-muted) at 4.34:1, below WCAG AA's 4.5:1. (text-muted-foreground
+                     * on a plain white background settles closer to 4.75:1 and passes —
+                     * this is specifically the on-bg-muted case.) Scoped to the inactive
+                     * state (rather than an unconditional text-slate-600) so it cannot
+                     * out-specificity TabsTrigger's own data-[state=active]:text-foreground.
                      */}
                     <TabsList className="grid grid-cols-4 w-full sm:w-[240px]">
                         <TabsTrigger

--- a/frontend/src/components/admin/dashboard/charts/SubmissionsTimelineChart.tsx
+++ b/frontend/src/components/admin/dashboard/charts/SubmissionsTimelineChart.tsx
@@ -105,17 +105,38 @@ export const SubmissionsTimelineChart = ({
                     onValueChange={(v) => setRange(v as TimeRange)}
                     className="w-full sm:w-auto"
                 >
+                    {/*
+                     * data-[state=inactive]:text-slate-600, not the inherited
+                     * text-muted-foreground (task 6.7e): TabsList's own base class sets
+                     * text-muted-foreground, which axe measured at 3.79-3.91:1 on white
+                     * elsewhere in the admin — below WCAG AA's 4.5:1. Scoped to the
+                     * inactive state (rather than an unconditional text-slate-600) so it
+                     * cannot out-specificity TabsTrigger's own
+                     * data-[state=active]:text-foreground.
+                     */}
                     <TabsList className="grid grid-cols-4 w-full sm:w-[240px]">
-                        <TabsTrigger value="7d" className="text-xs">
+                        <TabsTrigger
+                            value="7d"
+                            className="text-xs data-[state=inactive]:text-slate-600"
+                        >
                             7d
                         </TabsTrigger>
-                        <TabsTrigger value="30d" className="text-xs">
+                        <TabsTrigger
+                            value="30d"
+                            className="text-xs data-[state=inactive]:text-slate-600"
+                        >
                             30d
                         </TabsTrigger>
-                        <TabsTrigger value="90d" className="text-xs">
+                        <TabsTrigger
+                            value="90d"
+                            className="text-xs data-[state=inactive]:text-slate-600"
+                        >
                             90d
                         </TabsTrigger>
-                        <TabsTrigger value="all" className="text-xs">
+                        <TabsTrigger
+                            value="all"
+                            className="text-xs data-[state=inactive]:text-slate-600"
+                        >
                             {t('common.all', 'All')}
                         </TabsTrigger>
                     </TabsList>

--- a/frontend/src/components/ui/accordion.tsx
+++ b/frontend/src/components/ui/accordion.tsx
@@ -18,9 +18,21 @@ AccordionItem.displayName = 'AccordionItem';
 
 const AccordionTrigger = React.forwardRef<
     React.ElementRef<typeof AccordionPrimitive.Trigger>,
-    React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-    <AccordionPrimitive.Header className="flex">
+    React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger> & {
+        /**
+         * Radix's `Accordion.Header` renders a hardcoded `<h3>`. Fine when an
+         * `<h2>` precedes it in the document outline, but at least one call site
+         * (`ExplorerPanel`'s "Advanced configuration" accordion) nests it directly
+         * under a page's `<h1>` with nothing at `<h2>` in between — axe's
+         * `heading-order` rule (task 6.7e) flags the resulting skip. Opt in per
+         * call site rather than changing the default, since the right level
+         * depends on what's around each accordion — a nested accordion one level
+         * further in should stay at the default `<h3>`.
+         */
+        headingLevel?: 2;
+    }
+>(({ className, children, headingLevel, ...props }, ref) => {
+    const trigger = (
         <AccordionPrimitive.Trigger
             ref={ref}
             className={cn(
@@ -32,8 +44,18 @@ const AccordionTrigger = React.forwardRef<
             {children}
             <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
         </AccordionPrimitive.Trigger>
-    </AccordionPrimitive.Header>
-));
+    );
+
+    if (headingLevel === 2) {
+        return (
+            <AccordionPrimitive.Header asChild>
+                <h2 className="flex">{trigger}</h2>
+            </AccordionPrimitive.Header>
+        );
+    }
+
+    return <AccordionPrimitive.Header className="flex">{trigger}</AccordionPrimitive.Header>;
+});
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
 const AccordionContent = React.forwardRef<

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -75,8 +75,11 @@ export function EmptyState({
     className,
 }: EmptyStateProps) {
     if (variant === 'compact') {
+        // text-slate-600, not -400: axe (task 6.7e) measured text-slate-400 on white
+        // at 2.56:1 — below WCAG AA's 4.5:1. This is a shared primitive, so the fix
+        // lands once here instead of at every call site.
         return (
-            <p className={cn('text-sm text-slate-400 italic', className)}>
+            <p className={cn('text-sm text-slate-600 italic', className)}>
                 {title}
                 {body && <span className="ml-1">{body}</span>}
             </p>
@@ -107,10 +110,11 @@ export function EmptyState({
             ? 'text-lg font-black text-slate-900 tracking-tight'
             : 'text-base font-bold text-slate-600';
 
+    // text-slate-600, not -400 — see the `compact` branch above for why.
     const bodyClass =
         variant === 'card'
             ? 'text-sm text-slate-600 leading-relaxed'
-            : 'text-sm text-slate-400 max-w-xs';
+            : 'text-sm text-slate-600 max-w-xs';
 
     const wrapperAlign = variant === 'card' ? '' : 'items-center';
 

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -321,8 +321,11 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
             )}
 
             {explore.eigenvaluesIsLoading && (
+                // text-slate-600, not -400 — axe (task 6.7e) measured text-slate-400 on
+                // white at 2.56:1, a nominal-token reading (not an animation artifact:
+                // this survives settling). Same defect as ScreePlot/RecruitmentPage/etc.
                 <div
-                    className="flex items-center justify-center py-8 text-slate-400"
+                    className="flex items-center justify-center py-8 text-slate-600"
                     role="status"
                     aria-live="polite"
                 >
@@ -986,8 +989,10 @@ function InterpretShell({
                     )}
                     icon={ChartColumnStacked}
                 />
+                {/* text-slate-600, not -400 — same real (not animation-artifact) defect
+                    as the eigenvalues loading state above. */}
                 <div
-                    className="flex items-center justify-center py-12 text-slate-400"
+                    className="flex items-center justify-center py-12 text-slate-600"
                     role="status"
                     aria-live="polite"
                     data-testid="interpret-phase"

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -423,6 +423,16 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                                 value="advanced"
                                 className="border border-slate-200 rounded-xl overflow-hidden bg-slate-50/30"
                             >
+                                {/*
+                                 * Deliberately still the default <h3> (task 6.7e): this
+                                 * accordion is nested inside `advancedContent`, itself
+                                 * rendered inside ExplorerPanel's own "Advanced
+                                 * configuration" accordion (fixed to <h2> there) — so <h3>
+                                 * here is one level deeper than its <h2> parent, not a skip.
+                                 * axe never reaches this one anyway while the outer
+                                 * accordion starts collapsed; it's set correctly for when a
+                                 * user opens both.
+                                 */}
                                 <AccordionTrigger className="px-4 py-3 hover:no-underline data-[state=open]:border-b data-[state=open]:border-slate-200">
                                     <div className="flex flex-col items-start text-left">
                                         <span className="text-sm font-bold text-slate-700">

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -258,6 +258,7 @@ export default function ConcourseDetailPage() {
                                 size="sm"
                                 className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white"
                                 onClick={openAddItemDialog}
+                                aria-label={t('admin.concourse.add_item', 'Add Item')}
                             >
                                 <Plus className="size-4 sm:mr-1" />
                                 <span className="hidden sm:inline">
@@ -271,6 +272,7 @@ export default function ConcourseDetailPage() {
                                 size="sm"
                                 className="rounded-xl"
                                 onClick={openImportDialog}
+                                aria-label={t('admin.concourse.bulk_import', 'Bulk Import')}
                             >
                                 <Upload className="size-4 sm:mr-1" />
                                 <span className="hidden sm:inline">
@@ -284,6 +286,7 @@ export default function ConcourseDetailPage() {
                             className="rounded-xl"
                             onClick={exportCsv}
                             disabled={!concourse.items?.length}
+                            aria-label={t('admin.concourse.export_csv', 'Export CSV')}
                         >
                             <Download className="size-4 sm:mr-1" />
                             <span className="hidden sm:inline">
@@ -435,7 +438,7 @@ export default function ConcourseDetailPage() {
                     ) : (
                         <>
                             {languages.length === 1 && languages[0] && (
-                                <span className="text-xs text-slate-400 flex items-center gap-1">
+                                <span className="text-xs text-slate-600 flex items-center gap-1">
                                     <Globe className="size-3" />
                                     {langDisplayName(languages[0])}
                                 </span>
@@ -444,7 +447,7 @@ export default function ConcourseDetailPage() {
                                 <Button
                                     variant="ghost"
                                     size="sm"
-                                    className="h-9 rounded-xl text-xs text-slate-400 hover:text-indigo-600"
+                                    className="h-9 rounded-xl text-xs text-slate-600 hover:text-indigo-600"
                                     onClick={() => setAddLangOpen(true)}
                                     title={t(
                                         'admin.concourse.add_language_tooltip',
@@ -456,7 +459,7 @@ export default function ConcourseDetailPage() {
                             )}
                         </>
                     )}
-                    <span className="text-xs text-slate-400 ml-auto">
+                    <span className="text-xs text-slate-600 ml-auto">
                         {filteredItems.length} / {concourse.items?.length ?? 0}{' '}
                         {t('admin.concourse.items_label', 'items')}
                     </span>
@@ -646,7 +649,7 @@ export default function ConcourseDetailPage() {
             <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
                 <CardContent className="p-0">
                     {filteredItems.length === 0 ? (
-                        <div className="py-16 text-center text-slate-400 text-sm">
+                        <div className="py-16 text-center text-slate-600 text-sm">
                             {(concourse.items?.length ?? 0) === 0
                                 ? t(
                                       'admin.concourse.no_items',

--- a/frontend/src/pages/admin/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/admin/GeneralSettingsPage.tsx
@@ -500,7 +500,8 @@ export default function GeneralSettingsPage() {
                                     {t('admin.settings.danger.title')}
                                 </CardTitle>
                             </div>
-                            <CardDescription className="text-sm font-medium text-red-400">
+                            {/* text-red-700, not -400 — axe (task 6.7e) measured 2.76:1. */}
+                            <CardDescription className="text-sm font-medium text-red-700">
                                 {t('admin.settings.danger.description')}
                             </CardDescription>
                         </CardHeader>
@@ -520,8 +521,9 @@ export default function GeneralSettingsPage() {
                                 <Trash2 size={16} />
                                 {t('admin.settings.danger.delete_button')}
                             </Button>
+                            {/* text-red-700, not -400/80 — axe (task 6.7e) measured 2.27:1. */}
                             {!isArchived && (
-                                <p className="text-xs text-red-400/80 font-medium">
+                                <p className="text-xs text-red-700 font-medium">
                                     * {t('admin.settings.danger.notice').split('. ').pop()}
                                 </p>
                             )}

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -224,7 +224,7 @@ const RecruitmentPage = () => {
                                             )}
                                         />
                                     </div>
-                                    <p className="text-xs text-slate-400 font-mono break-all text-center px-4">
+                                    <p className="text-xs text-slate-600 font-mono break-all text-center px-4">
                                         {studyUrl}
                                     </p>
                                 </DialogContent>
@@ -257,20 +257,30 @@ const RecruitmentPage = () => {
                                                 'URL slug'
                                             )}
                                         </FormLabel>
-                                        <FormControl>
-                                            <div className="relative">
-                                                <div className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-mono text-xs select-none">
-                                                    /study/
-                                                </div>
+                                        {/*
+                                         * FormControl now wraps the <Input> directly, not the
+                                         * decorative wrapper div (task 6.7e). shadcn's
+                                         * FormControl uses Radix Slot to attach id/
+                                         * aria-describedby/aria-invalid to its *only* child —
+                                         * with the div as that child, those landed on the div
+                                         * instead of the input, so FormLabel's htmlFor pointed
+                                         * at a non-labelable element and the real <input> had
+                                         * no accessible name at all (axe: label).
+                                         */}
+                                        <div className="relative">
+                                            <div className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-600 font-mono text-xs select-none">
+                                                /study/
+                                            </div>
+                                            <FormControl>
                                                 <Input
                                                     {...field}
                                                     disabled={isSlugLocked}
                                                     className="h-11 rounded-xl bg-slate-50 border-slate-100 pl-14 font-mono text-xs focus-visible:ring-indigo-500"
                                                 />
-                                            </div>
-                                        </FormControl>
+                                            </FormControl>
+                                        </div>
                                         {isSlugLocked ? (
-                                            <p className="text-xs text-amber-600 flex items-center gap-1.5 mt-1.5">
+                                            <p className="text-xs text-amber-800 flex items-center gap-1.5 mt-1.5">
                                                 <Info className="size-3 shrink-0" />
                                                 {t(
                                                     'admin.recruitment.study_url.slug_locked',
@@ -460,7 +470,7 @@ const RecruitmentPage = () => {
                                             'Limit collection window'
                                         )}
                                     </Label>
-                                    <p className="text-xs text-slate-400 font-medium">
+                                    <p className="text-xs text-slate-600 font-medium">
                                         {t(
                                             'admin.recruitment.access_rules.window_toggle_help',
                                             'Restrict participant access to a specific time range.'
@@ -494,7 +504,7 @@ const RecruitmentPage = () => {
                                     {/* Heads the "Opens at"/"Closes at" pair below, both of
                                         which already carry their own Label/htmlFor — a real
                                         heading element, not the form-field <Label>. */}
-                                    <p className="text-2xs font-black text-slate-400 uppercase tracking-wider">
+                                    <p className="text-2xs font-black text-slate-600 uppercase tracking-wider">
                                         {t(
                                             'admin.recruitment.access_rules.collection_window',
                                             'Collection window'
@@ -578,7 +588,7 @@ const RecruitmentPage = () => {
                                             </div>
                                         </div>
                                     </div>
-                                    <p className="text-xs text-slate-400 font-medium">
+                                    <p className="text-xs text-slate-600 font-medium">
                                         {t(
                                             'admin.recruitment.access_rules.date_hint',
                                             'Leave empty for no time restriction.'
@@ -818,13 +828,13 @@ const RecruitmentPage = () => {
                             <TableRow className="hover:bg-transparent border-slate-100">
                                 <TableHead
                                     scope="col"
-                                    className="py-4 text-2xs font-black text-slate-400 pl-6"
+                                    className="py-4 text-2xs font-black text-slate-600 pl-6"
                                 >
                                     {t('admin.recruitment.table.name', 'Name / Cohort')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
-                                    className="py-4 text-2xs font-black text-slate-400 cursor-help"
+                                    className="py-4 text-2xs font-black text-slate-600 cursor-help"
                                     title={t(
                                         'admin.recruitment.table.type_help',
                                         'Public, Single-use, or Capacity-limited. See strategy descriptions in the “New access link” dialog.'
@@ -834,25 +844,25 @@ const RecruitmentPage = () => {
                                 </TableHead>
                                 <TableHead
                                     scope="col"
-                                    className="py-4 text-2xs font-black text-slate-400"
+                                    className="py-4 text-2xs font-black text-slate-600"
                                 >
                                     {t('admin.recruitment.table.token', 'Token')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
-                                    className="py-4 text-2xs font-black text-slate-400"
+                                    className="py-4 text-2xs font-black text-slate-600"
                                 >
                                     {t('admin.recruitment.table.usage', 'Usage')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
-                                    className="py-4 text-2xs font-black text-slate-400"
+                                    className="py-4 text-2xs font-black text-slate-600"
                                 >
                                     {t('admin.recruitment.table.status', 'Status')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
-                                    className="py-4 text-2xs font-black text-slate-400 text-right pr-6"
+                                    className="py-4 text-2xs font-black text-slate-600 text-right pr-6"
                                 >
                                     {t('admin.recruitment.table.actions', 'Actions')}
                                 </TableHead>
@@ -882,6 +892,12 @@ const RecruitmentPage = () => {
                                                     onClick: () => setIsCreateModalOpen(true),
                                                 }}
                                                 variant="inline"
+                                                // The page's only other heading is the
+                                                // StudyPageHeader <h1> — nothing else claims
+                                                // h2, so this is that page's first section
+                                                // heading, not the inline default's h3 (axe:
+                                                // heading-order, task 6.7e).
+                                                headingLevel={2}
                                             />
                                         </div>
                                     </TableCell>
@@ -965,7 +981,7 @@ const RecruitmentPage = () => {
                                                     ) : (
                                                         <Badge
                                                             variant="secondary"
-                                                            className="bg-slate-50 text-slate-400 border-slate-200 px-2 py-0 shadow-none text-[9px] font-black"
+                                                            className="bg-slate-50 text-slate-600 border-slate-200 px-2 py-0 shadow-none text-[9px] font-black"
                                                         >
                                                             {t(
                                                                 'admin.recruitment.usage.unused',
@@ -1036,7 +1052,7 @@ const RecruitmentPage = () => {
                                             ) : (
                                                 <Badge
                                                     variant="secondary"
-                                                    className="bg-slate-50 text-slate-400 border-slate-200 px-2 py-0 shadow-none text-[9px] font-black"
+                                                    className="bg-slate-50 text-slate-600 border-slate-200 px-2 py-0 shadow-none text-[9px] font-black"
                                                 >
                                                     {t('admin.recruitment.revoked', 'Revoked')}
                                                 </Badge>
@@ -1082,7 +1098,7 @@ const RecruitmentPage = () => {
                                                             />
                                                         </div>
                                                         <div className="flex flex-col items-center gap-2 w-full">
-                                                            <p className="text-xs text-slate-400 font-mono break-all text-center px-4">
+                                                            <p className="text-xs text-slate-600 font-mono break-all text-center px-4">
                                                                 {getFullUrl(link.token)}
                                                             </p>
                                                             <Button

--- a/frontend/src/pages/admin/StudyDesignPage.test.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.test.tsx
@@ -112,6 +112,17 @@ describe('StudyDesignPage Feature Tests', () => {
         expect(screen.getByText(/Grid balanced/i)).toBeInTheDocument();
     });
 
+    it('names the language switcher by its purpose, not just its visible value', async () => {
+        // Regression guard for task 6.7e: the trigger's only visible text sat in a
+        // `hidden sm:inline` span, so below the `sm` breakpoint it had no accessible
+        // name at all — invisible to a static checker (the child is a dynamic
+        // expression) and only caught by axe run at a small viewport. An explicit
+        // aria-label survives at every width and, per accname precedence, wins over
+        // the visible "EN" text either way.
+        renderPage();
+        expect(await screen.findByRole('button', { name: 'Select language' })).toBeInTheDocument();
+    });
+
     it('signals ready status in checklist when all required fields are valid', async () => {
         renderPage();
 

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -984,7 +984,8 @@ const StudyDesignPage = () => {
                             </div>
                         </div>
                         <div className="pt-6 border-t border-slate-100">
-                            <h4 className="text-2xs font-black text-slate-400 mb-3">
+                            {/* text-slate-600, not -400 — axe (task 6.7e) measured 2.56:1. */}
+                            <h4 className="text-2xs font-black text-slate-600 mb-3">
                                 {t('admin.design.checklist.languages', 'Languages')}
                             </h4>
                             <div className="space-y-2">

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -151,6 +151,19 @@ const StudyDesignPage = () => {
             className="flex flex-col h-full animate-in fade-in duration-500 overflow-hidden max-w-full"
             style={{ animationFillMode: 'forwards' }}
         >
+            {/*
+             * Sole page heading. The visible toolbar title below is an <h2> showing the
+             * *study's* title — correct for orientation inside the page, but it leaves
+             * the page with zero <h1>s (axe: page-has-heading-one), and every sibling
+             * study-scope page (Access, Data, Analysis, Settings) already has one via
+             * StudyPageHeader, whose h1 is the page's *functional* name rather than the
+             * study title (see CLAUDE.md's admin header policy). This page predates
+             * StudyPageHeader and has too much bespoke toolbar layout to convert here
+             * safely, so it gets the same sr-only h1 LandingPage uses for the same
+             * reason — visible layout unchanged, screen readers get one landmark
+             * heading that names the page instead of none.
+             */}
+            <h1 className="sr-only">{t('admin.sidebar.design', 'Design')}</h1>
             {/* Toolbar */}
             <div className="border-b bg-background px-3 sm:px-6 py-2 sm:py-3 shrink-0">
                 <div className="flex flex-wrap items-center justify-between gap-2 sm:gap-4 min-w-0">
@@ -199,6 +212,10 @@ const StudyDesignPage = () => {
                                         variant="outline"
                                         size="sm"
                                         data-testid="language-switcher"
+                                        aria-label={t(
+                                            'admin.design.toolbar.select_lang',
+                                            'Select language'
+                                        )}
                                         className="h-9 gap-2 font-bold bg-white border-slate-200 rounded-lg hover:border-indigo-300 hover:text-indigo-600 transition-all shadow-sm px-2 sm:px-3"
                                     >
                                         <Globe className="h-4 w-4 text-indigo-500" />


### PR DESCRIPTION
## Summary

Task 6.7e. The axe spec covered two public pages; the admin — where every defect in this remediation lived — was not covered at all. It now audits **seven admin routes at desktop and 375px**, with the full accessible-name rule set plus `color-contrast`.

**9/9 tests green across 9 consecutive runs at `--workers=6` under genuine CPU contention** (load average 9–17 on 8 cores). Review independently reproduced 45/45 over five more runs.

## The finding that reframed the task

The spec's first run reported 97 `color-contrast` violations, and an implementer began darkening Tailwind tokens across ~17 files. Two things made that suspect: their nominal contrast maths **disagreed with axe by 15–20%** and they could not explain it, and `InteractiveDataView.tsx:249` wraps its section in a 700ms `animate-in fade-in`.

An investigation measured the ancestor opacity at the moment axe runs: **0.00 on study-design, 0.012 on data.**

**48 of the 97 violations were measurement artifacts.** The 15–20% gap was the alpha blend, α ≈ 0.88 — the nominal maths had been right all along, and settled measurements match it to two decimals. The "systemic pastel-100/700 defect across 17 files" **does not exist**: every `-100` background with `-700` text passes settled (4.83, 4.50, 5.17, 5.23). The real failures are the `-50`/`-600` tier, `text-slate-400`, `text-red-400`, `text-amber-600`, and `text-muted-foreground` on `bg-muted`.

So this branch keeps 34 colour edits and **reverts 12**, and fixes the artifact class at the measurement rather than in the palette.

## `reducedMotion: 'reduce'`, and why it is not measurement-shopping

The spec now runs the `Accessibility Smoke` project under reduced motion rather than waiting for animations. The obvious objection is that this picks the measurement that gives the desired answer. It was tested directly: on both fade-carrying routes, three passes on fresh navigations — reduced motion + wait, no-preference + wait, and no-preference + wait + a 3-second settle as ground truth — **all returned zero violations at opacity 1**. It reaches the settled answer deterministically and in a third the time.

`index.css:209` already honours `prefers-reduced-motion`, so nothing is hidden that a user with that preference would not also see. And `text-slate-900` measures 4.35 mid-fade, so no palette change could fix the artifact class — confirming the spec, not the colours, was the right place to act.

## Real defects this found and fixed

- The study-designer **language switcher had no accessible name below `sm`** — flagged when the gate was built, and still unfixed until an audit ran at 375px.
- Three **`ConcourseDetailPage` header buttons** ("Add Item", "Bulk Import", "Export CSV") nameless below 640px, their only text in `hidden sm:inline` spans.
- A **`FormControl`/Slot mis-wiring** on `RecruitmentPage` that put the form item's `id` on a decorative `<div>`, so the label pointed at a non-labelable element.
- A missing `<h1>` on the design page, `heading-order` skips, and the genuinely-failing contrast tier.
- **Three instances of one defect** — `text-slate-400` on `aria-live` loading states, at 2.56:1, which a researcher reads for the duration of a network round-trip. Each review round found one more, because round 2's verification grep was scoped to the *page file* rather than the component tree the route mounts. Round 3 redid it as a component-tree sweep.

## Checklist

- [ ] `make ci` passes locally — **frontend green (1677 tests, biome + tsc clean, a11y gate at zero); backend `pytest` fails on a local Postgres credential issue reproducing identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — the spec was mutation-tested red-then-green in every round.
- [x] Translation keys added to all locales — new `aria-label` keys in all nine, reusing the visible label's own key so the accessible name matches the visible one.
- [x] API client regenerated if backend schemas changed — not applicable.

## Coverage boundary, stated in the spec itself

A green run does not prove the admin is accessible. `rules.ts` records what axe cannot see here: every audited route reports `color-contrast` *incompletes*, and recharts axis and legend text returns "background could not be determined because element contains an image node" — so **chart text contrast is never checked** on the two chart routes. axe also cannot flag a *named* control that should not be focusable at all, which is why the Data table's status chips remain Task 6.7g.

🤖 Generated with [Claude Code](https://claude.com/claude-code)