### PR TITLE
fix(e2e): target the privacy stat value by testid, not by DOM structure

### DIFF
--- a/frontend/e2e/study/rgpd-self-erasure.spec.ts
+++ b/frontend/e2e/study/rgpd-self-erasure.spec.ts
@@ -185,10 +185,13 @@ test.describe
             const anonymisedLabel = adminPage.getByText('Anonymised', { exact: true });
             await expect(anonymisedLabel).toBeVisible({ timeout: 10_000 });
 
-            // The sibling value <p> is the last <p> in the same parent div.
-            // We navigate via Playwright's locator chain: parent → last p.
-            const anonymisedCard = anonymisedLabel.locator('..');
-            const statValue = anonymisedCard.locator('p').last();
+            // The tile nests its icon and label in a row div, with the value as
+            // a sibling of that row — so the label's own parent holds no value.
+            // Walk up to the tile and take its `stat-value` testid rather than
+            // navigating by structure: task 6.3 restructured these tiles and a
+            // `parent → last p` chain silently started returning the label.
+            const anonymisedCard = anonymisedLabel.locator('../..');
+            const statValue = anonymisedCard.getByTestId('stat-value');
             await expect(statValue).toHaveText('1', { timeout: 10_000 });
 
             await adminPage.close();


### PR DESCRIPTION
## Summary

`main` is red. The GDPR self-erasure E2E test asserts the "Anonymised" tile shows `1`, but reads `"Anonymised"` — it is matching the label instead of the value.

**Cause:** task 6.3 (merged in #335) unified the privacy stat tiles, which nested the label alongside its icon in a row div. The test navigated by structure — `label → parent → last p` — and that chain now lands on the label's own `<p>`, since the value is a sibling of the row rather than of the label.

The tile already exposes `data-testid="stat-value"`. The test now walks up to the tile and uses it.

## How this reached main

I merged #335 while this check was failing. My CI-watch command piped its result into the merge in the same invocation and I did not read the output before proceeding. The failure was visible and I missed it.

Worth noting what the review of #335 did and did not cover: it verified the a11y gate, the full Vitest suite, lint, `tsc`, and measured the visual result in a live browser — thoroughly. But E2E cannot be run locally in this environment (Playwright boots its own backend, which cannot reach the local Postgres), so a DOM-structure dependency in a *study-flow* test was invisible to every check available before CI. The restructured component is on an admin page; the test that broke is in the participant GDPR suite.

## Checklist

- [ ] `make ci` passes locally — E2E cannot run in this environment; this is a one-line selector change in a spec file, verified by reading the current component structure. **CI is the check that matters here.**
- [x] Tests cover new/changed behavior — this *is* the test fix.
- [x] Translation keys added to all locales — no strings changed.
- [x] API client regenerated if backend schemas changed — not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)