### PR TITLE
fix(a11y): make the Data table's status chips indicators, not buttons

### DIFF
--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1693,6 +1693,28 @@ Run at **375px as well as desktop** — Task 6.7a found a language switcher whos
 
 ---
 
+### Task 6.7i: Finish the Data table's tab order
+
+**Two findings from Task 6.7g's review, one of them the more serious of the pair.**
+
+**1. The row's real action is mouse-only.** `InteractiveDataView.tsx:844-851` renders `<TableRow onClick={() => handleViewParticipant(...)}>` with `cursor-pointer` but **no `tabIndex`, no `onKeyDown`, no `role`**. Opening a participant — the primary action of the Data screen — cannot be done from the keyboard at all.
+
+Task 6.7g made this starker rather than causing it: the row now holds one focusable control that does nothing, and zero focusable paths to what it actually does. No task covered this; it was found by a reviewer reading the tab order.
+
+The dashboard card conversion (Task 3.3) is the worked example, including the stretched `::after` that preserves whole-area clicking. Mind the interaction: a row containing its own controls cannot simply become a `<button>`.
+
+**2. Two more inert tab stops per row.** The duplicate-IP badge (`columns.tsx:185`) and the `submitted_at` date tooltip (`:749`) are the same defect 6.7g fixed seven times over — `TooltipTrigger` rendering a focusable `<button>` that does nothing on activation. 6.7g's "8 → 1" is fixture-specific; a duplicate-IP row still carries two.
+
+Convert them the way 6.7g did — `role="img"` with the existing name, `title` for mouse users — so the per-row count reaches what a researcher can actually act on.
+
+- [ ] **Step 1: Count focusable controls in a duplicate-IP row** — the fixture must trip the badge, or the count will look already-correct
+- [ ] **Step 2: Convert the two chips**
+- [ ] **Step 3: Give the row a keyboard path to `handleViewParticipant`**, and assert focus → Enter → the participant opens
+- [ ] **Step 4: Confirm mouse click-through, sorting, filtering and the `is_discarded` styling still work**
+- [ ] **Step 5: Commit** — `fix(a11y): give the Data table's rows a keyboard path and drop the last inert stops`
+
+---
+
 ### Task 6.8: Charts mounting at zero size
 
 **The defect:** loading the `Data` screen logs the Recharts warning *"The width(-1) and height(-1) of chart should be greater than 0"* five times — charts are mounting inside collapsed containers. Harmless today, but it is console noise that will mask a real warning later.

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1851,7 +1851,8 @@
                 "email_provided": "E-Mail-Adresse angegeben",
                 "newsletter_consent": "Möchte Ergebnisse",
                 "interview_consent": "Nimmt Folgekontakt an",
-                "recruitment_link": "Rekrutierungslink"
+                "recruitment_link": "Rekrutierungslink",
+                "device_info": "Gerät: {{os}}, {{browser}}"
             },
             "toast": {
                 "discarded": "Teilnehmer verworfen",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1853,7 +1853,8 @@
                 "email_provided": "Email provided",
                 "newsletter_consent": "Wants results",
                 "interview_consent": "Accepts follow-up",
-                "recruitment_link": "Recruitment link"
+                "recruitment_link": "Recruitment link",
+                "device_info": "Device: {{os}}, {{browser}}"
             },
             "toast": {
                 "discarded": "Participant discarded",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1851,7 +1851,8 @@
                 "email_provided": "Correo electrónico proporcionado",
                 "newsletter_consent": "Quiere resultados",
                 "interview_consent": "Acepta seguimiento",
-                "recruitment_link": "Enlace de reclutamiento"
+                "recruitment_link": "Enlace de reclutamiento",
+                "device_info": "Dispositivo: {{os}}, {{browser}}"
             },
             "toast": {
                 "discarded": "Participante descartado",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1763,7 +1763,8 @@
                 "email_provided": "Sähköposti annettu",
                 "newsletter_consent": "Haluaa tulokset",
                 "interview_consent": "Hyväksyy seurannan",
-                "recruitment_link": "Rekrytointilinkki"
+                "recruitment_link": "Rekrytointilinkki",
+                "device_info": "Laite: {{os}}, {{browser}}"
             },
             "toast": {
                 "discarded": "Osallistuja hylätty",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1801,7 +1801,8 @@
                 "email_provided": "Email fourni",
                 "newsletter_consent": "Souhaite les résultats",
                 "interview_consent": "Accepte suivi",
-                "recruitment_link": "Lien de recrutement"
+                "recruitment_link": "Lien de recrutement",
+                "device_info": "Appareil : {{os}}, {{browser}}"
             },
             "toast": {
                 "discarded": "Participant écarté",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1851,7 +1851,8 @@
                 "email_provided": "E-mail fornita",
                 "newsletter_consent": "Vuole i risultati",
                 "interview_consent": "Accetta follow-up",
-                "recruitment_link": "Link di reclutamento"
+                "recruitment_link": "Link di reclutamento",
+                "device_info": "Dispositivo: {{os}}, {{browser}}"
             },
             "toast": {
                 "discarded": "Partecipante scartato",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1851,7 +1851,8 @@
                 "email_provided": "E-mailadres opgegeven",
                 "newsletter_consent": "Wil resultaten",
                 "interview_consent": "Accepteert vervolg",
-                "recruitment_link": "Wervingslink"
+                "recruitment_link": "Wervingslink",
+                "device_info": "Apparaat: {{os}}, {{browser}}"
             },
             "toast": {
                 "discarded": "Deelnemer verwijderd",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1851,7 +1851,8 @@
         "email_provided": "Podano e-mail",
         "newsletter_consent": "Chce wyniki",
         "interview_consent": "Akceptuje kontakt uzupełniający",
-        "recruitment_link": "Link rekrutacyjny"
+        "recruitment_link": "Link rekrutacyjny",
+        "device_info": "Urządzenie: {{os}}, {{browser}}"
       },
       "toast": {
         "discarded": "Uczestnik odrzucony",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1851,7 +1851,8 @@
                 "email_provided": "Email fornecido",
                 "newsletter_consent": "Quer resultados",
                 "interview_consent": "Aceita acompanhamento",
-                "recruitment_link": "Link de recrutamento"
+                "recruitment_link": "Link de recrutamento",
+                "device_info": "Dispositivo: {{os}}, {{browser}}"
             },
             "toast": {
                 "discarded": "Participante descartado",

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -142,36 +142,36 @@ export function ParticipantCell({
                     {participantId}
                 </span>
                 {ua && DeviceIcon && (
-                    <TooltipProvider>
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <div className="flex items-center gap-1">
-                                    <span className="inline-flex items-center text-slate-400">
-                                        {OsIcon ? (
-                                            <OsIcon className="w-3 h-3" />
-                                        ) : (
-                                            <DeviceIcon className="w-3 h-3" />
-                                        )}
-                                    </span>
-                                    {ua.browser !== 'Unknown' && (
-                                        <span className="inline-flex items-center text-slate-400">
-                                            {BrowserIcon ? (
-                                                <BrowserIcon className="w-3 h-3" />
-                                            ) : (
-                                                <Globe className="w-3 h-3" />
-                                            )}
-                                        </span>
-                                    )}
-                                </div>
-                            </TooltipTrigger>
-                            <TooltipContent
-                                side="bottom"
-                                className="max-w-xs break-all font-mono text-2xs"
-                            >
-                                {p.user_agent}
-                            </TooltipContent>
-                        </Tooltip>
-                    </TooltipProvider>
+                    <span
+                        role="img"
+                        aria-label={t(
+                            'admin.data.tooltips.device_info',
+                            'Device: {{os}}, {{browser}}',
+                            {
+                                os: ua.os,
+                                browser: ua.browser,
+                            }
+                        )}
+                        title={p.user_agent}
+                        className="flex items-center gap-1"
+                    >
+                        <span className="inline-flex items-center text-slate-400">
+                            {OsIcon ? (
+                                <OsIcon className="w-3 h-3" />
+                            ) : (
+                                <DeviceIcon className="w-3 h-3" />
+                            )}
+                        </span>
+                        {ua.browser !== 'Unknown' && (
+                            <span className="inline-flex items-center text-slate-400">
+                                {BrowserIcon ? (
+                                    <BrowserIcon className="w-3 h-3" />
+                                ) : (
+                                    <Globe className="w-3 h-3" />
+                                )}
+                            </span>
+                        )}
+                    </span>
                 )}
                 {p.is_discarded && (
                     <Badge variant="destructive" className="h-4 text-2xs px-1.5 font-semibold">
@@ -497,72 +497,55 @@ export function buildColumns({
             cell: ({ row }) => {
                 const p = row.original;
                 return (
-                    <TooltipProvider>
-                        <div className="flex items-center gap-1.5">
-                            {p.postsort.email && (
-                                <Tooltip>
-                                    <TooltipTrigger
-                                        aria-label={t(
-                                            'admin.data.tooltips.email_provided',
-                                            'Email provided'
-                                        )}
-                                    >
-                                        <div className="p-1 bg-indigo-50 rounded text-indigo-600 border border-indigo-100">
-                                            <Mail className="h-3 w-3" />
-                                        </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {t('admin.data.tooltips.email_provided', 'Email provided')}
-                                    </TooltipContent>
-                                </Tooltip>
-                            )}
-                            {p.postsort.newsletter_consent && (
-                                <Tooltip>
-                                    <TooltipTrigger
-                                        aria-label={t(
-                                            'admin.data.tooltips.newsletter_consent',
-                                            'Wants results'
-                                        )}
-                                    >
-                                        <div className="p-1 bg-emerald-50 rounded text-emerald-600 border border-emerald-100">
-                                            <FileText className="h-3 w-3" />
-                                        </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {t(
-                                            'admin.data.tooltips.newsletter_consent',
-                                            'Wants results'
-                                        )}
-                                    </TooltipContent>
-                                </Tooltip>
-                            )}
-                            {p.postsort.interview_consent && (
-                                <Tooltip>
-                                    <TooltipTrigger
-                                        aria-label={t(
-                                            'admin.data.tooltips.interview_consent',
-                                            'Accepts follow-up'
-                                        )}
-                                    >
-                                        <div className="p-1 bg-amber-50 rounded text-amber-600 border border-amber-100">
-                                            <MessagesSquare className="h-3 w-3" />
-                                        </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {t(
-                                            'admin.data.tooltips.interview_consent',
-                                            'Accepts follow-up'
-                                        )}
-                                    </TooltipContent>
-                                </Tooltip>
-                            )}
-                            {!p.postsort.email &&
-                                !p.postsort.newsletter_consent &&
-                                !p.postsort.interview_consent && (
-                                    <span className="text-2xs text-slate-300 font-medium">—</span>
+                    <div className="flex items-center gap-1.5">
+                        {p.postsort.email && (
+                            <span
+                                role="img"
+                                aria-label={t(
+                                    'admin.data.tooltips.email_provided',
+                                    'Email provided'
                                 )}
-                        </div>
-                    </TooltipProvider>
+                                title={t('admin.data.tooltips.email_provided', 'Email provided')}
+                                className="p-1 bg-indigo-50 rounded text-indigo-600 border border-indigo-100"
+                            >
+                                <Mail className="h-3 w-3" />
+                            </span>
+                        )}
+                        {p.postsort.newsletter_consent && (
+                            <span
+                                role="img"
+                                aria-label={t(
+                                    'admin.data.tooltips.newsletter_consent',
+                                    'Wants results'
+                                )}
+                                title={t('admin.data.tooltips.newsletter_consent', 'Wants results')}
+                                className="p-1 bg-emerald-50 rounded text-emerald-600 border border-emerald-100"
+                            >
+                                <FileText className="h-3 w-3" />
+                            </span>
+                        )}
+                        {p.postsort.interview_consent && (
+                            <span
+                                role="img"
+                                aria-label={t(
+                                    'admin.data.tooltips.interview_consent',
+                                    'Accepts follow-up'
+                                )}
+                                title={t(
+                                    'admin.data.tooltips.interview_consent',
+                                    'Accepts follow-up'
+                                )}
+                                className="p-1 bg-amber-50 rounded text-amber-600 border border-amber-100"
+                            >
+                                <MessagesSquare className="h-3 w-3" />
+                            </span>
+                        )}
+                        {!p.postsort.email &&
+                            !p.postsort.newsletter_consent &&
+                            !p.postsort.interview_consent && (
+                                <span className="text-2xs text-slate-300 font-medium">—</span>
+                            )}
+                    </div>
                 );
             },
         }),
@@ -643,77 +626,58 @@ export function buildColumns({
                 const hasAudio = p.audio_recordings && Object.keys(p.audio_recordings).length > 0;
                 const hasRecruitmentLink = !!p.recruitment_token;
 
+                const recruitmentLinkLabel = `${t(
+                    'admin.data.tooltips.recruitment_link',
+                    'Recruitment link'
+                )}: ${p.recruitment_token}`;
+                const suspectLabel = t('admin.data.tooltips.suspect');
+                const hasCommentsLabel = t('admin.data.tooltips.has_comments');
+                const hasAudioLabel = t('admin.data.tooltips.has_audio', 'Has audio responses');
                 return (
                     <div className="flex items-center gap-1.5">
-                        <TooltipProvider>
-                            {hasRecruitmentLink && (
-                                <Tooltip>
-                                    <TooltipTrigger
-                                        aria-label={`${t(
-                                            'admin.data.tooltips.recruitment_link',
-                                            'Recruitment link'
-                                        )}: ${p.recruitment_token}`}
-                                    >
-                                        <div className="p-1 bg-slate-50 rounded text-slate-500 border border-slate-200">
-                                            <Tag className="h-3 w-3" />
-                                        </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {t(
-                                            'admin.data.tooltips.recruitment_link',
-                                            'Recruitment link'
-                                        )}
-                                        : {p.recruitment_token}
-                                    </TooltipContent>
-                                </Tooltip>
-                            )}
-                            {isSuspect && (
-                                <Tooltip>
-                                    <TooltipTrigger aria-label={t('admin.data.tooltips.suspect')}>
-                                        <div className="p-1 bg-amber-50 rounded text-amber-500 border border-amber-100">
-                                            <AlertTriangle className="h-3 w-3" />
-                                        </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {t('admin.data.tooltips.suspect')}
-                                    </TooltipContent>
-                                </Tooltip>
-                            )}
-                            {hasComments && (
-                                <Tooltip>
-                                    <TooltipTrigger
-                                        aria-label={t('admin.data.tooltips.has_comments')}
-                                    >
-                                        <div className="p-1 bg-blue-50 rounded text-blue-500 border border-blue-100">
-                                            <MessageSquare className="h-3 w-3" />
-                                        </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {t('admin.data.tooltips.has_comments')}
-                                    </TooltipContent>
-                                </Tooltip>
-                            )}
-                            {hasAudio && (
-                                <Tooltip>
-                                    <TooltipTrigger
-                                        aria-label={t(
-                                            'admin.data.tooltips.has_audio',
-                                            'Has audio responses'
-                                        )}
-                                    >
-                                        <div className="p-1 bg-purple-50 rounded text-purple-500 border border-purple-100">
-                                            <Mic className="h-3 w-3" />
-                                        </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {t('admin.data.tooltips.has_audio', 'Has audio responses')}
-                                    </TooltipContent>
-                                </Tooltip>
-                            )}
-                            {!isSuspect && !hasComments && !hasAudio && !hasRecruitmentLink && (
-                                <span className="text-2xs text-slate-300 font-medium">—</span>
-                            )}
-                        </TooltipProvider>
+                        {hasRecruitmentLink && (
+                            <span
+                                role="img"
+                                aria-label={recruitmentLinkLabel}
+                                title={recruitmentLinkLabel}
+                                className="p-1 bg-slate-50 rounded text-slate-500 border border-slate-200"
+                            >
+                                <Tag className="h-3 w-3" />
+                            </span>
+                        )}
+                        {isSuspect && (
+                            <span
+                                role="img"
+                                aria-label={suspectLabel}
+                                title={suspectLabel}
+                                className="p-1 bg-amber-50 rounded text-amber-500 border border-amber-100"
+                            >
+                                <AlertTriangle className="h-3 w-3" />
+                            </span>
+                        )}
+                        {hasComments && (
+                            <span
+                                role="img"
+                                aria-label={hasCommentsLabel}
+                                title={hasCommentsLabel}
+                                className="p-1 bg-blue-50 rounded text-blue-500 border border-blue-100"
+                            >
+                                <MessageSquare className="h-3 w-3" />
+                            </span>
+                        )}
+                        {hasAudio && (
+                            <span
+                                role="img"
+                                aria-label={hasAudioLabel}
+                                title={hasAudioLabel}
+                                className="p-1 bg-purple-50 rounded text-purple-500 border border-purple-100"
+                            >
+                                <Mic className="h-3 w-3" />
+                            </span>
+                        )}
+                        {!isSuspect && !hasComments && !hasAudio && !hasRecruitmentLink && (
+                            <span className="text-2xs text-slate-300 font-medium">—</span>
+                        )}
                     </div>
                 );
             },

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -167,38 +167,94 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         renderWithProviders(<InteractiveDataView slug="demo" />);
         await screen.findByRole('table');
 
-        expect(screen.getByRole('button', { name: 'Email provided' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Wants results' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Accepts follow-up' })).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: 'Email provided' })).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: 'Wants results' })).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: 'Accepts follow-up' })).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: 'Recruitment link: REF123' })).toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: 'Recruitment link: REF123' })
-        ).toBeInTheDocument();
-        expect(
-            screen.getByRole('button', {
+            screen.getByRole('img', {
                 name: 'Potentially suspect: session duration < 2 minutes',
             })
         ).toBeInTheDocument();
         expect(
-            screen.getByRole('button', {
+            screen.getByRole('img', {
                 name: 'Contains participant comments on cards',
             })
         ).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Has audio responses' })).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: 'Has audio responses' })).toBeInTheDocument();
 
-        // The user-visible claim: this participant's row used to carry seven
-        // anonymous tab stops (a screen reader announcing only "button" x7)
-        // across the Consent and Flags columns. Scope to the row via the
-        // participant-id badge, then compute each button's *real* accessible
-        // name the way accname/browsers do (not an attribute-presence proxy)
-        // and assert none resolve to empty — not just the seven asserted
-        // above by exact text, which would miss a regression on an eighth,
-        // unasserted button.
+        // The user-visible claim (Task 6.7g): these seven facts are still
+        // announced during table navigation, but none of them are tab stops
+        // any more — a screen reader user tabbing through this row no longer
+        // hits seven anonymous-purpose "button"s that do nothing on
+        // activation. Scope to the row via the participant-id badge and
+        // assert none of the seven names resolve on `button` (they moved
+        // role, not just gained a label) while every one of them still
+        // resolves via `img` — the real accname algorithm, not an
+        // attribute-presence proxy.
         const row = screen.getByText('p1').closest('tr');
         if (!row) throw new Error('participant row not found');
-        const buttonNames = within(row)
-            .getAllByRole('button')
-            .map((button) => computeAccessibleName(button));
-        expect(buttonNames.every((name) => name.trim().length > 0)).toBe(true);
+        for (const name of [
+            'Email provided',
+            'Wants results',
+            'Accepts follow-up',
+            'Recruitment link: REF123',
+            'Potentially suspect: session duration < 2 minutes',
+            'Contains participant comments on cards',
+            'Has audio responses',
+        ]) {
+            expect(within(row).queryByRole('button', { name })).not.toBeInTheDocument();
+            expect(computeAccessibleName(within(row).getByRole('img', { name }))).toBe(name);
+        }
+    });
+
+    it('drops the row focusable-control count from 8 to 1 by converting per-row status chips into non-focusable indicators (Task 6.7g)', async () => {
+        // Same fixture as above, plus a user_agent so ParticipantCell's
+        // OS/browser chip (also in scope for 6.7g) renders too, and a
+        // submitted_at timestamp (already present via makeParticipant's
+        // default) whose own TooltipTrigger is explicitly OUT of this
+        // task's scope and must remain a real tab stop.
+        const participant = makeParticipant({
+            id: 'p1',
+            db_id: 1,
+            duration_seconds: 30, // < SUSPECT_DURATION_THRESHOLD (120)
+            recruitment_token: 'REF123',
+            user_agent:
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0 Safari/537.36',
+            postsort: {
+                email: 'ada@example.com',
+                newsletter_consent: true,
+                interview_consent: true,
+                card_comments: { s1: 'a comment' },
+            },
+            audio_recordings: { s1: {} },
+        });
+        mockDumpQuery.mockReturnValue({
+            data: {
+                ...dumpResponseWithTranslations(['en']),
+                participants: [participant],
+            },
+            isLoading: false,
+            error: null,
+        });
+
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        const row = screen.getByText('p1').closest('tr');
+        if (!row) throw new Error('participant row not found');
+
+        // Before this task: 7 status chips + the OS/browser chip (unreachable
+        // today via a bare `asChild` div, so it doesn't add to the count) +
+        // the submitted_at tooltip trigger = 8 focusable `button`s in this
+        // row. After: only the out-of-scope submitted_at trigger remains.
+        const focusable = within(row).getAllByRole('button');
+        expect(focusable).toHaveLength(1);
+
+        // The OS/browser fact is still announced, with the name it never had.
+        expect(
+            within(row).getByRole('img', { name: 'Device: Windows, Chrome' })
+        ).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
## Summary

Task 6.7g. The Data table rendered **seven `TooltipTrigger`s per participant row** — email provided, wants results, accepts follow-up, recruitment link, suspect duration, card comments, audio responses. An earlier task gave each an `aria-label`, which took the accessible-name gate to zero.

That was a strict improvement and the wrong end state. They are **pure status indicators — activating them does nothing** — and Radix renders each as a focusable `<button>`. Seven per row × 25 rows is up to **175 phantom tab stops per page**, each announcing a fact the researcher cannot act on.

**Result: 8 → 1 focusable controls per row.**

## Why this needed writing down rather than delegating to a check

Neither guard could see it. A *named* button is axe-clean, so extending axe over the admin (#331) does not catch it. The static accessible-name gate counts them as fixed, because they are. Only a human reading the tab order finds this class of defect — which is why it was recorded in the plan rather than left to tooling.

## Changes

Each chip is now `<span role="img" aria-label={…}>` carrying the name the earlier task already wrote, with a native `title` so mouse users keep the same text the dropped tooltip showed. Nothing was deleted.

`ParticipantCell` was worse than the seven: it used `TooltipTrigger asChild` over a nameless `<div>`, and since Radix injects **no `tabIndex`** under `asChild`, its OS/browser tooltip was **unreachable by keyboard entirely** *and* unnamed. It is now named for the first time, with the raw `user_agent` kept in `title` so the mouse diagnostic detail survives verbatim.

`asChild` was explicitly not used as the fix — it would have removed the tab stop *and* the accessible name, and the gate exempts it unconditionally, so the counter would have read zero while keyboard users lost access.

## How the claim was proven

The headline is about the tab order, so the test measures the tab order: `within(row).getAllByRole('button')` — what a tab press actually lands on, not the markup. Review reproduced the RED against unmodified source and got the literal assertion `expected [ …8 buttons ] to have a length of 1 but got 8`. The 8 is code-computed, not narrated.

Each of the seven names is asserted present as `getByRole('img', { name })` **and** absent as `queryByRole('button', { name })`, so a label-only fix cannot game it. The accessible-name gate's output is byte-identical before and after — used as external evidence that nothing else moved.

## Checklist

- [ ] `make ci` passes locally — **frontend green (196 files / 1691 tests, biome + tsc clean, a11y gate byte-identical); backend `pytest` fails on a local Postgres credential issue reproducing identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — see above.
- [x] Translation keys added to all locales — existing keys reused; one new device-info key in all nine, interpolation parity checked.
- [x] API client regenerated if backend schemas changed — not applicable.

## Recorded, not fixed

Review found the row's own action is **mouse-only**: `<TableRow onClick={…}>` carries no `tabIndex`, `role` or key handler, so opening a participant cannot be done from the keyboard. This change makes that starker rather than causing it — the row now holds one focusable control that does nothing and no focusable path to what it actually does. Together with two further inert tooltip stops per row, that is Task 6.7i in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)