### PR TITLE
style(i18n): one capitalisation rule — sentence case for every admin label

### DIFF
--- a/frontend/e2e/admin/analysis-workflow.spec.ts
+++ b/frontend/e2e/admin/analysis-workflow.spec.ts
@@ -140,8 +140,9 @@ test('full analysis workflow: run → results → history', async ({ page, testD
     await expect(summaryTab).toBeVisible();
     await summaryTab.click();
 
-    // FactorCharacteristicsTable renders "Factor Statistics" heading
-    await expect(page.getByText('Factor Statistics')).toBeVisible({ timeout: 10_000 });
+    // FactorCharacteristicsTable renders the "Factor statistics" heading
+    // (admin.analysis.factor_statistics — sentence case since task 4.2).
+    await expect(page.getByText('Factor statistics')).toBeVisible({ timeout: 10_000 });
 
     // The table has a visually-hidden caption
     const charTable = page.getByRole('table', {
@@ -150,7 +151,8 @@ test('full analysis workflow: run → results → history', async ({ page, testD
     await expect(charTable).toBeVisible();
 
     // With n_factors >= 2 the correlation matrix also appears
-    await expect(page.getByText('Factor Correlations')).toBeVisible({ timeout: 5_000 });
+    // (admin.analysis.factor_correlations — sentence case since task 4.2).
+    await expect(page.getByText('Factor correlations')).toBeVisible({ timeout: 5_000 });
 
     // -----------------------------------------------------------------------
     // 7. Assert Region 4 — Statements (distinguishing / consensus)

--- a/frontend/e2e/pages/AdminPage.ts
+++ b/frontend/e2e/pages/AdminPage.ts
@@ -157,7 +157,7 @@ export class AdminPage extends BasePage {
         const exportButton = this.page.getByRole('button', { name: /^export data$/i }).first();
         await exportButton.click();
         const downloadPromise = this.page.waitForEvent('download');
-        // Dropdown items: Research Package (ZIP), CSV, PQMethod (ZIP), R-Kit (ZIP), JSON Dump.
+        // Dropdown items: Research package (ZIP), CSV, PQMethod (ZIP), R-Kit (ZIP), JSON dump.
         // ^CSV$ avoids matching the others; case-insensitive for safety.
         await this.page.getByRole('menuitem', { name: /^csv$/i }).click();
         const download = await downloadPromise;

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -102,7 +102,7 @@
     },
     "admin": {
         "hub": {
-            "title": "Researcher Hub",
+            "title": "Researcher hub",
             "welcome": "Welcome back,",
             "new_project": "New project",
             "your_projects": "Your projects",
@@ -299,9 +299,9 @@
                 "tfa_subtitle": "Two-factor authentication",
                 "password_subtitle": "Password",
                 "enabled": "Enabled",
-                "setup_cta": "Setup 2FA now",
+                "setup_cta": "Set up 2FA now",
                 "configure_title": "Configure authenticator app",
-                "scan_desc": "Scan this QR code with your authenticator app (google authenticator, authy, etc.)",
+                "scan_desc": "Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)",
                 "enter_code": "Enter 6-digit code",
                 "enable_btn": "Enable 2FA",
                 "disable_btn": "Disable 2FA",
@@ -333,7 +333,7 @@
         "sidebar": {
             "home": "Dashboard",
             "add_study": "Add study",
-            "create_project": "CREATE NEW PROJECT",
+            "create_project": "Create new project",
             "dashboard": "Dashboard",
             "overview": "Overview",
             "design": "Design",
@@ -361,17 +361,17 @@
             "members": "Team members",
             "mobile_title": "Sidebar",
             "mobile_description": "Displays the mobile sidebar.",
-            "toggle": "Toggle Sidebar"
+            "toggle": "Toggle sidebar"
         },
         "concourse": {
             "title": "Concourse",
             "description": "Manage candidate statements for your Q-methodology study",
             "default_title": "Concourse",
             "default_title_for_project": "{{project}} concourse",
-            "create": "New Concourse",
+            "create": "New concourse",
             "create_success": "Concourse created",
             "create_error": "Failed to create concourse",
-            "create_dialog_title": "Create Concourse",
+            "create_dialog_title": "Create concourse",
             "create_dialog_desc": "A concourse is a collection of candidate statements from which you will select your Q-set.",
             "field_title": "Title",
             "field_title_placeholder": "e.g. Climate Change Attitudes",
@@ -385,8 +385,8 @@
             "updated": "Updated",
             "empty_title": "No concourses yet",
             "empty_desc": "Create a concourse to start collecting and organizing candidate statements for your Q-methodology research.",
-            "add_item": "Add Item",
-            "bulk_import": "Bulk Import",
+            "add_item": "Add item",
+            "bulk_import": "Bulk import",
             "import_desc": "Paste statements separated by newlines. Each line becomes one item.",
             "import_prefix": "Code prefix",
             "import_statements": "Statements",
@@ -406,12 +406,12 @@
             "source_placeholder": "e.g. Interview #3, Literature review",
             "no_items": "No items yet. Add your first statement.",
             "no_matches": "No items match your filters.",
-            "danger_zone": "Danger Zone",
-            "delete": "Delete Concourse",
+            "danger_zone": "Danger zone",
+            "delete": "Delete concourse",
             "delete_confirm": "Are you sure you want to delete this concourse and all its items?",
             "deleted": "Concourse deleted",
             "delete_error": "Failed to delete concourse",
-            "delete_item_title": "Delete Item",
+            "delete_item_title": "Delete item",
             "delete_item_confirm": "Delete this item? Cannot be undone.",
             "status": {
                 "proposed": "Proposed",
@@ -488,9 +488,9 @@
             "cancel_delete_tag": "Cancel deleting {{tag}}"
         },
         "concourse_import": {
-            "title": "Import from Concourse",
+            "title": "Import from concourse",
             "desc": "Select items from a concourse to import as study statements. Items are copied; changes to the concourse will not affect the study.",
-            "button_label": "Import from Concourse",
+            "button_label": "Import from concourse",
             "select_concourse": "Concourse",
             "select_placeholder": "Choose a concourse...",
             "code_prefix": "Code prefix",
@@ -526,7 +526,7 @@
             "n_factors": "Factors",
             "rotation_method": "Rotation",
             "none": "None",
-            "run": "Run Analysis",
+            "run": "Run analysis",
             "run_will_replace": "Running again will replace the current results view. Use the history panel to compare runs.",
             "running": "Analyzing...",
             "reanalyzing": "Re-analyzing...",
@@ -556,7 +556,7 @@
                 "bootstrap_on": "{{n}} iterations"
             },
             "tab_loadings": "Loadings",
-            "tab_factor_arrays": "Factor Arrays",
+            "tab_factor_arrays": "Factor arrays",
             "tab_statements": "Statements",
             "tab_summary": "Summary",
             "participant": "Participant",
@@ -569,14 +569,14 @@
             "type": "Type",
             "distinguishing": "Distinguishing",
             "consensus": "Consensus",
-            "variance_explained": "Variance Explained (%)",
-            "cumulative_variance": "Cumulative Variance (%)",
-            "n_flagged": "N Flagged Sorts",
-            "composite_reliability": "Composite Reliability",
-            "se_factor_scores": "SE of Factor Scores",
-            "factor_correlations": "Factor Correlations",
+            "variance_explained": "Variance explained (%)",
+            "cumulative_variance": "Cumulative variance (%)",
+            "n_flagged": "N flagged sorts",
+            "composite_reliability": "Composite reliability",
+            "se_factor_scores": "SE of factor scores",
+            "factor_correlations": "Factor correlations",
             "high_correlation": "High correlation",
-            "total_variance": "Total Variance Explained",
+            "total_variance": "Total variance explained",
             "method_used": "Method",
             "statements_label": "statements",
             "pca": "PCA",
@@ -609,22 +609,22 @@
             },
             "statements_help": "Z-scores show each factor's standardized position on each statement. D = distinguishing (significantly different between factors), C = consensus (no significant differences).",
             "z_scores_description": "Z-scores and factor array positions per statement",
-            "factor_statistics": "Factor Statistics",
+            "factor_statistics": "Factor statistics",
             "characteristics_help": "Eigenvalues reflect the amount of variance explained. Composite reliability reflects internal consistency among flagged sorts. SE of factor scores reflects the precision of the composite estimate.",
             "help_extraction": "PCA maximises explained variance. Centroid is less mathematically constrained.",
             "help_n_factors": "Each factor represents a distinct viewpoint.",
             "help_rotation": "Varimax separates factors for simpler structure.",
             "help_flagging": "Auto: flag participants loading on exactly one factor. Manual: override per participant.",
-            "guide_loadings_title": "Reading Factor Loadings",
+            "guide_loadings_title": "Reading factor loadings",
             "guide_loadings_1": "Each loading is a correlation (-1 to +1) between a participant and a factor (shared viewpoint).",
             "guide_loadings_2": "Highlighted values exceed the significance threshold shown above the table.",
-            "guide_arrays_title": "Interpreting Factor Arrays",
+            "guide_arrays_title": "Interpreting factor arrays",
             "guide_arrays_1": "Each factor array is the composite Q-sort representing one shared viewpoint.",
             "guide_arrays_2": "Read left-to-right as most disagreed to most agreed. Extreme positions carry the strongest signal for interpretation.",
-            "guide_statements_title": "Understanding Statement Scores",
+            "guide_statements_title": "Understanding statement scores",
             "guide_statements_1": "Z-scores show how strongly each factor agrees or disagrees with each statement (0 = neutral).",
             "guide_statements_2": "D = distinguishing (placed significantly differently across factors). Stars indicate significance level.",
-            "guide_summary_title": "Evaluating Your Solution",
+            "guide_summary_title": "Evaluating your solution",
             "guide_summary_1": "Eigenvalues measure how much variance a factor explains. The Kaiser criterion (eigenvalue > 1) is one common heuristic for deciding how many factors to retain.",
             "guide_summary_2": "Composite reliability reflects how consistently the flagged sorts define each factor. Higher values mean the factor estimate is based on more agreement among its defining sorts.",
             "benchmark_above": "Above threshold",
@@ -868,7 +868,7 @@
             "copy_success": "Study link copied to clipboard",
             "types": {
                 "public": "Open access (public)",
-                "individual": "Single-Use passcode",
+                "individual": "Single-use passcode",
                 "limited": "Capped participation"
             },
             "guidance": {
@@ -1069,13 +1069,13 @@
             "error": "Export failed. Try again.",
             "csv": "Export CSV",
             "json": "Export JSON",
-            "audio": "Export Audio (ZIP)",
+            "audio": "Export audio (ZIP)",
             "formats": {
                 "csv": "CSV",
                 "pqmethod": "PQMethod (ZIP)",
                 "rkit": "R-Kit (ZIP)",
-                "package": "Research Package (ZIP)",
-                "json": "JSON Dump"
+                "package": "Research package (ZIP)",
+                "json": "JSON dump"
             },
             "download": "Download",
             "package_dialog": {
@@ -1086,7 +1086,7 @@
         },
         "import": {
             "title": "Import study configuration",
-            "config": "Import Configuration",
+            "config": "Import configuration",
             "upload_desc": "Upload a previously exported study configuration file",
             "validate_desc": "Review configuration and provide a unique slug",
             "creating_desc": "Creating study...",
@@ -1141,7 +1141,7 @@
         "dialogs": {
             "create_study": {
                 "title": "Create new study",
-                "description": "Start a new q-methodology study. You can configure statements and settings later.",
+                "description": "Start a new Q-methodology study. You can configure statements and settings later.",
                 "study_title": "Study title",
                 "study_title_placeholder": "E.g. Perspectives on AI",
                 "url_slug": "URL slug",
@@ -1171,7 +1171,7 @@
             "suspect": "Suspect",
             "recent_activity": "Recent activity",
             "latest_participants": "Latest participants (last {{count}} of {{total}})",
-            "recently_completed": "Recently completed",
+            "recently_completed": "Completed",
             "in_progress": "In progress",
             "discarded": "Discarded",
             "started": "Started",
@@ -1236,7 +1236,7 @@
             },
             "state": {
                 "activate": "Activate study",
-                "switch_to_draft": "Draft Mode",
+                "switch_to_draft": "Draft mode",
                 "manage": "Manage status"
             },
             "notifications": {
@@ -1257,7 +1257,7 @@
             "editing_language_banner": "Editing the {{language}} version. Use the language selector in the toolbar to switch.",
             "multilang": {
                 "view_others": "View in other languages",
-                "other_formulations": "Other Formulations"
+                "other_formulations": "Other formulations"
             },
             "guidance": {
                 "title": "Design guidance",
@@ -1335,7 +1335,7 @@
                     "missing_title": "Title is missing for language '{{lang}}'.",
                     "missing_consent_title": "Consent title is missing for language '{{lang}}'.",
                     "missing_consent_description": "Consent description is missing for language '{{lang}}'.",
-                    "missing_grid_instructions": "Q-Sort instructions are missing for language '{{lang}}'.",
+                    "missing_grid_instructions": "Q-sort instructions are missing for language '{{lang}}'.",
                     "missing_step_title": "Step {{index}} title is missing for language '{{lang}}'.",
                     "missing_statement_translation": "Statement '{{code}}' is missing translations for: {{missing}}.",
                     "empty_statement_text": "Statement '{{code}}' has empty text for language '{{lang}}'.",
@@ -1375,7 +1375,7 @@
                 "desktop": "Desktop view"
             },
             "intro": {
-                "general_settings": "General Settings",
+                "general_settings": "General settings",
                 "welcome_title": "Welcome message",
                 "process_title": "Study steps overview",
                 "process_steps": {
@@ -1384,7 +1384,7 @@
                     "add_step": "Add step",
                     "empty": {
                         "title": "No custom steps defined",
-                        "desc": "The study will use the standard q-methodology workflow (meet, first impressions, perspective, why)."
+                        "desc": "The study will use the standard Q-methodology workflow (meet, first impressions, perspective, why)."
                     },
                     "fields": {
                         "title": "Step title",
@@ -1418,7 +1418,7 @@
                 "reset": "Reset instruction",
                 "consent_details": "Consent form details",
                 "fields": {
-                    "default_lang": "Default Language",
+                    "default_lang": "Default language",
                     "default_lang_help": "This language will be shown to participants by default if their browser language is not supported.",
                     "title": "Study title",
                     "title_placeholder": "Enter public title...",
@@ -1440,8 +1440,8 @@
                 "desc": "This is the core prompt that guides participants throughout the sorting process.",
                 "field_label": "Instruction text",
                 "placeholder": "E.g. Please rank the following statements from those you most agree with to those you most disagree with",
-                "grid_title": "Q-Sort instruction",
-                "grid_desc": "This is the core instruction guiding participants during the Q-Sort process.",
+                "grid_title": "Q-sort instruction",
+                "grid_desc": "This is the core instruction guiding participants during the Q-sort process.",
                 "pre_title": "Preliminary sort instruction",
                 "pre_desc": "Instruction given to participants during the initial rough sort.",
                 "pre_field_label": "Instruction text",
@@ -1450,7 +1450,7 @@
                 "pre_label": "Pre-instruction content",
                 "tips": {
                     "title": "Why is this important?",
-                    "desc": "In q-methodology, the 'condition of instruction' determines the point of view from which the participant sorts the items. It should be clear and consistent across all sorting phases."
+                    "desc": "In Q-methodology, the 'condition of instruction' determines the point of view from which the participant sorts the items. It should be clear and consistent across all sorting phases."
                 }
             },
             "questions": {
@@ -1482,7 +1482,7 @@
                     "dropdown": "Dropdown",
                     "radio": "Radio",
                     "checkboxes": "Checkboxes",
-                    "text_audio": "Text + Audio",
+                    "text_audio": "Text + audio",
                     "rating": "Rating scale"
                 },
                 "empty": {
@@ -1529,7 +1529,7 @@
                 },
                 "bulk": {
                     "title": "Bulk editor (quick paste)",
-                    "desc": "One statement per line. Supports \"code: text\" and excel copy-paste (multi-language).",
+                    "desc": "One statement per line. Supports \"code: text\" and Excel copy-paste (multi-language).",
                     "replace_all": "Replace all",
                     "append": "Append to list",
                     "sync_by_code": "Sync/Merge by code",
@@ -1569,7 +1569,7 @@
                     "randomize_desc": "Present statements in random order to each participant (consistent within session)"
                 },
                 "grid": {
-                    "title": "Q-Sort distribution grid",
+                    "title": "Q-sort distribution grid",
                     "desc": "The grid shape forces participants to discriminate between statements, approximating a normal distribution.",
                     "slot_count": "{{count}} slots allocated",
                     "stat_count": "{{count}} statements",
@@ -1582,7 +1582,7 @@
                     "add_extreme_columns": "Add extreme columns",
                     "symmetry_lock": "Symmetry lock",
                     "symmetry_lock_desc": "Automatically apply changes to opposite columns to maintain a balanced distribution.",
-                    "auto_balance": "Auto-Balance",
+                    "auto_balance": "Auto-balance",
                     "auto_balance_desc": "Reshape grid to a balanced semi-normal distribution",
                     "reshaped": "Grid reshaped to a balanced distribution",
                     "balanced": "Grid balanced to standard distribution",
@@ -1645,9 +1645,9 @@
                     "results_hint": "Email solely for results, anonymity preserved."
                 },
                 "audio": {
-                    "title": "Audio Recording",
+                    "title": "Audio recording",
                     "desc": "Allow participants to record audio responses instead of text.",
-                    "max_duration": "Maximum Duration",
+                    "max_duration": "Maximum duration",
                     "seconds": "seconds",
                     "max_duration_help": "Maximum recording time per question (30–600 seconds).",
                     "participant_choice_info": "Participants can respond with text, audio, or both for each question.",
@@ -1790,11 +1790,11 @@
                 "export": "Export hub"
             },
             "status": {
-                "started": "started",
+                "started": "Started",
                 "completed": "Completed",
                 "in_progress": "In progress",
                 "abandoned": "Abandoned",
-                "discarded": "discarded"
+                "discarded": "Discarded"
             },
             "step": {
                 "consent": "Consent",
@@ -1826,7 +1826,7 @@
                 "title": "Format guide",
                 "csv": {
                     "title": "Universal CSV",
-                    "desc": "Raw rectangular data. Best for r, python, SPSS, or excel analysis. Includes all metadata."
+                    "desc": "Raw rectangular data. Best for R, Python, SPSS, or Excel analysis. Includes all metadata."
                 },
                 "json": {
                     "title": "KenQ JSON",
@@ -1913,7 +1913,7 @@
                 "has_recruitment": "Has recruitment link"
             },
             "charts": {
-                "section_title": "Response Distributions",
+                "section_title": "Response distributions",
                 "distribution_label": "Distribution for {{question}}",
                 "multi_select_note": "Multiple selections allowed",
                 "responses_count": "{{count}} responses",
@@ -2042,10 +2042,10 @@
             "delete_error": "Could not delete study. Make sure all data has been cleared first.",
             "delete_error_desc": "Failed to delete study.",
             "storage": {
-                "title": "Audio Storage Usage",
-                "used": "Storage Used",
+                "title": "Audio storage usage",
+                "used": "Storage used",
                 "quota": "Quota",
-                "quota_label": "Storage Quota",
+                "quota_label": "Storage quota",
                 "quota_help": "Maximum total audio storage for this study (10–1000 MB).",
                 "error": "Failed to load storage usage.",
                 "warning_high_usage": "Storage usage is high. Consider increasing the quota or removing old recordings.",
@@ -2205,28 +2205,28 @@
         "participant": {
             "tabs": {
                 "session": "Metadata",
-                "presort": "Pre-Sort",
-                "grid": "Q-Sort Grid",
-                "postsort": "Post-Sort"
+                "presort": "Pre-sort",
+                "grid": "Q-sort grid",
+                "postsort": "Post-sort"
             },
             "grid": {
-                "detail_view": "Card Details",
+                "detail_view": "Card details",
                 "no_comment": "No comment provided.",
                 "select_instruction": "Select a card on the grid to view details.",
-                "read_only_mode": "Viewer Mode",
+                "read_only_mode": "Viewer mode",
                 "score": "Score"
             },
             "metadata": {
-                "title": "Session Metadata",
+                "title": "Session metadata",
                 "technology": "Technology",
                 "browser": "Browser",
-                "session": "Session Details",
-                "duration": "Total Duration",
+                "session": "Session details",
+                "duration": "Total duration",
                 "started": "Started",
                 "submitted": "Submitted",
                 "id": "Internal ID",
-                "ip_hash": "IP Hash",
-                "recruitment_token": "Recruitment Token",
+                "ip_hash": "IP hash",
+                "recruitment_token": "Recruitment token",
                 "device": {
                     "mobile": "Mobile",
                     "tablet": "Tablet",
@@ -2237,19 +2237,19 @@
                 "started": "Started",
                 "completed": "Completed",
                 "discarded": "Discarded",
-                "in_progress": "In Progress"
+                "in_progress": "In progress"
             },
             "survey": {
-                "presort": "Pre-Sort Questions",
-                "postsort": "Post-Sort Questions",
+                "presort": "Pre-sort questions",
+                "postsort": "Post-sort questions",
                 "no_answers": "No answers recorded for this section.",
                 "question_default": "Spoken response",
                 "answer_default": "Response",
                 "categories": {
-                    "identity": "Identity & Contact",
-                    "questions": "Questionnaire Responses",
-                    "comments": "Card Comments",
-                    "feedback": "General Feedback"
+                    "identity": "Identity & contact",
+                    "questions": "Questionnaire responses",
+                    "comments": "Card comments",
+                    "feedback": "General feedback"
                 }
             }
         },

--- a/frontend/src/api/mutator.ts
+++ b/frontend/src/api/mutator.ts
@@ -106,7 +106,7 @@ function handle403(
               'errors.access_denied_description',
               'You do not have permission to perform this action.'
           );
-    toast.error(i18n.t('errors.access_denied_title', 'Access Denied'), {
+    toast.error(i18n.t('errors.access_denied_title', 'Access denied'), {
         id: `403:${method}:${url}`, // dedupe identical 403s on the same endpoint
         description,
     });
@@ -132,7 +132,7 @@ function handle409(
 }
 
 function handle429(url: string): void {
-    toast.error(i18n.t('errors.rate_limited_title', 'Too Many Requests'), {
+    toast.error(i18n.t('errors.rate_limited_title', 'Too many requests'), {
         id: `429:${url}`,
         description: i18n.t(
             'errors.rate_limited_description',

--- a/frontend/src/components/admin/AppSidebar.tsx
+++ b/frontend/src/components/admin/AppSidebar.tsx
@@ -341,7 +341,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                             </SidebarMenuItem>
                         </SidebarMenu>
                         <SidebarGroupLabel className="px-2 text-xs font-semibold text-slate-600">
-                            {t('admin.sidebar.study_tools', 'Study Tools')}
+                            {t('admin.sidebar.study_tools', 'Study tools')}
                         </SidebarGroupLabel>
                         <SidebarMenu>
                             {studyNav.map((item) => (

--- a/frontend/src/components/admin/CommandMenu.tsx
+++ b/frontend/src/components/admin/CommandMenu.tsx
@@ -84,7 +84,7 @@ export const CommandMenu = () => {
         <Command.Dialog
             open={open}
             onOpenChange={setOpen}
-            label={t('admin.command_menu.title', 'Global Command Menu')}
+            label={t('admin.command_menu.title', 'Global command menu')}
             className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] px-4 bg-slate-950/20 backdrop-blur-md transition-all duration-300"
         >
             <div className="w-full max-w-[640px] rounded-2xl border border-slate-200 bg-white shadow-2xl overflow-hidden animate-in fade-in-0 zoom-in-95">
@@ -106,7 +106,7 @@ export const CommandMenu = () => {
 
                     {/* Projects */}
                     <Command.Group
-                        heading={t('admin.command_menu.switch_project', 'Switch Project')}
+                        heading={t('admin.command_menu.switch_project', 'Switch project')}
                         className="px-2 py-1.5 text-2xs font-bold text-muted-foreground"
                     >
                         {(Array.isArray(projects) ? projects : []).map((ws) => (
@@ -157,7 +157,7 @@ export const CommandMenu = () => {
 
                     {/* Studies (Filtered) */}
                     <Command.Group
-                        heading={t('admin.command_menu.switch_study', 'Switch Study')}
+                        heading={t('admin.command_menu.switch_study', 'Switch study')}
                         className="px-2 py-1.5 text-2xs font-bold text-muted-foreground"
                     >
                         {filteredStudies?.map((study) => (
@@ -194,7 +194,7 @@ export const CommandMenu = () => {
                     {/* Contextual Actions (only when study is active and valid) */}
                     {isValidStudy && (
                         <Command.Group
-                            heading={t('admin.command_menu.study_actions', 'Study Actions')}
+                            heading={t('admin.command_menu.study_actions', 'Study actions')}
                             className="px-2 py-1.5 text-2xs font-bold text-muted-foreground"
                         >
                             <Command.Item
@@ -291,7 +291,7 @@ export const CommandMenu = () => {
                                 <div className="flex h-6 w-6 items-center justify-center rounded bg-sky-100 dark:bg-sky-900/40">
                                     <Copy className="h-3.5 w-3.5 text-sky-600 dark:text-sky-400" />
                                 </div>
-                                <span>{t('admin.command_menu.copy_link', 'Copy Public Link')}</span>
+                                <span>{t('admin.command_menu.copy_link', 'Copy public link')}</span>
                             </Command.Item>
                         </Command.Group>
                     )}
@@ -325,7 +325,7 @@ export const CommandMenu = () => {
                         <kbd className="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-800 rounded text-2xs font-mono">
                             ⌘K
                         </kbd>
-                        <span>{t('admin.command_menu.to_open', 'to open')}</span>
+                        <span>{t('admin.command_menu.to_open', 'To open')}</span>
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/admin/CreateStudyDialog.tsx
+++ b/frontend/src/components/admin/CreateStudyDialog.tsx
@@ -147,12 +147,12 @@ export function CreateStudyDialog({ open, onOpenChange, projectSlug }: CreateStu
             <DialogContent className="sm:max-w-[425px]">
                 <DialogHeader className="space-y-3 pb-4 border-b border-slate-50">
                     <DialogTitle className="text-xl font-black tracking-tight text-slate-900">
-                        {t('admin.dialogs.create_study.title', 'Create New Study')}
+                        {t('admin.dialogs.create_study.title', 'Create new study')}
                     </DialogTitle>
                     <DialogDescription className="text-sm font-medium text-slate-500">
                         {t(
                             'admin.dialogs.create_study.description',
-                            'Start a new Q-Methodology study. You can configure statements and settings later.'
+                            'Start a new Q-methodology study. You can configure statements and settings later.'
                         )}
                     </DialogDescription>
                 </DialogHeader>
@@ -165,14 +165,14 @@ export function CreateStudyDialog({ open, onOpenChange, projectSlug }: CreateStu
                             render={({ field }) => (
                                 <FormItem>
                                     <FormLabel className="text-2xs font-black text-slate-500">
-                                        {t('admin.dialogs.create_study.study_title', 'Study Title')}
+                                        {t('admin.dialogs.create_study.study_title', 'Study title')}
                                     </FormLabel>
                                     <FormControl>
                                         <Input
                                             className="h-11 rounded-xl bg-slate-50 border-slate-100 focus-visible:ring-indigo-500 font-medium"
                                             placeholder={t(
                                                 'admin.dialogs.create_study.study_title_placeholder',
-                                                'e.g. Perspectives on AI'
+                                                'E.g. Perspectives on AI'
                                             )}
                                             {...field}
                                         />
@@ -188,7 +188,7 @@ export function CreateStudyDialog({ open, onOpenChange, projectSlug }: CreateStu
                             render={({ field }) => (
                                 <FormItem>
                                     <FormLabel className="text-2xs font-black text-slate-500">
-                                        {t('admin.dialogs.create_study.url_slug', 'URL Slug')}
+                                        {t('admin.dialogs.create_study.url_slug', 'URL slug')}
                                     </FormLabel>
                                     <FormControl>
                                         <Input
@@ -292,7 +292,7 @@ export function CreateStudyDialog({ open, onOpenChange, projectSlug }: CreateStu
                                 {createStudyMutation.isPending && (
                                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                                 )}
-                                {t('admin.dialogs.create_study.create', 'Create Study')}
+                                {t('admin.dialogs.create_study.create', 'Create study')}
                             </Button>
                         </DialogFooter>
                     </form>

--- a/frontend/src/components/admin/ImportStudyDialog.tsx
+++ b/frontend/src/components/admin/ImportStudyDialog.tsx
@@ -181,7 +181,7 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
             <DialogContent className="sm:max-w-[600px]">
                 <DialogHeader>
                     <DialogTitle>
-                        {t('admin.import.title', 'Import Study Configuration')}
+                        {t('admin.import.title', 'Import study configuration')}
                     </DialogTitle>
                     <DialogDescription>
                         {step === 'upload' &&
@@ -208,7 +208,7 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
                         >
                             <TabsList className="grid w-full grid-cols-2">
                                 <TabsTrigger value="file">
-                                    {t('admin.import.file_upload', 'File Upload')}
+                                    {t('admin.import.file_upload', 'File upload')}
                                 </TabsTrigger>
                                 <TabsTrigger value="paste">
                                     {t('admin.import.paste_json', 'Paste JSON')}
@@ -255,7 +255,7 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
                                     />
                                 </div>
                                 <Button onClick={handlePasteSubmit} className="w-full">
-                                    {t('admin.import.validate', 'Validate & Continue')}
+                                    {t('admin.import.validate', 'Validate & continue')}
                                 </Button>
                             </TabsContent>
                         </Tabs>
@@ -328,7 +328,7 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
                             <>
                                 <div className="space-y-3 p-4 bg-gray-50 rounded-lg border">
                                     <h4 className="font-semibold text-sm">
-                                        {t('admin.import.summary', 'Study Summary')}
+                                        {t('admin.import.summary', 'Study summary')}
                                     </h4>
                                     <dl className="grid grid-cols-2 gap-3 text-sm">
                                         <div>
@@ -365,7 +365,7 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
                                         </div>
                                         <div>
                                             <dt className="text-gray-500 text-xs">
-                                                {t('admin.import.grid', 'Grid Range')}
+                                                {t('admin.import.grid', 'Grid range')}
                                             </dt>
                                             <dd className="font-medium mt-1">
                                                 {validation.summary.grid_range}
@@ -376,7 +376,7 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
 
                                 <div className="space-y-2 pb-2">
                                     <Label htmlFor="new-slug">
-                                        {t('admin.import.new_slug', 'New Study Slug')}{' '}
+                                        {t('admin.import.new_slug', 'New study slug')}{' '}
                                         <span className="text-red-500">*</span>
                                     </Label>
                                     <Input
@@ -423,7 +423,7 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
                                 onClick={handleImport}
                                 disabled={!validation?.valid || !newSlug}
                             >
-                                {t('admin.import.create_study', 'Create Study')}
+                                {t('admin.import.create_study', 'Create study')}
                             </Button>
                         </>
                     )}

--- a/frontend/src/components/admin/analysis/FactorCharacteristicsTable.tsx
+++ b/frontend/src/components/admin/analysis/FactorCharacteristicsTable.tsx
@@ -71,19 +71,19 @@ export function FactorCharacteristicsTable({ result }: FactorCharacteristicsTabl
             })),
         },
         {
-            label: t('admin.analysis.variance_explained', 'Variance Explained (%)'),
+            label: t('admin.analysis.variance_explained', 'Variance explained (%)'),
             values: chars.map((c) => c.variance_explained.toFixed(1)),
         },
         {
-            label: t('admin.analysis.cumulative_variance', 'Cumulative Variance (%)'),
+            label: t('admin.analysis.cumulative_variance', 'Cumulative variance (%)'),
             values: chars.map((c) => c.cumulative_variance.toFixed(1)),
         },
         {
-            label: t('admin.analysis.n_flagged', 'N Flagged Sorts'),
+            label: t('admin.analysis.n_flagged', 'N flagged sorts'),
             values: chars.map((c) => String(c.n_flagged)),
         },
         {
-            label: t('admin.analysis.composite_reliability', 'Composite Reliability'),
+            label: t('admin.analysis.composite_reliability', 'Composite reliability'),
             values: chars.map((c) => c.composite_reliability.toFixed(3)),
             benchmark: chars.map((c) => ({
                 value: c.composite_reliability,
@@ -92,7 +92,7 @@ export function FactorCharacteristicsTable({ result }: FactorCharacteristicsTabl
             })),
         },
         {
-            label: t('admin.analysis.se_factor_scores', 'SE of Factor Scores'),
+            label: t('admin.analysis.se_factor_scores', 'SE of factor scores'),
             values: chars.map((c) => c.se_factor_scores.toFixed(3)),
             benchmark: chars.map((c) => ({
                 value: c.se_factor_scores,
@@ -119,7 +119,7 @@ export function FactorCharacteristicsTable({ result }: FactorCharacteristicsTabl
                 <div className="overflow-x-auto">
                     <div className="flex items-center gap-2 mb-2">
                         <h4 className="text-sm font-medium text-slate-700">
-                            {t('admin.analysis.factor_statistics', 'Factor Statistics')}
+                            {t('admin.analysis.factor_statistics', 'Factor statistics')}
                         </h4>
                         <TooltipProvider delayDuration={300}>
                             <Tooltip>
@@ -210,7 +210,7 @@ export function FactorCharacteristicsTable({ result }: FactorCharacteristicsTabl
             {result.n_factors >= 2 && (
                 <div>
                     <h4 className="text-sm font-medium text-slate-700 mb-2">
-                        {t('admin.analysis.factor_correlations', 'Factor Correlations')}
+                        {t('admin.analysis.factor_correlations', 'Factor correlations')}
                     </h4>
                     <div className="relative">
                         <div className="overflow-x-auto">
@@ -288,7 +288,7 @@ export function FactorCharacteristicsTable({ result }: FactorCharacteristicsTabl
             {/* Summary stats */}
             <div className="flex flex-wrap gap-4 text-xs text-slate-500 pt-2 border-t border-slate-100">
                 <span>
-                    {t('admin.analysis.total_variance', 'Total Variance Explained')}:{' '}
+                    {t('admin.analysis.total_variance', 'Total variance explained')}:{' '}
                     {result.total_variance_explained.toFixed(1)}%
                 </span>
                 <span>

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -396,7 +396,7 @@ export function buildColumns({
                                 )}
                             >
                                 <Clock className="w-3.5 h-3.5 mr-2" />
-                                {t('admin.data.status.in_progress', 'In Progress')}
+                                {t('admin.data.status.in_progress', 'In progress')}
                             </DropdownMenuItem>
                             <DropdownMenuItem
                                 onClick={() => {

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -343,7 +343,7 @@ export default function InteractiveDataView({
                                     <Clock className="w-5 h-5" />
                                 </div>
                                 <span className="text-xs font-bold text-slate-500">
-                                    {t('admin.data.stats.in_progress', 'In Progress')}
+                                    {t('admin.data.stats.in_progress', 'In progress')}
                                 </span>
                             </div>
 
@@ -689,7 +689,7 @@ export default function InteractiveDataView({
                                     className="font-bold cursor-pointer text-indigo-600 bg-indigo-50/50 gap-2"
                                 >
                                     <Package className="h-4 w-4" />
-                                    {t('admin.export.formats.package', 'Research Package (ZIP)')}
+                                    {t('admin.export.formats.package', 'Research package (ZIP)')}
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
                                     disabled={isExportLoading}
@@ -746,7 +746,7 @@ export default function InteractiveDataView({
                                     className="font-medium cursor-pointer gap-2"
                                 >
                                     <FileCode className="h-4 w-4" />
-                                    {t('admin.export.formats.json', 'JSON Dump')}
+                                    {t('admin.export.formats.json', 'JSON dump')}
                                 </DropdownMenuItem>
                             </DropdownMenuContent>
                         </DropdownMenu>

--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
@@ -231,7 +231,7 @@ export function ParticipantDetailContent({
         <div className="flex flex-col h-full bg-white">
             <div className="p-4 border-b border-slate-100 bg-slate-50/50">
                 <h3 className="text-xs font-black text-slate-500">
-                    {t('admin.participant.grid.detail_view', 'Card Details')}
+                    {t('admin.participant.grid.detail_view', 'Card details')}
                 </h3>
             </div>
             <div className="flex-1 p-3 sm:p-6 overflow-y-auto custom-scrollbar">
@@ -284,7 +284,7 @@ export function ParticipantDetailContent({
                             <div className="space-y-2">
                                 <div className="flex items-center gap-2 text-indigo-600 font-bold text-xs">
                                     <Mic className="w-3.5 h-3.5" />
-                                    {t('admin.audio.recording', 'Audio Recording')}
+                                    {t('admin.audio.recording', 'Audio recording')}
                                 </div>
                                 <AudioPlayer
                                     url={detailAudio.presigned_url}
@@ -372,12 +372,12 @@ export function ParticipantDetailContent({
                                         {t(
                                             `admin.participant.tabs.${tab}`,
                                             tab === 'presort'
-                                                ? 'Pre-Sort'
+                                                ? 'Pre-sort'
                                                 : tab === 'grid'
-                                                  ? 'Q-Sort Grid'
+                                                  ? 'Q-sort grid'
                                                   : tab === 'session'
-                                                    ? 'Session Metadata'
-                                                    : 'Post-Sort'
+                                                    ? 'Metadata'
+                                                    : 'Post-sort'
                                         )}
                                     </span>
                                 </div>
@@ -414,8 +414,8 @@ export function ParticipantDetailContent({
                                 disabled={isExporting}
                                 onClick={handleExportAudio}
                                 className="h-11 w-11 sm:h-auto sm:w-auto p-0 sm:p-2 text-slate-500 hover:text-indigo-600"
-                                title={t('admin.export.audio', 'Export Audio (ZIP)')}
-                                aria-label={t('admin.export.audio', 'Export Audio (ZIP)')}
+                                title={t('admin.export.audio', 'Export audio (ZIP)')}
+                                aria-label={t('admin.export.audio', 'Export audio (ZIP)')}
                             >
                                 <FileArchive className="w-5 h-5 sm:w-4 sm:h-4" />
                             </Button>
@@ -461,7 +461,7 @@ export function ParticipantDetailContent({
                                         <div className="w-1.5 h-1.5 rounded-full bg-indigo-500" />
                                         {t(
                                             'admin.participant.survey.presort',
-                                            'Pre-Sort Questions'
+                                            'Pre-sort questions'
                                         )}
                                     </h3>
                                     <SurveyResponseTable
@@ -492,7 +492,7 @@ export function ParticipantDetailContent({
                                 qsort={qsortForGridSort}
                                 conditionOfInstruction={t(
                                     'admin.participant.grid.read_only_mode',
-                                    'Viewer Mode'
+                                    'Viewer mode'
                                 )}
                                 sidebarContent={sidebarContent}
                                 onInteractionUtils={handleInteractionUtils}
@@ -544,7 +544,7 @@ export function ParticipantDetailContent({
                                         <div className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
                                         {t(
                                             'admin.participant.survey.postsort',
-                                            'Post-Sort Questions'
+                                            'Post-sort questions'
                                         )}
                                     </h3>
                                     <SurveyResponseTable
@@ -562,7 +562,7 @@ export function ParticipantDetailContent({
                                             <div className="w-1.5 h-1.5 rounded-full bg-violet-500" />
                                             {t(
                                                 'admin.participant.survey.audio_recordings',
-                                                'Audio Recordings'
+                                                'Audio recordings'
                                             )}
                                         </h3>
                                         <div className="space-y-3">

--- a/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
@@ -88,7 +88,7 @@ export function ParticipantMetadataCard({
                     <div className="flex items-center gap-2">
                         <Fingerprint className="h-5 w-5 text-indigo-500" />
                         <CardTitle className="text-base sm:text-lg font-black text-slate-900">
-                            {t('admin.participant.metadata.title', 'Session Metadata')}
+                            {t('admin.participant.metadata.title', 'Session metadata')}
                         </CardTitle>
                     </div>
 
@@ -190,7 +190,7 @@ export function ParticipantMetadataCard({
                 </div>
                 <div className="space-y-4">
                     <h4 className="text-2xs font-black text-slate-500">
-                        {t('admin.participant.metadata.session', 'Session Details')}
+                        {t('admin.participant.metadata.session', 'Session details')}
                     </h4>
                     <div className="space-y-3">
                         <div className="flex items-center gap-3">
@@ -217,7 +217,7 @@ export function ParticipantMetadataCard({
                                         : '---'}
                                 </p>
                                 <p className="text-2xs text-slate-500 font-bold mt-1">
-                                    {t('admin.participant.metadata.duration', 'Total Duration')}
+                                    {t('admin.participant.metadata.duration', 'Total duration')}
                                 </p>
                             </div>
                         </div>
@@ -280,7 +280,7 @@ export function ParticipantMetadataCard({
                                     <p className="text-2xs text-slate-500 font-bold mt-1">
                                         {t(
                                             'admin.participant.metadata.recruitment_link',
-                                            'Recruitment Link'
+                                            'Recruitment link'
                                         )}
                                     </p>
                                 </div>
@@ -296,7 +296,7 @@ export function ParticipantMetadataCard({
                                         {participant.ip_address.substring(0, 16)}...
                                     </p>
                                     <p className="text-2xs text-slate-500 font-bold mt-1">
-                                        {t('admin.participant.metadata.ip_hash', 'IP Hash')}
+                                        {t('admin.participant.metadata.ip_hash', 'IP hash')}
                                     </p>
                                 </div>
                             </div>

--- a/frontend/src/components/admin/dashboard/RecruitmentModule.tsx
+++ b/frontend/src/components/admin/dashboard/RecruitmentModule.tsx
@@ -67,7 +67,7 @@ const RecruitmentModule: React.FC<RecruitmentModuleProps> = ({ slug }) => {
             <CardContent className="p-4 space-y-4">
                 <div className="space-y-2">
                     <label htmlFor="public-url" className="text-2xs font-bold text-slate-500">
-                        {t('admin.recruitment.public_url_label', 'Public Participation URL')}
+                        {t('admin.recruitment.public_url_label', 'Public participation URL')}
                     </label>
                     <div className="flex gap-2 min-w-0">
                         <Input
@@ -121,7 +121,7 @@ const RecruitmentModule: React.FC<RecruitmentModuleProps> = ({ slug }) => {
                     >
                         <ExternalLink className="h-4 w-4 shrink-0" />
                         <span className="min-w-0 break-words">
-                            {t('admin.recruitment.live_study', 'Live Study')}
+                            {t('admin.recruitment.live_study', 'Live study')}
                         </span>
                     </Button>
                 </div>
@@ -155,7 +155,7 @@ const RecruitmentModule: React.FC<RecruitmentModuleProps> = ({ slug }) => {
                             >
                                 <Download className="h-3.5 w-3.5 shrink-0" />
                                 <span className="min-w-0 break-words">
-                                    {t('admin.recruitment.download_qr', 'Download Image')}
+                                    {t('admin.recruitment.download_qr', 'Download image')}
                                 </span>
                             </Button>
 

--- a/frontend/src/components/admin/dashboard/StudyStatusControl.tsx
+++ b/frontend/src/components/admin/dashboard/StudyStatusControl.tsx
@@ -233,39 +233,39 @@ const StudyStatusControl: React.FC<StudyStatusControlProps> = ({
     ) => {
         const config = {
             draft: {
-                title: t('admin.study_status.dialog.draft.title', 'Revert to Draft?'),
+                title: t('admin.study_status.dialog.draft.title', 'Revert to draft?'),
                 desc: t(
                     'admin.study_status.dialog.draft.desc',
                     'This will stop data collection but allow you to modify the study design. Existing data is preserved.'
                 ),
-                action: t('admin.study_status.dialog.draft.action', 'Revert to Draft'),
+                action: t('admin.study_status.dialog.draft.action', 'Revert to draft'),
                 variant: 'default' as const,
             },
             active: {
-                title: t('admin.study_status.dialog.active.title', 'Launch Study?'),
+                title: t('admin.study_status.dialog.active.title', 'Launch study?'),
                 desc: t(
                     'admin.study_status.dialog.active.desc',
                     'Activating the study will open it to participants.'
                 ),
-                action: t('admin.study_status.dialog.active.action', 'Set to Active'),
+                action: t('admin.study_status.dialog.active.action', 'Set to active'),
                 variant: 'default' as const,
             },
             paused: {
-                title: t('admin.study_status.dialog.paused.title', 'Pause Study?'),
+                title: t('admin.study_status.dialog.paused.title', 'Pause study?'),
                 desc: t(
                     'admin.study_status.dialog.paused.desc',
                     'Participants will not be able to enter the study while it is paused. You can resume later.'
                 ),
-                action: t('admin.study_status.dialog.paused.action', 'Pause Study'),
+                action: t('admin.study_status.dialog.paused.action', 'Pause study'),
                 variant: 'destructive', // Warning color
             },
             closed: {
-                title: t('admin.study_status.dialog.closed.title', 'Close Study?'),
+                title: t('admin.study_status.dialog.closed.title', 'Close study?'),
                 desc: t(
                     'admin.study_status.dialog.closed.desc',
                     'This will prevent new participants from entering. Existing sessions can still finish. You can reopen later.'
                 ),
-                action: t('admin.study_status.dialog.closed.action', 'Close Study'),
+                action: t('admin.study_status.dialog.closed.action', 'Close study'),
                 variant: 'destructive',
             },
         }[targetState];

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.test.ts
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.test.ts
@@ -39,7 +39,7 @@ describe('resolveAnswerLabel', () => {
     });
 
     it('returns t() fallback for "_recruitment_token"', () => {
-        expect(resolveAnswerLabel({}, '_recruitment_token', 'en', t)).toBe('Ref');
+        expect(resolveAnswerLabel({}, '_recruitment_token', 'en', t)).toBe('Recruitment token');
     });
 
     it('returns t() fallback for "missing_statement"', () => {

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.ts
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.ts
@@ -35,7 +35,7 @@ export function resolveAnswerLabel(
     if (key === 'interview_consent') return t('post.contact.interview_consent', 'Follow-up');
     if (key === 'newsletter_consent') return t('post.contact.newsletter_consent', 'Results');
     if (key === '_recruitment_token')
-        return t('admin.participant.metadata.recruitment_token', 'Ref');
+        return t('admin.participant.metadata.recruitment_token', 'Recruitment token');
     if (key === 'missing_statement')
         return t('post.extreme.missing_statement', 'Missing Statement');
     if (key === 'general_comment') return t('post.extreme.general_comment', 'General Comment');

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.tsx
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.tsx
@@ -162,25 +162,25 @@ export function SurveyResponseTable({
     // Define potential groups
     groups.push({
         id: 'identity',
-        title: t('admin.participant.survey.categories.identity', 'Identity & Contact'),
+        title: t('admin.participant.survey.categories.identity', 'Identity & contact'),
         icon: <UserIcon className="w-4 h-4" />,
         items: [],
     });
     groups.push({
         id: 'questions',
-        title: t('admin.participant.survey.categories.questions', 'Questionnaire Responses'),
+        title: t('admin.participant.survey.categories.questions', 'Questionnaire responses'),
         icon: <SurveyIcon className="w-4 h-4" />,
         items: [],
     });
     groups.push({
         id: 'comments',
-        title: t('admin.participant.survey.categories.comments', 'Card Comments'),
+        title: t('admin.participant.survey.categories.comments', 'Card comments'),
         icon: <MessageIcon className="w-4 h-4" />,
         items: [],
     });
     groups.push({
         id: 'feedback',
-        title: t('admin.participant.survey.categories.feedback', 'General Feedback'),
+        title: t('admin.participant.survey.categories.feedback', 'General feedback'),
         icon: <FeedbackIcon className="w-4 h-4" />,
         items: [],
     });

--- a/frontend/src/components/admin/dashboard/charts/DeviceBreakdownChart.tsx
+++ b/frontend/src/components/admin/dashboard/charts/DeviceBreakdownChart.tsx
@@ -48,7 +48,7 @@ export const DeviceBreakdownChart = ({ deviceBreakdown, className }: DeviceBreak
         <Card className={className}>
             <CardHeader className="pb-2">
                 <CardTitle className="text-base font-black">
-                    {t('admin.dashboard.devices.title', 'Device Distribution')}
+                    {t('admin.dashboard.devices.title', 'Device distribution')}
                 </CardTitle>
                 <CardDescription>
                     {t('admin.dashboard.devices.subtitle', 'How participants access your study')}

--- a/frontend/src/components/admin/dashboard/charts/SubmissionsTimelineChart.tsx
+++ b/frontend/src/components/admin/dashboard/charts/SubmissionsTimelineChart.tsx
@@ -94,7 +94,7 @@ export const SubmissionsTimelineChart = ({
             <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-2 sm:space-y-0 pb-2">
                 <div className="space-y-1">
                     <CardTitle className="text-base font-black flex items-center gap-2">
-                        {t('admin.dashboard.timeline.title', 'Submissions Timeline')}
+                        {t('admin.dashboard.timeline.title', 'Submissions timeline')}
                     </CardTitle>
                     <CardDescription>
                         {t('admin.dashboard.timeline.subtitle', 'Daily participation trends')}

--- a/frontend/src/components/admin/designer/BrandingEditor.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.tsx
@@ -236,7 +236,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                     <ImageIcon className="h-4 w-4 text-indigo-500" />
                                     {t(
                                         'admin.design.theme.partners.title',
-                                        'Institutional Partners'
+                                        'Institutional partners'
                                     )}
                                 </CardTitle>
                                 <TooltipProvider>
@@ -384,7 +384,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                     className="w-full flex items-center justify-center gap-2 py-4 border-2 border-dashed border-slate-200 rounded-2xl text-slate-500 hover:text-indigo-600 hover:border-indigo-300 hover:bg-indigo-50/50 transition-all font-bold text-sm disabled:opacity-50"
                                 >
                                     <Plus className="size-4" />
-                                    {t('admin.design.theme.partners.add', 'Add Partner')}
+                                    {t('admin.design.theme.partners.add', 'Add partner')}
                                 </button>
                             </div>
 

--- a/frontend/src/components/admin/designer/ConditionOfInstructionEditor.test.tsx
+++ b/frontend/src/components/admin/designer/ConditionOfInstructionEditor.test.tsx
@@ -35,8 +35,8 @@ describe('ConditionOfInstructionEditor', () => {
     it('renders instruction input', () => {
         renderEditor();
 
-        // Check for Q-Sort instruction
-        expect(screen.getByText('Q-Sort instruction')).toBeInTheDocument();
+        // Check for Q-sort instruction
+        expect(screen.getByText('Q-sort instruction')).toBeInTheDocument();
 
         // Check for Preliminary sort instruction
         expect(screen.getByText('Preliminary sort instruction')).toBeInTheDocument();

--- a/frontend/src/components/admin/designer/ConditionOfInstructionEditor.tsx
+++ b/frontend/src/components/admin/designer/ConditionOfInstructionEditor.tsx
@@ -139,7 +139,7 @@ const ConditionOfInstructionEditor = ({
         ) || {};
 
     const roughSortOn = isRoughSortEnabled(draft);
-    const fieldLabel = t('admin.design.condition.field_label', 'Instruction Text');
+    const fieldLabel = t('admin.design.condition.field_label', 'Instruction text');
     const resetLabel = t('common.reset_to_default');
 
     return (
@@ -218,7 +218,7 @@ const ConditionOfInstructionEditor = ({
                                 id="pre_instruction"
                                 title={t(
                                     'admin.design.condition.pre_title',
-                                    'Preliminary Sort Instruction'
+                                    'Preliminary sort instruction'
                                 )}
                                 description={t(
                                     'admin.design.condition.pre_desc',
@@ -241,10 +241,10 @@ const ConditionOfInstructionEditor = ({
 
                         <InstructionField
                             id="condition_of_instruction"
-                            title={t('admin.design.condition.grid_title', 'Q-Sort Instruction')}
+                            title={t('admin.design.condition.grid_title', 'Q-sort instruction')}
                             description={t(
                                 'admin.design.condition.grid_desc',
-                                'This is the core instruction guiding participants during the Q-Sort process.'
+                                'This is the core instruction guiding participants during the Q-sort process.'
                             )}
                             placeholder={t(
                                 'admin.design.condition.placeholder',

--- a/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
+++ b/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
@@ -159,7 +159,7 @@ export function ImportFromConcourseDialog({
                 <DialogHeader>
                     <DialogTitle className="text-lg font-black text-slate-900 flex items-center gap-2">
                         <Library className="size-5 text-indigo-600" />
-                        {t('admin.concourse_import.title', 'Import from Concourse')}
+                        {t('admin.concourse_import.title', 'Import from concourse')}
                     </DialogTitle>
                     <DialogDescription className="text-sm text-slate-500">
                         {t(

--- a/frontend/src/components/admin/designer/IntroductionEditor.test.tsx
+++ b/frontend/src/components/admin/designer/IntroductionEditor.test.tsx
@@ -99,7 +99,7 @@ describe('IntroductionEditor — field accessible names (Task 6.7b)', () => {
             initialState: { draft: mockDraft, activeLocale: 'en' },
         });
 
-    it('names the "Default Language" select and lets its label open it', async () => {
+    it('names the "Default language" select and lets its label open it', async () => {
         const user = userEvent.setup();
         renderEditor();
 
@@ -108,7 +108,7 @@ describe('IntroductionEditor — field accessible names (Task 6.7b)', () => {
         const trigger = screen.getByRole('combobox', { name: /default language/i });
         expect(trigger).toHaveAttribute('aria-expanded', 'false');
 
-        await user.click(screen.getByText('Default Language'));
+        await user.click(screen.getByText('Default language'));
         expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
 

--- a/frontend/src/components/admin/designer/LanguageManagerModal.tsx
+++ b/frontend/src/components/admin/designer/LanguageManagerModal.tsx
@@ -75,7 +75,7 @@ const LanguageManagerModal = ({ isOpen, onClose }: LanguageManagerModalProps) =>
                             <Languages className="h-5 w-5" />
                         </div>
                         <DialogTitle>
-                            {t('admin.design.languages.manage_title', 'Manage Languages')}
+                            {t('admin.design.languages.manage_title', 'Manage languages')}
                         </DialogTitle>
                     </div>
                     <DialogDescription>

--- a/frontend/src/components/admin/designer/MultiLangFieldIcon.tsx
+++ b/frontend/src/components/admin/designer/MultiLangFieldIcon.tsx
@@ -59,7 +59,7 @@ export const MultiLangFieldIcon = ({
                 className="w-80 max-h-[400px] overflow-y-auto rounded-xl shadow-xl border-slate-100 p-2"
             >
                 <DropdownMenuLabel className="text-2xs font-black text-slate-500 px-2 py-1.5">
-                    {t('admin.design.multilang.other_formulations', 'Other Formulations')}
+                    {t('admin.design.multilang.other_formulations', 'Other formulations')}
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator className="bg-slate-100 my-1" />
                 {otherTranslations.map((trans) => (

--- a/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
+++ b/frontend/src/components/admin/designer/PostSortConfigEditor.tsx
@@ -524,7 +524,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                     >
                                         <Mic className="w-5 h-5 text-indigo-600" />
                                         {t('admin.design.postsort.audio.title') ||
-                                            'Audio Recording'}
+                                            'Audio recording'}
                                     </Label>
                                     <CardDescription className="text-sm font-medium text-slate-500 leading-relaxed">
                                         {t('admin.design.postsort.audio.desc') ||
@@ -587,7 +587,7 @@ const PostSortConfigEditor = ({ readOnly, structureLocked }: PostSortConfigEdito
                                         className="text-sm font-bold text-slate-700"
                                     >
                                         {t('admin.design.postsort.audio.max_duration') ||
-                                            'Maximum Duration'}
+                                            'Maximum duration'}
                                     </Label>
                                     <div className="flex items-center gap-3">
                                         <Input

--- a/frontend/src/components/admin/designer/QSortEditor.test.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.test.tsx
@@ -74,7 +74,7 @@ describe('QSortEditor', () => {
             await user.click(distributionTab);
 
             // UI should switch to grid config
-            expect(screen.getByText('Q-Sort distribution grid')).toBeInTheDocument();
+            expect(screen.getByText('Q-sort distribution grid')).toBeInTheDocument();
         });
 
         it('displays statements tab content by default', () => {
@@ -372,7 +372,7 @@ describe('QSortEditor', () => {
     describe('Grid Configuration', () => {
         it('displays grid columns', () => {
             renderEditor({ activeSubStep: 'grid' });
-            expect(screen.getByText('Q-Sort distribution grid')).toBeInTheDocument();
+            expect(screen.getByText('Q-sort distribution grid')).toBeInTheDocument();
             // Should see input fields for the grid
             // (Assuming grid editor renders inputs implies it's working)
         });
@@ -388,7 +388,7 @@ describe('QSortEditor', () => {
     describe('Validation & Distribution', () => {
         it('validates grid total matches statement count', () => {
             renderEditor({ activeSubStep: 'grid' });
-            expect(screen.getByText('Q-Sort distribution grid')).toBeInTheDocument();
+            expect(screen.getByText('Q-sort distribution grid')).toBeInTheDocument();
         });
 
         it('maintains symmetry when symmetry lock is enabled', async () => {

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -940,7 +940,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                         <Library className="h-4 w-4" />
                                         {t(
                                             'admin.concourse_import.button_label',
-                                            'Import from Concourse'
+                                            'Import from concourse'
                                         )}
                                     </Button>
                                 )}
@@ -979,7 +979,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                             className="text-slate-500 hover:text-indigo-600 hover:bg-indigo-50 h-9 px-4 gap-2 rounded-xl font-bold transition-all"
                                         >
                                             <RotateCcw className="h-4 w-4" />
-                                            {t('admin.design.qsort.set.reset_codes', 'Reset Codes')}
+                                            {t('admin.design.qsort.set.reset_codes', 'Reset codes')}
                                         </Button>
                                         <Button
                                             variant="ghost"

--- a/frontend/src/components/admin/designer/UnsavedChangesDialog.tsx
+++ b/frontend/src/components/admin/designer/UnsavedChangesDialog.tsx
@@ -28,7 +28,7 @@ export function UnsavedChangesDialog({ blocker }: UnsavedChangesDialogProps) {
             <AlertDialogContent>
                 <AlertDialogHeader>
                     <AlertDialogTitle>
-                        {t('admin.design.unsaved_changes.title', 'Unsaved Changes')}
+                        {t('admin.design.unsaved_changes.title', 'Unsaved changes')}
                     </AlertDialogTitle>
                     <AlertDialogDescription>
                         {t(

--- a/frontend/src/components/postsort/Step1_Feedback.tsx
+++ b/frontend/src/components/postsort/Step1_Feedback.tsx
@@ -661,7 +661,7 @@ export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
                 >
                     {isUploadInProgress
                         ? t('audio.uploading', 'Uploading...')
-                        : t('common.next', 'Next Step')}
+                        : t('common.next', 'Next step')}
                     {!isUploadInProgress && <ArrowRight size={18} className="ml-2" />}
                 </Button>
             </div>

--- a/frontend/src/components/ui/sidebar.test.tsx
+++ b/frontend/src/components/ui/sidebar.test.tsx
@@ -18,24 +18,24 @@ import { Sidebar, SidebarProvider, SidebarTrigger } from '@/components/ui/sideba
 // click behavior (which state it toggles) differs.
 vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => true }));
 
-// SidebarTrigger's sr-only text ("Toggle Sidebar") and the mobile sheet's
+// SidebarTrigger's sr-only text ("Toggle sidebar") and the mobile sheet's
 // sr-only title/description ("Sidebar" / "Displays the mobile sidebar.")
 // were hardcoded English literals. AdminLayout renders SidebarTrigger on
 // every admin page; the mobile sheet renders whenever the admin chrome is
 // viewed below the md breakpoint.
 describe('SidebarTrigger', () => {
-    it('exposes a computed accessible name of "Toggle Sidebar"', () => {
+    it('exposes a computed accessible name of "Toggle sidebar"', () => {
         renderWithProviders(
             <SidebarProvider>
                 <SidebarTrigger />
             </SidebarProvider>
         );
 
-        expect(screen.getByRole('button', { name: 'Toggle Sidebar' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Toggle sidebar' })).toBeInTheDocument();
     });
 
     // The English name alone can't distinguish a real t() call from a
-    // literal that happens to already read "Toggle Sidebar" in English.
+    // literal that happens to already read "Toggle sidebar" in English.
     // Assert the real fr/admin.json translation.
     it("resolves to the researcher's active language, not just English", async () => {
         i18n.addResourceBundle('fr', 'admin', frAdmin, true, true);
@@ -69,7 +69,7 @@ describe('Sidebar mobile sheet', () => {
             </SidebarProvider>
         );
 
-        await user.click(screen.getByRole('button', { name: 'Toggle Sidebar' }));
+        await user.click(screen.getByRole('button', { name: 'Toggle sidebar' }));
 
         const dialog = await screen.findByRole('dialog', { name: 'Sidebar' });
         expect(dialog).toBeInTheDocument();

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -286,7 +286,7 @@ const SidebarTrigger = React.forwardRef<
             {...props}
         >
             <PanelLeft />
-            <span className="sr-only">{t('admin.sidebar.toggle', 'Toggle Sidebar')}</span>
+            <span className="sr-only">{t('admin.sidebar.toggle', 'Toggle sidebar')}</span>
         </Button>
     );
 });
@@ -300,10 +300,10 @@ const SidebarRail = React.forwardRef<HTMLButtonElement, React.ComponentProps<'bu
             <button
                 ref={ref}
                 data-sidebar="rail"
-                aria-label="Toggle Sidebar"
+                aria-label="Toggle sidebar"
                 tabIndex={-1}
                 onClick={toggleSidebar}
-                title="Toggle Sidebar"
+                title="Toggle sidebar"
                 className={cn(
                     'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
                     '[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',

--- a/frontend/src/hooks/admin/useStudyDesignPage.ts
+++ b/frontend/src/hooks/admin/useStudyDesignPage.ts
@@ -220,12 +220,12 @@ function buildChecklist(
 ): ChecklistItem[] {
     return [
         {
-            label: t('admin.design.checklist.study_title', 'Study Title'),
+            label: t('admin.design.checklist.study_title', 'Study title'),
             isComplete: !!currentTranslation?.title,
             required: true,
         },
         {
-            label: t('admin.design.checklist.consent_defined', 'Consent Form'),
+            label: t('admin.design.checklist.consent_defined', 'Consent form'),
             isComplete: !!(
                 currentTranslation?.consent_title && currentTranslation?.consent_description
             ),
@@ -455,7 +455,7 @@ export function useStudyDesignPage(): StudyDesignPageApi {
 
         if (isDirty) {
             toast.warning(
-                t('admin.design.sync.wait_save', 'Saving in progress... please wait a moment.')
+                t('admin.design.sync.wait_save', 'Saving in progress... Please wait a moment.')
             );
             return;
         }

--- a/frontend/src/pages/ConsentPage.tsx
+++ b/frontend/src/pages/ConsentPage.tsx
@@ -201,7 +201,7 @@ const ConsentPage: React.FC = () => {
                     >
                         <span className="min-w-0 break-words [overflow-wrap:anywhere]">
                             {config.ui_labels?.['welcome.start'] ||
-                                t('welcome.start', 'Get Started')}
+                                t('welcome.start', 'Get started')}
                         </span>
                         <ArrowRight size={18} className="shrink-0" />
                     </button>

--- a/frontend/src/pages/ResearcherHub.tsx
+++ b/frontend/src/pages/ResearcherHub.tsx
@@ -68,7 +68,7 @@ export default function ResearcherHub() {
                     <div className="flex items-center justify-between">
                         <div>
                             <h1 className="text-2xl font-bold tracking-tight text-slate-900">
-                                {t('admin.hub.title', 'Researcher Hub')}
+                                {t('admin.hub.title', 'Researcher hub')}
                             </h1>
                             <p className="text-sm text-muted-foreground mt-0.5">
                                 {user?.full_name || user?.email}
@@ -77,7 +77,7 @@ export default function ResearcherHub() {
                         {hasProjects && (
                             <Button size="sm" onClick={() => navigate('/app/projects/new')}>
                                 <Plus className="h-3.5 w-3.5 mr-2" />
-                                {t('admin.hub.new_project', 'New Project')}
+                                {t('admin.hub.new_project', 'New project')}
                             </Button>
                         )}
                     </div>
@@ -226,7 +226,7 @@ export default function ResearcherHub() {
                             'Create a project before adding concourses, Q-sets, or studies.'
                         )}
                         cta={{
-                            label: t('admin.hub.new_project', 'New Project'),
+                            label: t('admin.hub.new_project', 'New project'),
                             onClick: () => navigate('/app/projects/new'),
                         }}
                         variant="card"

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -295,7 +295,7 @@ const WelcomePage: React.FC<WelcomePageProps> = ({ highlightKey }) => {
                     )}
                 >
                     <span className="min-w-0 break-words [overflow-wrap:anywhere]">
-                        {config.ui_labels?.['welcome.start'] || t('welcome.start', 'Get Started')}
+                        {config.ui_labels?.['welcome.start'] || t('welcome.start', 'Get started')}
                     </span>
                     <ArrowRight
                         size={20}

--- a/frontend/src/pages/admin/AccountSettingsPage.test.tsx
+++ b/frontend/src/pages/admin/AccountSettingsPage.test.tsx
@@ -50,7 +50,7 @@ describe('AccountSettingsPage 2FA (authenticator app)', () => {
 
     it('shows the QR code + 6-digit-code form on entering setup mode', async () => {
         renderWithProviders(<AccountSettingsPage />);
-        fireEvent.click(screen.getByRole('button', { name: /setup 2fa now/i }));
+        fireEvent.click(screen.getByRole('button', { name: /set up 2fa now/i }));
 
         await waitFor(() => {
             expect(screen.getByPlaceholderText('000000')).toBeInTheDocument();
@@ -61,7 +61,7 @@ describe('AccountSettingsPage 2FA (authenticator app)', () => {
 
     it('enabling calls the mutation with the entered token', async () => {
         renderWithProviders(<AccountSettingsPage />);
-        fireEvent.click(screen.getByRole('button', { name: /setup 2fa now/i }));
+        fireEvent.click(screen.getByRole('button', { name: /set up 2fa now/i }));
 
         const codeInput = await screen.findByPlaceholderText('000000');
         fireEvent.change(codeInput, { target: { value: '123456' } });
@@ -78,7 +78,7 @@ describe('AccountSettingsPage 2FA (authenticator app)', () => {
             configurable: true,
         });
         renderWithProviders(<AccountSettingsPage />);
-        fireEvent.click(screen.getByRole('button', { name: /setup 2fa now/i }));
+        fireEvent.click(screen.getByRole('button', { name: /set up 2fa now/i }));
 
         const copyButton = await screen.findByRole('button', { name: 'Copy secret' });
         fireEvent.click(copyButton);

--- a/frontend/src/pages/admin/AccountSettingsPage.tsx
+++ b/frontend/src/pages/admin/AccountSettingsPage.tsx
@@ -300,7 +300,7 @@ const AccountSettingsPage = () => {
                                     onClick={() => setIs2FASetupMode(true)}
                                     className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
                                 >
-                                    {t('admin.account.security.setup_cta', 'Setup 2FA now')}
+                                    {t('admin.account.security.setup_cta', 'Set up 2FA now')}
                                 </Button>
                             )}
 
@@ -328,7 +328,7 @@ const AccountSettingsPage = () => {
                                             <p className="text-sm text-slate-600 leading-relaxed">
                                                 {t(
                                                     'admin.account.security.scan_desc',
-                                                    '1. Scan this QR code with an authenticator app.'
+                                                    'Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)'
                                                 )}
                                             </p>
                                             <div className="p-3 bg-white rounded-lg border border-slate-200 font-mono text-xs flex items-center justify-between select-all group">

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -1251,7 +1251,7 @@ function InterpretShell({
                                 </TabsTrigger>
                                 <TabsTrigger value="arrays" className="gap-1.5">
                                     <Grid3X3 className="size-3.5" aria-hidden="true" />
-                                    {t('admin.analysis.tab_factor_arrays', 'Factor Arrays')}
+                                    {t('admin.analysis.tab_factor_arrays', 'Factor arrays')}
                                 </TabsTrigger>
                                 <TabsTrigger value="statements" className="gap-1.5">
                                     <List className="size-3.5" aria-hidden="true" />
@@ -1267,7 +1267,7 @@ function InterpretShell({
                                 <GuidanceCard
                                     title={t(
                                         'admin.analysis.guide_loadings_title',
-                                        'Reading Factor Loadings'
+                                        'Reading factor loadings'
                                     )}
                                     type="info"
                                     collapsible
@@ -1300,7 +1300,7 @@ function InterpretShell({
                                 <GuidanceCard
                                     title={t(
                                         'admin.analysis.guide_arrays_title',
-                                        'Interpreting Factor Arrays'
+                                        'Interpreting factor arrays'
                                     )}
                                     type="info"
                                     collapsible
@@ -1336,7 +1336,7 @@ function InterpretShell({
                                 <GuidanceCard
                                     title={t(
                                         'admin.analysis.guide_statements_title',
-                                        'Understanding Statement Scores'
+                                        'Understanding statement scores'
                                     )}
                                     type="info"
                                     collapsible
@@ -1364,7 +1364,7 @@ function InterpretShell({
                                 <GuidanceCard
                                     title={t(
                                         'admin.analysis.guide_summary_title',
-                                        'Evaluating Your Solution'
+                                        'Evaluating your solution'
                                     )}
                                     type="info"
                                     collapsible

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -258,11 +258,11 @@ export default function ConcourseDetailPage() {
                                 size="sm"
                                 className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white"
                                 onClick={openAddItemDialog}
-                                aria-label={t('admin.concourse.add_item', 'Add Item')}
+                                aria-label={t('admin.concourse.add_item', 'Add item')}
                             >
                                 <Plus className="size-4 sm:mr-1" />
                                 <span className="hidden sm:inline">
-                                    {t('admin.concourse.add_item', 'Add Item')}
+                                    {t('admin.concourse.add_item', 'Add item')}
                                 </span>
                             </Button>
                         )}
@@ -272,11 +272,11 @@ export default function ConcourseDetailPage() {
                                 size="sm"
                                 className="rounded-xl"
                                 onClick={openImportDialog}
-                                aria-label={t('admin.concourse.bulk_import', 'Bulk Import')}
+                                aria-label={t('admin.concourse.bulk_import', 'Bulk import')}
                             >
                                 <Upload className="size-4 sm:mr-1" />
                                 <span className="hidden sm:inline">
-                                    {t('admin.concourse.bulk_import', 'Bulk Import')}
+                                    {t('admin.concourse.bulk_import', 'Bulk import')}
                                 </span>
                             </Button>
                         )}
@@ -1212,7 +1212,7 @@ export default function ConcourseDetailPage() {
                 <DialogContent className="border-slate-200 bg-white shadow-lg max-w-md">
                     <DialogHeader>
                         <DialogTitle className="text-lg font-black text-slate-900">
-                            {t('admin.concourse.add_item', 'Add Item')}
+                            {t('admin.concourse.add_item', 'Add item')}
                         </DialogTitle>
                     </DialogHeader>
                     <div className="space-y-3 py-2">
@@ -1303,7 +1303,7 @@ export default function ConcourseDetailPage() {
                             >
                                 {t('admin.concourse.field_source', 'Source')}
                                 <span className="text-slate-500 font-normal ml-1">
-                                    ({t('common.optional', 'optional')})
+                                    ({t('common.optional', 'Optional')})
                                 </span>
                             </Label>
                             <Input
@@ -1408,7 +1408,7 @@ export default function ConcourseDetailPage() {
                 <DialogContent className="border-slate-200 bg-white shadow-lg max-w-sm">
                     <DialogHeader>
                         <DialogTitle className="text-lg font-black text-slate-900">
-                            {t('admin.concourse.delete_item_title', 'Delete Item')}
+                            {t('admin.concourse.delete_item_title', 'Delete item')}
                         </DialogTitle>
                         <DialogDescription className="text-sm text-slate-500">
                             {t(
@@ -1452,7 +1452,7 @@ export default function ConcourseDetailPage() {
                 <DialogContent className="border-slate-200 bg-white shadow-lg max-w-lg">
                     <DialogHeader>
                         <DialogTitle className="text-lg font-black text-slate-900">
-                            {t('admin.concourse.bulk_import', 'Bulk Import')}
+                            {t('admin.concourse.bulk_import', 'Bulk import')}
                         </DialogTitle>
                         <DialogDescription className="text-sm text-slate-500">
                             {t(

--- a/frontend/src/pages/admin/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/admin/GeneralSettingsPage.tsx
@@ -269,7 +269,7 @@ export default function GeneralSettingsPage() {
                             <div className="flex items-center gap-2 mb-1">
                                 <HardDrive className="h-5 w-5 text-indigo-500" />
                                 <CardTitle className="text-lg font-black text-slate-900">
-                                    {t('admin.settings.storage.title', 'Audio Storage Usage')}
+                                    {t('admin.settings.storage.title', 'Audio storage usage')}
                                 </CardTitle>
                             </div>
                         </CardHeader>
@@ -294,7 +294,7 @@ export default function GeneralSettingsPage() {
                                     <div className="space-y-3">
                                         <div className="flex justify-between items-baseline">
                                             <span className="text-sm font-medium text-slate-700">
-                                                {t('admin.settings.storage.used', 'Storage Used')}
+                                                {t('admin.settings.storage.used', 'Storage used')}
                                             </span>
                                             <span className="text-2xl font-bold text-slate-900">
                                                 {storageUsage.total_mb.toFixed(2)} MB
@@ -336,7 +336,7 @@ export default function GeneralSettingsPage() {
                                             <HardDrive className="w-3 h-3" />
                                             {t(
                                                 'admin.settings.storage.quota_label',
-                                                'Storage Quota'
+                                                'Storage quota'
                                             )}
                                         </label>
                                         <div className="flex items-center gap-3">

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -643,7 +643,7 @@ const RecruitmentPage = () => {
                                         className="bg-indigo-600 hover:bg-indigo-700 shadow-sm font-bold rounded-xl"
                                     >
                                         <Plus className="h-4 w-4 mr-1.5" />
-                                        {t('admin.recruitment.new_link', 'New Access Link')}
+                                        {t('admin.recruitment.new_link', 'New access link')}
                                     </Button>
                                 </DialogTrigger>
                                 <DialogContent className="sm:max-w-[425px]">
@@ -654,7 +654,7 @@ const RecruitmentPage = () => {
                                             </div>
                                             {t(
                                                 'admin.recruitment.create_title',
-                                                'Create Access Links'
+                                                'Create access links'
                                             )}
                                         </DialogTitle>
                                     </DialogHeader>

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -262,7 +262,7 @@ const StudyDesignPage = () => {
                                         <span>
                                             {t(
                                                 'admin.design.toolbar.manage_langs',
-                                                'Manage Languages'
+                                                'Manage languages'
                                             )}
                                         </span>
                                     </DropdownMenuItem>
@@ -544,7 +544,7 @@ const StudyDesignPage = () => {
                                     {api.isSwitchingToDraft && (
                                         <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                                     )}
-                                    {t('admin.study_status.state.switch_to_draft', 'Draft Mode')}
+                                    {t('admin.study_status.state.switch_to_draft', 'Draft mode')}
                                 </Button>
                             )}
                         </div>
@@ -595,7 +595,7 @@ const StudyDesignPage = () => {
                                         )}
                                         {t(
                                             'admin.study_status.state.switch_to_draft',
-                                            'Draft Mode'
+                                            'Draft mode'
                                         )}
                                     </Button>
                                 )}
@@ -801,7 +801,7 @@ const StudyDesignPage = () => {
                                 <GuidanceCard
                                     title={t(
                                         'admin.design.guidance.intro_title',
-                                        'Welcome to the Studio'
+                                        'Welcome to the studio'
                                     )}
                                     description={t(
                                         'admin.design.guidance.intro_desc',
@@ -852,7 +852,7 @@ const StudyDesignPage = () => {
                                                 >
                                                     {t(
                                                         'admin.design.qsort.grid.unlock_hint',
-                                                        'Go to Data Explorer to purge sessions and unlock structure'
+                                                        'Go to data explorer to purge sessions and unlock structure'
                                                     )}
                                                 </Button>
                                             )}
@@ -884,7 +884,7 @@ const StudyDesignPage = () => {
                                     <GuidanceCard
                                         title={t(
                                             'admin.design.guidance.qsort_title',
-                                            'Statement & Grid Balance'
+                                            'Statement & grid balance'
                                         )}
                                         description={t(
                                             'admin.design.guidance.qsort_desc',
@@ -939,7 +939,7 @@ const StudyDesignPage = () => {
                                         className="gap-2 h-12 px-8 rounded-xl font-bold bg-white border-2 border-slate-900 text-slate-900 hover:bg-slate-900 hover:text-white transition-all shadow-md group"
                                         data-testid="next-step-button"
                                     >
-                                        {t('common.next', 'Next Step')}
+                                        {t('common.next', 'Next step')}
                                         <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
                                     </Button>
                                 ) : (
@@ -954,7 +954,7 @@ const StudyDesignPage = () => {
                                         data-testid="activate-button"
                                     >
                                         <Rocket className="h-5 w-5" />
-                                        {t('admin.study_status.state.activate', 'Activate Study')}
+                                        {t('admin.study_status.state.activate', 'Activate study')}
                                     </Button>
                                 )}
                             </div>
@@ -1060,7 +1060,7 @@ const StudyDesignPage = () => {
                             <AlertTriangle className="h-6 w-6 text-rose-500" />
                         </div>
                         <DialogTitle className="text-xl font-black text-slate-900 tracking-tight">
-                            {t('admin.design.validation.failed_title', 'Configuration Incomplete')}
+                            {t('admin.design.validation.failed_title', 'Configuration incomplete')}
                         </DialogTitle>
                         <DialogDescription className="text-sm font-medium text-slate-500 mt-2">
                             {t(


### PR DESCRIPTION
Phase 4 Task 4.2.

## What this changes

The admin mixed Title Case ("Add Item", "Bulk Import", "Draft Mode") with sentence case ("Create study", "Import study") **on the same screens**. Settles on sentence case: it is the majority and reads better at 13px.

74 values in `en/admin.json`, plus 114 `t()` fallbacks across 43 source files.

Acronyms, product names (`Markdown`, `KenQ`, `Velicer`, `R-Kit`) and the Q-vocabulary keep their case. Four casing fixes ride along in the *opposite* direction, same rule: `Q-Sort` → `Q-sort` (the file already said `Q-sort` 15 times), `q-methodology` → `Q-methodology`, and `r, python, excel, google authenticator, authy` → proper nouns restored.

## The larger half is in the source, not the JSON

CLAUDE.md requires every `t(key, 'fallback')` default to match the canonical English label — so changing `en/admin.json` alone would have **created** violations rather than fixing them.

Before this branch, **178 call sites diverged** from the JSON. 67 were casing-only — the same defect one layer down — and are fixed here. **Casing-only fallback divergence is now zero**, verified independently by review with its own parser.

111 wording divergences remain and are reported, not touched.

**And a finding worth more than the task itself: 38 call sites reference keys that exist in no locale file at all**, so the fallback is what renders — and `i18n-check` structurally cannot see them. That is a gap in the instrument, on a surface everyone assumed was covered.

## Labels a JSON sweep cannot see

Also covered: the `t(key) || 'literal'` idiom, defaults computed in a ternary under a template-literal key, two `SidebarRail` attributes hardcoded in English, and two Title-Cased fallbacks whose keys are missing from the locale files entirely.

The detector gap that cost the most was **hyphenation** — `Pre-Sort`, `Post-Sort`, `Q-Sort`, `Single-Use`, `Auto-Balance` are single tokens no word-boundary regex sees.

## `recently_completed`

Resolved the other way round: the JSON becomes `Completed` to match the existing fallback. Its three sibling status pills read "Started" / "In progress" / "Discarded", and the card is already titled "Recent activity" — "Recently" was redundant inside it. **Decided on language grounds**; the badge geometry was already fixed properly with `min-h-4` in task 6.4, so layout was deliberately not allowed to drive the wording.

## The other eight locales are untouched

Sentence case is an English-orthography rule that does not transfer — German capitalises nouns. `i18n-check` still reports two pre-existing `admin.analysis.*` keys missing from all eight locales; that drift predates this branch and is not silenced.

## A correction, made before it could propagate

The first version of this commit claimed `getByText()` takes a **case-sensitive** substring. **That is backwards**, and it mattered because the claim was explicitly commended to tasks 4.1 and 4.3.

Verified against the pinned `playwright-core@1.61.1` source: `escapeForTextSelector(s, false)` appends the `i` suffix, `createTextMatcher` sets `strict = false`, and the matcher does `t.normalized.toLowerCase().includes(selector.toLowerCase())`. Only `{ exact: true }` is case-sensitive. (`getByRole({name})` *is* case-insensitive — that half was right.)

So no locator ever broke, and the error pointed the conservative way. But it named the wrong risk surface. The genuinely case-sensitive Playwright matchers are **`toHaveText` / `toContainText` / `toHaveAccessibleName`**, whose `ExpectedTextMatcher.normalize` lowercases only when `ignoreCase` is truthy. There are 16 such assertions in the tree; **none touches a label this commit changes — which was luck, not diligence**, and is the check 4.1 and 4.3 must actually run.

## Verification

E2E cannot run in this environment, so reading is the only check available — and this task changes exactly the strings specs locate by. Review ran **two structurally different sweeps**: one enumerating every string and regex literal on every line of all 40 e2e files (context-blind by design, so it also catches the `toHaveClass`-style selectors a `locator(` grep cannot see), diffed against a 76-pair rendered-label change set and tested both case-sensitively and case-insensitively; the other every whole value plus every two-word window. Both clean. No screenshot or aria-snapshot assertions exist anywhere.

Gates: `lint`, `type-check`, `vitest` (198 files, 1766 passed, 6 skipped), `lint:a11y`, `i18n-check`, `check-interpolations` — all clean. The commit touches zero backend files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)