### PR TITLE
fix(admin): typographic floor, the frozen clear-date buttons, and charts mounting at zero size

### DIFF
--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1767,3 +1767,60 @@ These came out of the audit but are judgement calls, not defects with an obvious
 **Placeholders.** None. Task 1.1 is the only task that does not name its fix, and deliberately so: the production build hides the diagnostic signal, so the task ships a reproduction test plus three ordered hypotheses instead of a guess dressed as an answer.
 
 **Type consistency.** `formatDate` / `formatDateTime` / `formatRelative` (Task 4.3) keep the same signatures at every call site. `SlugInput`'s prop names (Task 6.1) match its three adoptions. `buildColumns`' parameter object (Task 1.1) is quoted from the current source.
+
+---
+
+### Task 6.9: The Recent Activity row's vertical rhythm at 320px
+
+**Found while verifying 6.4.** Task 6.4's badge fix is a containment fix: at 320px the
+"Recently completed" pill now grows to two lines instead of letting its text paint
+outside itself. Nothing spills, but the row does not look *deliberate*:
+
+- the completed row measures 93.88px and the in-progress row 77.27px — a 16.61px mismatch
+  that reads as "one row happened to grow", not as a list with two row sizes;
+- the duration ("5m 0s") is vertically centred against a 26px pill, so it floats with
+  visible air above and below and the pair reads as misaligned.
+
+Second, independent instance of the same shrinking-flex mechanism, found in the same pass:
+at 320px in Spanish, the in-progress row's label ("Clasificación preliminar") squeezes the
+progress bar down to a ~4px dot.
+
+**The lever is the row, not the badge.** Either top-align the duration with the pill, or
+give the row a fixed min-height so both variants match. Do not re-clamp the badge — that
+was the defect 6.4 fixed, and it is verified by measurement.
+
+**Files:** `frontend/src/components/admin/dashboard/RecentActivityCard.tsx`
+
+**Verify:** measure both row heights at 320px in EN *and* ES, and check the progress bar
+keeps a usable width in the long-locale case. English is the SHORT case on this surface —
+validating only in English is what let 6.4's defect through in the first place.
+
+---
+
+### Task 6.10: `ConcourseDetailPage` tag badges clamp user-supplied labels
+
+**Found while verifying 6.4**, unrelated to that diff. Three tag badges render
+`{tag.name}` — user-supplied, multi-word, unbounded — inside an `h-5` **hard clamp**
+(20px, ~3.4px of headroom over a 16.6px line box). A wrap escapes the pill by ~13px.
+
+- `ConcourseDetailPage.tsx:1026` — **priority.** Its container is `flex gap-1 mt-2` with
+  **no `flex-wrap`**, so several tags compete for one line and each shrinks to its longest
+  word. Structurally identical to the 6.4 badge-A failure. Two findings here: the clamp,
+  and the missing `flex-wrap`.
+- `ConcourseDetailPage.tsx:972` and `:1847` — inside `flex flex-wrap gap-2`, so items wrap
+  to new lines rather than competing. Residual risk is a single tag whose name exceeds the
+  container width; lower, but real at 320px.
+
+**Fix:** `min-h-5` rather than `h-5` (the 6.4 precedent — a floor, not a clamp), plus
+`flex-wrap` on the `:1026` container.
+
+**Verify by measurement, with a deliberately long multi-word tag name in the fixture.**
+Not with a short one — the whole class of defect only appears when the label outgrows the
+box.
+
+**Explicitly NOT in scope:** the rest of the `h-5 text-2xs` family was measured and is
+safe. `InteractiveDataView.columns.tsx:449,464` are multi-word but sit inside the table's
+`overflow-x-auto` container, so nothing squeezes them (the ES step badge measures 151px
+inside a 320px viewport). `AdminDashboard.tsx:724`, `ItemDetailSheet.tsx:135` and
+`AppSidebar.tsx:337,376` carry numeric counts or a single `⌘K` token — min-content equals
+max-content, so no wrap is possible. Leave all six alone.

--- a/frontend/src/components/admin/ProjectSwitcher.tsx
+++ b/frontend/src/components/admin/ProjectSwitcher.tsx
@@ -131,7 +131,7 @@ export function ProjectSwitcher() {
                                                 {/* Show Role Badge */}
                                                 <span
                                                     className={cn(
-                                                        'px-1 rounded-sm text-[8px]',
+                                                        'px-1 rounded-sm text-2xs',
                                                         project.user_role === 'owner'
                                                             ? 'bg-amber-100 text-amber-700'
                                                             : project.user_role === 'member'

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -174,7 +174,10 @@ export function ParticipantCell({
                     </span>
                 )}
                 {p.is_discarded && (
-                    <Badge variant="destructive" className="h-4 text-2xs px-1.5 font-semibold">
+                    <Badge
+                        variant="destructive"
+                        className="h-4 text-2xs leading-none px-1.5 font-semibold"
+                    >
                         {t('admin.data.detail.discarded_badge')}
                     </Badge>
                 )}
@@ -207,7 +210,7 @@ export function ParticipantCell({
                 // text-amber-800, not -600 — axe (task 6.7e) measured 3.07:1.
                 <Badge
                     variant="outline"
-                    className="h-4 text-2xs px-1.5 font-semibold bg-amber-50 text-amber-800 border-amber-200"
+                    className="h-4 text-2xs leading-none px-1.5 font-semibold bg-amber-50 text-amber-800 border-amber-200"
                 >
                     {t('admin.data.table.duplicate_ip', 'Duplicate IP')} #
                     {duplicateIpGroups.get(p.ip_address)}

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -176,7 +176,7 @@ export function ParticipantCell({
                 {p.is_discarded && (
                     <Badge
                         variant="destructive"
-                        className="h-4 text-2xs leading-none px-1.5 font-semibold"
+                        className="min-h-4 text-2xs leading-none px-1.5 font-semibold"
                     >
                         {t('admin.data.detail.discarded_badge')}
                     </Badge>
@@ -210,7 +210,7 @@ export function ParticipantCell({
                 // text-amber-800, not -600 — axe (task 6.7e) measured 3.07:1.
                 <Badge
                     variant="outline"
-                    className="h-4 text-2xs leading-none px-1.5 font-semibold bg-amber-50 text-amber-800 border-amber-200"
+                    className="min-h-4 text-2xs leading-none px-1.5 font-semibold bg-amber-50 text-amber-800 border-amber-200"
                 >
                     {t('admin.data.table.duplicate_ip', 'Duplicate IP')} #
                     {duplicateIpGroups.get(p.ip_address)}

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -119,7 +119,7 @@ function ParticipantRow({
                             className="h-4 bg-white text-slate-500 border-slate-200 gap-0.5 pl-1 pr-1.5 truncate max-w-[100px]"
                         >
                             <LinkIcon className="w-2.5 h-2.5 shrink-0" />
-                            <span className="font-mono text-[9px] truncate">
+                            <span className="font-mono text-2xs truncate">
                                 {participant.recruitment_token}
                             </span>
                         </Badge>
@@ -129,7 +129,7 @@ function ParticipantRow({
                 {/* Line 2: status-specific info */}
                 {isCompleted ? (
                     <div className="flex items-center gap-1.5">
-                        <Badge className="h-4 text-[9px] font-semibold bg-emerald-100 text-emerald-700 hover:bg-emerald-100 border-0 px-1.5">
+                        <Badge className="h-4 text-2xs font-semibold bg-emerald-100 text-emerald-700 hover:bg-emerald-100 border-0 px-1.5">
                             {t('admin.study_overview.recently_completed', 'Completed')}
                         </Badge>
                         {durationSeconds !== null && (

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -119,7 +119,7 @@ function ParticipantRow({
                             className="h-4 bg-white text-slate-500 border-slate-200 gap-0.5 pl-1 pr-1.5 truncate max-w-[100px]"
                         >
                             <LinkIcon className="w-2.5 h-2.5 shrink-0" />
-                            <span className="font-mono text-2xs truncate">
+                            <span className="font-mono text-2xs leading-none truncate">
                                 {participant.recruitment_token}
                             </span>
                         </Badge>
@@ -129,7 +129,10 @@ function ParticipantRow({
                 {/* Line 2: status-specific info */}
                 {isCompleted ? (
                     <div className="flex items-center gap-1.5">
-                        <Badge className="h-4 text-2xs font-semibold bg-emerald-100 text-emerald-700 hover:bg-emerald-100 border-0 px-1.5">
+                        {/* `h-4` clamps the pill to 16px, and the badge base adds py-0.5 —
+                            a 12px content box. `text-2xs` line-heights to 16.6-18px, so
+                            without `leading-none` the label wraps out of the pill at 320px. */}
+                        <Badge className="h-4 text-2xs leading-none font-semibold bg-emerald-100 text-emerald-700 hover:bg-emerald-100 border-0 px-1.5">
                             {t('admin.study_overview.recently_completed', 'Completed')}
                         </Badge>
                         {durationSeconds !== null && (

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -116,7 +116,7 @@ function ParticipantRow({
                     {participant.recruitment_token && (
                         <Badge
                             variant="outline"
-                            className="h-4 bg-white text-slate-500 border-slate-200 gap-0.5 pl-1 pr-1.5 truncate max-w-[100px]"
+                            className="min-h-4 bg-white text-slate-500 border-slate-200 gap-0.5 pl-1 pr-1.5 truncate max-w-[100px]"
                         >
                             <LinkIcon className="w-2.5 h-2.5 shrink-0" />
                             <span className="font-mono text-2xs leading-none truncate">
@@ -129,10 +129,15 @@ function ParticipantRow({
                 {/* Line 2: status-specific info */}
                 {isCompleted ? (
                     <div className="flex items-center gap-1.5">
-                        {/* `h-4` clamps the pill to 16px, and the badge base adds py-0.5 —
-                            a 12px content box. `text-2xs` line-heights to 16.6-18px, so
-                            without `leading-none` the label wraps out of the pill at 320px. */}
-                        <Badge className="h-4 text-2xs leading-none font-semibold bg-emerald-100 text-emerald-700 hover:bg-emerald-100 border-0 px-1.5">
+                        {/* `min-h-4`, not `h-4`: at 320px this badge is a shrinking flex
+                            item that gets ~109px for a label needing ~126px, so the two
+                            words wrap. A hard `h-4` clamped the pill to 16px and the
+                            second line painted OUTSIDE it. A floor lets the pill grow
+                            instead. Not fixable by shortening the label — `Completed` in
+                            English is short, but es/pt/nl render "Completados
+                            recientemente" and are longer still. Measured at 320/360/375/
+                            414/768/1440. */}
+                        <Badge className="min-h-4 text-2xs leading-none font-semibold bg-emerald-100 text-emerald-700 hover:bg-emerald-100 border-0 px-1.5">
                             {t('admin.study_overview.recently_completed', 'Completed')}
                         </Badge>
                         {durationSeconds !== null && (

--- a/frontend/src/components/admin/dashboard/charts/DeviceBreakdownChart.tsx
+++ b/frontend/src/components/admin/dashboard/charts/DeviceBreakdownChart.tsx
@@ -57,7 +57,18 @@ export const DeviceBreakdownChart = ({ deviceBreakdown, className }: DeviceBreak
             <CardContent>
                 <div className="flex flex-col items-center">
                     <div className="h-[200px] w-full mt-2">
-                        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+                        {/* See the matching comment in SubmissionsTimelineChart.tsx:
+                            width/height are both percentages, so Recharts'
+                            first render falls back to initialDimension
+                            (default {width:-1, height:-1}) and logs the
+                            "should be greater than 0" warning on every
+                            mount; minWidth alone doesn't prevent it. */}
+                        <ResponsiveContainer
+                            width="100%"
+                            height="100%"
+                            minWidth={0}
+                            initialDimension={{ width: 200, height: 200 }}
+                        >
                             <PieChart>
                                 <Pie
                                     data={data}

--- a/frontend/src/components/admin/dashboard/charts/QuestionDistributionCharts.tsx
+++ b/frontend/src/components/admin/dashboard/charts/QuestionDistributionCharts.tsx
@@ -240,7 +240,23 @@ export function QuestionDistributionCharts({
                             </CardDescription>
                         </CardHeader>
                         <CardContent>
-                            <ResponsiveContainer width="100%" height={chartHeight} minWidth={0}>
+                            {/* height is already a fixed pixel value (not a
+                                percentage), so this container doesn't hit
+                                Recharts' "-1,-1 initial size" warning path —
+                                only its width is percentage-based, and a
+                                positive height alone is enough to satisfy
+                                Recharts' size guard on first render.
+                                initialDimension is set anyway as a floor,
+                                matching the fix applied to the two chart
+                                components in this same section
+                                (SubmissionsTimelineChart, DeviceBreakdownChart)
+                                that do use percentage heights and did warn. */}
+                            <ResponsiveContainer
+                                width="100%"
+                                height={chartHeight}
+                                minWidth={0}
+                                initialDimension={{ width: 480, height: chartHeight }}
+                            >
                                 <BarChart
                                     data={item.bars}
                                     layout="vertical"

--- a/frontend/src/components/admin/dashboard/charts/SubmissionsTimelineChart.tsx
+++ b/frontend/src/components/admin/dashboard/charts/SubmissionsTimelineChart.tsx
@@ -146,7 +146,22 @@ export const SubmissionsTimelineChart = ({
             </CardHeader>
             <CardContent>
                 <div className="h-[200px] sm:h-[250px] md:h-[300px] w-full">
-                    <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+                    {/* width/height are both percentages, so Recharts' first
+                        render (before its ResizeObserver has fired) falls
+                        back to initialDimension, which defaults to
+                        {width:-1, height:-1} — logging "should be greater
+                        than 0" on every mount. minWidth/minHeight don't
+                        prevent this (they're applied as CSS, not fed into
+                        the size calculation); giving initialDimension a
+                        real floor does. The exact numbers only need to be
+                        positive — the ResizeObserver corrects them to the
+                        true size within a frame. */}
+                    <ResponsiveContainer
+                        width="100%"
+                        height="100%"
+                        minWidth={0}
+                        initialDimension={{ width: 520, height: 300 }}
+                    >
                         <LineChart
                             data={chartData}
                             margin={{ top: 5, right: 10, left: 0, bottom: 0 }}

--- a/frontend/src/components/admin/designer/InterfaceEditor.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.tsx
@@ -203,7 +203,7 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                 type="button"
                                                 disabled={readOnly}
                                                 onClick={() => resetLabel(inputKey)}
-                                                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[9px]
+                                                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-2xs
                                                          font-black text-slate-400
                                                          hover:bg-slate-100 hover:text-indigo-600 transition-colors"
                                                 title={t('common.reset_to_default')}

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -670,7 +670,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                     {t('common.optional')}
                                 </Badge>
                             </Label>
-                            <p className="text-[13px] font-medium text-indigo-600/80 leading-relaxed max-w-lg">
+                            <p className="text-sm font-medium text-indigo-600/80 leading-relaxed max-w-lg">
                                 {t('admin.design.postsort.email.desc')}
                             </p>
                         </div>

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -1282,7 +1282,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                         </div>
 
                                         <div
-                                            className="mt-2 text-xs sm:text-[13px] font-black w-8 h-8 sm:w-10 sm:h-10 rounded-xl sm:rounded-2xl border-2 bg-white flex items-center justify-center shadow-sm text-slate-700 tracking-tighter transition-all group-hover/col:border-indigo-600 group-hover/col:text-indigo-600"
+                                            className="mt-2 text-xs sm:text-sm font-black w-8 h-8 sm:w-10 sm:h-10 rounded-xl sm:rounded-2xl border-2 bg-white flex items-center justify-center shadow-sm text-slate-700 tracking-tighter transition-all group-hover/col:border-indigo-600 group-hover/col:text-indigo-600"
                                             data-testid={`grid-column-${idx}-score`}
                                         >
                                             {col.score > 0 ? `+${col.score}` : col.score}

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -303,7 +303,7 @@ export default function ConcourseDetailPage() {
                         >
                             <NotebookPen className="size-4" />
                             {memoUnreadCount > 0 && (
-                                <span className="absolute -top-1 -right-1 rounded-full bg-amber-100 text-amber-800 text-[10px] leading-none px-1.5 py-0.5 font-medium border border-white">
+                                <span className="absolute -top-1 -right-1 rounded-full bg-amber-100 text-amber-800 text-2xs leading-none px-1.5 py-0.5 font-medium border border-white">
                                     {memoUnreadCount}
                                 </span>
                             )}
@@ -418,7 +418,7 @@ export default function ConcourseDetailPage() {
                                 >
                                     {lang.toUpperCase()}
                                     {missingCountByLang[lang] && (
-                                        <span className="absolute -top-1 -right-1 size-4 rounded-full bg-amber-400 text-[10px] font-bold text-white flex items-center justify-center">
+                                        <span className="absolute -top-1 -right-1 size-4 rounded-full bg-amber-400 text-2xs font-bold text-white flex items-center justify-center">
                                             {missingCountByLang[lang]}
                                         </span>
                                     )}
@@ -863,7 +863,7 @@ export default function ConcourseDetailPage() {
                                                             >
                                                                 <MessageSquare className="size-3.5" />
                                                                 {(item.comment_count ?? 0) > 0 && (
-                                                                    <span className="absolute -top-1 -right-1 flex items-center justify-center size-4 rounded-full bg-indigo-600 text-white text-[9px] font-bold">
+                                                                    <span className="absolute -top-1 -right-1 flex items-center justify-center size-4 rounded-full bg-indigo-600 text-white text-2xs font-bold">
                                                                         {item.comment_count}
                                                                     </span>
                                                                 )}
@@ -1167,7 +1167,7 @@ export default function ConcourseDetailPage() {
                                                         >
                                                             <MessageSquare className="size-3.5" />
                                                             {(item.comment_count ?? 0) > 0 && (
-                                                                <span className="absolute -top-1 -right-1 flex items-center justify-center size-4 rounded-full bg-indigo-600 text-white text-[9px] font-bold">
+                                                                <span className="absolute -top-1 -right-1 flex items-center justify-center size-4 rounded-full bg-indigo-600 text-white text-2xs font-bold">
                                                                     {item.comment_count}
                                                                 </span>
                                                             )}

--- a/frontend/src/pages/admin/RecruitmentPage.test.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.test.tsx
@@ -12,7 +12,7 @@
  * study/form fixtures directly, with no query/router/API plumbing to fake out.
  */
 
-import { renderHook } from '@testing-library/react';
+import { fireEvent, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
 import { describe, expect, it, vi } from 'vitest';
@@ -51,8 +51,20 @@ function useTestForms() {
     return { slugForm, accessForm };
 }
 
-function baseApi(overrides: Partial<RecruitmentPageApi> = {}): RecruitmentPageApi {
-    const { result } = renderHook(() => useTestForms());
+/**
+ * Builds the mocked useRecruitmentPage() return value from a given pair of
+ * form instances. Split out from `baseApi` so callers that need the forms
+ * mounted in the same render tree as RecruitmentPage (see the Task 6.6
+ * Harness below) can supply their own instead of getting ones from an
+ * unrelated `renderHook()` tree.
+ */
+function baseApiFromForms(
+    forms: {
+        slugForm?: RecruitmentPageApi['slugForm'];
+        accessForm: RecruitmentPageApi['accessForm'];
+    },
+    overrides: Partial<RecruitmentPageApi> = {}
+): RecruitmentPageApi {
     return {
         slug: 'demo-study',
         navigate: vi.fn(),
@@ -61,8 +73,8 @@ function baseApi(overrides: Partial<RecruitmentPageApi> = {}): RecruitmentPageAp
         isSlugLocked: false,
         isArchived: false,
         studyUrl: 'https://example.com/study/demo-study',
-        slugForm: result.current.slugForm,
-        accessForm: result.current.accessForm,
+        slugForm: forms.slugForm as RecruitmentPageApi['slugForm'],
+        accessForm: forms.accessForm,
         passwordEnabled: false,
         showWindowPickers: false,
         setShowWindowPickers: vi.fn(),
@@ -85,6 +97,14 @@ function baseApi(overrides: Partial<RecruitmentPageApi> = {}): RecruitmentPageAp
         getFullUrl: vi.fn((token: string) => `https://example.com/study/demo-study?token=${token}`),
         ...overrides,
     };
+}
+
+function baseApi(overrides: Partial<RecruitmentPageApi> = {}): RecruitmentPageApi {
+    const { result } = renderHook(() => useTestForms());
+    return baseApiFromForms(
+        { slugForm: result.current.slugForm, accessForm: result.current.accessForm },
+        overrides
+    );
 }
 
 describe('RecruitmentPage — access rule switches (a11y)', () => {
@@ -169,5 +189,67 @@ describe('RecruitmentPage — group headings are real text, not dangling labels 
         const opensAt = screen.getByLabelText('Opens at');
         await user.click(screen.getByText('Opens at'));
         expect(opensAt).toHaveFocus();
+    });
+});
+
+describe('RecruitmentPage — clear-date buttons track the watched form values (Task 6.6)', () => {
+    // This guards the BEHAVIOUR (the clear button shows once a date is
+    // entered and hides once it's cleared), not the MECHANISM. Vitest does
+    // not run the React Compiler, so it can't reproduce the frozen-memo
+    // defect itself: on plain (uncompiled) React, `accessForm.watch(...)`
+    // called inline in JSX already re-renders correctly via react-hook-form's
+    // own subscription — the freeze only appears once the compiler folds the
+    // whole block into a memo keyed on `accessForm`/`isArchived`/
+    // `showWindowPickers`/`t`. The compiler-specific freeze (fixed by
+    // hoisting the watched values to `const startDate =
+    // accessForm.watch('startDate')` etc. in the component body, so the
+    // compiler emits an un-memoized read) can only be observed under a
+    // compiled build — see the E2E coverage / manual verification in
+    // task-6.4-6.8-report.md.
+    //
+    // baseApi()'s accessForm comes from a `useForm()` mounted via a separate
+    // `renderHook()` tree, so it never causes a re-render of RecruitmentPage
+    // itself when a field changes (RHF's re-render subscription belongs to
+    // whichever component *called* `useForm()`). This harness instead calls
+    // useForm() from inside the very tree under test, so field changes
+    // re-render RecruitmentPage the same way production's
+    // useRecruitmentPage() (called directly inside RecruitmentPage) does.
+    function Harness({ showWindowPickers }: { showWindowPickers: boolean }) {
+        const { slugForm, accessForm } = useTestForms();
+        mockUseRecruitmentPage.mockReturnValue(
+            baseApiFromForms({ slugForm, accessForm }, { showWindowPickers })
+        );
+        return <RecruitmentPage />;
+    }
+
+    // `datetime-local` is a segmented widget jsdom doesn't drive well via
+    // userEvent.type — fireEvent.change (the RTL-documented approach for
+    // this input type) sets the value directly and still fires the same
+    // React onChange that react-hook-form's `register` subscribes to.
+
+    it('shows the clear button once a start date is entered, and hides it once cleared', async () => {
+        renderWithProviders(<Harness showWindowPickers />);
+
+        expect(screen.queryByRole('button', { name: /clear date/i })).not.toBeInTheDocument();
+
+        fireEvent.change(screen.getByLabelText('Opens at'), {
+            target: { value: '2026-08-01T10:00' },
+        });
+        expect(await screen.findByRole('button', { name: /clear date/i })).toBeVisible();
+
+        fireEvent.change(screen.getByLabelText('Opens at'), { target: { value: '' } });
+        expect(screen.queryByRole('button', { name: /clear date/i })).not.toBeInTheDocument();
+    });
+
+    it('shows the clear button once an end date is entered, and hides it once cleared', async () => {
+        renderWithProviders(<Harness showWindowPickers />);
+
+        fireEvent.change(screen.getByLabelText('Closes at'), {
+            target: { value: '2026-08-15T10:00' },
+        });
+        expect(await screen.findByRole('button', { name: /clear date/i })).toBeVisible();
+
+        fireEvent.change(screen.getByLabelText('Closes at'), { target: { value: '' } });
+        expect(screen.queryByRole('button', { name: /clear date/i })).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/admin/RecruitmentPage.test.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.test.tsx
@@ -200,12 +200,21 @@ describe('RecruitmentPage — clear-date buttons track the watched form values (
     // called inline in JSX already re-renders correctly via react-hook-form's
     // own subscription — the freeze only appears once the compiler folds the
     // whole block into a memo keyed on `accessForm`/`isArchived`/
-    // `showWindowPickers`/`t`. The compiler-specific freeze (fixed by
-    // hoisting the watched values to `const startDate =
-    // accessForm.watch('startDate')` etc. in the component body, so the
-    // compiler emits an un-memoized read) can only be observed under a
-    // compiled build — see the E2E coverage / manual verification in
-    // task-6.4-6.8-report.md.
+    // `showWindowPickers`/`t`. It can only be observed under a compiled
+    // build — see task-6.4-6.8-report.md.
+    //
+    // DO NOT "simplify" the fix to `const startDate =
+    // accessForm.watch('startDate')` in the component body. That was tried
+    // and it does NOT work: `accessForm` is useRef-backed with stable
+    // identity, so the compiler emits `if ($[0] !== accessForm)` around the
+    // read and the value is computed once and reused forever — the identical
+    // bug, one level up. `useWatch({control, name})` is a hook call the
+    // compiler cannot fold into a memo guard, so the watched values become
+    // cache keys for the block that renders the buttons. Rationale in full
+    // at RecruitmentPage.tsx:103-116.
+    //
+    // This suite passes on BOTH the fixed and the unfixed source, so it will
+    // not catch that regression. This comment is the only guard rail here.
     //
     // baseApi()'s accessForm comes from a `useForm()` mounted via a separate
     // `renderHook()` tree, so it never causes a re-render of RecruitmentPage

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -947,7 +947,7 @@ const RecruitmentPage = () => {
                                             {link.type === 'individual' && (
                                                 <div className="text-2xs">
                                                     {link.usage_count > 0 ? (
-                                                        <Badge className="bg-emerald-50 text-emerald-700 border-emerald-100 px-2 py-0 shadow-none text-[9px] font-black">
+                                                        <Badge className="bg-emerald-50 text-emerald-700 border-emerald-100 px-2 py-0 shadow-none text-2xs font-black">
                                                             <CheckCircle2 className="size-3 mr-1" />
                                                             {t(
                                                                 'admin.recruitment.usage.completed',
@@ -955,7 +955,7 @@ const RecruitmentPage = () => {
                                                             )}
                                                         </Badge>
                                                     ) : (link.start_count || 0) > 0 ? (
-                                                        <Badge className="bg-amber-50 text-amber-700 border-amber-100 px-2 py-0 shadow-none text-[9px] font-black">
+                                                        <Badge className="bg-amber-50 text-amber-700 border-amber-100 px-2 py-0 shadow-none text-2xs font-black">
                                                             <Globe className="size-3 mr-1" />
                                                             {t(
                                                                 'admin.recruitment.usage.in_progress',
@@ -965,7 +965,7 @@ const RecruitmentPage = () => {
                                                     ) : (
                                                         <Badge
                                                             variant="secondary"
-                                                            className="bg-slate-50 text-slate-600 border-slate-200 px-2 py-0 shadow-none text-[9px] font-black"
+                                                            className="bg-slate-50 text-slate-600 border-slate-200 px-2 py-0 shadow-none text-2xs font-black"
                                                         >
                                                             {t(
                                                                 'admin.recruitment.usage.unused',
@@ -1030,13 +1030,13 @@ const RecruitmentPage = () => {
                                         </TableCell>
                                         <TableCell>
                                             {link.is_active ? (
-                                                <Badge className="bg-emerald-50 text-emerald-700 hover:bg-emerald-100 border-emerald-100 px-2 py-0 shadow-none text-[9px] font-black">
+                                                <Badge className="bg-emerald-50 text-emerald-700 hover:bg-emerald-100 border-emerald-100 px-2 py-0 shadow-none text-2xs font-black">
                                                     {t('admin.status.active')}
                                                 </Badge>
                                             ) : (
                                                 <Badge
                                                     variant="secondary"
-                                                    className="bg-slate-50 text-slate-600 border-slate-200 px-2 py-0 shadow-none text-[9px] font-black"
+                                                    className="bg-slate-50 text-slate-600 border-slate-200 px-2 py-0 shadow-none text-2xs font-black"
                                                 >
                                                     {t('admin.recruitment.revoked', 'Revoked')}
                                                 </Badge>

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -18,6 +18,7 @@ import {
     X,
     Calendar,
 } from 'lucide-react';
+import { useWatch } from 'react-hook-form';
 import { cn } from '@/lib/utils';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import { useTranslation } from 'react-i18next';
@@ -99,6 +100,22 @@ const RecruitmentPage = () => {
         copyToClipboard,
         getFullUrl,
     } = api;
+
+    // accessForm is a useRef-backed react-hook-form UseFormReturn with STABLE
+    // identity, so both a JSX-inline `accessForm.watch('startDate')` call and
+    // a hoisted `const startDate = accessForm.watch('startDate')` in the
+    // component body get folded by the React Compiler into a memo block
+    // keyed only on `accessForm`'s reference — which never changes — so the
+    // computed value is cached forever after the first render, freezing the
+    // clear-date buttons. `useWatch` is a real hook: the compiler cannot fold
+    // a hook call away like a plain method call, so its return value is
+    // recomputed on every render exactly like the underlying react-hook-form
+    // subscription intends. (Confirmed on the built bundle: the hoisted-const
+    // version produced `e[0]===v?ot=e[1]:(ot=v.watch("startDate"),e[0]=v,e[1]=ot)`
+    // — a memo cache keyed on `v` (accessForm) that never invalidates — the
+    // exact same shape of bug the fix was meant to remove.)
+    const startDate = useWatch({ control: accessForm.control, name: 'startDate' });
+    const endDate = useWatch({ control: accessForm.control, name: 'endDate' });
 
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
@@ -514,7 +531,7 @@ const RecruitmentPage = () => {
                                                     {...accessForm.register('startDate')}
                                                     className="h-11 pl-10 pr-10 rounded-xl bg-slate-50 border-slate-100 text-xs focus-visible:ring-indigo-500"
                                                 />
-                                                {accessForm.watch('startDate') && !isArchived && (
+                                                {startDate && !isArchived && (
                                                     <button
                                                         type="button"
                                                         onClick={() =>
@@ -552,7 +569,7 @@ const RecruitmentPage = () => {
                                                     {...accessForm.register('endDate')}
                                                     className="h-11 pl-10 pr-10 rounded-xl bg-slate-50 border-slate-100 text-xs focus-visible:ring-indigo-500"
                                                 />
-                                                {accessForm.watch('endDate') && !isArchived && (
+                                                {endDate && !isArchived && (
                                                     <button
                                                         type="button"
                                                         onClick={() =>

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -300,7 +300,7 @@ const StudyDesignPage = () => {
                             >
                                 <NotebookPen className="h-4 w-4" />
                                 {memoUnreadCount > 0 && (
-                                    <span className="absolute -top-1 -right-1 rounded-full bg-amber-100 text-amber-800 text-[10px] leading-none px-1.5 py-0.5 font-medium border border-white">
+                                    <span className="absolute -top-1 -right-1 rounded-full bg-amber-100 text-amber-800 text-2xs leading-none px-1.5 py-0.5 font-medium border border-white">
                                         {memoUnreadCount}
                                     </span>
                                 )}

--- a/frontend/src/styles/typography.css
+++ b/frontend/src/styles/typography.css
@@ -3,8 +3,8 @@
     /* Fluid Typography Variables */
     /* Viewport range: 320px - 1280px */
 
-    /* 2xs: 10px -> 11px */
-    --font-size-2xs: clamp(0.625rem, 0.60rem + 0.16vw, 0.6875rem);
+    /* 2xs: 11px -> 12px */
+    --font-size-2xs: clamp(0.6875rem, 0.66rem + 0.16vw, 0.75rem);
 
     /* xs: 12px -> 13px */
     --font-size-xs: clamp(0.75rem, 0.72rem + 0.16vw, 0.8125rem);


### PR DESCRIPTION
Phase 6 tasks 6.4, 6.6 and 6.8 of the admin UX remediation plan, plus the fixes from review.

## What this changes

**6.4 — typographic floor.** Raises the smallest text to 11px and removes off-scale sizes. `grep -rn "text-\[[0-9]*px\]" src/` now returns nothing: no bracketed font size survives anywhere in `frontend/src`.

**6.6 — the frozen clear-date buttons on Access.** `RecruitmentPage.tsx` compiled the whole collection-window block into one memo keyed on `accessForm`/`isArchived`/`showWindowPickers`/`t`, none of which change when a form field does, so the clear-date buttons never appeared or disappeared.

**6.8 — charts mounting at zero size.** Three charts passing `height="100%"` computed `-1 × -1` on first render and warned.

## Two places where the brief was wrong

Both prescriptions in my task briefs were incorrect. The implementer tested them, found them wrong, and deviated. The reviewer then reproduced both proofs independently rather than trusting the report.

**The brief said: hoist `const startDate = accessForm.watch('startDate')`.** That does not work. Compiled through the repo's own React Compiler preset it emits `if ($[0] !== accessForm) { t0 = accessForm.watch("startDate") }` — and `accessForm` is `useRef`-backed with stable identity, so the value is computed once and reused forever. It is the same bug, relocated one level up. The shipped fix is `useWatch({control, name})`, a hook call the compiler cannot fold into a memo guard, so the watched values become cache keys for the block that renders the buttons.

**The brief said: add `minWidth`/`minHeight`.** Against recharts 3.8.1's own source, those props are never read by `calculateChartDimensions`. They appear in exactly two places, neither in the guard: as format *arguments inside the warning string itself*, and as inline CSS on the container div. The warning advises the two props the code it guards ignores — which is how the brief came to prescribe them. The shipped fix is `initialDimension`, which seeds the pre-ResizeObserver state at `ResponsiveContainer.js:70-73`.

The brief also named one file; the implementer found the warnings actually come from three, and fixed all three.

## A correction I had to make to my own fix

Review found that raising `--font-size-2xs` pushed the "Recently completed" badge past its pill: at 320px it wrapped to two lines inside a container `h-4` clamps to 16px, and 9px of text painted outside the green rectangle — on the first card an admin sees on a phone.

My first fix was `leading-none`, reasoned from the CSS. **Measurement rejected it**: the badge still wrapped and still escaped, the overflow only falling from 9px to 4px. The cause is horizontal, not vertical — at 320px the badge is a shrinking flex item given ~109px for content needing ~126px, and no line-height addresses a width problem.

The fix in this PR is `min-h-4` instead of `h-4` — a floor rather than a clamp. One line renders identically; when the label does not fit, the pill grows instead of the text escaping it.

I nearly took a lexical shortcut instead: the code reads `t(…, 'Completed')` while `en/admin.json` says "Recently completed", and shortening English would have made 320px fit. Measurement showed that fixes one locale of nine — **Spanish gets *more* width than English** (116.36 vs 109.05px), because the flex floor is the longest single word and "recientemente" is wider than "completed". English is the short case here. The `t()` fallback/label mismatch is a real naming-canon violation and is logged as Phase 5 input rather than silently changed here.

## Verification

Measured in Chromium at 320/360/375/414/768/1440, in English and Spanish, on both affected pages:

- no text paints outside any badge's border box at any width;
- `documentElement.scrollWidth` equals `innerWidth` exactly at every width — not merely within tolerance;
- `responsive-overflow.spec.ts`: 3 passed;
- Vitest: 197 files, 1735 passed, 6 skipped;
- `ruff`, `biome`, `mypy` (84 files), `tsc`: all clean;
- a11y gate: 5 unnamed controls, 0 low-contrast, 0 label errors — matches baseline.

`make ci-fast` does **not** pass on this machine: it fails with 340 `asyncpg InvalidPasswordError` before reaching the frontend suite, a pre-existing local-Postgres credential problem unrelated to this frontend-only diff. Because `Makefile:172` (pytest) precedes `Makefile:173` (`npm run test`), a local DB failure means the frontend suite never runs — worth knowing when reading any "ci-fast passes" claim on this repo.

## A gate that ran and looked past the defect

`responsive-overflow.spec.ts` **does** iterate 320px. It missed this because its clipping assertion filters to `querySelectorAll('button')` and these badges are `div`s. Right instrument, right viewport, wrong node set. This PR does not add a guard on badge geometry; that gap is real and remains.

## Left behind, logged not fixed

- **Task 6.9** — the fix is containment, not finish. At 320px the completed row is 93.88px against the in-progress row's 77.27px, and the duration floats centred against a 26px pill. It reads as an acceptable fallback, not intended behaviour. The lever is the row, not the badge.
- **Task 6.10** — found while verifying: `ConcourseDetailPage` tag badges are `h-5` hard clamps around user-supplied, multi-word `{tag.name}`, and `:1026`'s container has no `flex-wrap`. Structurally the same defect as this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)