### PR TITLE
fix(a11y): give the Data table's rows a keyboard path to their own action

### DIFF
--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -1842,7 +1842,8 @@
                 "view": "Anzeigen",
                 "actions": "Details",
                 "duplicate_ip": "Doppelte IP",
-                "duplicate_ip_hint": "Teilt IP-Hash mit anderen Teilnehmern"
+                "duplicate_ip_hint": "Teilt IP-Hash mit anderen Teilnehmern",
+                "view_participant": "Teilnehmer {{id}} anzeigen"
             },
             "tooltips": {
                 "suspect": "Möglicherweise auffällig: Sitzungsdauer unter 2 Minuten",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1844,7 +1844,8 @@
                 "view": "View",
                 "actions": "Details",
                 "duplicate_ip": "Duplicate IP",
-                "duplicate_ip_hint": "Shares IP hash with other participants"
+                "duplicate_ip_hint": "Shares IP hash with other participants",
+                "view_participant": "View participant {{id}}"
             },
             "tooltips": {
                 "suspect": "Potentially suspect: session duration < 2 minutes",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -1842,7 +1842,8 @@
                 "view": "Ver",
                 "actions": "Detalles",
                 "duplicate_ip": "IP duplicada",
-                "duplicate_ip_hint": "Comparte el hash de IP con otros participantes"
+                "duplicate_ip_hint": "Comparte el hash de IP con otros participantes",
+                "view_participant": "Ver participante {{id}}"
             },
             "tooltips": {
                 "suspect": "Potencialmente sospechoso: duración de sesión < 2 minutos",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -1754,7 +1754,8 @@
                 "view": "Näytä",
                 "actions": "Tiedot",
                 "duplicate_ip": "Sama IP",
-                "duplicate_ip_hint": "Jakaa IP-tiivisteen muiden osallistujien kanssa"
+                "duplicate_ip_hint": "Jakaa IP-tiivisteen muiden osallistujien kanssa",
+                "view_participant": "Näytä osallistuja {{id}}"
             },
             "tooltips": {
                 "suspect": "Mahdollisesti epäilyttävä: istunnon kesto < 2 minuuttia",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -1792,7 +1792,8 @@
                 "view": "Voir",
                 "actions": "Détails",
                 "duplicate_ip": "IP dupliquée",
-                "duplicate_ip_hint": "Partage un hash IP avec d'autres participants"
+                "duplicate_ip_hint": "Partage un hash IP avec d'autres participants",
+                "view_participant": "Voir le participant {{id}}"
             },
             "tooltips": {
                 "suspect": "Potentiellement suspect : durée de session < 2 minutes",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -1842,7 +1842,8 @@
                 "view": "Visualizza",
                 "actions": "Dettagli",
                 "duplicate_ip": "IP duplicato",
-                "duplicate_ip_hint": "Condivide l'hash IP con altri partecipanti"
+                "duplicate_ip_hint": "Condivide l'hash IP con altri partecipanti",
+                "view_participant": "Visualizza partecipante {{id}}"
             },
             "tooltips": {
                 "suspect": "Potenzialmente sospetto: durata sessione < 2 minuti",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -1842,7 +1842,8 @@
                 "view": "Bekijken",
                 "actions": "Details",
                 "duplicate_ip": "Dubbel IP",
-                "duplicate_ip_hint": "Deelt IP-hash met andere deelnemers"
+                "duplicate_ip_hint": "Deelt IP-hash met andere deelnemers",
+                "view_participant": "Deelnemer {{id}} bekijken"
             },
             "tooltips": {
                 "suspect": "Mogelijk verdacht: sessieduur < 2 minuten",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -1842,7 +1842,8 @@
         "view": "Pokaż",
         "actions": "Szczegóły",
         "duplicate_ip": "Duplikat IP",
-        "duplicate_ip_hint": "Współdzieli hash IP z innymi uczestnikami"
+        "duplicate_ip_hint": "Współdzieli hash IP z innymi uczestnikami",
+        "view_participant": "Pokaż uczestnika {{id}}"
       },
       "tooltips": {
         "suspect": "Potencjalnie podejrzane: czas trwania sesji < 2 minuty",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -1842,7 +1842,8 @@
                 "view": "Ver",
                 "actions": "Detalhes",
                 "duplicate_ip": "IP duplicado",
-                "duplicate_ip_hint": "Partilha o hash de IP com outros participantes"
+                "duplicate_ip_hint": "Partilha o hash de IP com outros participantes",
+                "view_participant": "Ver participante {{id}}"
             },
             "tooltips": {
                 "suspect": "Potencialmente suspeito: duração da sessão < 2 minutos",

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -185,33 +185,38 @@ export function ParticipantCell({
                 // ("Duplicate IP #1") — role="img" would turn that readable
                 // text into a graphic node (NVDA: "graphic, Duplicate IP
                 // #1") and force the same wording into a hand-maintained
-                // aria-label. `title` keeps the hint/IP-hash-prefix for a
-                // mouse user hovering; the sr-only span repeats it as real
-                // content so a screen-reader user gets it reliably too (a
-                // `title` is announced as a description inconsistently
-                // across screen readers). Residual gap, accepted rather than
-                // solved here: a sighted keyboard-only or touch user with no
-                // screen reader still can't reach this detail, since there is
-                // no longer a focusable trigger to reveal it on demand.
+                // aria-label.
+                //
+                // One channel, not two (re-review, 2026-07-28): an earlier
+                // version of this fix kept BOTH a `title` and an sr-only
+                // span carrying the same hint text. That double-announces on
+                // any AT/browser pairing that surfaces the accessible
+                // description alongside the name (VoiceOver commonly; NVDA/
+                // JAWS in some modes) — once the name comes from content
+                // rather than `title` (HTML-AAM), `title` is exposed
+                // separately as the description, so the identical string
+                // reaches the tree twice. Kept the sr-only span only: it is
+                // ordinary text content, read exactly like the visible label
+                // next to it on every screen reader, with no separate
+                // "hover for description" step `title` requires — and no
+                // risk of NVDA/JAWS/VoiceOver each deciding differently
+                // whether to surface it. Traded away: the native
+                // browser-tooltip-on-hover a sighted mouse user got before.
+                // Accepted rather than solved here — see the submitted_at
+                // cell below for the same trade and the same reasoning.
                 // text-amber-800, not -600 — axe (task 6.7e) measured 3.07:1.
                 <Badge
                     variant="outline"
-                    title={`${t(
-                        'admin.data.table.duplicate_ip_hint',
-                        'Shares IP hash with other participants'
-                    )} (${p.ip_address.substring(0, 8)}...)`}
                     className="h-4 text-2xs px-1.5 font-semibold bg-amber-50 text-amber-800 border-amber-200"
                 >
                     {t('admin.data.table.duplicate_ip', 'Duplicate IP')} #
                     {duplicateIpGroups.get(p.ip_address)}
                     <span className="sr-only">
                         {' '}
-                        (
-                        {t(
+                        {`${t(
                             'admin.data.table.duplicate_ip_hint',
                             'Shares IP hash with other participants'
-                        )}
-                        , {p.ip_address.substring(0, 8)}...)
+                        )} (${p.ip_address.substring(0, 8)}...)`}
                     </span>
                 </Badge>
             )}
@@ -777,22 +782,25 @@ export function buildColumns({
                 // short date is already the accessible name via its own
                 // visible text, sitting in a sorted temporal column —
                 // role="img" would make a screen reader announce it as
-                // "graphic, Jan 1, 01:10" instead of a date. `title` keeps
-                // the full timestamp for a mouse user hovering; the sr-only
-                // span repeats it as real content so a screen-reader user
-                // gets the full timestamp reliably too (a `title` is
-                // announced as a description inconsistently across screen
-                // readers). Residual gap, accepted rather than solved here:
-                // a sighted keyboard-only or touch user with no screen
-                // reader still can't reach the full timestamp, since there
-                // is no longer a focusable trigger to reveal it on demand.
+                // "graphic, Jan 1, 01:10" instead of a date.
+                //
+                // One channel, not two (re-review, 2026-07-28): no `title`
+                // here alongside the sr-only span — keeping both would
+                // double-announce the full timestamp on any AT/browser
+                // pairing that surfaces the accessible description
+                // alongside the name (see the duplicate-IP badge above for
+                // the full HTML-AAM reasoning; identical trade here). The
+                // sr-only span is the one reliable channel to a screen
+                // reader; the trade-off accepted, not solved, is that a
+                // sighted mouse user no longer gets a hover tooltip for the
+                // full timestamp, and neither they nor a sighted
+                // keyboard-only/touch user without AT can reach it at all
+                // now — there is no longer any focusable trigger to reveal
+                // it on demand.
                 return (
-                    <span
-                        title={fullLabel}
-                        className="flex flex-col text-xs text-slate-500 font-medium"
-                    >
+                    <span className="flex flex-col text-xs text-slate-500 font-medium">
                         {shortLabel}
-                        <span className="sr-only"> ({fullLabel})</span>
+                        <span className="sr-only"> {fullLabel}</span>
                     </span>
                 );
             },

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -61,7 +61,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { parseUA } from '@/utils/uaParser';
 import { useTranslation } from 'react-i18next';
@@ -180,27 +179,27 @@ export function ParticipantCell({
                 )}
             </div>
             {p.ip_address && duplicateIpGroups.has(p.ip_address) && (
-                <TooltipProvider>
-                    <Tooltip>
-                        <TooltipTrigger>
-                            {/* text-amber-800, not -600 — axe (task 6.7e) measured 3.07:1. */}
-                            <Badge
-                                variant="outline"
-                                className="h-4 text-2xs px-1.5 font-semibold bg-amber-50 text-amber-800 border-amber-200"
-                            >
-                                {t('admin.data.table.duplicate_ip', 'Duplicate IP')} #
-                                {duplicateIpGroups.get(p.ip_address)}
-                            </Badge>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                            {t(
-                                'admin.data.table.duplicate_ip_hint',
-                                'Shares IP hash with other participants'
-                            )}{' '}
-                            ({p.ip_address.substring(0, 8)}...)
-                        </TooltipContent>
-                    </Tooltip>
-                </TooltipProvider>
+                // role="img", not a TooltipTrigger button (Task 6.7i, same
+                // defect shape as the seven chips 6.7g converted): this badge
+                // did nothing on activation, it only ever announced a fact.
+                // aria-label keeps the exact wording the badge's own text
+                // already computed as its accessible name; title carries the
+                // extra hint that used to live in TooltipContent, for mouse
+                // users hovering.
+                // text-amber-800, not -600 — axe (task 6.7e) measured 3.07:1.
+                <Badge
+                    variant="outline"
+                    role="img"
+                    aria-label={`${t('admin.data.table.duplicate_ip', 'Duplicate IP')} #${duplicateIpGroups.get(p.ip_address)}`}
+                    title={`${t(
+                        'admin.data.table.duplicate_ip_hint',
+                        'Shares IP hash with other participants'
+                    )} (${p.ip_address.substring(0, 8)}...)`}
+                    className="h-4 text-2xs px-1.5 font-semibold bg-amber-50 text-amber-800 border-amber-200"
+                >
+                    {t('admin.data.table.duplicate_ip', 'Duplicate IP')} #
+                    {duplicateIpGroups.get(p.ip_address)}
+                </Badge>
             )}
         </div>
     );
@@ -746,21 +745,22 @@ export function buildColumns({
                 const val = info.getValue();
                 if (!val) return <span className="text-slate-300">—</span>;
                 const date = new Date(val);
+                const shortLabel = format(date, 'MMM d, HH:mm', { locale: currentLocale });
+                const fullLabel = format(date, 'PPpp', { locale: currentLocale });
+                // role="img", not a TooltipTrigger button (Task 6.7i, same
+                // defect shape 6.7g fixed elsewhere in this file): the short
+                // date was already the accessible name via visible text; the
+                // full timestamp that used to live in TooltipContent is now
+                // the native `title` a mouse user hovers to see.
                 return (
-                    <TooltipProvider>
-                        <Tooltip>
-                            <TooltipTrigger>
-                                <div className="flex flex-col text-xs text-slate-500 font-medium">
-                                    <span>
-                                        {format(date, 'MMM d, HH:mm', { locale: currentLocale })}
-                                    </span>
-                                </div>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                {format(date, 'PPpp', { locale: currentLocale })}
-                            </TooltipContent>
-                        </Tooltip>
-                    </TooltipProvider>
+                    <span
+                        role="img"
+                        aria-label={shortLabel}
+                        title={fullLabel}
+                        className="flex flex-col text-xs text-slate-500 font-medium"
+                    >
+                        {shortLabel}
+                    </span>
                 );
             },
         }),

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -180,18 +180,22 @@ export function ParticipantCell({
                 )}
             </div>
             {p.ip_address && duplicateIpGroups.has(p.ip_address) && (
-                // role="img", not a TooltipTrigger button (Task 6.7i, same
-                // defect shape as the seven chips 6.7g converted): this badge
-                // did nothing on activation, it only ever announced a fact.
-                // aria-label keeps the exact wording the badge's own text
-                // already computed as its accessible name; title carries the
-                // extra hint that used to live in TooltipContent, for mouse
-                // users hovering.
+                // Plain badge, no role (Task 6.7i review finding 2): this
+                // already has an accessible name from its own visible text
+                // ("Duplicate IP #1") — role="img" would turn that readable
+                // text into a graphic node (NVDA: "graphic, Duplicate IP
+                // #1") and force the same wording into a hand-maintained
+                // aria-label. `title` keeps the hint/IP-hash-prefix for a
+                // mouse user hovering; the sr-only span repeats it as real
+                // content so a screen-reader user gets it reliably too (a
+                // `title` is announced as a description inconsistently
+                // across screen readers). Residual gap, accepted rather than
+                // solved here: a sighted keyboard-only or touch user with no
+                // screen reader still can't reach this detail, since there is
+                // no longer a focusable trigger to reveal it on demand.
                 // text-amber-800, not -600 — axe (task 6.7e) measured 3.07:1.
                 <Badge
                     variant="outline"
-                    role="img"
-                    aria-label={`${t('admin.data.table.duplicate_ip', 'Duplicate IP')} #${duplicateIpGroups.get(p.ip_address)}`}
                     title={`${t(
                         'admin.data.table.duplicate_ip_hint',
                         'Shares IP hash with other participants'
@@ -200,6 +204,15 @@ export function ParticipantCell({
                 >
                     {t('admin.data.table.duplicate_ip', 'Duplicate IP')} #
                     {duplicateIpGroups.get(p.ip_address)}
+                    <span className="sr-only">
+                        {' '}
+                        (
+                        {t(
+                            'admin.data.table.duplicate_ip_hint',
+                            'Shares IP hash with other participants'
+                        )}
+                        , {p.ip_address.substring(0, 8)}...)
+                    </span>
                 </Badge>
             )}
         </div>
@@ -760,19 +773,26 @@ export function buildColumns({
                 const date = new Date(val);
                 const shortLabel = format(date, 'MMM d, HH:mm', { locale: currentLocale });
                 const fullLabel = format(date, 'PPpp', { locale: currentLocale });
-                // role="img", not a TooltipTrigger button (Task 6.7i, same
-                // defect shape 6.7g fixed elsewhere in this file): the short
-                // date was already the accessible name via visible text; the
-                // full timestamp that used to live in TooltipContent is now
-                // the native `title` a mouse user hovers to see.
+                // Plain span, no role (Task 6.7i review finding 2): the
+                // short date is already the accessible name via its own
+                // visible text, sitting in a sorted temporal column —
+                // role="img" would make a screen reader announce it as
+                // "graphic, Jan 1, 01:10" instead of a date. `title` keeps
+                // the full timestamp for a mouse user hovering; the sr-only
+                // span repeats it as real content so a screen-reader user
+                // gets the full timestamp reliably too (a `title` is
+                // announced as a description inconsistently across screen
+                // readers). Residual gap, accepted rather than solved here:
+                // a sighted keyboard-only or touch user with no screen
+                // reader still can't reach the full timestamp, since there
+                // is no longer a focusable trigger to reveal it on demand.
                 return (
                     <span
-                        role="img"
-                        aria-label={shortLabel}
                         title={fullLabel}
                         className="flex flex-col text-xs text-slate-500 font-medium"
                     >
                         {shortLabel}
+                        <span className="sr-only"> ({fullLabel})</span>
                     </span>
                 );
             },
@@ -788,7 +808,12 @@ export function buildColumns({
                     <Button
                         variant="ghost"
                         size="icon"
-                        className="h-7 w-7 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50"
+                        // text-slate-500, not -400: -400 is 2.56:1 on white,
+                        // below WCAG 1.4.11's 3:1 non-text-contrast floor, and
+                        // this icon is the control's *only* visible
+                        // affordance (Task 6.7i review finding 1). -500 is
+                        // 4.76:1.
+                        className="h-7 w-7 text-slate-500 hover:text-indigo-600 hover:bg-indigo-50"
                         aria-label={t(
                             'admin.data.table.view_participant',
                             'View participant {{id}}',

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -20,6 +20,7 @@ import {
     ArrowUpDown,
     ArrowUp,
     ArrowDown,
+    ArrowRight,
     Clock,
     Globe,
     AlertTriangle,
@@ -226,6 +227,17 @@ export interface BuildColumnsParams {
     setStepFilter: (f: StepFilter) => void;
     setConsentFilters: (s: Set<ConsentType>) => void;
     setQualityFilter: (f: QualityFilter) => void;
+    /**
+     * The row's one real keyboard-and-mouse action (Task 6.7i). Wired to a
+     * dedicated `<Button>` in the trailing "row_actions" column so a
+     * screen-reader user tabbing through the table lands on a real,
+     * per-row-named control rather than relying on the `<TableRow>`'s
+     * mouse-only `onClick` (InteractiveDataView.tsx), which has no keyboard
+     * path at all. Kept as a real button inside a `<td>`, not a role on the
+     * `<tr>` itself, so the row keeps its native `row` semantics for table
+     * navigation (see the task report for the alternatives considered).
+     */
+    onViewParticipant: (participant: DumpParticipant) => void;
 }
 
 export function buildColumns({
@@ -243,6 +255,7 @@ export function buildColumns({
     setStepFilter,
     setConsentFilters,
     setQualityFilter,
+    onViewParticipant,
 }: BuildColumnsParams) {
     return [
         columnHelper.accessor('id', {
@@ -761,6 +774,41 @@ export function buildColumns({
                     >
                         {shortLabel}
                     </span>
+                );
+            },
+        }),
+        columnHelper.display({
+            id: 'row_actions',
+            header: () => (
+                <span className="sr-only">{t('admin.data.table.actions', 'Details')}</span>
+            ),
+            cell: ({ row }) => {
+                const p = row.original;
+                return (
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50"
+                        aria-label={t(
+                            'admin.data.table.view_participant',
+                            'View participant {{id}}',
+                            {
+                                id: p.id,
+                            }
+                        )}
+                        onClick={(e) => {
+                            // The row itself also navigates on click
+                            // (InteractiveDataView.tsx's `<TableRow
+                            // onClick>`, mouse-only); stop the bubble so a
+                            // click or Enter/Space on this button doesn't
+                            // fire handleViewParticipant twice (double
+                            // navigate()/history push).
+                            e.stopPropagation();
+                            onViewParticipant(p);
+                        }}
+                    >
+                        <ArrowRight className="h-3.5 w-3.5" />
+                    </Button>
                 );
             },
         }),

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.stopPropagation.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.stopPropagation.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Guards the row_actions button's "navigate exactly once" invariant
+ * (InteractiveDataView.columns.tsx / InteractiveDataView.tsx) against
+ * regression, and records how it was proven.
+ *
+ * Task 6.7i's own report called `e.stopPropagation()`'s effect "not directly
+ * testable in this stack" because a real Routes/Route render can't
+ * distinguish one navigate() call from two to the identical destination —
+ * the same route renders either way. That claim was wrong: mocking
+ * `useNavigate` and counting calls discriminates cleanly.
+ *
+ * RED, captured before the review round's fixes landed (both reverted
+ * locally, one at a time, to isolate each): with the row_actions button's
+ * `e.stopPropagation()` removed and *no* interactive-descendant guard on the
+ * row's own onClick, both tests below failed with "expected 1, got 2" —
+ * confirming the reviewer's independent finding. Restoring
+ * `stopPropagation()` alone (still no row guard) turned both GREEN.
+ *
+ * The row's onClick then gained its own interactive-descendant guard
+ * (`e.target.closest('button,a,input,select,[role="button"]')`, task 6.7i
+ * review minor finding 2) as defense-in-depth. That guard is now, by
+ * itself, sufficient to keep navigate() to one call even if a future
+ * control's own `stopPropagation()` is ever dropped — so at the current
+ * HEAD this file's two tests are a regression guard on the *observable*
+ * "navigate exactly once" behaviour with two independent layers protecting
+ * it, not a test that can still isolate which layer is doing the work. That
+ * is the intended effect of "belt-and-braces": the two protections were
+ * proven independently above, not because this file can keep telling them
+ * apart forever.
+ *
+ * Kept in its own file rather than folded into InteractiveDataView.test.tsx:
+ * mocking react-router-dom's `useNavigate` here would silently turn every
+ * *other* test in that file's real Routes/Route navigation into no-ops
+ * (mockNavigate never actually changes the location), which would make
+ * `screen.findByTestId('participant-detail')` never resolve there.
+ */
+
+import { renderWithProviders, screen } from '@/test-utils/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import type { DumpParticipant, DumpResponse } from './types';
+import InteractiveDataView from './InteractiveDataView';
+
+const { mockDumpQuery, mockNavigate } = vi.hoisted(() => ({
+    mockDumpQuery: vi.fn(),
+    mockNavigate: vi.fn(),
+}));
+
+vi.mock('@/api/generated', () => ({
+    useGetStudyDumpApiAdminStudiesSlugDumpGet: () => mockDumpQuery(),
+    getGetStudyDumpApiAdminStudiesSlugDumpGetQueryKey: (slug: string) => ['dump', slug],
+}));
+vi.mock('@/api/mutator', () => ({ customInstance: vi.fn() }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('react-router-dom', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router-dom')>();
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function makeParticipant(over: Partial<DumpParticipant> = {}): DumpParticipant {
+    return {
+        id: 'abcd1234',
+        db_id: 1,
+        duration_seconds: 619,
+        scores: [],
+        placements: {},
+        presort: {},
+        postsort: {},
+        language: 'en',
+        is_discarded: false,
+        created_at: '2026-01-01T00:00:00Z',
+        submitted_at: '2026-01-01T00:10:19Z',
+        status: 'completed',
+        ...over,
+    } as DumpParticipant;
+}
+
+function dumpResponse(): DumpResponse {
+    return {
+        study: {
+            slug: 'demo',
+            statements: [],
+            translations: [{ lang: 'en', title: 'Study' }],
+            presort_config: {},
+            postsort_config: {},
+            state: 'active',
+            rough_sort_enabled: true,
+        },
+        participants: [makeParticipant()],
+        statement_id_to_index: {},
+    } as unknown as DumpResponse;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockDumpQuery.mockReturnValue({ data: dumpResponse(), isLoading: false, error: null });
+});
+
+describe('InteractiveDataView — row_actions stopPropagation invariant (Task 6.7i review)', () => {
+    it('calls navigate exactly once when the View button is clicked directly', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        const viewButton = screen.getByRole('button', { name: 'View participant abcd1234' });
+        await user.click(viewButton);
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls navigate exactly once on Enter, not twice via the row', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        const viewButton = screen.getByRole('button', { name: 'View participant abcd1234' });
+        viewButton.focus();
+        await user.keyboard('{Enter}');
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.stopPropagation.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.stopPropagation.test.tsx
@@ -24,15 +24,25 @@
  *
  * The row's onClick then gained its own interactive-descendant guard
  * (`e.target.closest('button,a,input,select,[role="button"]')`, task 6.7i
- * review minor finding 2) as defense-in-depth. That guard is now, by
- * itself, sufficient to keep navigate() to one call even if a future
- * control's own `stopPropagation()` is ever dropped — so at the current
- * HEAD this file's two tests are a regression guard on the *observable*
- * "navigate exactly once" behaviour with two independent layers protecting
- * it, not a test that can still isolate which layer is doing the work. That
- * is the intended effect of "belt-and-braces": the two protections were
- * proven independently above, not because this file can keep telling them
- * apart forever.
+ * review minor finding 2) as defense-in-depth. Re-review (2026-07-28) found
+ * that once that guard exists, the two tests above can no longer isolate
+ * `stopPropagation()`'s own effect: with the guard present and
+ * `stopPropagation()` alone removed, both stay GREEN (2/2) — the guard
+ * matches on the click's target regardless of whether the button stopped
+ * propagation, so it alone is sufficient. That made the original framing
+ * ("the invariant is solved and tested") overstated: only the row-level
+ * guard was actually standing watch going forward.
+ *
+ * `GuardlessRowHarness` below closes that gap for real: it renders the
+ * *actual* row_actions column (imported from InteractiveDataView.columns.tsx
+ * via `buildColumns`, not reimplemented) inside a deliberately bare
+ * `<tr onClick>` that has no interactive-descendant guard at all — the
+ * production guard lives in InteractiveDataView.tsx, one file away, and
+ * this harness never imports it. So this test can only pass because of the
+ * button's own `e.stopPropagation()`; nothing else in the harness could
+ * account for GREEN. That is what makes it a standing regression test for
+ * the button-level layer specifically, independent of whatever
+ * InteractiveDataView.tsx's row handler does or stops doing in the future.
  *
  * Kept in its own file rather than folded into InteractiveDataView.test.tsx:
  * mocking react-router-dom's `useNavigate` here would silently turn every
@@ -41,11 +51,16 @@
  * `screen.findByTestId('participant-detail')` never resolve there.
  */
 
-import { renderWithProviders, screen } from '@/test-utils/test-utils';
+import { useMemo } from 'react';
+import { useReactTable, getCoreRowModel, flexRender } from '@tanstack/react-table';
+import type { TFunction } from 'i18next';
+import { enUS } from 'date-fns/locale';
+import { render, renderWithProviders, screen } from '@/test-utils/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import type { DumpParticipant, DumpResponse } from './types';
 import InteractiveDataView from './InteractiveDataView';
+import { buildColumns } from './InteractiveDataView.columns';
 
 const { mockDumpQuery, mockNavigate } = vi.hoisted(() => ({
     mockDumpQuery: vi.fn(),
@@ -124,5 +139,124 @@ describe('InteractiveDataView — row_actions stopPropagation invariant (Task 6.
         await user.keyboard('{Enter}');
 
         expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+});
+
+// Minimal `t()` stand-in: real interpolation (`{{id}}` -> value), no i18n
+// provider needed. The row_actions cell only ever calls `t()` with a
+// literal key + fallback + a flat interpolation object, so this covers it
+// exactly; every other column's `t()` calls never run because the harness
+// below only mounts the row_actions column.
+const fakeT = ((key: string, fallback?: string, opts?: Record<string, unknown>) => {
+    let result = fallback ?? key;
+    if (opts) {
+        for (const [name, value] of Object.entries(opts)) {
+            result = result.replaceAll(`{{${name}}}`, String(value));
+        }
+    }
+    return result;
+}) as unknown as TFunction;
+
+interface GuardlessRowHarnessProps {
+    participant: DumpParticipant;
+    onView: (participant: DumpParticipant) => void;
+    onRowClick: () => void;
+}
+
+/**
+ * Renders the *real* row_actions column (via `buildColumns`, the same
+ * factory InteractiveDataView.tsx uses) inside a bare `<tr onClick>` that
+ * has no interactive-descendant guard — unlike the production `<TableRow>`
+ * in InteractiveDataView.tsx, which does. This isolates the button's own
+ * `e.stopPropagation()` from that guard: nothing here could make the row
+ * handler stay silent except the button's own call.
+ */
+function GuardlessRowHarness({ participant, onView, onRowClick }: GuardlessRowHarnessProps) {
+    const columns = useMemo(
+        () =>
+            buildColumns({
+                t: fakeT,
+                currentLocale: enUS,
+                duplicateIpGroups: new Map(),
+                showLanguageColumn: false,
+                statusFilter: 'all',
+                consentFilters: new Set(),
+                qualityFilter: 'all',
+                stepFilter: 'all',
+                stepLabels: {},
+                toggleConsent: () => {},
+                setStatusFilter: () => {},
+                setStepFilter: () => {},
+                setConsentFilters: () => {},
+                setQualityFilter: () => {},
+                onViewParticipant: onView,
+            }).filter((column) => column.id === 'row_actions'),
+        [onView]
+    );
+    const table = useReactTable({
+        data: [participant],
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+    });
+    const [row] = table.getRowModel().rows;
+    return (
+        <table>
+            <tbody>
+                <tr onClick={onRowClick}>
+                    {row.getVisibleCells().map((cell) => (
+                        <td key={cell.id}>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </td>
+                    ))}
+                </tr>
+            </tbody>
+        </table>
+    );
+}
+
+describe("InteractiveDataView.columns — row_actions button's own stopPropagation, isolated from the row-level guard (Task 6.7i re-review)", () => {
+    it('stops the click reaching a guard-less row handler on mouse click', async () => {
+        const user = userEvent.setup();
+        const onView = vi.fn();
+        const onRowClick = vi.fn();
+        const participant = makeParticipant();
+
+        render(
+            <GuardlessRowHarness
+                participant={participant}
+                onView={onView}
+                onRowClick={onRowClick}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: 'View participant abcd1234' }));
+
+        expect(onView).toHaveBeenCalledTimes(1);
+        // If e.stopPropagation() were ever deleted from the row_actions
+        // button (InteractiveDataView.columns.tsx), this harness has no
+        // other guard to fall back on — onRowClick would fire too.
+        expect(onRowClick).not.toHaveBeenCalled();
+    });
+
+    it('stops the click reaching a guard-less row handler on Enter', async () => {
+        const user = userEvent.setup();
+        const onView = vi.fn();
+        const onRowClick = vi.fn();
+        const participant = makeParticipant();
+
+        render(
+            <GuardlessRowHarness
+                participant={participant}
+                onView={onView}
+                onRowClick={onRowClick}
+            />
+        );
+
+        const viewButton = screen.getByRole('button', { name: 'View participant abcd1234' });
+        viewButton.focus();
+        await user.keyboard('{Enter}');
+
+        expect(onView).toHaveBeenCalledTimes(1);
+        expect(onRowClick).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -44,6 +44,12 @@ function expectedSubmittedLabel(iso: string): string {
     return format(new Date(iso), 'MMM d, HH:mm', { locale: enUS });
 }
 
+// The submitted_at cell's `title` carries the full timestamp (Task 6.7i) —
+// same local-timezone-independence reasoning as expectedSubmittedLabel above.
+function expectedFullSubmittedLabel(iso: string): string {
+    return format(new Date(iso), 'PPpp', { locale: enUS });
+}
+
 const { mockDumpQuery } = vi.hoisted(() => ({ mockDumpQuery: vi.fn() }));
 
 vi.mock('@/api/generated', () => ({
@@ -276,12 +282,13 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         ).toBeInTheDocument();
 
         // The submitted_at date is also still announced, just no longer a
-        // tab stop (Task 6.7i).
-        expect(
-            within(row).getByRole('img', {
-                name: expectedSubmittedLabel('2026-01-01T00:10:19Z'),
-            })
-        ).toBeInTheDocument();
+        // tab stop (Task 6.7i). It carries no role at all now (review
+        // finding 2): it already has an accessible name from its own
+        // visible text, so role="img" would have turned it into a graphic
+        // node instead. Find it by its `title` (the full timestamp) and
+        // confirm the short label is still its visible text.
+        const dateCell = within(row).getByTitle(expectedFullSubmittedLabel('2026-01-01T00:10:19Z'));
+        expect(dateCell).toHaveTextContent(expectedSubmittedLabel('2026-01-01T00:10:19Z'));
     });
 
     it('counts focusable controls in a duplicate-IP row: the badge and the date are no longer tab stops, leaving exactly one real, named action (Task 6.7i)', async () => {
@@ -306,19 +313,24 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         const row = screen.getByText('p1').closest('tr');
         if (!row) throw new Error('participant row not found');
 
-        // The duplicate-IP badge is a fact, not a control: named via
-        // role="img", absent from the button role.
-        expect(within(row).getByRole('img', { name: 'Duplicate IP #1' })).toBeInTheDocument();
+        // The duplicate-IP badge is a fact, not a control: plain visible
+        // text, no role at all (Task 6.7i review finding 2 — it already had
+        // an accessible name from its own text, so role="img" would have
+        // wrongly turned it into a graphic node). Find it by its `title`
+        // (the hint/IP-hash-prefix) and confirm the visible label is there.
+        const badge = within(row).getByTitle(/Shares IP hash with other participants/);
+        expect(badge).toHaveTextContent('Duplicate IP #1');
+        expect(within(row).queryByRole('img', { name: /Duplicate IP/ })).not.toBeInTheDocument();
         expect(within(row).queryByRole('button', { name: /Duplicate IP/ })).not.toBeInTheDocument();
 
         // Same for the submitted_at date: was a TooltipTrigger button
-        // revealing the full timestamp on hover, now a named,
-        // non-focusable fact.
+        // revealing the full timestamp on hover, now plain text with a
+        // `title` — not a role="img" either, for the same reason.
+        const dateCell = within(row).getByTitle(expectedFullSubmittedLabel('2026-01-01T00:10:19Z'));
+        expect(dateCell).toHaveTextContent(expectedSubmittedLabel('2026-01-01T00:10:19Z'));
         expect(
-            within(row).getByRole('img', {
-                name: expectedSubmittedLabel('2026-01-01T00:10:19Z'),
-            })
-        ).toBeInTheDocument();
+            within(row).queryByRole('img', { name: expectedSubmittedLabel('2026-01-01T00:10:19Z') })
+        ).not.toBeInTheDocument();
 
         // Before this task, a duplicate-IP row carried two inert tab stops
         // (this badge's own TooltipTrigger, plus the untouched submitted_at

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -28,6 +28,8 @@ import { computeAccessibleName } from 'dom-accessibility-api';
 import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
+import { Routes, Route } from 'react-router-dom';
+import type { ReactElement } from 'react';
 import { format } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import type { DumpParticipant, DumpResponse } from './types';
@@ -223,8 +225,8 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         // Same fixture as above, plus a user_agent so ParticipantCell's
         // OS/browser chip (also in scope for 6.7g) renders too, and a
         // submitted_at timestamp (already present via makeParticipant's
-        // default) whose own TooltipTrigger is explicitly OUT of this
-        // task's scope and must remain a real tab stop.
+        // default), whose own TooltipTrigger was out of 6.7g's scope but is
+        // in 6.7i's (see below).
         const participant = makeParticipant({
             id: 'p1',
             db_id: 1,
@@ -259,13 +261,14 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         // the time via a bare `asChild` div, so it didn't add to the count) +
         // the submitted_at tooltip trigger = 8 focusable `button`s in this
         // row. After 6.7g: only the (then out-of-scope) submitted_at trigger
-        // remained. After this task's chip conversion (this row has no
-        // duplicate IP, so that badge never renders here): the submitted_at
-        // trigger is converted too — role="img" like the rest — so the row
-        // has zero focusable buttons. (A follow-up task gives the row its
-        // first real, operable action; see the 6.7i report.)
-        const focusable = within(row).queryAllByRole('button');
-        expect(focusable).toHaveLength(0);
+        // remained. After 6.7i's chip conversion (this row has no duplicate
+        // IP, so that badge never renders here): the submitted_at trigger is
+        // converted too — role="img" like the rest — but the row gained its
+        // own real action (the trailing "row_actions" column), so the count
+        // is still 1, for a different and now-functional reason.
+        const focusable = within(row).getAllByRole('button');
+        expect(focusable).toHaveLength(1);
+        expect(focusable[0]).toHaveAccessibleName('View participant p1');
 
         // The OS/browser fact is still announced, with the name it never had.
         expect(
@@ -281,12 +284,12 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         ).toBeInTheDocument();
     });
 
-    it('drops the duplicate-IP badge as an inert tab stop too: a duplicate-IP row loses both of its remaining phantom buttons (Task 6.7i)', async () => {
-        // The fixture must actually trip the duplicate-IP badge, or this
-        // count would already read "0 focusable buttons" from the
-        // submitted_at conversion alone, proving nothing about whether the
-        // badge itself got fixed. Two participants sharing an IP is what
-        // populates duplicateIpGroups (useInteractiveDataView.ts).
+    it('counts focusable controls in a duplicate-IP row: the badge and the date are no longer tab stops, leaving exactly one real, named action (Task 6.7i)', async () => {
+        // The fixture must actually trip the duplicate-IP badge — a row
+        // without it would already read "1 focusable button" before this
+        // task (the untouched submitted_at trigger), proving nothing about
+        // whether the badge itself got fixed. Two participants sharing an
+        // IP is what populates duplicateIpGroups (useInteractiveDataView.ts).
         const participants = [
             makeParticipant({ id: 'p1', db_id: 1, ip_address: '203.0.113.5' }),
             makeParticipant({ id: 'p2', db_id: 2, ip_address: '203.0.113.5' }),
@@ -319,10 +322,83 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
 
         // Before this task, a duplicate-IP row carried two inert tab stops
         // (this badge's own TooltipTrigger, plus the untouched submitted_at
-        // trigger from 6.7g). After: zero — this row has no real action yet
-        // either (that's the companion 6.7i task), so it is, for now,
-        // entirely unreachable by keyboard. That gap is closed next.
-        expect(within(row).queryAllByRole('button')).toHaveLength(0);
+        // trigger from 6.7g) and zero paths to the row's real action. After:
+        // exactly one focusable button, and it is that real action, not a
+        // leftover inert trigger.
+        const focusable = within(row).getAllByRole('button');
+        expect(focusable).toHaveLength(1);
+        expect(focusable[0]).toHaveAccessibleName('View participant p1');
+    });
+});
+
+describe('InteractiveDataView — row keyboard path (Task 6.7i)', () => {
+    // Real navigation (Routes/Route), not a mocked `useNavigate` — same
+    // pattern as AdminDashboard.test.tsx's keyboard-operable-cards suite.
+    // Proves the whole chain: focusable -> Enter -> onClick ->
+    // handleViewParticipant -> navigate() -> route change, not just that
+    // some callback fired with the right argument.
+    function renderWithRoutes(ui: ReactElement) {
+        return renderWithProviders(
+            <Routes>
+                <Route path="/" element={ui} />
+                <Route
+                    path="/admin/studies/demo/participants/:id"
+                    element={<div data-testid="participant-detail" />}
+                />
+            </Routes>
+        );
+    }
+
+    it("gives the row a keyboard path to its own action: focus the row's View control, press Enter, and the participant opens", async () => {
+        const user = userEvent.setup();
+        renderWithRoutes(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        const viewButton = screen.getByRole('button', { name: 'View participant abcd1234' });
+        expect(screen.queryByTestId('participant-detail')).not.toBeInTheDocument();
+
+        viewButton.focus();
+        await user.keyboard('{Enter}');
+
+        expect(await screen.findByTestId('participant-detail')).toBeInTheDocument();
+    });
+
+    it('still lets a mouse user click anywhere in the row, unchanged', async () => {
+        const user = userEvent.setup();
+        renderWithRoutes(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        const row = screen.getByText('abcd1234').closest('tr');
+        if (!row) throw new Error('participant row not found');
+        expect(screen.queryByTestId('participant-detail')).not.toBeInTheDocument();
+
+        // Click a cell that is NOT the new View button — the row's own
+        // onClick (InteractiveDataView.tsx, mouse-only, untouched by this
+        // task) must still fire.
+        await user.click(within(row).getByText('abcd1234'));
+
+        expect(await screen.findByTestId('participant-detail')).toBeInTheDocument();
+    });
+
+    it('also lets a mouse user click the View control directly, not only the row at large', async () => {
+        const user = userEvent.setup();
+        renderWithRoutes(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        const viewButton = screen.getByRole('button', { name: 'View participant abcd1234' });
+        expect(screen.queryByTestId('participant-detail')).not.toBeInTheDocument();
+
+        // The button sits inside the row, which has its own onClick
+        // (InteractiveDataView.tsx). Clicking the button dispatches one
+        // native click that bubbles to the row; the button's handler calls
+        // stopPropagation so the row's handler doesn't also fire — a real
+        // double-navigate would still land here (same destination), so this
+        // is a smoke check that the button itself is independently
+        // clickable, not a substitute for the stopPropagation reasoning
+        // documented at the call site.
+        await user.click(viewButton);
+
+        expect(await screen.findByTestId('participant-detail')).toBeInTheDocument();
     });
 });
 

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -28,8 +28,19 @@ import { computeAccessibleName } from 'dom-accessibility-api';
 import { renderWithProviders, screen, within } from '@/test-utils/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
+import { format } from 'date-fns';
+import { enUS } from 'date-fns/locale';
 import type { DumpParticipant, DumpResponse } from './types';
 import InteractiveDataView from './InteractiveDataView';
+
+// The submitted_at cell renders `format(date, 'MMM d, HH:mm', { locale })`
+// (InteractiveDataView.columns.tsx) in the *local* timezone of whatever
+// machine runs the test — computing the expected label the same way the
+// component does (rather than hardcoding a string like "Jan 1, 00:10")
+// keeps these assertions correct regardless of the runner's TZ.
+function expectedSubmittedLabel(iso: string): string {
+    return format(new Date(iso), 'MMM d, HH:mm', { locale: enUS });
+}
 
 const { mockDumpQuery } = vi.hoisted(() => ({ mockDumpQuery: vi.fn() }));
 
@@ -244,17 +255,74 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         const row = screen.getByText('p1').closest('tr');
         if (!row) throw new Error('participant row not found');
 
-        // Before this task: 7 status chips + the OS/browser chip (unreachable
-        // today via a bare `asChild` div, so it doesn't add to the count) +
+        // Before 6.7g: 7 status chips + the OS/browser chip (unreachable at
+        // the time via a bare `asChild` div, so it didn't add to the count) +
         // the submitted_at tooltip trigger = 8 focusable `button`s in this
-        // row. After: only the out-of-scope submitted_at trigger remains.
-        const focusable = within(row).getAllByRole('button');
-        expect(focusable).toHaveLength(1);
+        // row. After 6.7g: only the (then out-of-scope) submitted_at trigger
+        // remained. After this task's chip conversion (this row has no
+        // duplicate IP, so that badge never renders here): the submitted_at
+        // trigger is converted too — role="img" like the rest — so the row
+        // has zero focusable buttons. (A follow-up task gives the row its
+        // first real, operable action; see the 6.7i report.)
+        const focusable = within(row).queryAllByRole('button');
+        expect(focusable).toHaveLength(0);
 
         // The OS/browser fact is still announced, with the name it never had.
         expect(
             within(row).getByRole('img', { name: 'Device: Windows, Chrome' })
         ).toBeInTheDocument();
+
+        // The submitted_at date is also still announced, just no longer a
+        // tab stop (Task 6.7i).
+        expect(
+            within(row).getByRole('img', {
+                name: expectedSubmittedLabel('2026-01-01T00:10:19Z'),
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('drops the duplicate-IP badge as an inert tab stop too: a duplicate-IP row loses both of its remaining phantom buttons (Task 6.7i)', async () => {
+        // The fixture must actually trip the duplicate-IP badge, or this
+        // count would already read "0 focusable buttons" from the
+        // submitted_at conversion alone, proving nothing about whether the
+        // badge itself got fixed. Two participants sharing an IP is what
+        // populates duplicateIpGroups (useInteractiveDataView.ts).
+        const participants = [
+            makeParticipant({ id: 'p1', db_id: 1, ip_address: '203.0.113.5' }),
+            makeParticipant({ id: 'p2', db_id: 2, ip_address: '203.0.113.5' }),
+        ];
+        mockDumpQuery.mockReturnValue({
+            data: { ...dumpResponseWithTranslations(['en']), participants },
+            isLoading: false,
+            error: null,
+        });
+
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+        await screen.findByRole('table');
+
+        const row = screen.getByText('p1').closest('tr');
+        if (!row) throw new Error('participant row not found');
+
+        // The duplicate-IP badge is a fact, not a control: named via
+        // role="img", absent from the button role.
+        expect(within(row).getByRole('img', { name: 'Duplicate IP #1' })).toBeInTheDocument();
+        expect(within(row).queryByRole('button', { name: /Duplicate IP/ })).not.toBeInTheDocument();
+
+        // Same for the submitted_at date: was a TooltipTrigger button
+        // revealing the full timestamp on hover, now a named,
+        // non-focusable fact.
+        expect(
+            within(row).getByRole('img', {
+                name: expectedSubmittedLabel('2026-01-01T00:10:19Z'),
+            })
+        ).toBeInTheDocument();
+
+        // Before this task, a duplicate-IP row carried two inert tab stops
+        // (this badge's own TooltipTrigger, plus the untouched submitted_at
+        // trigger from 6.7g). After: zero — this row has no real action yet
+        // either (that's the companion 6.7i task), so it is, for now,
+        // entirely unreachable by keyboard. That gap is closed next.
+        expect(within(row).queryAllByRole('button')).toHaveLength(0);
     });
 });
 

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -285,10 +285,17 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         // tab stop (Task 6.7i). It carries no role at all now (review
         // finding 2): it already has an accessible name from its own
         // visible text, so role="img" would have turned it into a graphic
-        // node instead. Find it by its `title` (the full timestamp) and
-        // confirm the short label is still its visible text.
-        const dateCell = within(row).getByTitle(expectedFullSubmittedLabel('2026-01-01T00:10:19Z'));
-        expect(dateCell).toHaveTextContent(expectedSubmittedLabel('2026-01-01T00:10:19Z'));
+        // node instead. The visible short label and the sr-only full
+        // timestamp are two separate text-node-owning elements (RTL's
+        // getByText matches an element's own direct text nodes, not its
+        // descendants' — no `title` any more, single channel, see
+        // columns.tsx), so both are queried independently.
+        expect(
+            within(row).getByText(expectedSubmittedLabel('2026-01-01T00:10:19Z'))
+        ).toBeInTheDocument();
+        expect(
+            within(row).getByText(expectedFullSubmittedLabel('2026-01-01T00:10:19Z'))
+        ).toBeInTheDocument();
     });
 
     it('counts focusable controls in a duplicate-IP row: the badge and the date are no longer tab stops, leaving exactly one real, named action (Task 6.7i)', async () => {
@@ -316,18 +323,27 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         // The duplicate-IP badge is a fact, not a control: plain visible
         // text, no role at all (Task 6.7i review finding 2 — it already had
         // an accessible name from its own text, so role="img" would have
-        // wrongly turned it into a graphic node). Find it by its `title`
-        // (the hint/IP-hash-prefix) and confirm the visible label is there.
-        const badge = within(row).getByTitle(/Shares IP hash with other participants/);
-        expect(badge).toHaveTextContent('Duplicate IP #1');
+        // wrongly turned it into a graphic node). "Duplicate IP #1" is the
+        // badge's own direct text (RTL's getByText matches an element's own
+        // text nodes, not its descendants' — so this specifically excludes
+        // the nested sr-only span's text); the hint/IP-hash-prefix lives
+        // only in that sr-only span now (no `title` any more, single
+        // channel — see columns.tsx), queried separately below.
+        expect(within(row).getByText('Duplicate IP #1')).toBeInTheDocument();
+        expect(within(row).getByText(/Shares IP hash with other participants/)).toBeInTheDocument();
         expect(within(row).queryByRole('img', { name: /Duplicate IP/ })).not.toBeInTheDocument();
         expect(within(row).queryByRole('button', { name: /Duplicate IP/ })).not.toBeInTheDocument();
 
         // Same for the submitted_at date: was a TooltipTrigger button
-        // revealing the full timestamp on hover, now plain text with a
-        // `title` — not a role="img" either, for the same reason.
-        const dateCell = within(row).getByTitle(expectedFullSubmittedLabel('2026-01-01T00:10:19Z'));
-        expect(dateCell).toHaveTextContent(expectedSubmittedLabel('2026-01-01T00:10:19Z'));
+        // revealing the full timestamp on hover, now plain text, split
+        // across a visible short label and an sr-only full timestamp — not
+        // a role="img" either, for the same reason.
+        expect(
+            within(row).getByText(expectedSubmittedLabel('2026-01-01T00:10:19Z'))
+        ).toBeInTheDocument();
+        expect(
+            within(row).getByText(expectedFullSubmittedLabel('2026-01-01T00:10:19Z'))
+        ).toBeInTheDocument();
         expect(
             within(row).queryByRole('img', { name: expectedSubmittedLabel('2026-01-01T00:10:19Z') })
         ).not.toBeInTheDocument();

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -857,7 +857,34 @@ export default function InteractiveDataView({
                                             !!row.original.is_discarded &&
                                                 'opacity-60 grayscale-[0.5]'
                                         )}
-                                        onClick={() => handleViewParticipant(row.original)}
+                                        onClick={(e) => {
+                                            // Belt-and-braces (Task 6.7i
+                                            // review finding, minor 2): the
+                                            // row_actions button already
+                                            // calls stopPropagation, but
+                                            // nothing enforced that "every
+                                            // future control inside a row
+                                            // must do the same." Guarding
+                                            // here makes that robust by
+                                            // construction instead of an
+                                            // unwritten rule. (Once this
+                                            // guard exists, it alone is
+                                            // enough to keep navigate() to a
+                                            // single call even if a future
+                                            // control's own stopPropagation
+                                            // is ever dropped — see the
+                                            // InteractiveDataView.stopPropagation.test.tsx
+                                            // header comment for how that
+                                            // was verified.)
+                                            if (
+                                                (e.target as HTMLElement).closest(
+                                                    'button,a,input,select,[role="button"]'
+                                                )
+                                            ) {
+                                                return;
+                                            }
+                                            handleViewParticipant(row.original);
+                                        }}
                                     >
                                         {row.getVisibleCells().map((cell) => (
                                             <TableCell

--- a/frontend/src/hooks/admin/useInteractiveDataView.ts
+++ b/frontend/src/hooks/admin/useInteractiveDataView.ts
@@ -368,6 +368,7 @@ export function useInteractiveDataView({
                 setStepFilter,
                 setConsentFilters,
                 setQualityFilter,
+                onViewParticipant: handleViewParticipant,
             }),
         [
             t,
@@ -380,6 +381,7 @@ export function useInteractiveDataView({
             stepFilter,
             toggleConsent,
             stepLabels,
+            handleViewParticipant,
         ]
     );
 


### PR DESCRIPTION
## Summary

Task 6.7i. `<TableRow onClick={…}>` carried `cursor-pointer` but **no `tabIndex`, `role` or key handler** — so opening a participant, the primary action of the Data screen where a researcher inspects their collected responses, was **mouse-only**.

An earlier task made this starker rather than causing it: after removing seven inert tab stops per row, the row held one focusable control that did nothing and no focusable path to what it actually does.

**Result: 2 inert tab stops per row → 1 real, named action.**

## The shape, and what was rejected

A dedicated `<Button>` in a trailing "Details" column, wired to `handleViewParticipant`.

`role="button"` on the `<tr>` was rejected: an explicit role **replaces the implicit `row` role** that NVDA and JAWS table mode and the VoiceOver rotor depend on. Wrapping the row in a `<button>` was rejected too — nesting interactive elements is invalid, and the row still holds its own controls.

Review verified the resulting semantics by rendering rather than reading: 7 headers / 7 cells parity holds, the `<tr>` carries no role, the button's name is per-row distinguishable (`View participant abcd1234`), and the empty state's `colSpan` picked the new column up automatically.

## Three defects this task introduced, and how each was caught

Worth recording, because they are all the same shape — a correct move whose precondition had quietly stopped holding.

**The new button's icon failed non-text contrast.** `text-slate-400` = 2.56:1 against WCAG 1.4.11's 3:1, on the *sole* visual identification of the screen's primary action. **Neither guard can see this** — axe does not automate non-text contrast, and the repo's gate only flags text-bearing nodes.

**`role="img"` was applied to text-bearing content.** The pattern came from the seven status chips an earlier task converted — but those were **icon-only**, and without the role and label they had no name at all. The duplicate-IP badge and the date already had names, from their own visible text. The role turned readable text into a graphic node: a screen reader announced *"graphic, Jan 1, 01:10"* for a date in a sorted temporal column.

**Then the fix for that did it again.** Adding an `sr-only` span *while keeping* `title` put the same sentence into the accessibility tree twice — the name computed from content, the `title` exposed separately as the description. Resolved to one channel per piece of information.

## A test that had stopped guarding what it claimed

The report stated `stopPropagation()` was proven load-bearing, and it had been — historically. But once the row's interactive-descendant guard landed, review removed `stopPropagation()` alone and **the suite stayed green**: a defence-in-depth pair with only one live guard, and a claim the next reader would have trusted.

Closed with a harness that isolates the button's layer and goes red against it.

## Checklist

- [ ] `make ci` passes locally — **frontend green (197 files / 1700 tests, biome + tsc clean, gate unchanged); backend `pytest` fails on a local Postgres credential issue reproducing identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — focus → Enter → participant opens, verified red against the pre-fix source; the duplicate-IP fixture genuinely trips the badge, so the count is measured rather than assumed.
- [x] Translation keys added to all locales — new key in all nine, fallback matching `en/admin.json`.
- [x] API client regenerated if backend schemas changed — not applicable.

## Known trade-off

Dropping `title` in favour of `sr-only` means mouse users lose the hover tooltip on the duplicate-IP hint and the full timestamp. That detail remains unreachable for a sighted keyboard or touch user with no assistive technology — recovering it would mean reintroducing a focusable trigger, which is the defect this task removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)