### PR TITLE
fix(admin): measure the slug prefix, align the access rows, unify the stat tiles

### DIFF
--- a/frontend/src/components/ui/slug-input.test.tsx
+++ b/frontend/src/components/ui/slug-input.test.tsx
@@ -1,0 +1,133 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SlugInput } from './slug-input';
+
+/**
+ * jsdom never computes real layout — every element's getBoundingClientRect()
+ * and offsetWidth report 0, and jsdom's global ResizeObserver polyfill
+ * (src/setupTests.ts) is a no-op that never invokes its callback. So no test
+ * in this file can observe genuine pixel geometry; a hard-coded `pl-32`
+ * would satisfy a naive "gap >= 8" assertion here just as well as a real
+ * measurement does. To actually prove the padding is *derived from* the
+ * measured prefix width — not a constant — this file replaces the global
+ * ResizeObserver with a controllable mock that lets a test fire the
+ * observer's callback with an arbitrary `contentRect.width` and check the
+ * component's padding tracks it.
+ */
+
+type ROCallback = ConstructorParameters<typeof ResizeObserver>[0];
+
+let observedCallbacks: ROCallback[];
+
+class ControllableResizeObserver {
+    callback: ROCallback;
+    constructor(callback: ROCallback) {
+        this.callback = callback;
+        observedCallbacks.push(callback);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+function fireResize(width: number, index = 0) {
+    const callback = observedCallbacks[index];
+    act(() => {
+        // biome-ignore lint/suspicious/noExplicitAny: minimal ResizeObserverEntry stub for the test
+        callback([{ contentRect: { width } } as any], null as unknown as ResizeObserver);
+    });
+}
+
+describe('SlugInput', () => {
+    beforeEach(() => {
+        observedCallbacks = [];
+        vi.stubGlobal('ResizeObserver', ControllableResizeObserver);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    // Brief's own smoke test (task-6.1-brief.md step 1). It passes even
+    // before the prefix has been measured (jsdom's zero-width layout makes
+    // input.left and prefix.right both 0, so the assertion only exercises
+    // the fallback/gutter constant) — it does NOT prove the padding is
+    // measurement-driven. Test below does.
+    it('keeps a gutter between the prefix and the value', () => {
+        render(<SlugInput prefix="/app/" value="example-project" onChange={() => {}} />);
+        const input = screen.getByRole('textbox');
+        const prefix = screen.getByText('/app/');
+        const gap =
+            input.getBoundingClientRect().left +
+            Number.parseFloat(getComputedStyle(input).paddingLeft) -
+            prefix.getBoundingClientRect().right;
+        expect(gap).toBeGreaterThanOrEqual(8);
+    });
+
+    it('derives the input’s left padding from the measured prefix width, not a constant', () => {
+        render(<SlugInput prefix="/app/" value="example-project" onChange={() => {}} />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+
+        fireResize(40);
+        expect(input.style.paddingLeft).toBe('52px'); // 40 + 12px gutter
+
+        fireResize(100);
+        expect(input.style.paddingLeft).toBe('112px'); // 100 + 12px gutter — tracks the new width
+    });
+
+    it('measures independently per prefix, so two instances with different prefixes do not share one padding', () => {
+        render(
+            <>
+                <SlugInput prefix="/app/" value="a" onChange={() => {}} />
+                <SlugInput prefix="/study/" value="b" onChange={() => {}} />
+            </>
+        );
+        const [shortInput, longInput] = screen.getAllByRole('textbox') as HTMLInputElement[];
+
+        fireResize(30, 0); // "/app/" measured narrow
+        fireResize(70, 1); // "/study/" measured wider
+
+        expect(shortInput.style.paddingLeft).toBe('42px');
+        expect(longInput.style.paddingLeft).toBe('82px');
+        expect(shortInput.style.paddingLeft).not.toBe(longInput.style.paddingLeft);
+    });
+
+    it('falls back to a fixed padding before any measurement has arrived', () => {
+        render(<SlugInput prefix="/app/" value="example-project" onChange={() => {}} />);
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        // No fireResize() call yet — the observer hasn't reported a width.
+        expect(input.style.paddingLeft).toBe('48px');
+    });
+
+    it('calls onChange with the raw string value, not the event', () => {
+        const onChange = vi.fn();
+        render(<SlugInput prefix="/app/" value="" onChange={onChange} />);
+        const input = screen.getByRole('textbox');
+        fireEvent.change(input, { target: { value: 'my-slug' } });
+        expect(onChange).toHaveBeenCalledWith('my-slug');
+    });
+
+    it('forwards id and a ref to the underlying input (required for FormControl/Slot composition)', () => {
+        let refValue: HTMLInputElement | null = null;
+        render(
+            <SlugInput
+                prefix="/app/"
+                value=""
+                onChange={() => {}}
+                id="project-slug"
+                ref={(node) => {
+                    refValue = node;
+                }}
+            />
+        );
+        const input = screen.getByRole('textbox');
+        expect(input).toHaveAttribute('id', 'project-slug');
+        expect(refValue).toBe(input);
+    });
+});

--- a/frontend/src/components/ui/slug-input.test.tsx
+++ b/frontend/src/components/ui/slug-input.test.tsx
@@ -9,20 +9,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SlugInput } from './slug-input';
 
 /**
- * jsdom never computes real layout — every element's getBoundingClientRect()
- * and offsetWidth report 0, and jsdom's global ResizeObserver polyfill
- * (src/setupTests.ts) is a no-op that never invokes its callback. So no test
- * in this file can observe genuine pixel geometry; a hard-coded `pl-32`
- * would satisfy a naive "gap >= 8" assertion here just as well as a real
- * measurement does. To actually prove the padding is *derived from* the
- * measured prefix width — not a constant — this file replaces the global
- * ResizeObserver with a controllable mock that lets a test fire the
- * observer's callback with an arbitrary `contentRect.width` and check the
- * component's padding tracks it.
+ * jsdom never computes real layout — every element's getBoundingClientRect(),
+ * offsetLeft and offsetWidth report 0, and jsdom's global ResizeObserver
+ * polyfill (src/setupTests.ts) is a no-op that never invokes its callback.
+ * So no test in this file can observe genuine pixel geometry; a hard-coded
+ * `pl-32` would satisfy a naive "gap >= 8" assertion here just as well as a
+ * real measurement does. To actually prove the padding is *derived from*
+ * the prefix's measured position and width — not a constant — this file
+ * replaces the global ResizeObserver with a controllable mock, and stubs
+ * `offsetLeft`/`offsetWidth` on the specific prefix node under test, so a
+ * test can set an arbitrary measured geometry and check the component's
+ * padding tracks it.
  */
 
 type ROCallback = ConstructorParameters<typeof ResizeObserver>[0];
 
+let observedNodes: Element[];
 let observedCallbacks: ROCallback[];
 
 class ControllableResizeObserver {
@@ -31,21 +33,27 @@ class ControllableResizeObserver {
         this.callback = callback;
         observedCallbacks.push(callback);
     }
-    observe() {}
+    observe(node: Element) {
+        observedNodes.push(node);
+    }
     unobserve() {}
     disconnect() {}
 }
 
-function fireResize(width: number, index = 0) {
+/** Stubs the observed prefix node's offsetLeft/offsetWidth, then fires its observer callback. */
+function fireResize(offsetLeft: number, offsetWidth: number, index = 0) {
+    const node = observedNodes[index];
     const callback = observedCallbacks[index];
+    Object.defineProperty(node, 'offsetLeft', { value: offsetLeft, configurable: true });
+    Object.defineProperty(node, 'offsetWidth', { value: offsetWidth, configurable: true });
     act(() => {
-        // biome-ignore lint/suspicious/noExplicitAny: minimal ResizeObserverEntry stub for the test
-        callback([{ contentRect: { width } } as any], null as unknown as ResizeObserver);
+        callback([] as unknown as ResizeObserverEntry[], null as unknown as ResizeObserver);
     });
 }
 
 describe('SlugInput', () => {
     beforeEach(() => {
+        observedNodes = [];
         observedCallbacks = [];
         vi.stubGlobal('ResizeObserver', ControllableResizeObserver);
     });
@@ -70,15 +78,26 @@ describe('SlugInput', () => {
         expect(gap).toBeGreaterThanOrEqual(8);
     });
 
-    it('derives the input’s left padding from the measured prefix width, not a constant', () => {
+    it('derives the input’s left padding from the measured prefix position and width, not a constant', () => {
         render(<SlugInput prefix="/app/" value="example-project" onChange={() => {}} />);
         const input = screen.getByRole('textbox') as HTMLInputElement;
 
-        fireResize(40);
-        expect(input.style.paddingLeft).toBe('52px'); // 40 + 12px gutter
+        // offsetLeft=12 (the prefix's own `left-3`) + offsetWidth=40 + 12px gutter.
+        fireResize(12, 40);
+        expect(input.style.paddingLeft).toBe('64px');
 
-        fireResize(100);
-        expect(input.style.paddingLeft).toBe('112px'); // 100 + 12px gutter — tracks the new width
+        fireResize(12, 100);
+        expect(input.style.paddingLeft).toBe('124px'); // tracks the new width
+
+        // Regression check for the exact defect flagged in review: an
+        // earlier version of this component added prefixWidth + gutter
+        // WITHOUT the prefix's own 12px offsetLeft, which placed the value
+        // at the prefix's right edge (a ~1px gap) instead of after a real
+        // gutter. If offsetLeft is ever forgotten again, the padding below
+        // would be 52px, not 64px, and this assertion would catch it.
+        fireResize(12, 40);
+        expect(input.style.paddingLeft).toBe('64px');
+        expect(input.style.paddingLeft).not.toBe('52px');
     });
 
     it('measures independently per prefix, so two instances with different prefixes do not share one padding', () => {
@@ -90,19 +109,26 @@ describe('SlugInput', () => {
         );
         const [shortInput, longInput] = screen.getAllByRole('textbox') as HTMLInputElement[];
 
-        fireResize(30, 0); // "/app/" measured narrow
-        fireResize(70, 1); // "/study/" measured wider
+        fireResize(12, 30, 0); // "/app/" measured narrow
+        fireResize(12, 70, 1); // "/study/" measured wider
 
-        expect(shortInput.style.paddingLeft).toBe('42px');
-        expect(longInput.style.paddingLeft).toBe('82px');
+        expect(shortInput.style.paddingLeft).toBe('54px');
+        expect(longInput.style.paddingLeft).toBe('94px');
         expect(shortInput.style.paddingLeft).not.toBe(longInput.style.paddingLeft);
     });
 
-    it('falls back to a fixed padding before any measurement has arrived', () => {
+    it('measures synchronously on mount, without waiting for the observer to fire', () => {
+        // useLayoutEffect calls measure() itself before ever attaching the
+        // ResizeObserver — this is what removes the one-frame flash of
+        // FALLBACK_PADDING_PX a plain useEffect produced (measured live:
+        // 48px -> 58.84px). No fireResize() call here: by the time render()
+        // returns, the padding already reflects the initial measurement
+        // (jsdom's zero-layout numbers: offsetLeft=0, offsetWidth=0, so
+        // 0 + 0 + 12px gutter), not the 48px fallback.
         render(<SlugInput prefix="/app/" value="example-project" onChange={() => {}} />);
         const input = screen.getByRole('textbox') as HTMLInputElement;
-        // No fireResize() call yet — the observer hasn't reported a width.
-        expect(input.style.paddingLeft).toBe('48px');
+        expect(input.style.paddingLeft).toBe('12px');
+        expect(input.style.paddingLeft).not.toBe('48px');
     });
 
     it('calls onChange with the raw string value, not the event', () => {
@@ -129,5 +155,19 @@ describe('SlugInput', () => {
         const input = screen.getByRole('textbox');
         expect(input).toHaveAttribute('id', 'project-slug');
         expect(refValue).toBe(input);
+    });
+
+    it('replaces the default prefix classes wholesale when prefixClassName is given', () => {
+        render(
+            <SlugInput
+                prefix="/study/"
+                value=""
+                onChange={() => {}}
+                prefixClassName="text-slate-600 font-mono"
+            />
+        );
+        const prefix = screen.getByText('/study/');
+        expect(prefix.className).toBe('text-slate-600 font-mono');
+        expect(prefix.className).not.toContain('border-r');
     });
 });

--- a/frontend/src/components/ui/slug-input.tsx
+++ b/frontend/src/components/ui/slug-input.tsx
@@ -8,17 +8,29 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-/** Breathing room, in px, kept between the measured prefix and the value text. */
+/** Breathing room, in px, kept between the measured prefix's right edge and the value text. */
 const PREFIX_GUTTER_PX = 12;
 
 /**
- * Padding used before the prefix has been measured at least once (first
- * paint, or an environment — like jsdom — that never fires ResizeObserver).
- * It only ever shows up as a brief flash in real browsers; the two prior
- * hard-coded paddings this component replaces (`pl-32`, `pl-14`) are proof
- * a guessed constant is not a substitute for the real measurement below.
+ * Padding used before the prefix has been measured at least once. In a real
+ * browser this is only ever visible for the single frame between mount and
+ * the layout-effect's synchronous measurement below; it exists mainly for
+ * jsdom, which never fires ResizeObserver at all. The two prior hard-coded
+ * paddings this component replaces (`pl-32`, `pl-14`) are proof a guessed
+ * constant is not a substitute for the real measurement.
  */
 const FALLBACK_PADDING_PX = 48;
+
+/**
+ * Default look for the prefix text: matches ProjectSettingsPage/CreateProjectPage's
+ * original `/app/` styling, including the vertical divider (`border-r`) that
+ * separated it from the value — dropped by an earlier version of this
+ * component without being called out, which this restores. Pass
+ * `prefixClassName` to replace it wholesale for a differently-styled value
+ * (see RecruitmentPage.tsx's call site for the monospace, divider-less case).
+ */
+const DEFAULT_PREFIX_CLASSES =
+    'pointer-events-none absolute left-3 top-1/2 flex h-4 -translate-y-1/2 select-none items-center whitespace-nowrap border-r border-slate-300 pr-3 text-xs font-bold text-slate-400';
 
 export interface SlugInputProps
     extends Omit<React.ComponentPropsWithoutRef<'input'>, 'value' | 'onChange' | 'prefix'> {
@@ -26,15 +38,30 @@ export interface SlugInputProps
     prefix: string;
     value: string;
     onChange: (value: string) => void;
+    /**
+     * Replaces `DEFAULT_PREFIX_CLASSES` wholesale (not merged — pass the
+     * full class list) when a call site needs a differently-styled prefix,
+     * e.g. to match a monospace value instead of the default sans-serif one.
+     */
+    prefixClassName?: string;
 }
 
 /**
  * A text input prefixed with a fixed string, whose left padding is derived
- * from the prefix's own measured width (ref + ResizeObserver) instead of a
- * guessed Tailwind class. The same `pl-*` guess shipped twice and was wrong
- * in both directions: `pl-32` (128px) for a ~60px "/app/" prefix left a 68px
- * gap, and `pl-14` (56px) for an exactly-56px "/study/" prefix made the
- * value collide with it. Measuring removes the guess entirely.
+ * from the prefix's own measured position and width (ref + ResizeObserver)
+ * instead of a guessed Tailwind class. The same `pl-*` guess shipped twice
+ * and was wrong in both directions: `pl-32` (128px) for a ~60px "/app/"
+ * prefix left a 68px gap, and `pl-14` (56px) for an exactly-56px "/study/"
+ * prefix made the value collide with it. Measuring removes the guess
+ * entirely.
+ *
+ * The prefix span is positioned `left-3` (12px in from the input's own left
+ * edge) — the padding formula below measures `offsetLeft` (that 12px) *and*
+ * `offsetWidth` (the prefix's rendered size), not just the latter. Adding
+ * only `prefixWidth + PREFIX_GUTTER_PX` (an earlier version of this file)
+ * places the value's first glyph at the prefix's *right edge*, which is the
+ * same defect this component exists to remove, just shrunk from 68px too
+ * much to 1px too little.
  *
  * Forwards ref, id, and any other native input props to the underlying
  * `<input>` (not the decorative wrapper) so it composes correctly inside
@@ -45,35 +72,34 @@ export interface SlugInputProps
  * at a non-labelable element).
  */
 const SlugInput = React.forwardRef<HTMLInputElement, SlugInputProps>(
-    ({ prefix, value, onChange, className, style, ...rest }, forwardedRef) => {
+    ({ prefix, value, onChange, className, style, prefixClassName, ...rest }, forwardedRef) => {
         const prefixRef = React.useRef<HTMLSpanElement>(null);
-        const [prefixWidth, setPrefixWidth] = React.useState<number | null>(null);
+        const [paddingLeft, setPaddingLeft] = React.useState<number | null>(null);
 
-        React.useEffect(() => {
+        // useLayoutEffect (not useEffect) + a synchronous measure() call
+        // before the ResizeObserver is even attached: without both, the
+        // first frame paints with FALLBACK_PADDING_PX and only corrects
+        // itself once the observer's first (async) callback fires — a
+        // visible flash from 48px to the real value.
+        React.useLayoutEffect(() => {
             const node = prefixRef.current;
             if (!node) {
                 return undefined;
             }
 
-            const observer = new ResizeObserver((entries) => {
-                const measured = entries[0]?.contentRect.width;
-                if (typeof measured === 'number') {
-                    setPrefixWidth(measured);
-                }
-            });
+            const measure = () => {
+                setPaddingLeft(node.offsetLeft + node.offsetWidth + PREFIX_GUTTER_PX);
+            };
+            measure();
+
+            const observer = new ResizeObserver(measure);
             observer.observe(node);
             return () => observer.disconnect();
         }, []);
 
-        const paddingLeft =
-            prefixWidth === null ? FALLBACK_PADDING_PX : prefixWidth + PREFIX_GUTTER_PX;
-
         return (
             <div className="relative">
-                <span
-                    ref={prefixRef}
-                    className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 select-none whitespace-nowrap text-xs font-bold text-slate-400"
-                >
+                <span ref={prefixRef} className={prefixClassName ?? DEFAULT_PREFIX_CLASSES}>
                     {prefix}
                 </span>
                 <input
@@ -81,7 +107,7 @@ const SlugInput = React.forwardRef<HTMLInputElement, SlugInputProps>(
                     ref={forwardedRef}
                     value={value}
                     onChange={(event) => onChange(event.target.value)}
-                    style={{ paddingLeft, ...style }}
+                    style={{ paddingLeft: paddingLeft ?? FALLBACK_PADDING_PX, ...style }}
                     className={cn(
                         'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
                         className

--- a/frontend/src/components/ui/slug-input.tsx
+++ b/frontend/src/components/ui/slug-input.tsx
@@ -1,0 +1,96 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/** Breathing room, in px, kept between the measured prefix and the value text. */
+const PREFIX_GUTTER_PX = 12;
+
+/**
+ * Padding used before the prefix has been measured at least once (first
+ * paint, or an environment — like jsdom — that never fires ResizeObserver).
+ * It only ever shows up as a brief flash in real browsers; the two prior
+ * hard-coded paddings this component replaces (`pl-32`, `pl-14`) are proof
+ * a guessed constant is not a substitute for the real measurement below.
+ */
+const FALLBACK_PADDING_PX = 48;
+
+export interface SlugInputProps
+    extends Omit<React.ComponentPropsWithoutRef<'input'>, 'value' | 'onChange' | 'prefix'> {
+    /** Static, non-editable text rendered before the value, e.g. "/app/". */
+    prefix: string;
+    value: string;
+    onChange: (value: string) => void;
+}
+
+/**
+ * A text input prefixed with a fixed string, whose left padding is derived
+ * from the prefix's own measured width (ref + ResizeObserver) instead of a
+ * guessed Tailwind class. The same `pl-*` guess shipped twice and was wrong
+ * in both directions: `pl-32` (128px) for a ~60px "/app/" prefix left a 68px
+ * gap, and `pl-14` (56px) for an exactly-56px "/study/" prefix made the
+ * value collide with it. Measuring removes the guess entirely.
+ *
+ * Forwards ref, id, and any other native input props to the underlying
+ * `<input>` (not the decorative wrapper) so it composes correctly inside
+ * `FormControl` — whose Radix `Slot` clones id/aria-describedby/aria-invalid
+ * onto this component's single child and expects them to land on the real
+ * control, not a `<div>` (see RecruitmentPage.tsx's task 6.7e comment for
+ * the a11y bug that pattern otherwise causes: FormLabel's `htmlFor` pointing
+ * at a non-labelable element).
+ */
+const SlugInput = React.forwardRef<HTMLInputElement, SlugInputProps>(
+    ({ prefix, value, onChange, className, style, ...rest }, forwardedRef) => {
+        const prefixRef = React.useRef<HTMLSpanElement>(null);
+        const [prefixWidth, setPrefixWidth] = React.useState<number | null>(null);
+
+        React.useEffect(() => {
+            const node = prefixRef.current;
+            if (!node) {
+                return undefined;
+            }
+
+            const observer = new ResizeObserver((entries) => {
+                const measured = entries[0]?.contentRect.width;
+                if (typeof measured === 'number') {
+                    setPrefixWidth(measured);
+                }
+            });
+            observer.observe(node);
+            return () => observer.disconnect();
+        }, []);
+
+        const paddingLeft =
+            prefixWidth === null ? FALLBACK_PADDING_PX : prefixWidth + PREFIX_GUTTER_PX;
+
+        return (
+            <div className="relative">
+                <span
+                    ref={prefixRef}
+                    className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 select-none whitespace-nowrap text-xs font-bold text-slate-400"
+                >
+                    {prefix}
+                </span>
+                <input
+                    {...rest}
+                    ref={forwardedRef}
+                    value={value}
+                    onChange={(event) => onChange(event.target.value)}
+                    style={{ paddingLeft, ...style }}
+                    className={cn(
+                        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+                        className
+                    )}
+                />
+            </div>
+        );
+    }
+);
+SlugInput.displayName = 'SlugInput';
+
+export { SlugInput };

--- a/frontend/src/pages/admin/CreateProjectPage.tsx
+++ b/frontend/src/pages/admin/CreateProjectPage.tsx
@@ -21,6 +21,7 @@ import {
     FormDescription,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { SlugInput } from '@/components/ui/slug-input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import { createProjectApiAdminProjectsPost } from '@/api/generated';
@@ -159,18 +160,14 @@ export default function CreateProjectPage() {
                                             {t('admin.project.create.url_label')}
                                         </FormLabel>
                                         <FormControl>
-                                            <div className="relative">
-                                                <Input
-                                                    placeholder={t(
-                                                        'admin.project.create.url_placeholder'
-                                                    )}
-                                                    className="h-12 rounded-xl pl-32 bg-white/50 border-slate-200 focus:bg-white transition-all shadow-sm"
-                                                    {...field}
-                                                />
-                                                <div className="absolute left-3 top-1/2 -translate-y-1/2 text-xs font-bold text-slate-400 select-none border-r pr-3 mr-3 h-4 flex items-center">
-                                                    /app/
-                                                </div>
-                                            </div>
+                                            <SlugInput
+                                                {...field}
+                                                prefix="/app/"
+                                                placeholder={t(
+                                                    'admin.project.create.url_placeholder'
+                                                )}
+                                                className="h-12 rounded-xl bg-white/50 border-slate-200 focus:bg-white transition-all shadow-sm"
+                                            />
                                         </FormControl>
                                         <FormDescription className="text-2xs italic font-medium px-1">
                                             {t('admin.project.create.url_description')}

--- a/frontend/src/pages/admin/DataPrivacyPage.test.tsx
+++ b/frontend/src/pages/admin/DataPrivacyPage.test.tsx
@@ -275,3 +275,56 @@ describe('DataPrivacyPage', () => {
         expect(screen.queryByRole('button', { name: /^anonymise$/i })).not.toBeInTheDocument();
     });
 });
+
+describe('DataPrivacyPage — stat tiles (Task 6.3)', () => {
+    beforeEach(() => {
+        mockInventoryHook.mockReset();
+        mockAnonymiseMutation.mockReset();
+        mockPreviewHook.mockReset();
+        mockPreviewHook.mockReturnValue({
+            data: { candidates: 0, cutoff: new Date().toISOString() },
+            isFetching: false,
+        });
+        mockInventoryHook.mockReturnValue({
+            data: mockInventory,
+            isLoading: false,
+            error: null,
+        });
+        mockAnonymiseMutation.mockReturnValue({
+            mutate: vi.fn(),
+            isPending: false,
+        });
+    });
+
+    it('lays the four participant tiles on one row at desktop width', () => {
+        renderWithProviders(<DataPrivacyPage />);
+        // lg (1024px), not sm (640px): verified live that sm:grid-cols-4
+        // squeezes each tile to ~100px once the admin sidebar's fixed width
+        // is subtracted from a 640-900px viewport, which is too narrow for
+        // an icon + label to render legibly — the same "one row on desktop"
+        // pattern StudyOverviewPage/InteractiveDataView already use lg: for.
+        // Below lg, grid-cols-2 still avoids the orphan bug (a full 2x2
+        // grid has no leftover cell, unlike the old sm:grid-cols-3).
+        expect(screen.getByTestId('participants-snapshot')).toHaveClass('lg:grid-cols-4');
+    });
+
+    it('does not colour a zero differently from its neighbours', () => {
+        renderWithProviders(<DataPrivacyPage />);
+        const values = screen.getAllByTestId('stat-value');
+        // Started/Completed/Discarded/Anonymised + Recordings/Total size —
+        // all six tiles on this page render through the same Stat component.
+        expect(values.length).toBeGreaterThanOrEqual(4);
+        const colours = new Set(values.map((v) => v.className.match(/text-\w+-\d+/)?.[0]));
+        expect(colours.size).toBe(1);
+    });
+
+    it('gives the audio-storage tiles the same grid treatment as the participants snapshot', () => {
+        renderWithProviders(<DataPrivacyPage />);
+        const snapshot = screen.getByTestId('participants-snapshot');
+        const audio = screen.getByTestId('audio-storage-snapshot');
+        // Same column classes at both breakpoints -> tiles render at the
+        // same width in both cards, instead of two tiles stretching across
+        // a 2-column row while four tiles above share a 4-column row.
+        expect(audio.className).toBe(snapshot.className);
+    });
+});

--- a/frontend/src/pages/admin/DataPrivacyPage.test.tsx
+++ b/frontend/src/pages/admin/DataPrivacyPage.test.tsx
@@ -314,8 +314,15 @@ describe('DataPrivacyPage — stat tiles (Task 6.3)', () => {
         // Started/Completed/Discarded/Anonymised + Recordings/Total size —
         // all six tiles on this page render through the same Stat component.
         expect(values.length).toBeGreaterThanOrEqual(4);
-        const colours = new Set(values.map((v) => v.className.match(/text-\w+-\d+/)?.[0]));
-        expect(colours.size).toBe(1);
+        const colours = values.map((v) => v.className.match(/text-\w+-\d+/)?.[0]);
+        // Asserting the actual colour, not just Set-size uniqueness: a Set
+        // of extracted colours is satisfiable by *removing* the colour
+        // class from every tile too (every entry becomes `undefined`, still
+        // one distinct value) — that would pass without a single tile
+        // actually being coloured text-slate-900.
+        for (const colour of colours) {
+            expect(colour).toBe('text-slate-900');
+        }
     });
 
     it('gives the audio-storage tiles the same grid treatment as the participants snapshot', () => {

--- a/frontend/src/pages/admin/DataPrivacyPage.tsx
+++ b/frontend/src/pages/admin/DataPrivacyPage.tsx
@@ -22,6 +22,10 @@ import {
     FileSignature,
     PencilLine,
     Eye,
+    CheckCircle2,
+    Trash2,
+    HardDrive,
+    type LucideIcon,
 } from 'lucide-react';
 
 import {
@@ -398,23 +402,29 @@ export default function DataPrivacyPage() {
                         </div>
                     </CardHeader>
                     <CardContent className="p-6">
-                        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+                        <div
+                            data-testid="participants-snapshot"
+                            className="grid grid-cols-2 lg:grid-cols-4 gap-4"
+                        >
                             <Stat
+                                icon={Users}
                                 label={t('admin.privacy.stat_started', 'Started')}
                                 value={participants.started}
                             />
                             <Stat
+                                icon={CheckCircle2}
                                 label={t('admin.privacy.stat_completed', 'Completed')}
                                 value={participants.completed}
                             />
                             <Stat
+                                icon={Trash2}
                                 label={t('admin.privacy.stat_discarded', 'Discarded')}
                                 value={participants.discarded}
                             />
                             <Stat
+                                icon={ShieldCheck}
                                 label={t('admin.privacy.stat_anonymised', 'Anonymised')}
                                 value={participants.anonymised}
-                                highlight
                             />
                         </div>
 
@@ -458,12 +468,17 @@ export default function DataPrivacyPage() {
                             </div>
                         </CardHeader>
                         <CardContent className="p-6">
-                            <div className="grid grid-cols-2 gap-4">
+                            <div
+                                data-testid="audio-storage-snapshot"
+                                className="grid grid-cols-2 lg:grid-cols-4 gap-4"
+                            >
                                 <Stat
+                                    icon={Mic2}
                                     label={t('admin.privacy.audio_count', 'Recordings')}
                                     value={audio.count}
                                 />
                                 <Stat
+                                    icon={HardDrive}
                                     label={t('admin.privacy.audio_mb', 'Total size')}
                                     value={`${audio.total_mb.toFixed(2)} MB`}
                                 />
@@ -696,20 +711,41 @@ export default function DataPrivacyPage() {
 // ─── sub-components ────────────────────────────────────────────────────────────
 
 interface StatProps {
+    icon: LucideIcon;
     label: string;
     value: number | string;
-    highlight?: boolean;
 }
 
-function Stat({ label, value, highlight = false }: StatProps) {
+/**
+ * One stat tile — used for both the participants snapshot and audio
+ * storage. Previously this page had its own uppercase, icon-less tile
+ * style, distinct from the sentence-case-with-icon convention `Data` and
+ * `Overview` use for the same kind of "label above a big number" display;
+ * task 6.3 unifies on this one. Unlike those pages' clickable filter cards,
+ * these tiles are static, so the icon badge stays a single neutral colour
+ * across every tile rather than colour-coding by category — task 6.3 also
+ * found one tile's value coloured indigo for no semantic reason, and a
+ * per-tile colour scheme here would only reintroduce that.
+ */
+function Stat({ icon: Icon, label, value }: StatProps) {
     return (
         <div className="bg-slate-50 rounded-xl p-4">
-            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">
-                {label}
-            </p>
-            <p
-                className={`text-2xl font-black ${highlight ? 'text-indigo-600' : 'text-slate-900'}`}
-            >
+            <div className="flex items-center gap-2 mb-1.5">
+                <div className="p-1.5 rounded-lg bg-slate-100 text-slate-500 shrink-0">
+                    <Icon className="h-4 w-4" aria-hidden="true" />
+                </div>
+                {/* min-w-0 + break-words (same convention as StudyOverviewPage's
+                    metric cards): without min-w-0, a flex child cannot shrink
+                    below its content's intrinsic width, so at narrow tile
+                    widths the label overflowed the tile and was clipped by
+                    the parent Card's overflow-hidden instead of wrapping —
+                    found live at 768-900px, where the sidebar has not yet
+                    gone off-canvas but 4 columns are already active. */}
+                <p className="min-w-0 text-xs font-semibold text-slate-500 leading-tight break-words">
+                    {label}
+                </p>
+            </div>
+            <p data-testid="stat-value" className="text-2xl font-black text-slate-900">
                 {value}
             </p>
         </div>

--- a/frontend/src/pages/admin/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/admin/ProjectSettingsPage.tsx
@@ -11,6 +11,7 @@ import {
     FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { SlugInput } from '@/components/ui/slug-input';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -168,19 +169,15 @@ export default function ProjectSettingsPage() {
                                                 {t('admin.projects.settings.general.label_slug')}
                                             </FormLabel>
                                             <FormControl>
-                                                <div className="relative">
-                                                    <Input
-                                                        {...field}
-                                                        placeholder={t(
-                                                            'admin.projects.settings.general.placeholder_slug'
-                                                        )}
-                                                        className="h-11 rounded-xl pl-32 bg-white/50"
-                                                        disabled={!isOwner}
-                                                    />
-                                                    <div className="absolute left-3 top-1/2 -translate-y-1/2 text-xs font-bold text-slate-400 select-none border-r pr-3 mr-3 h-4 flex items-center">
-                                                        /app/
-                                                    </div>
-                                                </div>
+                                                <SlugInput
+                                                    {...field}
+                                                    prefix="/app/"
+                                                    placeholder={t(
+                                                        'admin.projects.settings.general.placeholder_slug'
+                                                    )}
+                                                    className="h-11 rounded-xl bg-white/50"
+                                                    disabled={!isOwner}
+                                                />
                                             </FormControl>
                                             <FormDescription className="text-2xs italic">
                                                 {t('admin.projects.settings.general.slug_hint')}

--- a/frontend/src/pages/admin/RecruitmentPage.test.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.test.tsx
@@ -125,6 +125,17 @@ describe('RecruitmentPage — access rule switches (a11y)', () => {
     });
 });
 
+describe('RecruitmentPage — access-rule rows share one shape (Task 6.2)', () => {
+    it('renders both access-rule rows with the same container treatment', () => {
+        mockUseRecruitmentPage.mockReturnValue(baseApi());
+        renderWithProviders(<RecruitmentPage />);
+
+        const rows = screen.getAllByTestId('access-rule-row');
+        expect(rows).toHaveLength(2);
+        expect(rows[0].className).toBe(rows[1].className);
+    });
+});
+
 describe('RecruitmentPage — group headings are real text, not dangling labels (Task 6.7b)', () => {
     // "Full URL" and "Collection window" head a read-only URL readout and a
     // pair of already-individually-labelled date fields, respectively —

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -368,42 +368,30 @@ const RecruitmentPage = () => {
                         )}
                         {/* Password Protection */}
                         <div className="space-y-4">
-                            <div className="flex items-center justify-between gap-4 p-4 bg-slate-50/50 rounded-xl border border-slate-100">
-                                <div className="space-y-0.5">
-                                    <Label
-                                        id="password-toggle-label"
-                                        htmlFor="password-toggle"
-                                        className="text-sm font-bold text-slate-700"
-                                    >
-                                        {t(
-                                            'admin.recruitment.access_rules.password_toggle',
-                                            'Require a password'
-                                        )}
-                                    </Label>
-                                    <p className="text-xs text-slate-500">
-                                        {t(
-                                            'admin.recruitment.access_rules.password_toggle_desc',
-                                            'Participants must enter a password before starting the study.'
-                                        )}
-                                    </p>
-                                </div>
-                                <Switch
-                                    id="password-toggle"
-                                    aria-labelledby="password-toggle-label"
-                                    checked={passwordEnabled}
-                                    onCheckedChange={(checked) => {
-                                        accessForm.setValue('passwordEnabled', checked, {
+                            <AccessRuleRow
+                                labelId="password-toggle-label"
+                                switchId="password-toggle"
+                                label={t(
+                                    'admin.recruitment.access_rules.password_toggle',
+                                    'Require a password'
+                                )}
+                                description={t(
+                                    'admin.recruitment.access_rules.password_toggle_desc',
+                                    'Participants must enter a password before starting the study.'
+                                )}
+                                checked={passwordEnabled}
+                                onCheckedChange={(checked) => {
+                                    accessForm.setValue('passwordEnabled', checked, {
+                                        shouldDirty: true,
+                                    });
+                                    if (!checked) {
+                                        accessForm.setValue('accessPassword', '', {
                                             shouldDirty: true,
                                         });
-                                        if (!checked) {
-                                            accessForm.setValue('accessPassword', '', {
-                                                shouldDirty: true,
-                                            });
-                                        }
-                                    }}
-                                    disabled={isSlugLocked}
-                                />
-                            </div>
+                                    }
+                                }}
+                                disabled={isSlugLocked}
+                            />
 
                             {passwordEnabled && (
                                 <div className="space-y-2 animate-in fade-in slide-in-from-top-2 duration-300">
@@ -459,47 +447,35 @@ const RecruitmentPage = () => {
                             derives its initial state from the form values:
                             on if either date was previously set. */}
                         <div className="space-y-4">
-                            <div className="flex items-start justify-between gap-4">
-                                <div className="space-y-0.5">
-                                    <Label
-                                        id="window-toggle-label"
-                                        htmlFor="window-toggle"
-                                        className="text-sm font-black text-slate-700"
-                                    >
-                                        {t(
-                                            'admin.recruitment.access_rules.window_toggle',
-                                            'Limit collection window'
-                                        )}
-                                    </Label>
-                                    <p className="text-xs text-slate-600 font-medium">
-                                        {t(
-                                            'admin.recruitment.access_rules.window_toggle_help',
-                                            'Restrict participant access to a specific time range.'
-                                        )}
-                                    </p>
-                                </div>
-                                <Switch
-                                    id="window-toggle"
-                                    aria-labelledby="window-toggle-label"
-                                    checked={showWindowPickers}
-                                    onCheckedChange={(checked) => {
-                                        setShowWindowPickers(checked);
-                                        if (!checked) {
-                                            if (accessForm.getValues('startDate')) {
-                                                accessForm.setValue('startDate', '', {
-                                                    shouldDirty: true,
-                                                });
-                                            }
-                                            if (accessForm.getValues('endDate')) {
-                                                accessForm.setValue('endDate', '', {
-                                                    shouldDirty: true,
-                                                });
-                                            }
+                            <AccessRuleRow
+                                labelId="window-toggle-label"
+                                switchId="window-toggle"
+                                label={t(
+                                    'admin.recruitment.access_rules.window_toggle',
+                                    'Limit collection window'
+                                )}
+                                description={t(
+                                    'admin.recruitment.access_rules.window_toggle_help',
+                                    'Restrict participant access to a specific time range.'
+                                )}
+                                checked={showWindowPickers}
+                                onCheckedChange={(checked) => {
+                                    setShowWindowPickers(checked);
+                                    if (!checked) {
+                                        if (accessForm.getValues('startDate')) {
+                                            accessForm.setValue('startDate', '', {
+                                                shouldDirty: true,
+                                            });
                                         }
-                                    }}
-                                    disabled={isArchived}
-                                />
-                            </div>
+                                        if (accessForm.getValues('endDate')) {
+                                            accessForm.setValue('endDate', '', {
+                                                shouldDirty: true,
+                                            });
+                                        }
+                                    }
+                                }}
+                                disabled={isArchived}
+                            />
                             {showWindowPickers && (
                                 <>
                                     {/* Heads the "Opens at"/"Closes at" pair below, both of
@@ -1149,3 +1125,54 @@ const RecruitmentPage = () => {
 };
 
 export default RecruitmentPage;
+
+// ─── sub-components ────────────────────────────────────────────────────────────
+
+interface AccessRuleRowProps {
+    labelId: string;
+    switchId: string;
+    label: string;
+    description: string;
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+    disabled?: boolean;
+}
+
+/**
+ * One row under "Access rules": a label/description pair with a switch.
+ * Password protection and the collection-window toggle used to be built
+ * independently and drifted apart — different padding/surface, different
+ * label weight (task 6.2) — so their switches ended up 17px apart
+ * horizontally. Extracted so the two rows share one shape and cannot drift
+ * again.
+ */
+function AccessRuleRow({
+    labelId,
+    switchId,
+    label,
+    description,
+    checked,
+    onCheckedChange,
+    disabled,
+}: AccessRuleRowProps) {
+    return (
+        <div
+            data-testid="access-rule-row"
+            className="flex items-center justify-between gap-4 p-4 bg-slate-50/50 rounded-xl border border-slate-100"
+        >
+            <div className="space-y-0.5">
+                <Label id={labelId} htmlFor={switchId} className="text-sm font-bold text-slate-700">
+                    {label}
+                </Label>
+                <p className="text-xs text-slate-500">{description}</p>
+            </div>
+            <Switch
+                id={switchId}
+                aria-labelledby={labelId}
+                checked={checked}
+                onCheckedChange={onCheckedChange}
+                disabled={disabled}
+            />
+        </div>
+    );
+}

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -41,6 +41,7 @@ import {
     DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { SlugInput } from '@/components/ui/slug-input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
@@ -258,27 +259,27 @@ const RecruitmentPage = () => {
                                             )}
                                         </FormLabel>
                                         {/*
-                                         * FormControl now wraps the <Input> directly, not the
+                                         * FormControl must wrap SlugInput directly, not a
                                          * decorative wrapper div (task 6.7e). shadcn's
                                          * FormControl uses Radix Slot to attach id/
                                          * aria-describedby/aria-invalid to its *only* child —
-                                         * with the div as that child, those landed on the div
-                                         * instead of the input, so FormLabel's htmlFor pointed
-                                         * at a non-labelable element and the real <input> had
-                                         * no accessible name at all (axe: label).
+                                         * SlugInput forwards those (and its ref) to the real
+                                         * <input> it renders internally, not its wrapper div.
+                                         * Wrapping anything else here regresses to the div
+                                         * receiving them instead: FormLabel's htmlFor would
+                                         * then point at a non-labelable element and the real
+                                         * <input> would have no accessible name at all
+                                         * (axe: label — task 6.1 reuses this component at
+                                         * ProjectSettingsPage/CreateProjectPage too).
                                          */}
-                                        <div className="relative">
-                                            <div className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-600 font-mono text-xs select-none">
-                                                /study/
-                                            </div>
-                                            <FormControl>
-                                                <Input
-                                                    {...field}
-                                                    disabled={isSlugLocked}
-                                                    className="h-11 rounded-xl bg-slate-50 border-slate-100 pl-14 font-mono text-xs focus-visible:ring-indigo-500"
-                                                />
-                                            </FormControl>
-                                        </div>
+                                        <FormControl>
+                                            <SlugInput
+                                                {...field}
+                                                prefix="/study/"
+                                                disabled={isSlugLocked}
+                                                className="h-11 rounded-xl bg-slate-50 border-slate-100 font-mono text-xs focus-visible:ring-indigo-500"
+                                            />
+                                        </FormControl>
                                         {isSlugLocked ? (
                                             <p className="text-xs text-amber-800 flex items-center gap-1.5 mt-1.5">
                                                 <Info className="size-3 shrink-0" />

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -273,9 +273,16 @@ const RecruitmentPage = () => {
                                          * ProjectSettingsPage/CreateProjectPage too).
                                          */}
                                         <FormControl>
+                                            {/* prefixClassName: deliberate, not the SlugInput
+                                                default — matches this field's monospace,
+                                                slate-600 value instead of the default sans
+                                                slate-400, and skips the divider (review note
+                                                on task 6.1: the typeface change was silent in
+                                                an earlier version of this file). */}
                                             <SlugInput
                                                 {...field}
                                                 prefix="/study/"
+                                                prefixClassName="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 select-none whitespace-nowrap font-mono text-xs text-slate-600"
                                                 disabled={isSlugLocked}
                                                 className="h-11 rounded-xl bg-slate-50 border-slate-100 font-mono text-xs focus-visible:ring-indigo-500"
                                             />


### PR DESCRIPTION
## Summary

Tasks 6.1–6.3 of the UX audit remediation — the first visual-finish batch. Unlike the accessibility work that preceded it, these are defects a human found by looking at the screens and measuring what was off. **All seven measurements were still real**, three of them reproducing to the exact number.

## Changes

**A slug input that measures its own prefix.** The same pattern shipped with two hard-coded paddings, wrong in opposite directions: `pl-32` (128px) for a ~60px `/app/` prefix left a **68px gap**, while `pl-14` (56px) for a 56px `/study/` prefix made the text **collide**, reading `/studybioeconomy-futures`. A `SlugInput` component now derives its padding from the live DOM.

**Both access-rule rows on one component.** The two settings rows under "Access rules" were built differently — one with `p-4` and a surface, one with neither — so their switches sat **17px apart** (exactly the padding plus border) and their labels used different weights. Extracted into one `AccessRuleRow` so they cannot drift again.

**The stat tiles unified.** Four tiles in a three-column grid orphaned the fourth beside two empty cells; its zero was indigo while its neighbours' were black, for no reason; the "Audio storage" tiles rendered ~390px against ~253px above; and the labels were uppercase-without-icon here but sentence-case-with-icon on two other screens.

## The fix reproduced the defect it exists to remove

Worth recording, because it is the sharpest instance of a lesson this remediation has been paying for.

`SlugInput` genuinely measured its prefix — that part worked. But the formula was `prefixWidth + GUTTER`, and the prefix sits at `absolute left-3`. So the 12px of breathing room was **consumed by the offset instead of added after it**, placing the value's first glyph exactly at the prefix's right edge.

Live-measured gutter: **1.00px** at both call sites. 68px too much had become 1px too little — and the rewrite had also dropped the `border-r` divider the old markup carried.

The unit test could not see it: jsdom reports every rect as zero, so an assertion of `gap >= 8` is trivially true there.

**And the browser check did not see it either, because it was made by eye.** The implementer opened the app, looked, and reported a "clean single gutter". Review opened the same app and read the coordinates: prefix right edge 378.84px, value starting at 379.84px.

Now `offsetLeft + offsetWidth + gutter`, read from the live DOM, so changing the prefix's positioning class cannot silently break it again. Re-review stood the stack up independently and measured **12.094 / 12.094 / 12.391px**.

## One deviation from the brief, upheld

The brief specified `sm:grid-cols-4` for the stat grid; `lg:grid-cols-4` shipped. Review reproduced the reasoning by swapping the class on the live DOM at 820px: `sm` gives **95px tiles with character-level wrapping**, because the grid's content box is only 428px there — the admin sidebar is fixed-width, so a viewport-keyed breakpoint is the wrong signal. `lg` gives 206px tiles and single-line labels, matches existing precedent in `InteractiveDataView`, and leaves no orphan at any width.

## Checklist

- [ ] `make ci` passes locally — **frontend green (197 files / 1736 tests, biome + tsc clean, a11y gate and baseline unchanged); backend `pytest` fails on a local Postgres credential issue reproducing identically on `main`.** No backend file touched.
- [x] Tests cover new/changed behavior — the `SlugInput` test asserts two different measured widths produce two different paddings, an assertion a constant cannot satisfy. The implementer explicitly labelled the brief's own suggested test as proving nothing, since `pl-32` would have passed it.
- [x] Translation keys added to all locales — no new strings; the six privacy labels were already sentence-case in all nine.
- [x] API client regenerated if backend schemas changed — not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)