### PR TITLE
fix(a11y): raise the admin's contrast floor to AA

### DIFF
--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1850,3 +1850,38 @@ form false-positives on any `<Button>`, because `\b` matches inside `disabled:op
 **Verify by computation against the actual background**, not against white — several admin
 surfaces are tinted, and a promoted shade that passes on white can still fail on its own
 background (6.5 found `slate-500` at 4.34:1 on `bg-slate-100` and 4.26:1 on `bg-indigo-50`).
+
+---
+
+### Task 6.12: A failed save can be navigated away from silently
+
+**Found by the verification pass on Task 6.5's F1 fix. Pre-existing, and the most
+consequential thing this plan has turned up — this one loses user work.**
+
+`useStudyPersistence.ts:40` (the `beforeunload` guard) and `:52` (the router blocker) both
+enumerate only `'modified' | 'saving'`. But `syncStatus` is a **four**-value union, and
+`'error'` is *sticky* (`:75` refuses to downgrade it while the draft is dirty).
+
+So: a researcher edits a study, the save fails, the status parks on `'error'` with the
+draft still dirty — and **both guards are blind to it**. They close the tab or navigate
+away and lose the edits with no warning. The one state where a warning matters most is the
+one state neither guard covers.
+
+This is exactly the F1 shape, one file over: an enumeration written over a four-value union
+that silently handles three. F1 existed because `'error'` was dropped from that union in
+prose; this exists because it was dropped from the same union in code.
+
+**Second finding, same file.** `:159-162` — the merge-throw path sets `'error'` with a
+`console.error` and **no `toast.error`**, unlike the sibling paths at `:139` and `:166`.
+The Save button's accessible name is "Save" in both `'modified'` and `'error'` at ≥md, so
+a screen-reader user on that path receives **no signal at all** that the save failed.
+
+**Fix:** add `'error'` to both guard enumerations; add the missing `toast.error`. Small —
+roughly one token each — but it changes navigation-guard behaviour, so it needs its own
+tests rather than riding along in a styling PR. That is why 6.5 logged it instead of
+grabbing it.
+
+**Verify:** drive the real `'error'` state (not `setState`) through each of the three paths
+that set it — `:145` unmergeable 409, `:161` merge threw, `:165` other failure — and assert
+the guard fires and the toast appears. Task 6.5's own tests drove state via `setState`, so
+nothing currently guards `'error'`'s reachability or stickiness; do not repeat that.

--- a/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-26-admin-ux-remediation.md
@@ -1824,3 +1824,29 @@ safe. `InteractiveDataView.columns.tsx:449,464` are multi-word but sit inside th
 inside a 320px viewport). `AdminDashboard.tsx:724`, `ItemDetailSheet.tsx:135` and
 `AppSidebar.tsx:337,376` carry numeric counts or a single `⌘K` token — min-content equals
 max-content, so no wrap is possible. Leave all six alone.
+
+---
+
+### Task 6.11: `QSortEditor`'s readOnly dim, on every launched study
+
+**Found during Task 6.5's opacity sweep, reported rather than grabbed** — its label closes
+at `QSortEditor.tsx:1434`, before any line 6.5 promoted, so it is out of that commit's
+blast radius and was deliberately left alone.
+
+Same shape as 6.5's finding F3: a resting `opacity-*` at `QSortEditor.tsx:1417` composites
+pre-existing tokens down to **3.3542:1** — under the 4.5:1 floor for text. `readOnly` here
+means `draft.state !== 'draft'`, so this is **every launched study**: the steady state of
+the surface, not an edge case.
+
+**Fix:** the `StudyStatusControl` precedent — remove the opacity and carry the
+de-emphasis another way (6.5 used `bg-slate-50` plus a `grayscale` filter, which, unlike
+opacity, applies to foreground and background as a group and so leaves the ratio
+essentially unmoved). Record the computed ratio in a code comment and add a regression test
+asserting the token **and** the absence of a resting opacity.
+
+**Use `/(?:^|\s)opacity-\d/`, not `/\bopacity-\d/`.** Task 6.5 found the precedent's `\b`
+form false-positives on any `<Button>`, because `\b` matches inside `disabled:opacity-50`.
+
+**Verify by computation against the actual background**, not against white — several admin
+surfaces are tinted, and a promoted shade that passes on white can still fail on its own
+background (6.5 found `slate-500` at 4.34:1 on `bg-slate-100` and 4.26:1 on `bg-indigo-50`).

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -93,13 +93,13 @@ function getStateIcon(state: string | undefined) {
                 </span>
             );
         case 'draft':
-            return <Circle className="h-3 w-3 text-slate-400" />;
+            return <Circle className="h-3 w-3 text-slate-500" />;
         case 'paused':
             return <Clock className="h-3 w-3 text-amber-500" />;
         case 'closed':
             return <CheckCircle2 className="h-3 w-3 text-blue-500" />;
         default:
-            return <Circle className="h-3 w-3 text-slate-400" />;
+            return <Circle className="h-3 w-3 text-slate-500" />;
     }
 }
 

--- a/frontend/src/components/admin/CommandMenu.tsx
+++ b/frontend/src/components/admin/CommandMenu.tsx
@@ -95,7 +95,7 @@ export const CommandMenu = () => {
                             'admin.command_menu.placeholder',
                             'Type a command or search...'
                         )}
-                        className="flex h-12 w-full bg-transparent py-3 text-sm outline-none placeholder:text-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+                        className="flex h-12 w-full bg-transparent py-3 text-sm outline-none placeholder:text-slate-500 disabled:cursor-not-allowed disabled:opacity-50"
                         autoFocus
                     />
                 </div>
@@ -185,7 +185,7 @@ export const CommandMenu = () => {
                             </Command.Item>
                         ))}
                         {(!filteredStudies || filteredStudies.length === 0) && (
-                            <div className="px-4 py-3 text-sm text-slate-400 italic">
+                            <div className="px-4 py-3 text-sm text-slate-500 italic">
                                 {t('admin.command_menu.no_studies', 'No studies in this project.')}
                             </div>
                         )}
@@ -314,7 +314,7 @@ export const CommandMenu = () => {
                     </Command.Group>
                 </Command.List>
 
-                <div className="border-t px-4 py-2 flex items-center justify-between text-xs text-slate-400">
+                <div className="border-t px-4 py-2 flex items-center justify-between text-xs text-slate-500">
                     <div className="flex items-center gap-2">
                         <Search className="h-3 w-3" />
                         <span>

--- a/frontend/src/components/admin/CreateStudyDialog.tsx
+++ b/frontend/src/components/admin/CreateStudyDialog.tsx
@@ -218,7 +218,7 @@ export function CreateStudyDialog({ open, onOpenChange, projectSlug }: CreateStu
                                         <FormLabel className="text-2xs font-black text-slate-500">
                                             {t('admin.dialogs.create_study.languages', 'Languages')}
                                         </FormLabel>
-                                        <p className="text-xs font-medium text-slate-400 mt-1">
+                                        <p className="text-xs font-medium text-slate-500 mt-1">
                                             {t(
                                                 'admin.dialogs.create_study.languages_desc',
                                                 'Select languages to enable for this study. Content will be initialized with localized defaults.'

--- a/frontend/src/components/admin/GuidanceCard.tsx
+++ b/frontend/src/components/admin/GuidanceCard.tsx
@@ -133,7 +133,7 @@ export const GuidanceCard: React.FC<GuidanceCardProps> = ({
                         <span className="text-sm font-medium text-slate-600 flex-1">{title}</span>
                         <ChevronDown
                             className={cn(
-                                'size-3.5 shrink-0 text-slate-400 transition-transform duration-200',
+                                'size-3.5 shrink-0 text-slate-500 transition-transform duration-200',
                                 open && 'rotate-180'
                             )}
                         />

--- a/frontend/src/components/admin/ProjectSwitcher.tsx
+++ b/frontend/src/components/admin/ProjectSwitcher.tsx
@@ -83,7 +83,7 @@ export function ProjectSwitcher() {
                                         : t('admin.sidebar.select_project')}
                                 </span>
                             </div>
-                            <ChevronsUpDown className="ml-auto size-4 text-slate-400" />
+                            <ChevronsUpDown className="ml-auto size-4 text-slate-500" />
                         </SidebarMenuButton>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent
@@ -92,7 +92,7 @@ export function ProjectSwitcher() {
                         side={isMobile ? 'bottom' : 'right'}
                         sideOffset={4}
                     >
-                        <DropdownMenuLabel className="px-2 py-1.5 text-xs font-semibold text-slate-400">
+                        <DropdownMenuLabel className="px-2 py-1.5 text-xs font-semibold text-slate-500">
                             {t('admin.command_menu.switch_project', 'Projects')}
                         </DropdownMenuLabel>
                         <div className="space-y-1 my-1">

--- a/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
@@ -198,9 +198,9 @@ export function AnalysisHistoryPanel({
                     )}
                 </div>
                 {collapsed ? (
-                    <ChevronDown className="size-4 text-slate-400" aria-hidden="true" />
+                    <ChevronDown className="size-4 text-slate-500" aria-hidden="true" />
                 ) : (
-                    <ChevronUp className="size-4 text-slate-400" aria-hidden="true" />
+                    <ChevronUp className="size-4 text-slate-500" aria-hidden="true" />
                 )}
             </button>
 
@@ -274,7 +274,7 @@ export function AnalysisHistoryPanel({
                                                 </span>
                                             )}
                                             {loadingRunId === run.id && (
-                                                <span className="text-xs text-slate-400">
+                                                <span className="text-xs text-slate-500">
                                                     {t(
                                                         'admin.analysis.history.loading_run',
                                                         'Loading…'
@@ -307,14 +307,14 @@ export function AnalysisHistoryPanel({
                                                     <span className="text-slate-500 text-xs">
                                                         ·
                                                     </span>
-                                                    <span className="text-xs text-slate-400 italic">
+                                                    <span className="text-xs text-slate-500 italic">
                                                         {run.ran_by_email}
                                                     </span>
                                                 </>
                                             )}
                                         </div>
                                         {run.notes && editingId !== run.id && (
-                                            <p className="mt-1 text-xs text-slate-400 italic">
+                                            <p className="mt-1 text-xs text-slate-500 italic">
                                                 {truncate(run.notes, 40)}
                                             </p>
                                         )}
@@ -357,7 +357,7 @@ export function AnalysisHistoryPanel({
                                             <button
                                                 type="button"
                                                 onClick={handleCancelEdit}
-                                                className="shrink-0 text-slate-400 hover:text-slate-600"
+                                                className="shrink-0 text-slate-500 hover:text-slate-600"
                                                 aria-label={t(
                                                     'admin.analysis.history.cancel_edit_aria',
                                                     'Cancel editing'
@@ -374,7 +374,7 @@ export function AnalysisHistoryPanel({
                                             <button
                                                 type="button"
                                                 onClick={() => handleStartEdit(run)}
-                                                className="text-slate-400 hover:text-slate-600 p-1 rounded transition-colors"
+                                                className="text-slate-500 hover:text-slate-600 p-1 rounded transition-colors"
                                                 title={t(
                                                     'admin.analysis.history.edit_notes',
                                                     'Edit notes'
@@ -389,7 +389,7 @@ export function AnalysisHistoryPanel({
                                             <button
                                                 type="button"
                                                 onClick={() => setDeleteTargetId(run.id)}
-                                                className="text-slate-400 hover:text-red-500 p-1 rounded transition-colors"
+                                                className="text-slate-500 hover:text-red-500 p-1 rounded transition-colors"
                                                 title={t(
                                                     'admin.analysis.history.delete_run',
                                                     'Delete run'

--- a/frontend/src/components/admin/analysis/FactorArraysView.tsx
+++ b/frontend/src/components/admin/analysis/FactorArraysView.tsx
@@ -119,7 +119,7 @@ export function FactorArraysView({
                                 <Tooltip>
                                     <TooltipTrigger asChild>
                                         <Info
-                                            className="size-3.5 text-slate-400 cursor-help"
+                                            className="size-3.5 text-slate-500 cursor-help"
                                             aria-hidden="true"
                                         />
                                     </TooltipTrigger>

--- a/frontend/src/components/admin/analysis/FactorCharacteristicsTable.tsx
+++ b/frontend/src/components/admin/analysis/FactorCharacteristicsTable.tsx
@@ -125,7 +125,7 @@ export function FactorCharacteristicsTable({ result }: FactorCharacteristicsTabl
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <Info
-                                        className="size-3.5 text-slate-400 cursor-help"
+                                        className="size-3.5 text-slate-500 cursor-help"
                                         aria-hidden="true"
                                     />
                                 </TooltipTrigger>

--- a/frontend/src/components/admin/analysis/FactorLoadingsTable.tsx
+++ b/frontend/src/components/admin/analysis/FactorLoadingsTable.tsx
@@ -140,7 +140,7 @@ export function FactorLoadingsTable({
                         <Tooltip>
                             <TooltipTrigger asChild>
                                 <Info
-                                    className="size-3.5 text-slate-400 cursor-help"
+                                    className="size-3.5 text-slate-500 cursor-help"
                                     aria-hidden="true"
                                 />
                             </TooltipTrigger>
@@ -245,7 +245,7 @@ export function FactorLoadingsTable({
                                                 ))}
                                             </span>
                                         ) : (
-                                            <span className="text-slate-300">&mdash;</span>
+                                            <span className="text-slate-500">&mdash;</span>
                                         )}
                                     </td>
                                 </tr>

--- a/frontend/src/components/admin/analysis/FactorNoteEditor.tsx
+++ b/frontend/src/components/admin/analysis/FactorNoteEditor.tsx
@@ -130,7 +130,7 @@ export const FactorNoteEditor = forwardRef<FactorNoteEditorHandle, FactorNoteEdi
                     <div className="flex items-center justify-between gap-2">
                         <span
                             className={`text-2xs ${
-                                isOverLimit ? 'text-rose-600 font-semibold' : 'text-slate-400'
+                                isOverLimit ? 'text-rose-600 font-semibold' : 'text-slate-500'
                             }`}
                         >
                             {t('admin.analysis.factor_note.char_count', '{{n}}/{{max}}', {
@@ -154,7 +154,7 @@ export const FactorNoteEditor = forwardRef<FactorNoteEditorHandle, FactorNoteEdi
                             <button
                                 type="button"
                                 onClick={handleCancel}
-                                className="text-slate-400 hover:text-slate-600 p-1"
+                                className="text-slate-500 hover:text-slate-600 p-1"
                                 aria-label={t(
                                     'admin.analysis.factor_note.cancel_aria',
                                     'Cancel editing'
@@ -182,14 +182,14 @@ export const FactorNoteEditor = forwardRef<FactorNoteEditorHandle, FactorNoteEdi
                         )}
                     >
                         <NotebookText
-                            className="size-3 text-slate-400 mt-0.5 shrink-0"
+                            className="size-3 text-slate-500 mt-0.5 shrink-0"
                             aria-hidden="true"
                         />
                         <p className="flex-1 min-w-0 text-xs text-slate-600 leading-snug">
                             {currentNote}
                         </p>
                         <Pencil
-                            className="size-3 text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                            className="size-3 text-slate-500 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
                             aria-hidden="true"
                         />
                     </button>
@@ -197,7 +197,7 @@ export const FactorNoteEditor = forwardRef<FactorNoteEditorHandle, FactorNoteEdi
                     <button
                         type="button"
                         onClick={handleStart}
-                        className="text-2xs text-slate-400 hover:text-slate-600 italic flex items-center gap-1.5 transition-colors"
+                        className="text-2xs text-slate-500 hover:text-slate-600 italic flex items-center gap-1.5 transition-colors"
                     >
                         <NotebookText className="size-3" aria-hidden="true" />
                         {t(

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
@@ -143,7 +143,7 @@ function ParticipantMaterialCard({
                                         )}
                                     />
                                 ) : (
-                                    <p className="text-2xs text-slate-400 italic">
+                                    <p className="text-2xs text-slate-500 italic">
                                         {t(
                                             'admin.analysis.factor_voices.url_unavailable',
                                             'Audio URL not available.'
@@ -187,7 +187,7 @@ function ParticipantMaterialCard({
                                                 'admin.analysis.interpret.insert_comment_quote',
                                                 'Insert comment as quote'
                                             )}
-                                            className="ml-auto text-slate-400 hover:text-emerald-700 text-xs"
+                                            className="ml-auto text-slate-500 hover:text-emerald-700 text-xs"
                                         >
                                             ▸+
                                         </button>
@@ -273,7 +273,7 @@ export function FactorVoicesPanel({
                         type="button"
                         onClick={() => setTooltipOpen((o) => !o)}
                         onBlur={() => setTooltipOpen(false)}
-                        className="text-slate-400 hover:text-slate-600 transition-colors"
+                        className="text-slate-500 hover:text-slate-600 transition-colors"
                         aria-label={t(
                             'admin.analysis.factor_voices.context_aria',
                             'About this panel'
@@ -294,7 +294,7 @@ export function FactorVoicesPanel({
 
             {isLoading && (
                 <div
-                    className="flex items-center gap-2 text-sm text-slate-400 py-2"
+                    className="flex items-center gap-2 text-sm text-slate-500 py-2"
                     role="status"
                     aria-live="polite"
                 >
@@ -317,7 +317,7 @@ export function FactorVoicesPanel({
             )}
 
             {hasNoMaterial && (
-                <p className="text-xs text-slate-400 italic py-1">
+                <p className="text-xs text-slate-500 italic py-1">
                     {t(
                         'admin.analysis.factor_voices.no_material',
                         'No post-sort audio recordings or written comments from participants flagged on this factor.'

--- a/frontend/src/components/admin/analysis/StatementsTable.tsx
+++ b/frontend/src/components/admin/analysis/StatementsTable.tsx
@@ -18,7 +18,7 @@ interface StatementsTableProps {
 type SortKey = 'code' | 'type' | `z${number}` | `a${number}`;
 
 function zScoreColor(z: number | null): string {
-    if (z === null) return 'text-slate-400';
+    if (z === null) return 'text-slate-500';
     if (z >= 1.5) return 'text-blue-700 bg-blue-50';
     if (z >= 0.5) return 'text-blue-600 bg-blue-50/50';
     if (z <= -1.5) return 'text-red-700 bg-red-50';
@@ -129,7 +129,7 @@ export function StatementsTable({ result }: StatementsTableProps) {
                         <UiTooltip>
                             <TooltipTrigger asChild>
                                 <Info
-                                    className="size-3.5 text-slate-400 cursor-help"
+                                    className="size-3.5 text-slate-500 cursor-help"
                                     aria-hidden="true"
                                 />
                             </TooltipTrigger>
@@ -252,7 +252,7 @@ export function StatementsTable({ result }: StatementsTableProps) {
                                                     ? '-'
                                                     : `${z > 0 ? '+' : ''}${z.toFixed(2)}`}
                                                 {stab && (
-                                                    <span className="text-slate-400 font-normal">
+                                                    <span className="text-slate-500 font-normal">
                                                         {' '}
                                                         ±{stab.z_se.toFixed(2)}
                                                     </span>

--- a/frontend/src/components/admin/concourse/ItemDetailSheet.tsx
+++ b/frontend/src/components/admin/concourse/ItemDetailSheet.tsx
@@ -200,14 +200,14 @@ function VersionList({
     if (isLoading) {
         return (
             <div className="flex items-center justify-center py-12">
-                <Loader2 className="size-5 animate-spin text-slate-400" />
+                <Loader2 className="size-5 animate-spin text-slate-500" />
             </div>
         );
     }
 
     if (versions.length === 0) {
         return (
-            <p className="text-center text-sm text-slate-400 py-12">
+            <p className="text-center text-sm text-slate-500 py-12">
                 {t('admin.concourse.no_history', 'No edit history yet.')}
             </p>
         );
@@ -255,7 +255,7 @@ function VersionList({
                                     </span>
                                 )}
                             </div>
-                            <span className="text-2xs text-slate-400">
+                            <span className="text-2xs text-slate-500">
                                 {formatDate(v.changed_at)}
                             </span>
                         </div>
@@ -270,7 +270,7 @@ function VersionList({
                                             key={tr.language_code}
                                             className="text-sm text-slate-700"
                                         >
-                                            <span className="text-2xs font-bold text-slate-400 mr-1.5">
+                                            <span className="text-2xs font-bold text-slate-500 mr-1.5">
                                                 {tr.language_code?.toUpperCase()}
                                             </span>
                                             {tr.text}
@@ -309,14 +309,14 @@ function CommentList({
     if (isLoading) {
         return (
             <div className="flex items-center justify-center py-12">
-                <Loader2 className="size-5 animate-spin text-slate-400" />
+                <Loader2 className="size-5 animate-spin text-slate-500" />
             </div>
         );
     }
 
     if (comments.length === 0) {
         return (
-            <p className="text-center text-sm text-slate-400 py-12">
+            <p className="text-center text-sm text-slate-500 py-12">
                 {t('admin.concourse.no_comments', 'No comments yet.')}
             </p>
         );
@@ -335,7 +335,7 @@ function CommentList({
                                 ? (memberNames[c.user_id] ?? `#${c.user_id}`)
                                 : t('common.unknown', 'Unknown')}
                         </span>
-                        <span className="text-2xs text-slate-400">{formatDate(c.created_at)}</span>
+                        <span className="text-2xs text-slate-500">{formatDate(c.created_at)}</span>
                     </div>
                     <p className="text-sm text-slate-800 whitespace-pre-wrap">{c.body}</p>
                 </div>

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -155,7 +155,7 @@ export function ParticipantCell({
                         title={p.user_agent}
                         className="flex items-center gap-1"
                     >
-                        <span className="inline-flex items-center text-slate-400">
+                        <span className="inline-flex items-center text-slate-500">
                             {OsIcon ? (
                                 <OsIcon className="w-3 h-3" />
                             ) : (
@@ -163,7 +163,7 @@ export function ParticipantCell({
                             )}
                         </span>
                         {ua.browser !== 'Unknown' && (
-                            <span className="inline-flex items-center text-slate-400">
+                            <span className="inline-flex items-center text-slate-500">
                                 {BrowserIcon ? (
                                     <BrowserIcon className="w-3 h-3" />
                                 ) : (
@@ -282,7 +282,7 @@ export function buildColumns({
         columnHelper.accessor('id', {
             header: () => (
                 <div className="flex items-center gap-1.5">
-                    <Users className="w-3.5 h-3.5 text-slate-400" />
+                    <Users className="w-3.5 h-3.5 text-slate-500" />
                     <span>{t('admin.data.table.participant')}</span>
                 </div>
             ),
@@ -303,7 +303,7 @@ export function buildColumns({
                               onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
                               className="h-8 text-xs font-semibold p-0 hover:bg-transparent flex items-center gap-1.5"
                           >
-                              <Globe className="w-3.5 h-3.5 text-slate-400" />
+                              <Globe className="w-3.5 h-3.5 text-slate-500" />
                               {t('admin.data.table.lang')}
                               {column.getIsSorted() === 'asc' ? (
                                   <ArrowUp className="ml-2 h-3 w-3 text-indigo-500" />
@@ -316,7 +316,7 @@ export function buildColumns({
                       ),
                       cell: (info) => (
                           <div className="flex items-center gap-2 text-slate-600 font-medium">
-                              <Globe className="h-3.5 w-3.5 text-slate-300" />
+                              <Globe className="h-3.5 w-3.5 text-slate-500" />
                               <span className="text-xs font-medium">
                                   {info.getValue() === 'US' ? 'EN' : info.getValue()}
                               </span>
@@ -333,7 +333,7 @@ export function buildColumns({
                         onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
                         className="h-8 text-xs font-semibold p-0 hover:bg-transparent flex items-center gap-1.5"
                     >
-                        <Sparkles className="w-3.5 h-3.5 text-slate-400" />
+                        <Sparkles className="w-3.5 h-3.5 text-slate-500" />
                         {t('admin.data.table.status', 'Status')}
                         {column.getIsSorted() === 'asc' ? (
                             <ArrowUp className="ml-1 h-3 w-3 text-indigo-500" />
@@ -353,7 +353,7 @@ export function buildColumns({
                                     'h-6 w-6 p-0 rounded',
                                     statusFilter !== 'all' || stepFilter !== 'all'
                                         ? 'text-indigo-600 bg-indigo-50'
-                                        : 'text-slate-400 hover:text-slate-600'
+                                        : 'text-slate-500 hover:text-slate-600'
                                 )}
                             >
                                 <Filter className="h-3 w-3" />
@@ -369,7 +369,7 @@ export function buildColumns({
                                 {t('admin.data.filters.all_statuses', 'All')}
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
-                            <DropdownMenuLabel className="text-2xs text-slate-400">
+                            <DropdownMenuLabel className="text-2xs text-slate-500">
                                 {t('admin.data.table.status', 'Status')}
                             </DropdownMenuLabel>
                             <DropdownMenuItem
@@ -412,7 +412,7 @@ export function buildColumns({
                                 {t('admin.data.status.abandoned', 'Abandoned')}
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
-                            <DropdownMenuLabel className="text-2xs text-slate-400">
+                            <DropdownMenuLabel className="text-2xs text-slate-500">
                                 {t('admin.data.table.current_step', 'Current step')}
                             </DropdownMenuLabel>
                             {Object.entries(stepLabels).map(([step, [key, fallback]]) => (
@@ -488,7 +488,7 @@ export function buildColumns({
                                     'h-6 w-6 p-0 rounded',
                                     consentFilters.size > 0
                                         ? 'text-indigo-600 bg-indigo-50'
-                                        : 'text-slate-400 hover:text-slate-600'
+                                        : 'text-slate-500 hover:text-slate-600'
                                 )}
                             >
                                 <Filter className="h-3 w-3" />
@@ -579,7 +579,7 @@ export function buildColumns({
                         {!p.postsort.email &&
                             !p.postsort.newsletter_consent &&
                             !p.postsort.interview_consent && (
-                                <span className="text-2xs text-slate-300 font-medium">—</span>
+                                <span className="text-2xs text-slate-500 font-medium">—</span>
                             )}
                     </div>
                 );
@@ -590,7 +590,7 @@ export function buildColumns({
             header: () => (
                 <div className="flex items-center gap-1">
                     <div className="flex items-center gap-1.5">
-                        <AlertTriangle className="w-3.5 h-3.5 text-slate-400" />
+                        <AlertTriangle className="w-3.5 h-3.5 text-slate-500" />
                         <span>{t('admin.data.table.flags')}</span>
                     </div>
                     <DropdownMenu>
@@ -603,7 +603,7 @@ export function buildColumns({
                                     'h-6 w-6 p-0 rounded',
                                     qualityFilter !== 'all'
                                         ? 'text-indigo-600 bg-indigo-50'
-                                        : 'text-slate-400 hover:text-slate-600'
+                                        : 'text-slate-500 hover:text-slate-600'
                                 )}
                             >
                                 <Filter className="h-3 w-3" />
@@ -712,7 +712,7 @@ export function buildColumns({
                             </span>
                         )}
                         {!isSuspect && !hasComments && !hasAudio && !hasRecruitmentLink && (
-                            <span className="text-2xs text-slate-300 font-medium">—</span>
+                            <span className="text-2xs text-slate-500 font-medium">—</span>
                         )}
                     </div>
                 );
@@ -725,7 +725,7 @@ export function buildColumns({
                     onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
                     className="h-8 text-xs font-semibold p-0 hover:bg-transparent flex items-center justify-end gap-1.5 w-full text-right"
                 >
-                    <Clock className="w-3.5 h-3.5 text-slate-400" />
+                    <Clock className="w-3.5 h-3.5 text-slate-500" />
                     {t('admin.data.table.duration')}
                     {column.getIsSorted() === 'asc' ? (
                         <ArrowUp className="ml-2 h-3 w-3 text-indigo-500" />
@@ -739,7 +739,7 @@ export function buildColumns({
             cell: (info) => {
                 const seconds = info.getValue();
                 if (seconds === null)
-                    return <span className="text-slate-300 text-right block">—</span>;
+                    return <span className="text-slate-500 text-right block">—</span>;
                 return (
                     <div className="flex items-center justify-end gap-1.5 font-mono text-xs text-slate-600">
                         {seconds >= 3600
@@ -764,7 +764,7 @@ export function buildColumns({
                     onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
                     className="h-8 text-xs font-semibold p-0 hover:bg-transparent flex items-center gap-1.5"
                 >
-                    <Calendar className="w-3.5 h-3.5 text-slate-400" />
+                    <Calendar className="w-3.5 h-3.5 text-slate-500" />
                     {t('admin.data.table.submitted')}
                     {column.getIsSorted() === 'asc' ? (
                         <ArrowUp className="ml-2 h-3 w-3 text-indigo-500" />
@@ -777,7 +777,7 @@ export function buildColumns({
             ),
             cell: (info) => {
                 const val = info.getValue();
-                if (!val) return <span className="text-slate-300">—</span>;
+                if (!val) return <span className="text-slate-500">—</span>;
                 const date = new Date(val);
                 const shortLabel = format(date, 'MMM d, HH:mm', { locale: currentLocale });
                 const fullLabel = format(date, 'PPpp', { locale: currentLocale });

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -448,3 +448,66 @@ describe('InteractiveDataView — sort-header icon contrast (Task 6.7d)', () => 
         expect(sortButton).toBeInTheDocument();
     });
 });
+
+describe('InteractiveDataView — discarded rows carry no resting opacity (task 6.5 review, F2)', () => {
+    function renderWithDiscardedRow() {
+        mockDumpQuery.mockReturnValue({
+            data: {
+                study: {
+                    slug: 'demo',
+                    statements: [],
+                    translations: [{ lang: 'en', title: 'Study' }],
+                    presort_config: {},
+                    postsort_config: {},
+                    state: 'active',
+                    rough_sort_enabled: true,
+                },
+                participants: [makeParticipant({ id: 'p1', db_id: 1, is_discarded: true })],
+                statement_id_to_index: {},
+            } as unknown as DumpResponse,
+            isLoading: false,
+            error: null,
+        });
+        return renderWithProviders(<InteractiveDataView slug="demo" />);
+    }
+
+    it('de-emphasises a discarded row without compositing its cells below the floor', async () => {
+        // The row used to read `opacity-60 grayscale-[0.5]`. Opacity
+        // multiplies into the computed contrast, so promoting the cells'
+        // colour token alone would have left them failing: the four `—`
+        // empty-value markers and the device/browser/language glyphs sat at
+        // slate-500 @ 60% over white = #a2acb9 → 2.30:1, under even the 3:1
+        // non-text floor — and the row is not an inactive component, it stays
+        // clickable. A future "just bump the shade" edit that reinstates the
+        // opacity has to trip this.
+        renderWithDiscardedRow();
+
+        const table = await screen.findByRole('table');
+        const bodyRow = within(table).getAllByRole('row')[1];
+
+        expect(bodyRow.className).not.toMatch(/(?:^|\s)opacity-\d/);
+        // The de-emphasis is still signalled — by a surface tint and a
+        // desaturation, neither of which reduces foreground contrast.
+        expect(bodyRow).toHaveClass('bg-slate-50');
+        expect(bodyRow).toHaveClass('grayscale-[0.5]');
+    });
+
+    it('leaves the row operable, which is why the inactive-component exemption never applied', async () => {
+        renderWithDiscardedRow();
+
+        const table = await screen.findByRole('table');
+        const bodyRow = within(table).getAllByRole('row')[1];
+
+        expect(bodyRow).toHaveClass('cursor-pointer');
+    });
+
+    it('applies neither treatment to a live row', async () => {
+        renderWithProviders(<InteractiveDataView slug="demo" />);
+
+        const table = await screen.findByRole('table');
+        const bodyRow = within(table).getAllByRole('row')[1];
+
+        expect(bodyRow).not.toHaveClass('bg-slate-50');
+        expect(bodyRow.className).not.toMatch(/(?:^|\s)opacity-\d/);
+    });
+});

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -854,8 +854,30 @@ export default function InteractiveDataView({
                                         key={row.id}
                                         className={cn(
                                             'cursor-pointer hover:bg-indigo-50/40 transition-all border-slate-50 group border-b last:border-0',
+                                            // No `opacity-60` on a discarded row (task 6.5
+                                            // review, F2). `is_discarded` is a persisted
+                                            // flag, so this is a RESTING state, and the row
+                                            // keeps `cursor-pointer` and an unconditional
+                                            // onClick that navigates — it is an operable
+                                            // component, so WCAG's inactive-component
+                                            // exemption does not apply to it. At 60% the
+                                            // seven promoted cells inside (the four `—`
+                                            // empty-value markers plus the OS, browser and
+                                            // language glyphs) composited to slate-500 @ 60%
+                                            // over white = #a2acb9 → 2.30:1, under even the
+                                            // 3:1 non-text floor.
+                                            //
+                                            // The de-emphasis itself is worth keeping, so it
+                                            // is carried by two signals that do not touch
+                                            // contrast: a slate-50 surface (slate-500 on
+                                            // #f8fafc = 4.55:1, still clears 4.5:1) and the
+                                            // existing desaturation, which drains the colour
+                                            // out of the ID badge and the status chips. The
+                                            // row also names itself in words — see the
+                                            // "Discarded" badge in
+                                            // InteractiveDataView.columns.tsx.
                                             !!row.original.is_discarded &&
-                                                'opacity-60 grayscale-[0.5]'
+                                                'bg-slate-50 grayscale-[0.5]'
                                         )}
                                         onClick={(e) => {
                                             // Belt-and-braces (Task 6.7i

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -97,7 +97,7 @@ function CollapsibleSection({
                     <h2 className="text-sm font-bold text-slate-700 flex-1">{title}</h2>
                     <ChevronDown
                         className={cn(
-                            'h-4 w-4 text-slate-400 transition-transform duration-200',
+                            'h-4 w-4 text-slate-500 transition-transform duration-200',
                             open && 'rotate-180'
                         )}
                     />
@@ -259,7 +259,7 @@ export default function InteractiveDataView({
             {/* Section 1: Key indicators */}
             <CollapsibleSection
                 title={t('admin.data.sections.key_indicators', 'Key indicators')}
-                icon={<BarChart3 className="h-4 w-4 text-slate-400" />}
+                icon={<BarChart3 className="h-4 w-4 text-slate-500" />}
             >
                 <div className="grid grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-4">
                     {/* Primary Metrics: Completed & In Progress */}
@@ -449,7 +449,7 @@ export default function InteractiveDataView({
             {/* Section 2: Responses */}
             <CollapsibleSection
                 title={t('admin.data.sections.responses', 'Responses')}
-                icon={<Users className="h-4 w-4 text-slate-400" />}
+                icon={<Users className="h-4 w-4 text-slate-500" />}
             >
                 {hasActiveFilters && (
                     <div className="flex items-center gap-2 flex-wrap">
@@ -639,7 +639,7 @@ export default function InteractiveDataView({
                     {/* Left Group: Search */}
                     <div className="flex items-center gap-3 flex-1 min-w-0 sm:max-w-sm lg:max-w-2xl">
                         <div className="relative group w-full">
-                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400 group-focus-within:text-indigo-500 transition-colors pointer-events-none" />
+                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500 group-focus-within:text-indigo-500 transition-colors pointer-events-none" />
                             <Input
                                 placeholder={t(
                                     'admin.data.search.placeholder',
@@ -757,7 +757,7 @@ export default function InteractiveDataView({
                                     <Button
                                         variant="ghost"
                                         size="icon"
-                                        className="h-9 w-9 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+                                        className="h-9 w-9 rounded-lg text-slate-500 hover:text-slate-600 hover:bg-slate-100"
                                         aria-label={t('admin.design.toolbar.more_actions')}
                                     >
                                         <MoreVertical className="h-4 w-4" />
@@ -920,7 +920,7 @@ export default function InteractiveDataView({
                                                 variant="inline"
                                             />
                                         ) : (
-                                            <div className="flex flex-col items-center justify-center gap-4 text-slate-400">
+                                            <div className="flex flex-col items-center justify-center gap-4 text-slate-500">
                                                 <div className="p-4 bg-slate-50 rounded-full">
                                                     <Search className="w-8 h-8 opacity-20" />
                                                 </div>
@@ -1001,7 +1001,7 @@ export default function InteractiveDataView({
             {/* Section 3: Key statistics */}
             <CollapsibleSection
                 title={t('admin.data.sections.key_statistics', 'Key statistics')}
-                icon={<BarChart3 className="h-4 w-4 text-slate-400" />}
+                icon={<BarChart3 className="h-4 w-4 text-slate-500" />}
             >
                 {liveParticipants.length > 0 && (
                     <div className="grid gap-4 md:grid-cols-12 mb-4">

--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
@@ -230,7 +230,7 @@ export function ParticipantDetailContent({
     const sidebarContent = (
         <div className="flex flex-col h-full bg-white">
             <div className="p-4 border-b border-slate-100 bg-slate-50/50">
-                <h3 className="text-xs font-black text-slate-400">
+                <h3 className="text-xs font-black text-slate-500">
                     {t('admin.participant.grid.detail_view', 'Card Details')}
                 </h3>
             </div>
@@ -243,7 +243,7 @@ export function ParticipantDetailContent({
                                     {detailStatement.code ||
                                         `${t('admin.participant.metadata.id', 'ID')}: ${detailStatement.id}`}
                                 </Badge>
-                                <span className="text-xs font-medium text-slate-400">
+                                <span className="text-xs font-medium text-slate-500">
                                     {t('common.score', 'Score')}:{' '}
                                     <span className="text-slate-900 font-bold">
                                         {participant.placements[String(detailStatement.id)]}
@@ -300,15 +300,15 @@ export function ParticipantDetailContent({
 
                         {/* No Response */}
                         {!detailComment && !detailAudio && (
-                            <div className="text-center py-8 text-slate-400 text-sm">
+                            <div className="text-center py-8 text-slate-500 text-sm">
                                 {t('admin.participant.grid.no_response', 'No response provided.')}
                             </div>
                         )}
                     </div>
                 ) : (
-                    <div className="h-full flex flex-col items-center justify-center text-slate-400 text-center space-y-2">
+                    <div className="h-full flex flex-col items-center justify-center text-slate-500 text-center space-y-2">
                         <div className="p-3 bg-slate-50 rounded-full">
-                            <MousePointer2 className="w-6 h-6 text-slate-300" />
+                            <MousePointer2 className="w-6 h-6 text-slate-500" />
                         </div>
                         <p className="text-sm font-medium">
                             {t(
@@ -353,7 +353,7 @@ export function ParticipantDetailContent({
                             <TabsTrigger
                                 key={tab}
                                 value={tab}
-                                className="min-h-[44px] sm:h-14 min-w-[44px] rounded-none border-b-2 border-transparent px-3 sm:px-0 text-xs sm:text-xs font-black text-slate-400 data-[state=active]:border-indigo-500 data-[state=active]:text-indigo-600 data-[state=active]:bg-transparent transition-all"
+                                className="min-h-[44px] sm:h-14 min-w-[44px] rounded-none border-b-2 border-transparent px-3 sm:px-0 text-xs sm:text-xs font-black text-slate-500 data-[state=active]:border-indigo-500 data-[state=active]:text-indigo-600 data-[state=active]:bg-transparent transition-all"
                             >
                                 <div className="flex items-center gap-2">
                                     {tab === 'session' && (
@@ -390,7 +390,7 @@ export function ParticipantDetailContent({
                             size="sm"
                             disabled={isExporting}
                             onClick={handleExportCSV}
-                            className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-400 hover:text-indigo-600"
+                            className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-500 hover:text-indigo-600"
                             title={t('admin.export.csv', 'Export CSV')}
                             aria-label={t('admin.export.csv', 'Export CSV')}
                         >
@@ -401,7 +401,7 @@ export function ParticipantDetailContent({
                             size="sm"
                             disabled={isExporting}
                             onClick={handleExportJSON}
-                            className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-400 hover:text-indigo-600"
+                            className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-500 hover:text-indigo-600"
                             title={t('admin.export.json', 'Export JSON')}
                             aria-label={t('admin.export.json', 'Export JSON')}
                         >
@@ -413,7 +413,7 @@ export function ParticipantDetailContent({
                                 size="sm"
                                 disabled={isExporting}
                                 onClick={handleExportAudio}
-                                className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-400 hover:text-indigo-600"
+                                className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-500 hover:text-indigo-600"
                                 title={t('admin.export.audio', 'Export Audio (ZIP)')}
                                 aria-label={t('admin.export.audio', 'Export Audio (ZIP)')}
                             >
@@ -457,7 +457,7 @@ export function ParticipantDetailContent({
                                 className="space-y-6 max-w-7xl mx-auto"
                             >
                                 <div className="space-y-4">
-                                    <h3 className="text-2xs font-black text-slate-400 flex items-center gap-2">
+                                    <h3 className="text-2xs font-black text-slate-500 flex items-center gap-2">
                                         <div className="w-1.5 h-1.5 rounded-full bg-indigo-500" />
                                         {t(
                                             'admin.participant.survey.presort',
@@ -540,7 +540,7 @@ export function ParticipantDetailContent({
                                 className="space-y-8 max-w-7xl mx-auto"
                             >
                                 <div className="space-y-4">
-                                    <h3 className="text-2xs font-black text-slate-400 flex items-center gap-2">
+                                    <h3 className="text-2xs font-black text-slate-500 flex items-center gap-2">
                                         <div className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
                                         {t(
                                             'admin.participant.survey.postsort',
@@ -558,7 +558,7 @@ export function ParticipantDetailContent({
                                 {/* Audio Recordings */}
                                 {hasAudioRecordings && (
                                     <div className="space-y-4">
-                                        <h3 className="text-2xs font-black text-slate-400 flex items-center gap-2">
+                                        <h3 className="text-2xs font-black text-slate-500 flex items-center gap-2">
                                             <div className="w-1.5 h-1.5 rounded-full bg-violet-500" />
                                             {t(
                                                 'admin.participant.survey.audio_recordings',

--- a/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
@@ -147,7 +147,7 @@ export function ParticipantMetadataCard({
             <CardContent className="p-3 sm:p-6 grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
                 {/* Tech Info */}
                 <div className="space-y-4">
-                    <h4 className="text-2xs font-black text-slate-400">
+                    <h4 className="text-2xs font-black text-slate-500">
                         {t('admin.participant.metadata.technology', 'Technology')}
                     </h4>
                     <div className="space-y-3">
@@ -189,7 +189,7 @@ export function ParticipantMetadataCard({
                     </div>
                 </div>
                 <div className="space-y-4">
-                    <h4 className="text-2xs font-black text-slate-400">
+                    <h4 className="text-2xs font-black text-slate-500">
                         {t('admin.participant.metadata.session', 'Session Details')}
                     </h4>
                     <div className="space-y-3">

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -11,17 +11,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import {
-    TrendingUp,
-    Eye,
-    Link as LinkIcon,
-    Monitor,
-    Smartphone,
-    Tablet,
-    Table as TableIcon,
-} from 'lucide-react';
+import { TrendingUp, Eye, Link as LinkIcon, Table as TableIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { parseUA } from '@/utils/uaParser';
 import { getStepInfo } from '@/utils/studySteps';
 
 const dateLocales: Record<string, Locale> = {
@@ -30,12 +21,6 @@ const dateLocales: Record<string, Locale> = {
     fi: fi,
     de: de,
 };
-
-const DEVICE_ICONS = {
-    mobile: Smartphone,
-    tablet: Tablet,
-    desktop: Monitor,
-} as const;
 
 function getParticipantColor(id: string) {
     const hue = (id.charCodeAt(0) + id.charCodeAt(1)) % 360;
@@ -80,8 +65,6 @@ function ParticipantRow({
     const colors = getParticipantColor(participant.code);
     const isCompleted = participant.status === 'completed';
     const activityTime = getActivityTime(participant);
-    const ua = parseUA(participant.user_agent as string | undefined);
-    const DeviceIcon = DEVICE_ICONS[ua.device];
     const lang = participant.language_used?.toUpperCase() || '??';
 
     const durationSeconds = computeDurationSeconds(participant);
@@ -166,11 +149,19 @@ function ParticipantRow({
                         />
                     </div>
                 ) : (
-                    <span className="text-2xs text-slate-400">—</span>
+                    <span className="text-2xs text-slate-500">—</span>
                 )}
 
-                {/* Line 3: time · device · language */}
-                <div className="flex items-center gap-1 text-2xs text-slate-400 truncate">
+                {/* Line 3: time · language.
+                    The device glyph that used to sit between these two separators is gone
+                    (task 6.5). It was a 10px lucide `Monitor`/`Smartphone`/`Tablet` with no
+                    accessible name and no text equivalent: screen-reader users got nothing,
+                    and at 10px no sighted user can tell a tablet from a phone. Removed
+                    rather than labelled — this row already truncates at 320px and a visible
+                    "Desktop"/"Escritorio" would push the timestamp out. The device is still
+                    reported, with text, on the participant detail card
+                    (ParticipantMetadataCard) and, with an aria-label, in the Data table. */}
+                <div className="flex items-center gap-1 text-2xs text-slate-500 truncate">
                     <TooltipProvider>
                         <Tooltip>
                             <TooltipTrigger asChild>
@@ -192,8 +183,6 @@ function ParticipantRow({
                             </TooltipContent>
                         </Tooltip>
                     </TooltipProvider>
-                    <span aria-hidden="true">·</span>
-                    <DeviceIcon className="h-2.5 w-2.5 shrink-0" />
                     {showLanguage && (
                         <>
                             <span aria-hidden="true">·</span>
@@ -275,7 +264,7 @@ export default function RecentActivityCard({
             </CardHeader>
             <CardContent className="p-0">
                 {recentParticipants.length === 0 ? (
-                    <div className="p-6 text-center text-slate-400 text-xs">
+                    <div className="p-6 text-center text-slate-500 text-xs">
                         {t('admin.study_overview.no_participants', 'No participants yet.')}
                     </div>
                 ) : (

--- a/frontend/src/components/admin/dashboard/RecruitmentModule.tsx
+++ b/frontend/src/components/admin/dashboard/RecruitmentModule.tsx
@@ -66,7 +66,7 @@ const RecruitmentModule: React.FC<RecruitmentModuleProps> = ({ slug }) => {
             </CardHeader>
             <CardContent className="p-4 space-y-4">
                 <div className="space-y-2">
-                    <label htmlFor="public-url" className="text-2xs font-bold text-slate-400">
+                    <label htmlFor="public-url" className="text-2xs font-bold text-slate-500">
                         {t('admin.recruitment.public_url_label', 'Public Participation URL')}
                     </label>
                     <div className="flex gap-2 min-w-0">
@@ -159,7 +159,7 @@ const RecruitmentModule: React.FC<RecruitmentModuleProps> = ({ slug }) => {
                                 </span>
                             </Button>
 
-                            <p className="text-xs text-slate-400 text-center leading-relaxed max-w-[200px]">
+                            <p className="text-xs text-slate-500 text-center leading-relaxed max-w-[200px]">
                                 {t(
                                     'admin.recruitment.qr_print_hint',
                                     'Scan or print this code for physical recruitment materials (flyers, posters).'

--- a/frontend/src/components/admin/dashboard/StudyStatusControl.test.tsx
+++ b/frontend/src/components/admin/dashboard/StudyStatusControl.test.tsx
@@ -74,6 +74,23 @@ describe('StudyStatusControl — the reachable step tile is a real, keyboard-ope
         expect(await screen.findByText(/launch study\?/i)).toBeInTheDocument();
     });
 
+    it('carries no resting opacity on a reachable step — the class alone would not have fixed it', () => {
+        // Task 6.5. The reachable-but-inactive tile used to read
+        // `text-slate-400 opacity-60`. Opacity multiplies into the computed
+        // contrast, so promoting the colour on its own would have left it
+        // failing: slate-500 at 60% over white resolves to #a2acb9 → 2.30:1,
+        // and the tile's icon (slate-500 on bg-slate-100) to ~2.2:1, under
+        // even the 3:1 non-text floor. A future "just bump the shade" edit
+        // that reinstates the opacity has to trip this.
+        setup();
+
+        const tile = screen.getByRole('button', { name: /active/i });
+        const content = tile.firstElementChild;
+        expect(content).not.toBeNull();
+        expect(content).toHaveClass('text-slate-500');
+        expect(content?.className).not.toMatch(/\bopacity-\d/);
+    });
+
     it('leaves an unreachable step as plain, non-interactive content', () => {
         setup();
 

--- a/frontend/src/components/admin/dashboard/StudyStatusControl.tsx
+++ b/frontend/src/components/admin/dashboard/StudyStatusControl.tsx
@@ -76,9 +76,14 @@ function StatusStepButton({ step, currentState, renderActionDialog }: StatusStep
                 'relative flex flex-col items-center justify-center p-2.5 rounded-lg transition-all border',
                 isActive
                     ? cn('bg-white shadow-sm z-10', step.activeClass, step.border)
-                    : 'bg-transparent border-transparent hover:bg-slate-50 text-slate-400 opacity-60 hover:opacity-100',
-                isClickable &&
-                    'cursor-pointer hover:border-slate-200 hover:shadow-sm hover:opacity-100'
+                    : // No `opacity-60` here (task 6.5). Opacity multiplies into the
+                      // computed contrast: text-slate-500 at 60% over white resolves to
+                      // #a2acb9 → 2.30:1, and the inactive step's icon (slate-500 on
+                      // bg-slate-100) drops to ~2.2:1, under even the 3:1 non-text floor.
+                      // The active step is already distinguished by bg-white + shadow +
+                      // its own accent colour, so the dimming was redundant signalling.
+                      'bg-transparent border-transparent hover:bg-slate-50 text-slate-500',
+                isClickable && 'cursor-pointer hover:border-slate-200 hover:shadow-sm'
             )}
         >
             <div
@@ -87,7 +92,7 @@ function StatusStepButton({ step, currentState, renderActionDialog }: StatusStep
                     isActive ? step.bg : 'bg-slate-100'
                 )}
             >
-                <step.icon className={cn('h-4 w-4', isActive ? step.color : 'text-slate-400')} />
+                <step.icon className={cn('h-4 w-4', isActive ? step.color : 'text-slate-500')} />
             </div>
             <div className="text-sm font-bold tracking-tight mb-0.5">{step.label}</div>
             <div className="text-2xs text-muted-foreground font-medium text-center">

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.tsx
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.tsx
@@ -44,12 +44,12 @@ function renderValue(
         );
     if (value === false)
         return (
-            <Badge variant="outline" className="text-slate-400 border-slate-200">
+            <Badge variant="outline" className="text-slate-500 border-slate-200">
                 {t('common.no', 'No')}
             </Badge>
         );
     if (value === null || value === undefined || value === '')
-        return <span className="text-slate-300">—</span>;
+        return <span className="text-slate-500">—</span>;
 
     const q = questionsMap[key];
     if (q?.options && Array.isArray(q.options)) {
@@ -103,7 +103,7 @@ export function SurveyResponseTable({
                     className
                 )}
             >
-                <FeedbackIcon className="h-8 w-8 text-slate-300 mx-auto mb-2" />
+                <FeedbackIcon className="h-8 w-8 text-slate-500 mx-auto mb-2" />
                 <p className="text-sm font-medium text-slate-500">
                     {t(
                         'admin.participant.survey.no_answers',
@@ -269,9 +269,13 @@ export function SurveyResponseTable({
                                 <span className="text-xs font-black text-slate-500 group-data-[state=open]:text-slate-900 transition-colors">
                                     {group.title}
                                 </span>
+                                {/* slate-600/indigo-600, not -400 (task 6.5): this count sits
+                                    on bg-slate-100 closed and bg-indigo-50 open, so the usual
+                                    slate-500 promotion only reaches 4.34:1 here. The open
+                                    state's indigo-400 measured 2.67:1 on indigo-50. */}
                                 <Badge
                                     variant="secondary"
-                                    className="ml-2 bg-slate-100 text-slate-400 group-data-[state=open]:bg-indigo-50 group-data-[state=open]:text-indigo-400"
+                                    className="ml-2 bg-slate-100 text-slate-600 group-data-[state=open]:bg-indigo-50 group-data-[state=open]:text-indigo-600"
                                 >
                                     {group.items.length}
                                 </Badge>
@@ -297,7 +301,11 @@ export function SurveyResponseTable({
                                                     />
                                                 )}
                                             </div>
-                                            <p className="text-2xs font-mono text-slate-400 mt-1 tracking-tighter opacity-70">
+                                            {/* No `opacity-70` (task 6.5): opacity multiplies
+                                                into the computed contrast — slate-500 at 70%
+                                                over white resolves to #929eae → 2.72:1, so the
+                                                colour promotion alone would not have landed. */}
+                                            <p className="text-2xs font-mono text-slate-500 mt-1 tracking-tighter">
                                                 {t('admin.participant.metadata.id', 'ID')}:{' '}
                                                 {item.id || item.key}
                                             </p>

--- a/frontend/src/components/admin/designer/ActivateStudyDialog.tsx
+++ b/frontend/src/components/admin/designer/ActivateStudyDialog.tsx
@@ -101,7 +101,7 @@ export function ActivateStudyDialog({
                                         />
                                     ) : (
                                         <Circle
-                                            className="h-4 w-4 text-slate-300 mt-0.5 flex-shrink-0"
+                                            className="h-4 w-4 text-slate-500 mt-0.5 flex-shrink-0"
                                             aria-hidden="true"
                                         />
                                     )}

--- a/frontend/src/components/admin/designer/BrandingEditor.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.tsx
@@ -67,7 +67,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                 'About accent color'
                                             )}
                                         >
-                                            <Info className="h-3.5 w-3.5 text-slate-400 hover:text-indigo-500 transition-colors" />
+                                            <Info className="h-3.5 w-3.5 text-slate-500 hover:text-indigo-500 transition-colors" />
                                         </TooltipTrigger>
                                         <TooltipContent side="right" className="max-w-xs">
                                             <p className="text-xs">
@@ -181,7 +181,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                 'About the study logo'
                                             )}
                                         >
-                                            <Info className="h-3.5 w-3.5 text-slate-400" />
+                                            <Info className="h-3.5 w-3.5 text-slate-500" />
                                         </TooltipTrigger>
                                         <TooltipContent side="right">
                                             <p className="text-xs">
@@ -247,7 +247,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                 'About institutional partners'
                                             )}
                                         >
-                                            <Info className="h-3.5 w-3.5 text-slate-400" />
+                                            <Info className="h-3.5 w-3.5 text-slate-500" />
                                         </TooltipTrigger>
                                         <TooltipContent side="right">
                                             <p className="text-xs">
@@ -285,14 +285,14 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                             className="max-w-full max-h-full object-contain"
                                                         />
                                                     ) : (
-                                                        <ImageIcon className="text-slate-300 w-6 h-6" />
+                                                        <ImageIcon className="text-slate-500 w-6 h-6" />
                                                     )}
                                                 </div>
                                                 <div className="flex-1 space-y-3">
                                                     <div className="grid gap-1.5">
                                                         <Label
                                                             htmlFor={`partner-name-${partner.id ?? index}`}
-                                                            className="text-2xs font-black text-slate-400"
+                                                            className="text-2xs font-black text-slate-500"
                                                         >
                                                             {t(
                                                                 'admin.design.theme.partners.name_placeholder',

--- a/frontend/src/components/admin/designer/ConditionOfInstructionEditor.tsx
+++ b/frontend/src/components/admin/designer/ConditionOfInstructionEditor.tsx
@@ -72,7 +72,7 @@ const InstructionField = ({
                         type="button"
                         onClick={onReset}
                         className="flex items-center gap-1.5 px-2 py-1 rounded-md text-2xs
-                                   font-medium text-slate-400
+                                   font-medium text-slate-500
                                    hover:text-indigo-600 hover:bg-slate-50 transition-colors"
                     >
                         <RotateCcw className="size-3" />

--- a/frontend/src/components/admin/designer/ImageUploadInput.tsx
+++ b/frontend/src/components/admin/designer/ImageUploadInput.tsx
@@ -129,7 +129,7 @@ const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
                         {label}
                     </Label>
                     {recommendedSize && (
-                        <span className="text-2xs font-semibold text-slate-400 tracking-tighter">
+                        <span className="text-2xs font-semibold text-slate-500 tracking-tighter">
                             {t('admin.design.theme.upload.recommended', 'Recommended')}:{' '}
                             {recommendedSize}
                         </span>
@@ -228,7 +228,7 @@ const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
                                 </>
                             ) : (
                                 <>
-                                    <Upload className="h-8 w-8 text-slate-400" />
+                                    <Upload className="h-8 w-8 text-slate-500" />
                                     <p className="text-sm font-medium text-slate-700">
                                         {t(
                                             'admin.design.theme.upload.drag_drop',
@@ -267,7 +267,7 @@ const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
                     <button
                         type="button"
                         onClick={handleClear}
-                        className="absolute top-2 right-2 p-1.5 bg-white rounded-full shadow-md text-slate-400 hover:text-red-500 hover:bg-red-50 transition-all"
+                        className="absolute top-2 right-2 p-1.5 bg-white rounded-full shadow-md text-slate-500 hover:text-red-500 hover:bg-red-50 transition-all"
                         aria-label={
                             removeAriaLabel ??
                             t('admin.design.theme.upload.remove_default', 'Remove image')

--- a/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
+++ b/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
@@ -214,7 +214,7 @@ export function ImportFromConcourseDialog({
                     {/* Item list */}
                     {isLoadingConcourse && (
                         <div className="py-8 flex justify-center">
-                            <Loader2 className="size-5 animate-spin text-slate-400" />
+                            <Loader2 className="size-5 animate-spin text-slate-500" />
                         </div>
                     )}
 
@@ -303,7 +303,7 @@ export function ImportFromConcourseDialog({
                     )}
 
                     {!isLoadingConcourse && filteredItems.length === 0 && concourseId && (
-                        <div className="py-8 text-center text-slate-400 text-sm">
+                        <div className="py-8 text-center text-slate-500 text-sm">
                             {showOnlyAccepted
                                 ? t(
                                       'admin.concourse_import.no_accepted',
@@ -317,7 +317,7 @@ export function ImportFromConcourseDialog({
                     )}
 
                     {!concourseId && !isLoadingConcourse && (
-                        <div className="py-8 text-center text-slate-400 text-sm">
+                        <div className="py-8 text-center text-slate-500 text-sm">
                             {t(
                                 'admin.concourse_import.no_concourses',
                                 'No concourses in this project. Create one first.'

--- a/frontend/src/components/admin/designer/InterfaceEditor.test.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.test.tsx
@@ -189,3 +189,53 @@ describe('InterfaceEditor', () => {
         });
     });
 });
+
+/**
+ * Contrast regression test for the step-guidance block (task 6.5 review, F4).
+ * The block carried `stepEnabled ? '' : 'opacity-50'`. The <Label>/<Input> pair
+ * inside it is genuinely exempt — the input really is `disabled` — but two nodes
+ * in the same block are attached to no control at all and are precisely the ones
+ * that explain the state: the "Step N: <name>" badge (indigo-900 on
+ * bg-indigo-50/50, 10.81:1 → 2.76:1) and the "(step disabled)" marker beside it
+ * (slate-500, 4.76:1 → 1.96:1). Dimming the sentence that says why the block is
+ * dimmed, until it cannot be read, is self-defeating.
+ */
+describe('InterfaceEditor — a disabled step block carries no resting opacity (task 6.5 review, F4)', () => {
+    function renderWithPresortDisabled() {
+        return renderWithStore(<InterfaceEditor />, {
+            initialState: {
+                draft: {
+                    slug: 'test',
+                    state: 'draft',
+                    presort_config: { enabled: false },
+                    translations: [{ language_code: 'en', ui_labels: {} }],
+                },
+                activeLocale: 'en',
+            },
+        });
+    }
+
+    it('does not composite the step badge and its "(step disabled)" marker', () => {
+        renderWithPresortDisabled();
+
+        const marker = screen.getByText('(step disabled)');
+        const block = marker.closest('[aria-disabled="true"]');
+        expect(block).not.toBeNull();
+        expect((block as HTMLElement).className).not.toMatch(/(?:^|\s)opacity-\d/);
+    });
+
+    it('keeps the disabled state announced and carried by the controls themselves', () => {
+        renderWithPresortDisabled();
+
+        const marker = screen.getByText('(step disabled)');
+        const block = marker.closest('[aria-disabled="true"]') as HTMLElement;
+
+        // The state is still exposed to AT, still stated in words, and still
+        // painted on the inputs — where ui/input's `disabled:opacity-50` applies
+        // to a component WCAG genuinely exempts.
+        expect(block).toHaveAttribute('aria-disabled', 'true');
+        for (const input of Array.from(block.querySelectorAll('input'))) {
+            expect(input).toBeDisabled();
+        }
+    });
+});

--- a/frontend/src/components/admin/designer/InterfaceEditor.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.tsx
@@ -447,9 +447,23 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                         return (
                             <div
                                 key={step.id}
-                                className={`space-y-6 transition-opacity ${
-                                    stepEnabled ? '' : 'opacity-50'
-                                }`}
+                                // No `opacity-50` on a disabled step (task 6.5 review,
+                                // F4). The exemption that covers the <Label>/<Input>
+                                // pair below — the input really is `disabled`, so it is
+                                // an inactive component — does not reach the two nodes
+                                // that explain the state and are attached to no control
+                                // at all: the "Step N: <name>" badge (indigo-900 on
+                                // bg-indigo-50/50 fell from 10.81:1 to 2.76:1) and the
+                                // "(step disabled)" marker beside it (slate-500, 4.76:1
+                                // → 1.96:1). Dimming the sentence that says *why* the
+                                // block is dimmed until it cannot be read is
+                                // self-defeating, so the opacity is gone and the
+                                // disabled affordance is carried where WCAG does exempt
+                                // it: the Inputs are `disabled` and ui/input ships
+                                // `disabled:opacity-50 disabled:cursor-not-allowed`, the
+                                // reset Button is disabled too, and the state is stated
+                                // in words by the marker. `aria-disabled` is unchanged.
+                                className="space-y-6"
                                 aria-disabled={!stepEnabled || undefined}
                             >
                                 <div className="flex items-center justify-between">

--- a/frontend/src/components/admin/designer/InterfaceEditor.tsx
+++ b/frontend/src/components/admin/designer/InterfaceEditor.tsx
@@ -188,7 +188,7 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                             }
                                                         )}
                                                     >
-                                                        <Info className="size-3 text-slate-400" />
+                                                        <Info className="size-3 text-slate-500" />
                                                     </TooltipTrigger>
                                                     <TooltipContent className="text-2xs">
                                                         {t(
@@ -204,7 +204,7 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                 disabled={readOnly}
                                                 onClick={() => resetLabel(inputKey)}
                                                 className="flex items-center gap-1.5 px-2 py-1 rounded-md text-2xs
-                                                         font-black text-slate-400
+                                                         font-black text-slate-500
                                                          hover:bg-slate-100 hover:text-indigo-600 transition-colors"
                                                 title={t('common.reset_to_default')}
                                             >
@@ -300,7 +300,7 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                 <div key={inputKey} className="space-y-2.5">
                                                     <Label
                                                         htmlFor={`interface-term-${inputKey}`}
-                                                        className="text-2xs font-black text-slate-400"
+                                                        className="text-2xs font-black text-slate-500"
                                                     >
                                                         {t(
                                                             `admin.design.interface.terms.${termKey}`
@@ -485,7 +485,7 @@ const InterfaceEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                         <div key={field} className="space-y-2.5">
                                             <Label
                                                 htmlFor={`step-help-${step.id}-${field}`}
-                                                className="text-2xs font-black text-slate-400"
+                                                className="text-2xs font-black text-slate-500"
                                             >
                                                 {t(`study.help.${field}`)}
                                             </Label>

--- a/frontend/src/components/admin/designer/LanguageManagerModal.tsx
+++ b/frontend/src/components/admin/designer/LanguageManagerModal.tsx
@@ -127,7 +127,7 @@ const LanguageManagerModal = ({ isOpen, onClose }: LanguageManagerModalProps) =>
                                         </div>
                                     ) : (
                                         <div className="opacity-0 group-hover:opacity-100 transition-opacity">
-                                            <Plus className="h-5 w-5 text-slate-400" />
+                                            <Plus className="h-5 w-5 text-slate-500" />
                                         </div>
                                     )}
                                 </button>

--- a/frontend/src/components/admin/designer/MultiLangFieldIcon.tsx
+++ b/frontend/src/components/admin/designer/MultiLangFieldIcon.tsx
@@ -46,7 +46,7 @@ export const MultiLangFieldIcon = ({
                     variant="ghost"
                     size="sm"
                     className={cn(
-                        'h-6 w-6 p-0 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-md transition-all',
+                        'h-6 w-6 p-0 text-slate-500 hover:text-indigo-600 hover:bg-indigo-50 rounded-md transition-all',
                         className
                     )}
                     title={t('admin.design.multilang.view_others', 'View in other languages')}
@@ -58,7 +58,7 @@ export const MultiLangFieldIcon = ({
                 align="end"
                 className="w-80 max-h-[400px] overflow-y-auto rounded-xl shadow-xl border-slate-100 p-2"
             >
-                <DropdownMenuLabel className="text-2xs font-black text-slate-400 px-2 py-1.5">
+                <DropdownMenuLabel className="text-2xs font-black text-slate-500 px-2 py-1.5">
                     {t('admin.design.multilang.other_formulations', 'Other Formulations')}
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator className="bg-slate-100 my-1" />

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -172,7 +172,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                             <div className="flex flex-wrap gap-3">
                                 {extremeColumns.length === 0 ? (
                                     <div className="flex items-center gap-4">
-                                        <span className="text-sm text-slate-400 font-medium italic">
+                                        <span className="text-sm text-slate-500 font-medium italic">
                                             {t('admin.design.postsort.extreme.no_columns')}
                                         </span>
                                         {availableScores.length >= 2 &&
@@ -204,7 +204,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                                 <button
                                                     type="button"
                                                     onClick={() => removeExtremeColumn(score)}
-                                                    className="ml-1 text-slate-400 hover:text-red-500 transition-colors"
+                                                    className="ml-1 text-slate-500 hover:text-red-500 transition-colors"
                                                     aria-label={t(
                                                         'admin.design.postsort.extreme.remove',
                                                         'Remove {{score}}',

--- a/frontend/src/components/admin/designer/ProcessStepEditor.tsx
+++ b/frontend/src/components/admin/designer/ProcessStepEditor.tsx
@@ -111,7 +111,7 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                     <div className="flex flex-col min-w-0 text-left">
                                         <span className="text-sm font-bold text-slate-700 truncate tracking-tight">
                                             {step.title || (
-                                                <span className="text-slate-400 font-medium italic">
+                                                <span className="text-slate-500 font-medium italic">
                                                     {t(
                                                         'admin.design.intro.process_steps.defaults.new_step'
                                                     )}
@@ -119,14 +119,14 @@ const ProcessStepItem = ({ id, step, onUpdate, onDelete, readOnly }: ProcessStep
                                             )}
                                         </span>
                                         {step.description && (
-                                            <span className="text-xs text-slate-400 font-medium truncate mt-0.5">
+                                            <span className="text-xs text-slate-500 font-medium truncate mt-0.5">
                                                 {step.description}
                                             </span>
                                         )}
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-all">
-                                    <AccordionTrigger className="py-2 hover:no-underline text-slate-400 hover:text-indigo-600">
+                                    <AccordionTrigger className="py-2 hover:no-underline text-slate-500 hover:text-indigo-600">
                                         <span className="sr-only">
                                             {t('admin.design.intro.process_steps.fields.toggle')}
                                         </span>
@@ -552,7 +552,7 @@ export function ProcessStepEditor({
                         variant="ghost"
                         size="sm"
                         onClick={resetSteps}
-                        className="h-11 rounded-xl font-bold text-slate-400 hover:text-red-500 hover:bg-red-50 transition-all"
+                        className="h-11 rounded-xl font-bold text-slate-500 hover:text-red-500 hover:bg-red-50 transition-all"
                     >
                         <RotateCcw className="h-4 w-4 mr-2" />
                         {t('admin.design.intro.process_steps.reset.process_steps')}

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -203,7 +203,7 @@ function SortableStatementItem({
                             variant="ghost"
                             size="icon"
                             onClick={() => setEditingId(null)}
-                            className="h-9 w-9 text-slate-400 hover:bg-slate-50 rounded-xl"
+                            className="h-9 w-9 text-slate-500 hover:bg-slate-50 rounded-xl"
                             aria-label={t(
                                 'admin.design.qsort.set.cancel_edit',
                                 'Cancel editing {{code}}',
@@ -851,7 +851,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                         )}
                                     </div>
                                     <div className="flex justify-between items-center bg-slate-50 p-3 rounded-xl border border-slate-100">
-                                        <p className="text-xs font-black text-slate-400 px-1">
+                                        <p className="text-xs font-black text-slate-500 px-1">
                                             {t('admin.design.qsort.bulk.detected', {
                                                 count: bulkText
                                                     .split('\n')
@@ -884,7 +884,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                     <Quote className="h-4 w-4 text-slate-500" />
                                 </div>
                                 {t('admin.design.qsort.set.title')}
-                                <span className="text-slate-400 font-medium ml-1">
+                                <span className="text-slate-500 font-medium ml-1">
                                     ({statements.length})
                                 </span>
                             </h3>
@@ -1146,7 +1146,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                                 <Button
                                                     variant="ghost"
                                                     size="icon"
-                                                    className="h-10 w-10 text-slate-400 hover:text-indigo-600 rounded-xl hover:bg-indigo-50 transition-all"
+                                                    className="h-10 w-10 text-slate-500 hover:text-indigo-600 rounded-xl hover:bg-indigo-50 transition-all"
                                                     aria-label={t(
                                                         'admin.design.qsort.grid.tooltip_title'
                                                     )}
@@ -1459,10 +1459,10 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                             >
                                 <div className="flex items-center gap-4">
                                     <div className="p-3 bg-slate-50 rounded-2xl border border-slate-100">
-                                        <Quote className="h-5 w-5 text-slate-400" />
+                                        <Quote className="h-5 w-5 text-slate-500" />
                                     </div>
                                     <div>
-                                        <p className="text-2xs font-black text-slate-400">
+                                        <p className="text-2xs font-black text-slate-500">
                                             {t('admin.design.qsort.grid.statements')}
                                         </p>
                                         <p className="text-xl font-black text-slate-900">
@@ -1475,10 +1475,10 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
 
                                 <div className="flex items-center gap-4">
                                     <div className="p-3 bg-slate-50 rounded-2xl border border-slate-100">
-                                        <Grid3X3 className="h-5 w-5 text-slate-400" />
+                                        <Grid3X3 className="h-5 w-5 text-slate-500" />
                                     </div>
                                     <div>
-                                        <p className="text-2xs font-black text-slate-400">
+                                        <p className="text-2xs font-black text-slate-500">
                                             {t('common.slots')}
                                         </p>
                                         <p className="text-xl font-black text-slate-900">

--- a/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.a11y.test.tsx
@@ -433,3 +433,77 @@ describe('QuestionBuilder — action-button accessible names (Task 6.7c)', () =>
         expect(removeOption).not.toHaveClass('text-slate-300');
     });
 });
+
+/**
+ * Contrast regression test for the read-only question card (task 6.5 review,
+ * F3). `readOnly` is `api.isFullyReadOnly` = `draft.state !== 'draft'` — every
+ * active, paused or closed study, i.e. the normal steady state of any launched
+ * study. The card carried `readOnly && 'opacity-80'`, which multiplied into the
+ * computed contrast of every promoted node beneath it: the "Untitled"
+ * placeholder and the field labels landed at slate-500 @ 80% over white =
+ * #8390a2 → 3.25:1, and the question-type chip at 3.17:1 on its composited
+ * slate-50 pill. A class swap alone would have looked fixed and still failed,
+ * so the assertion is on the absence of the opacity as well as on the token.
+ */
+describe('QuestionBuilder — a read-only card carries no resting opacity (task 6.5 review, F3)', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: weak typing for test utility
+    const renderCard = (readOnly: boolean, overrides: any = {}) =>
+        renderWithStore(<QuestionBuilder type="post" readOnly={readOnly} />, {
+            initialState: {
+                ...overrides,
+                draft: {
+                    slug: 'test',
+                    state: readOnly ? 'active' : 'draft',
+                    postsort_config: {
+                        questions: {
+                            q1: { type: 'text', label: 'First question', required: false },
+                        },
+                    },
+                },
+                activeLocale: 'en',
+            },
+        });
+
+    it('does not dim the whole card when the study is launched', async () => {
+        renderCard(true);
+
+        const card = (await screen.findByText('First question')).closest(
+            '[data-testid="question-item"]'
+        );
+        expect(card).not.toBeNull();
+        expect(card?.className).not.toMatch(/(?:^|\s)opacity-\d/);
+    });
+
+    it('still marks read-only on the controls, where WCAG does exempt it', async () => {
+        const user = userEvent.setup();
+        renderCard(true);
+
+        const card = (await screen.findByText('First question')).closest(
+            '[data-testid="question-item"]'
+        ) as HTMLElement;
+
+        // The drag handle and the delete button are not rendered at all on a
+        // read-only card — that, not a 20% dim, is what carries the affordance.
+        expect(within(card).queryByRole('button', { name: /reorder/i })).not.toBeInTheDocument();
+        expect(within(card).queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+
+        await user.click(within(card).getByTestId('question-accordion-trigger'));
+        expect(within(card).getByDisplayValue('First question')).toHaveAttribute('readonly');
+    });
+
+    it('gives the question-type chip a token that clears 4.5:1 on its own slate-50 pill', async () => {
+        const user = userEvent.setup();
+        renderCard(false);
+
+        const card = (await screen.findByText('First question')).closest(
+            '[data-testid="question-item"]'
+        ) as HTMLElement;
+        await user.click(within(card).getByTestId('question-accordion-trigger'));
+
+        // slate-500 on bg-slate-50 is 4.55:1 — a 1% margin. slate-600 is 7.24:1.
+        const chip = within(card).getByTestId('question-type-label');
+        expect(chip).toHaveClass('text-slate-600');
+        expect(chip).not.toHaveClass('text-slate-500');
+        expect(chip.className).not.toMatch(/(?:^|\s)opacity-\d/);
+    });
+});

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -201,8 +201,25 @@ const QuestionItem = (props: QuestionItemProps) => {
             data-testid="question-item"
             className={cn(
                 'group relative bg-white border-none shadow-sm rounded-2xl overflow-hidden transition-all mb-4',
-                isDragging && 'opacity-50 z-50 shadow-xl ring-2 ring-indigo-500/20',
-                readOnly && 'opacity-80'
+                isDragging && 'opacity-50 z-50 shadow-xl ring-2 ring-indigo-500/20'
+                // No `readOnly && 'opacity-80'` (task 6.5 review, F3). `readOnly` is
+                // `api.isFullyReadOnly` = `draft.state !== 'draft'`, i.e. every active,
+                // paused or closed study — the normal steady state of any launched
+                // study, not an edge case, and nothing here is a disabled *component*
+                // that WCAG would exempt. Opacity multiplies into the computed
+                // contrast, so at 80% the promoted text inside landed at slate-500 @
+                // 80% over white = #8390a2 → 3.25:1 (the "Untitled" placeholder and the
+                // field labels) and 3.17:1 for the question-type chip on its slate-50
+                // pill — the latter being, to two decimals, the 3.24:1 case this repo's
+                // own a11y gate documents as the failure it exists to catch
+                // (scripts/check-a11y-names.mjs). Removing it puts them at 4.76:1.
+                //
+                // Nothing is lost: read-only-ness was never carried by a 20% dim. The
+                // drag handle, the copy-from-language menu and the delete button are
+                // not rendered at all, every Input is `readOnly` with
+                // `cursor-not-allowed opacity-70`, and every Switch is `disabled` —
+                // three stronger, still-present signals, each on a control where the
+                // inactive-component exemption genuinely does apply.
             )}
         >
             <div className="flex items-start p-4 gap-4">
@@ -393,7 +410,14 @@ const QuestionItem = (props: QuestionItemProps) => {
 
                                     <div
                                         data-testid="question-type-label"
-                                        className="text-2xs text-slate-500 font-black bg-slate-50 px-2 py-1 rounded-lg"
+                                        // slate-600, not slate-500 (task 6.5 review, F3):
+                                        // this chip is the one promoted node here that
+                                        // does not sit on white. slate-500 on bg-slate-50
+                                        // is 4.55:1 — a 1% margin over the 4.5:1 floor for
+                                        // 11-12px text, the same zero-margin fragility the
+                                        // review flagged elsewhere. slate-600 on slate-50
+                                        // is 7.24:1.
+                                        className="text-2xs text-slate-600 font-black bg-slate-50 px-2 py-1 rounded-lg"
                                     >
                                         {question.type}
                                     </div>

--- a/frontend/src/components/admin/designer/QuestionBuilder.tsx
+++ b/frontend/src/components/admin/designer/QuestionBuilder.tsx
@@ -273,7 +273,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                         </div>
                                         <span className="text-sm font-bold text-slate-900 truncate tracking-tight">
                                             {label || (
-                                                <span className="text-slate-400 italic font-medium">
+                                                <span className="text-slate-500 italic font-medium">
                                                     {t('admin.design.questions.defaults.untitled')}
                                                 </span>
                                             )}
@@ -300,7 +300,7 @@ const QuestionItem = (props: QuestionItemProps) => {
                                                     </Button>
                                                 </DropdownMenuTrigger>
                                                 <DropdownMenuContent align="end" className="w-56">
-                                                    <div className="px-2 py-1.5 text-2xs font-black text-slate-400">
+                                                    <div className="px-2 py-1.5 text-2xs font-black text-slate-500">
                                                         {t(
                                                             'admin.design.questions.actions.copy_from'
                                                         )}
@@ -393,7 +393,7 @@ const QuestionItem = (props: QuestionItemProps) => {
 
                                     <div
                                         data-testid="question-type-label"
-                                        className="text-2xs text-slate-400 font-black bg-slate-50 px-2 py-1 rounded-lg"
+                                        className="text-2xs text-slate-500 font-black bg-slate-50 px-2 py-1 rounded-lg"
                                     >
                                         {question.type}
                                     </div>
@@ -1191,7 +1191,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
 
                         {!readOnly && !structureLocked && (
                             <div className="space-y-4">
-                                <div className="text-2xs font-black text-slate-400">
+                                <div className="text-2xs font-black text-slate-500">
                                     {t('admin.design.questions.basic_fields')}
                                 </div>
                                 <div className="flex flex-wrap gap-3">
@@ -1211,7 +1211,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                                             onClick={() => addQuestion(field.type as QuestionType)}
                                             className="bg-white rounded-xl border-slate-200 hover:border-indigo-500 hover:text-indigo-600 hover:bg-indigo-50/30 transition-all font-bold h-10 px-4 shadow-sm active:scale-95"
                                         >
-                                            <field.icon className="h-4 w-4 mr-2 text-slate-400 group-hover:text-indigo-500" />
+                                            <field.icon className="h-4 w-4 mr-2 text-slate-500 group-hover:text-indigo-500" />
                                             {t(`admin.design.questions.types.${field.label}`)}
                                         </Button>
                                     ))}
@@ -1221,7 +1221,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
 
                         {!readOnly && !structureLocked && (
                             <div className="space-y-4">
-                                <div className="text-2xs font-black text-slate-400">
+                                <div className="text-2xs font-black text-slate-500">
                                     {t('admin.design.questions.choice_fields')}
                                 </div>
                                 <div className="flex flex-wrap gap-3">
@@ -1242,7 +1242,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                                             onClick={() => addQuestion(field.type as QuestionType)}
                                             className="bg-white rounded-xl border-slate-200 hover:border-indigo-500 hover:text-indigo-600 hover:bg-indigo-50/30 transition-all font-bold h-10 px-4 shadow-sm active:scale-95"
                                         >
-                                            <field.icon className="h-4 w-4 mr-2 text-slate-400 group-hover:text-indigo-500" />
+                                            <field.icon className="h-4 w-4 mr-2 text-slate-500 group-hover:text-indigo-500" />
                                             {t(`admin.design.questions.types.${field.label}`)}
                                         </Button>
                                     ))}
@@ -1252,7 +1252,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
 
                         {!readOnly && !structureLocked && (
                             <div className="space-y-4">
-                                <div className="text-2xs font-black text-slate-400">
+                                <div className="text-2xs font-black text-slate-500">
                                     {t('admin.design.questions.scale_fields')}
                                 </div>
                                 <div className="flex flex-wrap gap-3">
@@ -1263,7 +1263,7 @@ const QuestionBuilder = ({ type, readOnly, structureLocked }: QuestionBuilderPro
                                         onClick={() => addQuestion('rating')}
                                         className="bg-white rounded-xl border-slate-200 hover:border-indigo-500 hover:text-indigo-600 hover:bg-indigo-50/30 transition-all font-bold h-10 px-4 shadow-sm active:scale-95"
                                     >
-                                        <BarChart3 className="h-4 w-4 mr-2 text-slate-400 group-hover:text-indigo-500" />
+                                        <BarChart3 className="h-4 w-4 mr-2 text-slate-500 group-hover:text-indigo-500" />
                                         {t('admin.design.questions.types.rating')}
                                     </Button>
                                 </div>

--- a/frontend/src/components/admin/memo/CommentThread.tsx
+++ b/frontend/src/components/admin/memo/CommentThread.tsx
@@ -102,7 +102,7 @@ export function CommentThread({
                         </div>
                         <div className="whitespace-pre-wrap">
                             {c.deleted ? (
-                                <em className="text-slate-400">
+                                <em className="text-slate-500">
                                     {t('admin.memo.deleted_body', '[deleted comment]')}
                                 </em>
                             ) : (

--- a/frontend/src/pages/admin/AccountSettingsPage.tsx
+++ b/frontend/src/pages/admin/AccountSettingsPage.tsx
@@ -222,7 +222,7 @@ const AccountSettingsPage = () => {
                                                     className="h-11 rounded-xl bg-slate-50 border-slate-200"
                                                 />
                                             </FormControl>
-                                            <p className="text-2xs text-slate-400 italic">
+                                            <p className="text-2xs text-slate-500 italic">
                                                 {t(
                                                     'admin.account.personal.email_locked',
                                                     "Your email address can't be changed here yet. Contact your administrator to update it."

--- a/frontend/src/pages/admin/AdminUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminUsersPage.tsx
@@ -242,7 +242,7 @@ export default function AdminUsersPage() {
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="relative w-full sm:max-w-xs">
-                    <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                    <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-500" />
                     <Input
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
@@ -388,7 +388,7 @@ export default function AdminUsersPage() {
                             {linkCopied ? (
                                 <Check className="size-3 text-emerald-600" />
                             ) : (
-                                <Copy className="size-3 text-slate-400" />
+                                <Copy className="size-3 text-slate-500" />
                             )}
                         </Button>
                     </div>
@@ -579,7 +579,7 @@ function UserRow({
                             </Badge>
                         )}
                     </div>
-                    <span className="truncate text-xs font-medium text-slate-400">
+                    <span className="truncate text-xs font-medium text-slate-500">
                         {user.full_name || t('admin.users.no_name', 'No name')}
                     </span>
                     <div className="flex flex-wrap items-center gap-1.5">
@@ -597,7 +597,7 @@ function UserRow({
                             );
                         })}
                     </div>
-                    <span className="text-2xs font-medium text-slate-400">
+                    <span className="text-2xs font-medium text-slate-500">
                         {lastSeen
                             ? t('admin.users.last_seen', 'Last seen {{when}}', { when: lastSeen })
                             : t('admin.users.never_logged_in', 'Never logged in')}
@@ -615,7 +615,7 @@ function UserRow({
                         aria-label={t('admin.users.actions_aria', 'Actions for {{email}}', {
                             email: user.email,
                         })}
-                        className="size-9 shrink-0 p-0 text-slate-400 hover:bg-slate-100 hover:text-slate-700 rounded-lg"
+                        className="size-9 shrink-0 p-0 text-slate-500 hover:bg-slate-100 hover:text-slate-700 rounded-lg"
                     >
                         <MoreVertical className="size-4" />
                     </Button>

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -827,7 +827,7 @@ export default function ConcourseDetailPage() {
                                                                     'common.cancel',
                                                                     'Cancel'
                                                                 )}
-                                                                className="size-8 p-0 text-slate-400 hover:bg-slate-100"
+                                                                className="size-8 p-0 text-slate-500 hover:bg-slate-100"
                                                                 onClick={() => setEditingItem(null)}
                                                             >
                                                                 <X className="size-3.5" />
@@ -842,7 +842,7 @@ export default function ConcourseDetailPage() {
                                                                     'admin.concourse.history',
                                                                     'History'
                                                                 )}
-                                                                className="size-8 p-0 text-slate-400 hover:text-slate-700"
+                                                                className="size-8 p-0 text-slate-500 hover:text-slate-700"
                                                                 onClick={() =>
                                                                     openSheet(item, 'history')
                                                                 }
@@ -856,7 +856,7 @@ export default function ConcourseDetailPage() {
                                                                     'admin.concourse.comments',
                                                                     'Comments'
                                                                 )}
-                                                                className="relative size-8 p-0 text-slate-400 hover:text-slate-700"
+                                                                className="relative size-8 p-0 text-slate-500 hover:text-slate-700"
                                                                 onClick={() =>
                                                                     openSheet(item, 'comments')
                                                                 }
@@ -887,7 +887,7 @@ export default function ConcourseDetailPage() {
                                                                     'common.delete',
                                                                     'Delete'
                                                                 )}
-                                                                className="size-8 p-0 text-slate-400 hover:text-red-500 hover:bg-red-50"
+                                                                className="size-8 p-0 text-slate-500 hover:text-red-500 hover:bg-red-50"
                                                                 onClick={() =>
                                                                     setDeleteConfirmId(item.id)
                                                                 }
@@ -994,7 +994,7 @@ export default function ConcourseDetailPage() {
                                                         className={cn(
                                                             'text-sm leading-normal',
                                                             isMissingTranslation
-                                                                ? 'text-slate-400 italic'
+                                                                ? 'text-slate-500 italic'
                                                                 : 'text-slate-800'
                                                         )}
                                                     >
@@ -1004,7 +1004,7 @@ export default function ConcourseDetailPage() {
                                                             </span>
                                                         )}
                                                         {text || (
-                                                            <span className="text-slate-300">
+                                                            <span className="text-slate-500">
                                                                 {t(
                                                                     'admin.concourse.no_translation',
                                                                     'No text'
@@ -1131,7 +1131,7 @@ export default function ConcourseDetailPage() {
                                                                 'common.cancel',
                                                                 'Cancel'
                                                             )}
-                                                            className="size-8 p-0 text-slate-400 hover:bg-slate-100"
+                                                            className="size-8 p-0 text-slate-500 hover:bg-slate-100"
                                                             onClick={() => setEditingItem(null)}
                                                         >
                                                             <X className="size-3.5" />
@@ -1146,7 +1146,7 @@ export default function ConcourseDetailPage() {
                                                                 'admin.concourse.history',
                                                                 'History'
                                                             )}
-                                                            className="size-8 p-0 text-slate-400 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
+                                                            className="size-8 p-0 text-slate-500 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
                                                             onClick={() =>
                                                                 openSheet(item, 'history')
                                                             }
@@ -1160,7 +1160,7 @@ export default function ConcourseDetailPage() {
                                                                 'admin.concourse.comments',
                                                                 'Comments'
                                                             )}
-                                                            className="relative size-8 p-0 text-slate-400 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
+                                                            className="relative size-8 p-0 text-slate-500 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
                                                             onClick={() =>
                                                                 openSheet(item, 'comments')
                                                             }
@@ -1188,7 +1188,7 @@ export default function ConcourseDetailPage() {
                                                                 'common.delete',
                                                                 'Delete'
                                                             )}
-                                                            className="size-8 p-0 text-slate-400 hover:text-red-500 hover:bg-red-50 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
+                                                            className="size-8 p-0 text-slate-500 hover:text-red-500 hover:bg-red-50 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity"
                                                             onClick={() =>
                                                                 setDeleteConfirmId(item.id)
                                                             }
@@ -1302,7 +1302,7 @@ export default function ConcourseDetailPage() {
                                 className="text-2xs font-black text-slate-500"
                             >
                                 {t('admin.concourse.field_source', 'Source')}
-                                <span className="text-slate-400 font-normal ml-1">
+                                <span className="text-slate-500 font-normal ml-1">
                                     ({t('common.optional', 'optional')})
                                 </span>
                             </Label>
@@ -1561,7 +1561,7 @@ export default function ConcourseDetailPage() {
                                 )}
                                 className="rounded-xl min-h-[200px] font-mono text-sm"
                             />
-                            <p className="text-xs text-slate-400">
+                            <p className="text-xs text-slate-500">
                                 {t(
                                     'admin.concourse.import_csv_hint',
                                     'CSV/TSV needs columns: code, language, text.'
@@ -1600,7 +1600,7 @@ export default function ConcourseDetailPage() {
                             )}
                         </div>
                         {importText.trim() && (
-                            <p className="text-xs text-slate-400">
+                            <p className="text-xs text-slate-500">
                                 {importText.split('\n').filter((l) => l.trim()).length}{' '}
                                 {t('admin.concourse.items_to_import', 'statements to import')}
                             </p>
@@ -1698,7 +1698,7 @@ export default function ConcourseDetailPage() {
                                                 <Button
                                                     variant="ghost"
                                                     size="sm"
-                                                    className="h-7 px-2 text-slate-400 text-xs"
+                                                    className="h-7 px-2 text-slate-500 text-xs"
                                                     onClick={() => setDeleteTagId(null)}
                                                     aria-label={t(
                                                         'admin.concourse.cancel_delete_tag',
@@ -1713,7 +1713,7 @@ export default function ConcourseDetailPage() {
                                             <Button
                                                 variant="ghost"
                                                 size="sm"
-                                                className="h-7 w-7 p-0 text-slate-400 hover:text-red-500 hover:bg-red-50"
+                                                className="h-7 w-7 p-0 text-slate-500 hover:text-red-500 hover:bg-red-50"
                                                 onClick={() => setDeleteTagId(tag.id)}
                                                 aria-label={t(
                                                     'admin.concourse.delete_tag',
@@ -1728,7 +1728,7 @@ export default function ConcourseDetailPage() {
                                 ))}
                             </div>
                         ) : (
-                            <p className="text-center text-sm text-slate-400 py-4">
+                            <p className="text-center text-sm text-slate-500 py-4">
                                 {t(
                                     'admin.concourse.no_tags',
                                     'No tags yet. Create your first tag above.'
@@ -1819,7 +1819,7 @@ function TagCheckboxGroup({
                 site in this file, so only one instance is ever mounted. */}
             <p id="tag-checkbox-group-heading" className="text-2xs font-black text-slate-500">
                 {label}
-                <span className="text-slate-400 font-normal ml-1">
+                <span className="text-slate-500 font-normal ml-1">
                     ({selectedIds.length}/{tags.length})
                 </span>
             </p>

--- a/frontend/src/pages/admin/ConcourseListPage.tsx
+++ b/frontend/src/pages/admin/ConcourseListPage.tsx
@@ -122,8 +122,8 @@ export default function ConcourseListPage() {
 
     return (
         <div className="flex flex-1 flex-col items-center justify-center gap-2">
-            <Loader2 className="size-6 animate-spin text-slate-400" />
-            <p className="text-sm text-slate-400">
+            <Loader2 className="size-6 animate-spin text-slate-500" />
+            <p className="text-sm text-slate-500">
                 {t('admin.concourse.loading', 'Setting up concourse...')}
             </p>
         </div>

--- a/frontend/src/pages/admin/DataPrivacyPage.tsx
+++ b/frontend/src/pages/admin/DataPrivacyPage.tsx
@@ -189,7 +189,7 @@ function ConsentLocaleRow({
                         {consent_title}
                     </span>
                 ) : (
-                    <span className="text-sm text-slate-400 italic truncate">
+                    <span className="text-sm text-slate-500 italic truncate">
                         {t('admin.privacy.consent.no_title', '(no title)')}
                     </span>
                 )}
@@ -221,7 +221,7 @@ function ConsentLocaleRow({
                     </DialogContent>
                 </Dialog>
             ) : (
-                <span className="text-xs text-slate-400 italic shrink-0">
+                <span className="text-xs text-slate-500 italic shrink-0">
                     {t('admin.privacy.consent.no_body', '(empty)')}
                 </span>
             )}
@@ -600,7 +600,7 @@ export default function DataPrivacyPage() {
                                 }}
                                 className="h-10 rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                             />
-                            <p className="text-xs text-slate-400">
+                            <p className="text-xs text-slate-500">
                                 {t(
                                     'admin.privacy.cutoff_help',
                                     'Only completed participants submitted strictly before this date will be anonymised.'
@@ -626,7 +626,7 @@ export default function DataPrivacyPage() {
                                 {isPreviewFetching ? '…' : candidateCount}
                             </span>
                             {!isPreviewFetching && candidateCount === 0 && (
-                                <p className="text-xs text-slate-400 mt-1">
+                                <p className="text-xs text-slate-500 mt-1">
                                     {t(
                                         'admin.privacy.preview_zero',
                                         'No participants qualify for this cutoff. Try an earlier date.'

--- a/frontend/src/pages/admin/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/admin/GeneralSettingsPage.tsx
@@ -277,7 +277,7 @@ export default function GeneralSettingsPage() {
                         <CardContent className="p-6">
                             {isLoadingStorage ? (
                                 <div className="flex items-center justify-center py-8">
-                                    <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
+                                    <Loader2 className="w-6 h-6 animate-spin text-slate-500" />
                                 </div>
                             ) : storageError ? (
                                 <Alert className="bg-red-50 border-red-200">

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -214,7 +214,7 @@ export default function ProjectMembersPage() {
                                                                 member.user.email}
                                                         </span>
                                                         {member.user.full_name && (
-                                                            <span className="text-xs text-slate-400 font-medium flex items-center gap-1">
+                                                            <span className="text-xs text-slate-500 font-medium flex items-center gap-1">
                                                                 <Mail className="size-3" />{' '}
                                                                 {member.user.email}
                                                             </span>
@@ -295,14 +295,14 @@ export default function ProjectMembersPage() {
                                                     </Select>
                                                 )}
                                             </TableCell>
-                                            <TableCell className="text-xs font-medium text-slate-400">
+                                            <TableCell className="text-xs font-medium text-slate-500">
                                                 {new Date(member.joined_at).toLocaleDateString()}
                                             </TableCell>
                                             <TableCell className="text-right px-6">
                                                 <Button
                                                     variant="ghost"
                                                     size="sm"
-                                                    className="size-9 min-h-[44px] min-w-[44px] p-0 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                                                    className="size-9 min-h-[44px] min-w-[44px] p-0 text-slate-500 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
                                                     onClick={() =>
                                                         requestRemoveMember(
                                                             member.user_id,
@@ -362,7 +362,7 @@ export default function ProjectMembersPage() {
                     <Card className="border-none shadow-sm bg-white rounded-2xl overflow-hidden">
                         <CardHeader className="pb-2">
                             <CardTitle className="text-sm font-black text-slate-900 flex items-center gap-2">
-                                <Shield className="size-4 text-slate-400" />
+                                <Shield className="size-4 text-slate-500" />
                                 {t('admin.projects.settings.team.permissions_matrix.title')}
                             </CardTitle>
                         </CardHeader>
@@ -608,7 +608,7 @@ function InviteMemberModal({ slug, isOwner }: { slug: string; isOwner: boolean }
                                         {copied ? (
                                             <Check className="size-3 text-emerald-600" />
                                         ) : (
-                                            <Copy className="size-3 text-slate-400" />
+                                            <Copy className="size-3 text-slate-500" />
                                         )}
                                     </Button>
                                 </div>

--- a/frontend/src/pages/admin/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/admin/ProjectSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Briefcase, Settings, Save, Globe } from 'lucide-react';
+import { Briefcase, Settings, Save, Globe, ShieldAlert } from 'lucide-react';
 import { useLoaderData, useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -179,8 +179,26 @@ export default function ProjectSettingsPage() {
                                                     disabled={!isOwner}
                                                 />
                                             </FormControl>
-                                            <FormDescription className="text-2xs italic">
-                                                {t('admin.projects.settings.general.slug_hint')}
+                                            {/* Task 6.5, step 3. This is not a hint, it is a
+                                                consequence: renaming the slug rewrites every
+                                                dashboard link the researcher has already
+                                                circulated. It used to render in the page's
+                                                most discreet style (text-2xs italic). It now
+                                                carries the admin's established inline-notice
+                                                treatment, copied verbatim from
+                                                GeneralSettingsPage's archiving notice, so it
+                                                reads with the same weight as other
+                                                consequential copy on a settings surface.
+                                                Still a FormDescription, so the input keeps
+                                                its aria-describedby wiring. */}
+                                            <FormDescription className="bg-amber-50/50 p-4 rounded-2xl border border-amber-100 text-xs font-medium text-amber-800 flex items-start gap-3">
+                                                <ShieldAlert
+                                                    className="w-4 h-4 mt-0.5 shrink-0"
+                                                    aria-hidden="true"
+                                                />
+                                                <span>
+                                                    {t('admin.projects.settings.general.slug_hint')}
+                                                </span>
                                             </FormDescription>
                                             <FormMessage />
                                         </FormItem>

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -429,7 +429,7 @@ const RecruitmentPage = () => {
                                         )}
                                     </Label>
                                     <div className="relative">
-                                        <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+                                        <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
                                         <Input
                                             id="access-password"
                                             type="text"
@@ -523,7 +523,7 @@ const RecruitmentPage = () => {
                                                 )}
                                             </Label>
                                             <div className="relative">
-                                                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400 pointer-events-none" />
+                                                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500 pointer-events-none" />
                                                 <Input
                                                     id="start-date"
                                                     type="datetime-local"
@@ -539,7 +539,7 @@ const RecruitmentPage = () => {
                                                                 shouldDirty: true,
                                                             })
                                                         }
-                                                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                                                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-600"
                                                         aria-label={t(
                                                             'admin.recruitment.access_rules.clear_date',
                                                             'Clear date'
@@ -561,7 +561,7 @@ const RecruitmentPage = () => {
                                                 )}
                                             </Label>
                                             <div className="relative">
-                                                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400 pointer-events-none" />
+                                                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500 pointer-events-none" />
                                                 <Input
                                                     id="end-date"
                                                     type="datetime-local"
@@ -577,7 +577,7 @@ const RecruitmentPage = () => {
                                                                 shouldDirty: true,
                                                             })
                                                         }
-                                                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                                                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-600"
                                                         aria-label={t(
                                                             'admin.recruitment.access_rules.clear_date',
                                                             'Clear date'
@@ -742,7 +742,7 @@ const RecruitmentPage = () => {
                                                 )}
                                             </Label>
                                             <div className="relative">
-                                                <Users className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+                                                <Users className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
                                                 <Input
                                                     id="name"
                                                     placeholder={t(
@@ -772,7 +772,7 @@ const RecruitmentPage = () => {
                                                           )}
                                                 </Label>
                                                 <div className="relative">
-                                                    <QrCode className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+                                                    <QrCode className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
                                                     <Input
                                                         id="count"
                                                         type="number"
@@ -909,7 +909,7 @@ const RecruitmentPage = () => {
                                     <TableRow key={link.id}>
                                         <TableCell className="font-bold text-slate-900 pl-6">
                                             {link.name || (
-                                                <span className="text-slate-300 italic font-normal">
+                                                <span className="text-slate-500 italic font-normal">
                                                     {t('admin.recruitment.unnamed', 'Unnamed')}
                                                 </span>
                                             )}
@@ -996,7 +996,7 @@ const RecruitmentPage = () => {
                                                 <div className="flex flex-col gap-1.5">
                                                     <span className="text-2xs font-black text-slate-700">
                                                         {link.usage_count}
-                                                        <span className="text-slate-300 font-medium">
+                                                        <span className="text-slate-500 font-medium">
                                                             {' '}
                                                             / {link.capacity}
                                                         </span>
@@ -1066,7 +1066,7 @@ const RecruitmentPage = () => {
                                                         <Button
                                                             variant="ghost"
                                                             size="icon"
-                                                            className="h-9 w-9 min-h-[44px] min-w-[44px] text-slate-400 hover:text-indigo-600"
+                                                            className="h-9 w-9 min-h-[44px] min-w-[44px] text-slate-500 hover:text-indigo-600"
                                                             aria-label={t(
                                                                 'admin.recruitment.show_qr',
                                                                 'Show QR code'
@@ -1125,7 +1125,7 @@ const RecruitmentPage = () => {
                                                 <Button
                                                     variant="ghost"
                                                     size="icon"
-                                                    className="h-9 w-9 min-h-[44px] min-w-[44px] text-slate-400 hover:text-red-600"
+                                                    className="h-9 w-9 min-h-[44px] min-w-[44px] text-slate-500 hover:text-red-600"
                                                     onClick={() => handleRevoke(link.id)}
                                                     disabled={isRevokingLink}
                                                     aria-label={t(

--- a/frontend/src/pages/admin/StudyDesignPage.test.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.test.tsx
@@ -1,3 +1,4 @@
+import { act } from '@testing-library/react';
 import { renderWithProviders, screen, waitFor, within, fireEvent } from '@/test-utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -458,5 +459,76 @@ describe('StudyDesignPage Feature Tests', () => {
         } finally {
             await i18n.changeLanguage('en');
         }
+    });
+
+    /*
+     * Task 6.5 review, F1. `syncStatus` is a FOUR-value union
+     * (store/useStudyDesigner.ts) and 'error' is set on three real paths in
+     * hooks/useStudyPersistence.ts — save conflict, merge failure, save failure —
+     * where it is also sticky. On a draft study none of the button's three
+     * `disabled` conditions holds in that state, so the Save button stays enabled
+     * and focusable: it is the user's retry control. It used to fall through to the
+     * muted "saved" arm and paint at `text-slate-400` = 2.56:1 on white, failing
+     * both 1.4.3 (4.5:1) and 1.4.11 (3:1), with no `disabled:opacity-50` to claim
+     * WCAG's inactive-component exemption — the component is not inactive. Worse,
+     * it rendered a green tick and the word "Saved" over a save that had failed.
+     */
+    describe('the Save button in the error state', () => {
+        async function renderInErrorState() {
+            renderPage();
+            await screen.findByTestId('readiness-checklist');
+
+            // The 'error' arm is only reachable on a dirty draft: the persistence
+            // effect downgrades any status to 'synced' while the draft matches the
+            // server, and refuses to downgrade 'error' once the draft differs.
+            await act(async () => {
+                useStudyDesigner.getState().updateDraft((d) => {
+                    d.randomize_statement_order = !d.randomize_statement_order;
+                });
+            });
+            await act(async () => {
+                useStudyDesigner.setState({ syncStatus: 'error' });
+            });
+
+            return screen.getByTitle('Save error');
+        }
+
+        it('leaves the retry control enabled, which is why no exemption applies to it', async () => {
+            const button = await renderInErrorState();
+
+            expect(button).toBeEnabled();
+            expect(button).not.toHaveAttribute('aria-disabled', 'true');
+        });
+
+        it('paints it at a token that clears the floor, and carries no resting opacity', async () => {
+            const button = await renderInErrorState();
+
+            // red-700 on red-50 = 5.91:1 (text 4.5:1, non-text 3:1 — both cleared).
+            // The token alone would not be enough: any resting opacity would
+            // multiply straight back into the computed ratio, which is the whole
+            // defect class this task exists to remove.
+            expect(button).toHaveClass('text-red-700');
+            expect(button).toHaveClass('bg-red-50');
+            expect(button).not.toHaveClass('text-slate-400');
+            expect(button.className).not.toMatch(/(?:^|\s)opacity-\d/);
+        });
+
+        it('reads as a failed save rather than borrowing the green "Saved" tick', async () => {
+            const button = await renderInErrorState();
+
+            expect(button).toHaveTextContent('Save');
+            expect(button).not.toHaveTextContent('Saved');
+            expect(button.querySelector('svg.lucide-circle-alert')).not.toBeNull();
+            expect(button.querySelector('svg.lucide-circle-check-big')).toBeNull();
+        });
+
+        it('still mutes the synced state, where the button really is disabled', async () => {
+            renderPage();
+            await screen.findByTestId('readiness-checklist');
+
+            const button = screen.getByTitle('Save');
+            expect(button).toBeDisabled();
+            expect(button).toHaveClass('text-slate-400');
+        });
     });
 });

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -229,7 +229,7 @@ const StudyDesignPage = () => {
                                     align="end"
                                     className="w-56 rounded-xl shadow-xl border-slate-100 p-1.5"
                                 >
-                                    <DropdownMenuLabel className="px-2 py-1.5 text-xs font-semibold text-slate-400">
+                                    <DropdownMenuLabel className="px-2 py-1.5 text-xs font-semibold text-slate-500">
                                         {t('admin.design.toolbar.select_lang', 'Select language')}
                                     </DropdownMenuLabel>
                                     <DropdownMenuSeparator className="bg-slate-100 my-1" />
@@ -358,7 +358,7 @@ const StudyDesignPage = () => {
                                             'admin.design.toolbar.more_actions',
                                             'More actions'
                                         )}
-                                        className="h-9 w-9 p-0 rounded-lg text-slate-400 border-slate-200 hover:bg-slate-50 hover:text-slate-600"
+                                        className="h-9 w-9 p-0 rounded-lg text-slate-500 border-slate-200 hover:bg-slate-50 hover:text-slate-600"
                                     >
                                         <MoreHorizontal className="h-4 w-4" />
                                     </Button>
@@ -684,7 +684,7 @@ const StudyDesignPage = () => {
                                         <AlertTriangle size={14} className="text-amber-500 ml-1" />
                                     )}
                                     {api.isStructureLocked && (
-                                        <Lock size={12} className="text-slate-400 ml-1" />
+                                        <Lock size={12} className="text-slate-500 ml-1" />
                                     )}
                                 </TabsTrigger>
                                 <TabsTrigger
@@ -959,7 +959,7 @@ const StudyDesignPage = () => {
                                         ) : item.required ? (
                                             <CircleDashed
                                                 data-testid="checklist-item-incomplete"
-                                                className="h-4 w-4 text-slate-300 shrink-0 mt-0.5"
+                                                className="h-4 w-4 text-slate-500 shrink-0 mt-0.5"
                                             />
                                         ) : (
                                             <CircleDashed

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -17,6 +17,7 @@ import {
     ChevronLeft,
     ChevronRight,
     Save,
+    AlertCircle,
     Languages,
     MoreHorizontal,
     Upload,
@@ -318,7 +319,11 @@ const StudyDesignPage = () => {
                                 // Use the standardised toolbar.save key (Wave E.1).
                                 // The previous "save_changes" key was orphaned —
                                 // never present in any locale file.
-                                title={t('admin.design.toolbar.save', 'Save')}
+                                title={
+                                    api.syncStatus === 'error'
+                                        ? t('admin.design.sync.error', 'Save error')
+                                        : t('admin.design.toolbar.save', 'Save')
+                                }
                                 disabled={
                                     api.syncStatus === 'synced' ||
                                     api.syncStatus === 'saving' ||
@@ -326,13 +331,38 @@ const StudyDesignPage = () => {
                                 }
                                 className={cn(
                                     'h-9 px-2 sm:px-3 font-bold rounded-lg shadow-sm transition-all active:scale-95 gap-2',
-                                    api.syncStatus === 'modified'
-                                        ? 'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100 hover:border-amber-300'
-                                        : 'bg-white text-slate-400 border-slate-200'
+                                    // `syncStatus` is a FOUR-value union
+                                    // (store/useStudyDesigner.ts:35), and 'error' is set
+                                    // on three real paths in hooks/useStudyPersistence.ts
+                                    // (:145 conflict, :161 merge failure, :165 save
+                                    // failure) — and it is sticky (:75 refuses to
+                                    // downgrade it). On a draft study none of the three
+                                    // `disabled` conditions holds there, so the button
+                                    // stays enabled and focusable: it IS the retry
+                                    // control. Task 6.5 folded that state into the muted
+                                    // "saved" arm, painting the one control the user has
+                                    // to find at text-slate-400 = 2.56:1 on white — under
+                                    // 1.4.3 (4.5:1) AND 1.4.11 (3:1) — with no
+                                    // `disabled:opacity-50` to claim WCAG's
+                                    // inactive-component exemption, because the component
+                                    // is not inactive. It gets its own arm: red-700 on
+                                    // red-50 = 5.91:1, and a failed save now reads as
+                                    // failed instead of borrowing the green "Saved" tick.
+                                    // The muted arm below is now reachable only while
+                                    // 'synced'/'saving'/read-only, i.e. only while the
+                                    // button really is disabled — which is what makes the
+                                    // exemption on it true rather than merely asserted.
+                                    api.syncStatus === 'error'
+                                        ? 'bg-red-50 text-red-700 border-red-200 hover:bg-red-100 hover:border-red-300'
+                                        : api.syncStatus === 'modified'
+                                          ? 'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100 hover:border-amber-300'
+                                          : 'bg-white text-slate-400 border-slate-200'
                                 )}
                             >
                                 {api.syncStatus === 'saving' ? (
                                     <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : api.syncStatus === 'error' ? (
+                                    <AlertCircle className="h-4 w-4" />
                                 ) : api.syncStatus === 'modified' ? (
                                     <Save className="h-4 w-4" />
                                 ) : (
@@ -341,7 +371,8 @@ const StudyDesignPage = () => {
                                 <span className="hidden md:inline">
                                     {api.syncStatus === 'saving'
                                         ? t('admin.sync.saving', 'Saving...')
-                                        : api.syncStatus === 'modified'
+                                        : api.syncStatus === 'modified' ||
+                                            api.syncStatus === 'error'
                                           ? t('admin.design.toolbar.save', 'Save')
                                           : t('admin.design.toolbar.saved', 'Saved')}
                                 </span>


### PR DESCRIPTION
Phase 6 Task 6.5. 189 real source sites triaged by hand, plus the four resting-opacity defects review found afterwards.

## What this changes

`text-slate-400` (**2.56:1**) and `text-slate-300` (**1.48:1**) carried real content across the admin: participant metadata, the responses table's `—` values, the "36 / 36 items" counter, icon-only control foregrounds. Both are below AA.

204 grep hits read individually — 13 were `not.toHaveClass` regression assertions, 2 were prose in comments — leaving 189 real sites: **90 text**, **95 informative icons / icon-only control foregrounds**, **1 placeholder** promoted to `text-slate-500`; **3 left** as genuinely decorative and annotated in place; **2** under WCAG's inactive-component exemption.

Also: the slug-change warning now uses the admin's existing inline-notice treatment, and the unlabelled 10px `lucide-monitor` glyph is gone along with its orphan separator (device info still reaches users as text on the participant detail card and via `aria-label` in the Data table).

## Five places the brief was wrong

My brief was wrong five times. All five were caught by people who computed rather than accepted, and all five are confirmed to 4 s.f.:

| claim | brief | actual |
|---|---|---|
| `text-slate-300` | 1.68:1 | **1.4847:1** |
| `slate-500` on `bg-slate-100` | "passes" | **4.3439** — fails |
| `slate-500` on `bg-indigo-50` | "passes" | **4.2558** — fails |
| `slate-500` @60% opacity | not considered | **2.2981** |
| `slate-500` @70% opacity | not considered | **2.7187** |

The important one is structural: **my classification taxonomy had no bucket for opacity.** It warned against string-matching in prose, then handed over a grid to sort by that omitted the mechanism. A pure class swap on those sites yields a diff that looks fixed and passes any class-name check.

The plan's own headline number was also wrong — `text-slate-400` is 2.56:1, not 2.85:1. That matters, because at 2.56:1 it fails the **3:1 non-text** threshold too, so "it's only an icon" is not a valid exemption for this shade.

## The four defects review found afterwards

All four are the same shape — a resting `opacity-*` compositing into a promoted node — and all four were missed by a report that claimed completeness.

- **F1 (major)** `StudyDesignPage.tsx` — justified as "unreachable in an enabled state", but `syncStatus` is a **four**-value union and the enumeration dropped `'error'`, set on three real paths and *sticky*. In that state the Save button is enabled, is the retry control, and sat at **2.56:1**. Task 6.7i's defect reproduced inside the commit written to remove it. Fixing it surfaced worse: the error state also rendered a green check and the word **"Saved" over a failed save**. It now gets its own arm (red-700 on red-50, **5.9146:1**).
- **F2** `InteractiveDataView.tsx` — discarded rows keep `opacity-60` while staying `cursor-pointer` with a live `onClick`; seven promoted cells at **2.30:1**. An interactive row is not an inactive component.
- **F3** `QuestionBuilder.tsx` — `readOnly && opacity-80`, and `readOnly` means every **launched** study, i.e. the steady state. **3.13:1** — the number this repo's own a11y gate ships as its canonical failure example.
- **F4** `InterfaceEditor.tsx` — a fourth undisclosed resting opacity.

Two obvious fixes were rejected **with numbers**: `text-red-600` on red-50 is **4.4148** and fails; `opacity-80 + slate-600` reaches 4.5418 but re-introduces the mechanism.

Affordances were not traded away. F2's dimming is now carried by `bg-slate-50` plus a kept `grayscale-[0.5]` — and a `filter`, unlike `opacity`, applies to foreground and background as a group, so it moves the ratio slightly **up** (4.5484 → 4.5728, independently reproduced).

## Verification

- **Background audit**: the JSX ancestor chain of all 187 promoted nodes parsed with the TypeScript compiler API, then all 18 non-white flags adjudicated by hand. **No promoted site fails its own background.** Closest passes by 0.0026.
- **Slug notice measured in a browser at 320px in all nine locales**: 6.9620:1, `scrollWidth == clientWidth` everywhere. English is the short case — 2 lines against Dutch's 4. `aria-describedby` verified in the rendered DOM, not from the JSX (the existing test mocks `ui/form` wholesale and would not have caught a break).
- **Tests RED-verified** by restoring the literal prior source, not by breaking syntax.
- lint, `tsc -b`, `lint:a11y`, `i18n-check` all clean; vitest **1759 passed / 6 skipped**.

`make ci-fast` does not pass on this machine — 340 asyncpg `InvalidPasswordError` collection errors, a known local Postgres problem, and because pytest precedes the frontend suite a local DB failure means the frontend tests never run. Frontend tools were run directly.

## One correction carried forward

The regression-test precedent used `/\bopacity-\d/`. That **false-positives on any `<Button>`**, because `\b` matches inside `disabled:opacity-50` — verified by executing it against `ui/button.tsx`'s real base string. New assertions use `/(?:^|\s)opacity-\d/`.

## Logged, not fixed

- **Task 6.12 — this one loses user work.** `useStudyPersistence.ts`'s `beforeunload` guard and router blocker both enumerate three of `syncStatus`'s four values. The missing one is `'error'`, which is sticky while the draft is dirty — so after a failed save a researcher can close the tab and lose their edits **with no warning**. The same file's merge-throw path also sets `'error'` with no `toast.error`, so a screen-reader user gets no signal at all. Pre-existing, small to fix, but it changes navigation-guard behaviour and needs its own tests rather than a ride-along here.
- **Task 6.11** — `QSortEditor`'s `readOnly` dim, 3.3542:1 on every launched study. Same shape as F3, outside this commit's blast radius.

## A note on the instruments

The a11y gate reports green, and that means less than it looks: per `check-a11y-names.mjs` it inspects **controls only** and matches `text-slate-300` plus alpha-bearing tokens — plain tokens are excluded by design. **It never looked at 186 of these 189 sites.** `responsive-overflow.spec.ts` covers `querySelectorAll('button')` on one route, and never visits project settings, so it says nothing about the slug notice. Hence the independent measurement. Now that the admin debt is paid, extending the gate to plain tokens on a path scope is worth its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)