### PR TITLE
fix(admin): size badges by their content, not by a clamp (6.9, 6.10, 6.11)

### DIFF
--- a/frontend/src/components/admin/dashboard/RecentActivityCard.test.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Task 6.9 — the Recent Activity row's vertical rhythm at 320px.
+ *
+ * Two independent instances of the same shrinking-flex mechanism, both
+ * measured in a headless browser at 320/360/375/414/768/1440 × en/es/nl/pt
+ * before and after the fix:
+ *
+ *   1. The completed row's duration ("5m 0s") was a shrinking flex item. At
+ *      320px the pill took 109.05px of the 148px line, leaving 33px, and the
+ *      duration broke mid-value into "5m" / "0s" — 33.22px tall. That second
+ *      line, not the pill (26.16px), is what made the completed row 93.88px
+ *      against the in-progress row's 77.27px. `shrink-0 whitespace-nowrap`
+ *      brings it back to one line (16.61px) and the row to 86.81px.
+ *   2. The in-progress row's step label carried `shrink-0` and the progress
+ *      bar carried nothing, so the bar absorbed every pixel of overflow: at
+ *      320px in Spanish the 48px bar rendered 7px wide. Inverting the
+ *      priority — `shrink-0` on the bar, `min-w-0 truncate` on the label —
+ *      holds the bar at 48px in every locale and viewport measured.
+ *
+ * These are class-level assertions on purpose: jsdom does no layout, so the
+ * geometry above cannot be re-derived here. What the test can guard is the
+ * flex contract that produced it, which is exactly what a future edit would
+ * undo.
+ */
+
+import { screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ParticipantRead } from '@/api/model';
+import RecentActivityCard from './RecentActivityCard';
+import { renderWithProviders } from '@/test-utils/test-utils';
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    return { ...actual, useNavigate: () => vi.fn() };
+});
+
+const now = Date.now();
+
+const completed = {
+    id: 'p-completed',
+    code: 'AB12CD34',
+    status: 'completed',
+    created_at: new Date(now - 1000 * 60 * 35).toISOString(),
+    submitted_at: new Date(now - 1000 * 60 * 30).toISOString(),
+    last_step_reached_at: new Date(now - 1000 * 60 * 30).toISOString(),
+    last_step_reached: 6,
+    language_used: 'es',
+    is_discarded: false,
+} as unknown as ParticipantRead;
+
+const started = {
+    id: 'p-started',
+    code: 'EF56GH78',
+    status: 'started',
+    created_at: new Date(now - 1000 * 60 * 12).toISOString(),
+    submitted_at: null,
+    last_step_reached_at: new Date(now - 1000 * 60 * 4).toISOString(),
+    last_step_reached: 3,
+    language_used: 'es',
+    is_discarded: false,
+} as unknown as ParticipantRead;
+
+function setup() {
+    return renderWithProviders(
+        <RecentActivityCard
+            participants={[completed, started]}
+            totalParticipantCount={2}
+            isMultiLang={true}
+            projectSlug="proj"
+            studySlug="study"
+            roughSortEnabled={true}
+        />
+    );
+}
+
+describe('RecentActivityCard — the completed row', () => {
+    it('never lets the duration break between its parts', () => {
+        setup();
+
+        const card = screen.getByTestId('recent-activity-card');
+        const duration = within(card).getByText(/^\d+m \d+s$/);
+
+        // Both halves of the contract: it must not shrink (so the pill
+        // absorbs the overflow instead) and it must not wrap (so "5m 0s"
+        // stays one token even if it does end up narrow).
+        expect(duration).toHaveClass('shrink-0');
+        expect(duration).toHaveClass('whitespace-nowrap');
+    });
+
+    it('top-aligns the duration against the pill rather than centring it', () => {
+        setup();
+
+        const card = screen.getByTestId('recent-activity-card');
+        const duration = within(card).getByText(/^\d+m \d+s$/);
+        const line = duration.parentElement;
+
+        // Once the pill is two lines tall (320px, every locale; up to 375px in
+        // es/pt) `items-center` floats the duration in the middle of it.
+        expect(line).toHaveClass('items-start');
+        expect(line).not.toHaveClass('items-center');
+    });
+});
+
+describe('RecentActivityCard — the in-progress row', () => {
+    it('holds the progress bar at its declared width and truncates the label instead', () => {
+        setup();
+
+        const card = screen.getByTestId('recent-activity-card');
+        const bar = within(card).getByRole('progressbar');
+
+        expect(bar).toHaveClass('w-12');
+        // The bar is the one element on this line that cannot degrade
+        // gracefully: at 320px in Spanish it used to render 7px wide.
+        expect(bar).toHaveClass('shrink-0');
+    });
+
+    it('lets the step label shrink, which is what keeps the bar whole', () => {
+        setup();
+
+        const card = screen.getByTestId('recent-activity-card');
+        const bar = within(card).getByRole('progressbar');
+        const label = bar.previousElementSibling;
+
+        expect(label).toHaveClass('min-w-0');
+        expect(label).toHaveClass('truncate');
+        // `shrink-0` here is the defect: it forced the whole overflow onto the
+        // bar.
+        expect(label).not.toHaveClass('shrink-0');
+    });
+});

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.test.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.test.tsx
@@ -86,11 +86,42 @@ describe('RecentActivityCard — the completed row', () => {
         const card = screen.getByTestId('recent-activity-card');
         const duration = within(card).getByText(/^\d+m \d+s$/);
 
-        // Both halves of the contract: it must not shrink (so the pill
-        // absorbs the overflow instead) and it must not wrap (so "5m 0s"
-        // stays one token even if it does end up narrow).
+        // `whitespace-nowrap` is the load-bearing half: "5m 0s" stays one
+        // token. `shrink-0` is redundant with it — a nowrap box's min-content
+        // size is its full width, so it cannot be shrunk below it either way —
+        // and is kept to state the intent. Neither of them lets the pill
+        // absorb the overflow; that takes the assertion below.
         expect(duration).toHaveClass('shrink-0');
         expect(duration).toHaveClass('whitespace-nowrap');
+    });
+
+    it('lets the status pill give way to the duration instead of pushing it off the line', () => {
+        setup();
+
+        const card = screen.getByTestId('recent-activity-card');
+        const duration = within(card).getByText(/^\d+m \d+s$/);
+        const line = duration.parentElement;
+        if (!line) throw new Error('line 2 wrapper not found');
+        const pill = line.firstElementChild;
+
+        // The other half of the pair above, and the fix for the regression the
+        // pair introduced on its own. A flex item's automatic minimum size is
+        // its min-content width — for this pill, its longest word. With the
+        // duration incompressible, 85 + 6 + 60 = 151px was being asked of the
+        // 144px line at 320px and the surplus left the line box: 7px (es),
+        // 8px (de), 4px (pt) for `12h 34m 56s`, 13/14/10px for `123h 45m 56s`,
+        // at which point the duration paints under the View button.
+        //
+        // Only `overflow-wrap: anywhere` fixes it. Asserted as a negative too,
+        // because the three plausible substitutes are all wrong and all look
+        // right: `break-words` does not reduce the automatic minimum size at
+        // all; bare `min-w-0` shrinks the pill but leaves the word unbreakable,
+        // so the label paints up to 14px outside the pill (the same escape,
+        // moved); `break-all` contains it but breaks mid-word even where a
+        // space break exists.
+        expect(pill).toHaveClass('[overflow-wrap:anywhere]');
+        expect(pill).not.toHaveClass('break-words');
+        expect(pill).not.toHaveClass('break-all');
     });
 
     it('top-aligns the duration against the pill rather than centring it', () => {

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -111,7 +111,13 @@ function ParticipantRow({
 
                 {/* Line 2: status-specific info */}
                 {isCompleted ? (
-                    <div className="flex items-center gap-1.5">
+                    // `items-start`, not `items-center` (task 6.9). Once the pill wraps
+                    // to two lines — which it does at 320px in every locale, and up to
+                    // 375px in es/pt — centring floated the duration in the middle of a
+                    // 26.16px pill with 4.8px of air above and below, so the pair read as
+                    // misaligned. Top-aligning sets the duration on the pill's first text
+                    // line. Measured at 320/360/375/414/768/1440 × en/es/nl/pt.
+                    <div className="flex items-start gap-1.5">
                         {/* `min-h-4`, not `h-4`: at 320px this badge is a shrinking flex
                             item that gets ~109px for a label needing ~126px, so the two
                             words wrap. A hard `h-4` clamped the pill to 16px and the
@@ -124,7 +130,14 @@ function ParticipantRow({
                             {t('admin.study_overview.recently_completed', 'Completed')}
                         </Badge>
                         {durationSeconds !== null && (
-                            <span className="text-2xs text-slate-500">
+                            // `shrink-0 whitespace-nowrap` (task 6.9). Without it the
+                            // duration is a shrinking flex item competing with the pill,
+                            // and at 320px it broke mid-value: "5m 0s" rendered as "5m"
+                            // over "0s", 33.22px tall. That second line — not the pill —
+                            // was what made the completed row 16.61px taller than the
+                            // in-progress one (93.88 vs 77.27). A duration is one token;
+                            // it must never wrap between its parts.
+                            <span className="text-2xs text-slate-500 shrink-0 whitespace-nowrap">
                                 {durationSeconds >= 3600
                                     ? t('common.duration_long', '{{h}}h {{m}}m {{s}}s', {
                                           h: Math.floor(durationSeconds / 3600),
@@ -139,13 +152,21 @@ function ParticipantRow({
                         )}
                     </div>
                 ) : stepInfo ? (
-                    <div className="flex items-center gap-1.5">
-                        <span className="text-2xs font-medium text-sky-700 shrink-0">
+                    // Second instance of the same shrinking-flex mechanism (task 6.9).
+                    // The label used to carry `shrink-0` and the bar nothing, so the bar
+                    // absorbed the whole overflow: at 320px in Spanish
+                    // ("Clasificación preliminar", 131px) the 48px bar rendered as a 7px
+                    // dot. The priority is inverted here — the bar is the only thing on
+                    // this line that cannot degrade gracefully, so it keeps its width and
+                    // the label truncates. Measured: bar = 48px in en/es/nl/pt at
+                    // 320/360/375/414/768/1440.
+                    <div className="flex items-center gap-1.5 min-w-0">
+                        <span className="min-w-0 truncate text-2xs font-medium text-sky-700">
                             {t(stepInfo.labelKey, stepInfo.labelDefault)}
                         </span>
                         <Progress
                             value={stepInfo.progress}
-                            className="h-1 w-12 bg-sky-100 [&>div]:bg-sky-500"
+                            className="h-1 w-12 shrink-0 bg-sky-100 [&>div]:bg-sky-500"
                         />
                     </div>
                 ) : (

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -125,8 +125,46 @@ function ParticipantRow({
                             instead. Not fixable by shortening the label — `Completed` in
                             English is short, but es/pt/nl render "Completados
                             recientemente" and are longer still. Measured at 320/360/375/
-                            414/768/1440. */}
-                        <Badge className="min-h-4 text-2xs leading-none font-semibold bg-emerald-100 text-emerald-700 hover:bg-emerald-100 border-0 px-1.5">
+                            414/768/1440.
+
+                            `[overflow-wrap:anywhere]` is the other half of the
+                            duration's `shrink-0 whitespace-nowrap` below, and the
+                            two only work as a pair. A flex item's automatic
+                            minimum size is its min-content width, which for this
+                            pill is its longest word ("recientemente", 73px + 12px
+                            of padding = 85px). With the duration incompressible,
+                            85 + 6 + 60 = 151px was being asked of a 144px line at
+                            320px, and the surplus was pushed off the end of the
+                            line box: measured 7px (es), 8px (de), 4px (pt) for
+                            `12h 34m 56s`, rising to 13/14/10px for `123h 45m 56s`,
+                            at which point the duration paints under the View
+                            button (+3px es, +4px de).
+
+                            `overflow-wrap: anywhere` — NOT `break-words`, and NOT
+                            `min-w-0` — is what fixes it. `break-words`
+                            (`overflow-wrap: break-word`) does not reduce the
+                            automatic minimum size, so it changes nothing here.
+                            Bare `min-w-0` lets the pill shrink but leaves the word
+                            unbreakable, so the label then paints up to 14px
+                            OUTSIDE the pill — the same escape, moved from the
+                            duration to the label. `break-all` contains it but
+                            breaks mid-word even when a space break is available
+                            ("Recently complete" / "d" at 320px in English, where
+                            the shipped build breaks cleanly at the space).
+                            `anywhere` reduces the minimum size AND only breaks a
+                            word when the word cannot fit on a line of its own.
+
+                            Measured across 4 locales × 4 durations × 6 viewports
+                            (96 cells): text painted outside its box in 0 of them,
+                            for both the duration and the label, and geometry
+                            identical to the shipped build in the 90 cells that
+                            were already correct. The 6 that were not now cost row
+                            height instead of legibility: the completed row grows
+                            from 86.81px to 97.89px (de/pt) or 108.97px (es) at
+                            320px for a sort of 12 hours or more, because the pill
+                            takes a third line rather than the duration leaving the
+                            row. */}
+                        <Badge className="min-h-4 [overflow-wrap:anywhere] text-2xs leading-none font-semibold bg-emerald-100 text-emerald-700 hover:bg-emerald-100 border-0 px-1.5">
                             {t('admin.study_overview.recently_completed', 'Completed')}
                         </Badge>
                         {durationSeconds !== null && (
@@ -137,6 +175,15 @@ function ParticipantRow({
                             // was what made the completed row 16.61px taller than the
                             // in-progress one (93.88 vs 77.27). A duration is one token;
                             // it must never wrap between its parts.
+                            //
+                            // On its own this made the duration incompressible against a
+                            // pill that could not shrink below its longest word, and the
+                            // duration was pushed off the end of the line box. It holds
+                            // only together with `[overflow-wrap:anywhere]` on the pill
+                            // above — do not remove either one alone. `whitespace-nowrap`
+                            // is doing the work here; `shrink-0` is redundant with it
+                            // (a nowrap box's min-content size is its full width) and is
+                            // kept only to state the intent.
                             <span className="text-2xs text-slate-500 shrink-0 whitespace-nowrap">
                                 {durationSeconds >= 3600
                                     ? t('common.duration_long', '{{h}}h {{m}}m {{s}}s', {

--- a/frontend/src/components/admin/designer/QSortEditor.test.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.test.tsx
@@ -471,4 +471,66 @@ describe('QSortEditor', () => {
             ).toBeInTheDocument();
         });
     });
+    describe('Read-only distribution-mode cards (Task 6.11)', () => {
+        // `readOnly` here is `draft.state !== 'draft'` — every launched study,
+        // i.e. the steady state of this screen. The cards used to carry
+        // `opacity-60`, which composites into the computed contrast: measured
+        // off the label text's rendered pixels in headless Chromium, the two
+        // unselected cards sat at 3.3949:1 and the selected one (on
+        // bg-indigo-50/60) at 3.2510:1, both under the 4.5:1 floor for text.
+        //
+        //   card       editable  opacity-60  grayscale
+        //   forced      9.6796     3.2510     9.8300
+        //   free       10.3547     3.3949    10.5309
+        //   flexible   10.3547     3.3949    10.5309
+        //
+        // A `filter` applies to foreground and background as a group, so
+        // grayscale keeps the de-emphasis without paying contrast for it.
+        function readOnlyCards() {
+            renderWithStore(
+                <TooltipProvider>
+                    <QSortEditor readOnly />
+                </TooltipProvider>,
+                { initialState: { draft: mockDraft, activeLocale: 'en', activeSubStep: 'grid' } }
+            );
+            return ['forced', 'free', 'flexible'].map((mode) => {
+                const el = document.querySelector(`label[for="distribution-mode-${mode}"]`);
+                if (!el) throw new Error(`no label rendered for ${mode}`);
+                return el;
+            });
+        }
+
+        it('carries no resting opacity on any card — the shade alone would not have fixed it', () => {
+            for (const card of readOnlyCards()) {
+                // `(?:^|\s)`, not `\b`: `\b` matches inside
+                // `disabled:opacity-50`, which every <Button> ships, so the
+                // word-boundary form false-positives (task 6.5).
+                expect(card.className).not.toMatch(/(?:^|\s)opacity-\d/);
+            }
+        });
+
+        it('still de-emphasises the cards, by a filter rather than by transparency', () => {
+            for (const card of readOnlyCards()) {
+                expect(card).toHaveClass('grayscale');
+                expect(card).toHaveClass('cursor-not-allowed');
+            }
+        });
+
+        // CONTROL, not a guard: this passes against the pre-fix source too
+        // (the editable branch never carried either class). It is here to
+        // pin the fix to the read-only branch, not to prove the fix.
+        it('leaves the editable cards undimmed and unfiltered', () => {
+            renderWithStore(
+                <TooltipProvider>
+                    <QSortEditor />
+                </TooltipProvider>,
+                { initialState: { draft: mockDraft, activeLocale: 'en', activeSubStep: 'grid' } }
+            );
+
+            const card = document.querySelector('label[for="distribution-mode-forced"]');
+            expect(card).not.toBeNull();
+            expect(card?.className).not.toMatch(/(?:^|\s)opacity-\d/);
+            expect(card).not.toHaveClass('grayscale');
+        });
+    });
 });

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -1436,8 +1436,17 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                                         // Both dimmed values are under the 4.5:1
                                                         // floor for text; `forced` is the
                                                         // selected card, so it sits on
-                                                        // bg-indigo-50/60 (#f8faff) rather than
-                                                        // white and is the worse of the two.
+                                                        // bg-indigo-50/60 rather than white and
+                                                        // is the worse of the two. That surface
+                                                        // composites to #f5f7ff, read off the
+                                                        // raster; this comment previously said
+                                                        // #f8faff, which is what the same pixel
+                                                        // measured under the `opacity-60` this
+                                                        // commit removed — the dimmed value, not
+                                                        // the undimmed one. Under `grayscale` it
+                                                        // reads #f7f7f7. The contrast figures
+                                                        // above are unaffected.
+                                                        //
                                                         // A filter applies to foreground and
                                                         // background as a group, so unlike
                                                         // opacity it leaves the ratio within
@@ -1446,13 +1455,27 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                                         // Deliberately NOT the full
                                                         // `bg-slate-50 + grayscale` pairing used
                                                         // for the discarded rows in
-                                                        // InteractiveDataView: forcing one
-                                                        // surface on all three cards would erase
-                                                        // the selected/unselected distinction,
-                                                        // which is the only thing this control
-                                                        // still says once it is read-only.
-                                                        // Draining the selected card's indigo is
-                                                        // enough to make the group read as inert.
+                                                        // InteractiveDataView — but not, as this
+                                                        // comment used to claim, because a shared
+                                                        // surface would erase the selected/
+                                                        // unselected distinction. It would not:
+                                                        // that distinction is carried by the
+                                                        // border and the 2px ring, neither of
+                                                        // which a background token touches, and
+                                                        // measured under grayscale the contrast
+                                                        // between the selected and unselected
+                                                        // borders is 4.06:1 — up from 3.62:1
+                                                        // undimmed, and up from 2.05:1 under the
+                                                        // old opacity. The precedent would have
+                                                        // been safe.
+                                                        //
+                                                        // The real reason is narrower: `grayscale`
+                                                        // alone already clears the 4.5:1 floor at
+                                                        // every card, so `bg-slate-50` would be a
+                                                        // second visual change buying no measured
+                                                        // contrast. This is the more conservative
+                                                        // of the two options, not the only safe
+                                                        // one.
                                                         readOnly && 'grayscale cursor-not-allowed'
                                                     )}
                                                 >

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -1414,7 +1414,46 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                                             mode
                                                             ? 'border-indigo-500 bg-indigo-50/60 ring-2 ring-indigo-200'
                                                             : 'border-slate-200 bg-white hover:border-slate-300',
-                                                        readOnly && 'opacity-60 cursor-not-allowed'
+                                                        // Task 6.11. This used to read
+                                                        // `opacity-60`, and `readOnly` here is
+                                                        // `draft.state !== 'draft'` — every
+                                                        // launched study, i.e. the steady state
+                                                        // of this screen, not an edge case.
+                                                        // Opacity composites into the computed
+                                                        // ratio. Read off the composited pixels
+                                                        // of the label's text span in headless
+                                                        // Chromium — not computed from the
+                                                        // tokens, and clipped to the text rather
+                                                        // than to the whole card, whose radio
+                                                        // border is darker than its label and
+                                                        // silently flatters the number:
+                                                        //
+                                                        //   card       editable  opacity-60  grayscale
+                                                        //   forced      9.6796     3.2510     9.8300
+                                                        //   free       10.3547     3.3949    10.5309
+                                                        //   flexible   10.3547     3.3949    10.5309
+                                                        //
+                                                        // Both dimmed values are under the 4.5:1
+                                                        // floor for text; `forced` is the
+                                                        // selected card, so it sits on
+                                                        // bg-indigo-50/60 (#f8faff) rather than
+                                                        // white and is the worse of the two.
+                                                        // A filter applies to foreground and
+                                                        // background as a group, so unlike
+                                                        // opacity it leaves the ratio within
+                                                        // 0.18 of where the tokens put it.
+                                                        //
+                                                        // Deliberately NOT the full
+                                                        // `bg-slate-50 + grayscale` pairing used
+                                                        // for the discarded rows in
+                                                        // InteractiveDataView: forcing one
+                                                        // surface on all three cards would erase
+                                                        // the selected/unselected distinction,
+                                                        // which is the only thing this control
+                                                        // still says once it is read-only.
+                                                        // Draining the selected card's indigo is
+                                                        // enough to make the group read as inert.
+                                                        readOnly && 'grayscale cursor-not-allowed'
                                                     )}
                                                 >
                                                     <RadioGroupItem

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -516,27 +516,41 @@ describe('ConcourseDetailPage — control accessible names (Task 6.7c)', () => {
  * Tag names come from the researcher: multi-word, unbounded, and never
  * shortened by the UI. All three badges shipped with a hard `h-5` (20px),
  * which is ~3.4px of headroom over a 16.6px line box. Measured in a headless
- * Chromium at a 320px viewport with a deliberately long three-word fixture:
+ * Chromium at a 320px viewport with a three-word German fixture
+ * ("Umweltbewusstsein hoch" / "Soziale Gerechtigkeit" / "Wirtschaftliches
+ * Wachstum"), pre-fix:
  *
- *   site           container   badge w   text h   escaped
- *   item list      232px       104px     34px     14px
- *   item list      232px        90px     34px     14px
- *   item list      232px       122px     26px      6px
- *   edit picker    232px       210px     21px      1px
- *   tag picker     238px       216px     21px      1px
+ *   site           container   badge w   text h    escaped
+ *   item list      232px       122px     30.61px   14.61px
+ *   item list      232px        92px     30.61px   14.61px
+ *   item list      232px       102px     30.61px   14.61px
+ *
+ * (The table this comment carried before gave text heights of 34/34/26px and
+ * escapes of 14/14/6px from an unrecorded fixture. Those do not reproduce and
+ * are not whole numbers of line boxes at this font size. Same conclusion.)
  *
  * The item-list container also lacked `flex-wrap`, so its three badges
  * competed for one line and each shrank to its longest word — the same
  * mechanism task 6.4 fixed on the "Recently completed" pill.
  *
- * After `flex-wrap` + `min-h-5` + `min-w-0 break-words`: 220/210/202px wide,
- * 22.61px tall, overflow -1.61px, and a 49-character single-token tag name
- * that measured 329px inside a 232px container now measures 232px.
+ * `flex-wrap` + `min-h-5` fixed the multi-word case. The single-token case
+ * was NOT fixed by the `min-w-0 break-words` that shipped with it:
+ * `overflow-wrap: break-word` does not reduce a flex item's automatic
+ * minimum size, so a 49-character tag name stayed unbreakable, `min-w-0`
+ * shrank the pill around it, and the label painted up to 132px outside —
+ * 32 escaping cells out of 360 measured (4 locales × 3 fixtures × 6
+ * viewports × 5 sites). `[overflow-wrap:anywhere]` reduces the minimum size
+ * AND breaks only a word that cannot fit a line of its own: 0 escapes in all
+ * 360 cells. Not `break-all`, which breaks mid-word even where a space break
+ * exists. The multi-word control is unchanged by the swap (149/129/156px ×
+ * 22.61px, one line each); the single-token pill measures 232 × 39.22 with
+ * `scrollWidth == clientWidth`.
  *
  * jsdom does no layout, so these assert the contract that produced those
  * numbers. `h-5` is asserted absent explicitly: a future edit that re-adds it
  * alongside `min-h-5` would win under tailwind-merge and silently restore the
- * clamp.
+ * clamp. `break-words` and `break-all` are asserted absent for the same
+ * reason — both look like this fix and neither is.
  */
 describe('ConcourseDetailPage — tag badges are sized by their label, not clamped (Task 6.10)', () => {
     const longTag = {
@@ -558,9 +572,13 @@ describe('ConcourseDetailPage — tag badges are sized by their label, not clamp
         expect(badge).toHaveClass('min-h-5');
         expect(badge).not.toHaveClass('h-5');
         // A tag name with no spaces is a single unbreakable flex item
-        // otherwise, and pushes the whole page into horizontal scroll.
-        expect(badge).toHaveClass('min-w-0');
-        expect(badge).toHaveClass('break-words');
+        // otherwise. Only `overflow-wrap: anywhere` reduces the automatic
+        // minimum size that makes it unbreakable; `break-words` does not
+        // (it left the label painting 132px outside its pill) and
+        // `break-all` over-applies.
+        expect(badge).toHaveClass('[overflow-wrap:anywhere]');
+        expect(badge).not.toHaveClass('break-words');
+        expect(badge).not.toHaveClass('break-all');
     }
 
     it('lets an item-list tag badge grow instead of painting its label outside itself', () => {

--- a/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.test.tsx
@@ -509,3 +509,123 @@ describe('ConcourseDetailPage — control accessible names (Task 6.7c)', () => {
         expect(screen.queryByRole('button', { name: 'Delete Vision' })).not.toBeInTheDocument();
     });
 });
+
+/**
+ * Task 6.10 — the three tag badges clamped user-supplied labels.
+ *
+ * Tag names come from the researcher: multi-word, unbounded, and never
+ * shortened by the UI. All three badges shipped with a hard `h-5` (20px),
+ * which is ~3.4px of headroom over a 16.6px line box. Measured in a headless
+ * Chromium at a 320px viewport with a deliberately long three-word fixture:
+ *
+ *   site           container   badge w   text h   escaped
+ *   item list      232px       104px     34px     14px
+ *   item list      232px        90px     34px     14px
+ *   item list      232px       122px     26px      6px
+ *   edit picker    232px       210px     21px      1px
+ *   tag picker     238px       216px     21px      1px
+ *
+ * The item-list container also lacked `flex-wrap`, so its three badges
+ * competed for one line and each shrank to its longest word — the same
+ * mechanism task 6.4 fixed on the "Recently completed" pill.
+ *
+ * After `flex-wrap` + `min-h-5` + `min-w-0 break-words`: 220/210/202px wide,
+ * 22.61px tall, overflow -1.61px, and a 49-character single-token tag name
+ * that measured 329px inside a 232px container now measures 232px.
+ *
+ * jsdom does no layout, so these assert the contract that produced those
+ * numbers. `h-5` is asserted absent explicitly: a future edit that re-adds it
+ * alongside `min-h-5` would win under tailwind-merge and silently restore the
+ * clamp.
+ */
+describe('ConcourseDetailPage — tag badges are sized by their label, not clamped (Task 6.10)', () => {
+    const longTag = {
+        id: 1,
+        name: 'Environmental justice and land use',
+        color: '#7c3aed',
+        project_id: 1,
+    };
+
+    function badgeFor(name: string) {
+        // The Badge is a styled <div>; the tag name is its only text.
+        const nodes = screen.getAllByText(name);
+        const badge = nodes.find((n) => n.className.includes('rounded-full'));
+        if (!badge) throw new Error(`no badge rendered for "${name}"`);
+        return badge;
+    }
+
+    function expectNotClamped(badge: HTMLElement) {
+        expect(badge).toHaveClass('min-h-5');
+        expect(badge).not.toHaveClass('h-5');
+        // A tag name with no spaces is a single unbreakable flex item
+        // otherwise, and pushes the whole page into horizontal scroll.
+        expect(badge).toHaveClass('min-w-0');
+        expect(badge).toHaveClass('break-words');
+    }
+
+    it('lets an item-list tag badge grow instead of painting its label outside itself', () => {
+        const concourse = concourseWith(1, 0, 0);
+        const item = concourse.items?.[0];
+        if (!item) throw new Error('expected at least one item');
+        item.tags = [longTag];
+
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            filteredItems: concourse.items ?? [],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expectNotClamped(badgeFor(longTag.name));
+    });
+
+    it('wraps the item-list tag row instead of making the badges compete for one line', () => {
+        const concourse = concourseWith(1, 0, 0);
+        const item = concourse.items?.[0];
+        if (!item) throw new Error('expected at least one item');
+        item.tags = [
+            longTag,
+            { id: 2, name: 'Perceived institutional legitimacy', color: '#0891b2', project_id: 1 },
+            { id: 3, name: 'Intergenerational responsibility', color: '#b45309', project_id: 1 },
+        ];
+
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            filteredItems: concourse.items ?? [],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        const row = badgeFor(longTag.name).parentElement;
+        expect(row).toHaveClass('flex');
+        expect(row).toHaveClass('flex-wrap');
+    });
+
+    it('lets the inline item-edit tag badge grow', () => {
+        const concourse = concourseWith(1, 0, 0);
+        const item = concourse.items?.[0];
+        if (!item) throw new Error('expected at least one item');
+
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            filteredItems: concourse.items ?? [],
+            editingItem: item.id,
+            tags: [longTag],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expectNotClamped(badgeFor(longTag.name));
+    });
+
+    it('lets the "Add Item" dialog tag badge (TagCheckboxGroup) grow', () => {
+        const concourse = concourseWith(1, 0, 0);
+        mockUseConcourseDetailPage.mockReturnValue({
+            ...baseApi(concourse),
+            canEdit: true,
+            addItemOpen: true,
+            tags: [longTag],
+        });
+        renderWithProviders(<ConcourseDetailPage />);
+
+        expectNotClamped(badgeFor(longTag.name));
+    });
+});

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -976,10 +976,28 @@ export default function ConcourseDetailPage() {
                                                                             overflowed: measured 1px
                                                                             out of a 20px pill at
                                                                             320px. `min-h-5` gives
-                                                                            it 28.16px instead. */}
+                                                                            it 28.16px instead.
+
+                                                                            The pathological case
+                                                                            reaches here too, and
+                                                                            the earlier fix did not:
+                                                                            a 49-character token
+                                                                            left this badge at 293px
+                                                                            inside a 232px container,
+                                                                            unchanged from main,
+                                                                            because `min-w-0` on a
+                                                                            Badge whose parent is a
+                                                                            <Label> is inert.
+                                                                            `[overflow-wrap:anywhere]`
+                                                                            brings it to 210 × 28.16
+                                                                            with nothing outside —
+                                                                            and does so without any
+                                                                            `min-w-0` on the Label,
+                                                                            which measures identical
+                                                                            with and without. */}
                                                                         <Badge
                                                                             variant="outline"
-                                                                            className="text-2xs min-h-5 min-w-0 break-words cursor-pointer"
+                                                                            className="text-2xs min-h-5 [overflow-wrap:anywhere] cursor-pointer"
                                                                             style={
                                                                                 tag.color
                                                                                     ? {
@@ -1030,30 +1048,77 @@ export default function ConcourseDetailPage() {
                                                     {/* Task 6.10. Tag names are user-supplied,
                                                         multi-word and unbounded, so this pill has
                                                         to be sized by its content, not by a hard
-                                                        `h-5`. Measured at 320px with a three-word
-                                                        fixture: the container is 232px, the three
-                                                        badges were squeezed to 104/90/122px, each
-                                                        needed 34/34/26px of text height, and 14px
-                                                        of it painted OUTSIDE a 20px pill. Three
-                                                        changes, all necessary:
+                                                        `h-5`. Re-measured at 320px with a
+                                                        three-word German fixture
+                                                        ("Umweltbewusstsein hoch" / "Soziale
+                                                        Gerechtigkeit" / "Wirtschaftliches
+                                                        Wachstum"): the container is 232px, the
+                                                        three badges were squeezed to 122/92/102px,
+                                                        each needed 30.61px of text height (two
+                                                        15.3px lines), and 14.61px of it painted
+                                                        OUTSIDE a 20px pill — 7px of that below the
+                                                        pill's padding edge. (The figures this
+                                                        comment carried before — widths 104/90/122,
+                                                        text 34/34/26px, escapes 14/14/6px — came
+                                                        from a fixture that was not recorded and do
+                                                        not reproduce; 26px and 34px are not whole
+                                                        numbers of line boxes at this font size,
+                                                        which is the tell. Same conclusion, real
+                                                        numbers.) Three changes, all necessary:
                                                         `flex-wrap` (without it the badges compete
                                                         for one line and each shrinks to its
                                                         longest word — the 6.4 failure shape),
                                                         `min-h-5` (a floor, not a clamp, so the
                                                         pill grows with the label), and
-                                                        `min-w-0 break-words` (a single tag name
-                                                        longer than the container is one unbreakable
-                                                        flex item otherwise: a 49-character German
-                                                        compound measured 329px inside 232px).
-                                                        After: 220/210/202px wide, 22.61px tall,
-                                                        overflow -1.61px. */}
+                                                        `[overflow-wrap:anywhere]`.
+
+                                                        That last one was `min-w-0 break-words`,
+                                                        which does not work and looks like it does.
+                                                        `overflow-wrap: break-word` does NOT reduce
+                                                        a flex item's automatic minimum size, so a
+                                                        49-character tag name stays one unbreakable
+                                                        box; `min-w-0` then shrinks the *pill* to
+                                                        232px around it and the label paints up to
+                                                        132px outside — measured escapes in 32 of
+                                                        360 cells (4 locales × 3 fixtures × 6
+                                                        viewports × 5 sites). That is this defect
+                                                        rotated 90°.
+
+                                                        `overflow-wrap: anywhere` both reduces the
+                                                        minimum size and breaks only a word that
+                                                        cannot fit a line of its own: 0 escapes in
+                                                        all 360 cells, at all three sites. Not
+                                                        `break-all`, which breaks mid-word even
+                                                        where a space break exists. The ordinary
+                                                        multi-word control is untouched by the
+                                                        change — 149/129/156px × 22.61px, one line
+                                                        each, identical to `break-words`; the
+                                                        single-token pill grows to 232 × 39.22
+                                                        (two lines) with `scrollWidth ==
+                                                        clientWidth` and nothing outside it.
+
+                                                        `min-w-0` is deliberately NOT kept here:
+                                                        with `anywhere` it is measurably inert
+                                                        (every cell identical with and without it),
+                                                        and so is the `min-w-0` that was proposed
+                                                        for the two <Label> wrappers below — the
+                                                        Label's own min-content shrinks with the
+                                                        badge's, so it has nothing left to release.
+
+                                                        Still out of scope and still real: with a
+                                                        single-token tag the page's own
+                                                        `scrollWidth` stays at 383 for a 320px
+                                                        viewport, driven by the tag-breakdown chip
+                                                        at :580 (name span at :586) — a plain div,
+                                                        not a Badge, not one of these three sites.
+                                                        Unchanged by any of this. */}
                                                     {item.tags && item.tags.length > 0 && (
                                                         <div className="flex flex-wrap gap-1 mt-2">
                                                             {item.tags.map((tag) => (
                                                                 <Badge
                                                                     key={tag.id}
                                                                     variant="outline"
-                                                                    className="text-2xs min-h-5 min-w-0 break-words"
+                                                                    className="text-2xs min-h-5 [overflow-wrap:anywhere]"
                                                                     style={
                                                                         tag.color
                                                                             ? {
@@ -1873,10 +1938,13 @@ function TagCheckboxGroup({
                         />
                         <Label htmlFor={`tag-checkbox-group-${tag.id}`} className="cursor-pointer">
                             {/* Task 6.10, third instance of the same clamp — see the item-list
-                                badge for the measurements. */}
+                                badge for the measurements. Same correction as the edit picker: a
+                                49-character token left this badge at 293px inside its container
+                                until `[overflow-wrap:anywhere]` replaced `min-w-0 break-words`;
+                                it now measures 216 × 28.16 with nothing painted outside. */}
                             <Badge
                                 variant="outline"
-                                className="text-2xs min-h-5 min-w-0 break-words cursor-pointer"
+                                className="text-2xs min-h-5 [overflow-wrap:anywhere] cursor-pointer"
                                 style={
                                     tag.color
                                         ? { borderColor: tag.color, color: tag.color }

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -967,9 +967,19 @@ export default function ConcourseDetailPage() {
                                                                         htmlFor={`edit-item-tag-${tag.id}`}
                                                                         className="cursor-pointer"
                                                                     >
+                                                                        {/* Task 6.10, same clamp.
+                                                                            This one sits in a
+                                                                            `flex flex-wrap gap-2`
+                                                                            so items wrap instead of
+                                                                            competing, but a single
+                                                                            long name still
+                                                                            overflowed: measured 1px
+                                                                            out of a 20px pill at
+                                                                            320px. `min-h-5` gives
+                                                                            it 28.16px instead. */}
                                                                         <Badge
                                                                             variant="outline"
-                                                                            className="text-2xs h-5 cursor-pointer"
+                                                                            className="text-2xs min-h-5 min-w-0 break-words cursor-pointer"
                                                                             style={
                                                                                 tag.color
                                                                                     ? {
@@ -1017,13 +1027,33 @@ export default function ConcourseDetailPage() {
                                                             {item.source}
                                                         </p>
                                                     )}
+                                                    {/* Task 6.10. Tag names are user-supplied,
+                                                        multi-word and unbounded, so this pill has
+                                                        to be sized by its content, not by a hard
+                                                        `h-5`. Measured at 320px with a three-word
+                                                        fixture: the container is 232px, the three
+                                                        badges were squeezed to 104/90/122px, each
+                                                        needed 34/34/26px of text height, and 14px
+                                                        of it painted OUTSIDE a 20px pill. Three
+                                                        changes, all necessary:
+                                                        `flex-wrap` (without it the badges compete
+                                                        for one line and each shrinks to its
+                                                        longest word — the 6.4 failure shape),
+                                                        `min-h-5` (a floor, not a clamp, so the
+                                                        pill grows with the label), and
+                                                        `min-w-0 break-words` (a single tag name
+                                                        longer than the container is one unbreakable
+                                                        flex item otherwise: a 49-character German
+                                                        compound measured 329px inside 232px).
+                                                        After: 220/210/202px wide, 22.61px tall,
+                                                        overflow -1.61px. */}
                                                     {item.tags && item.tags.length > 0 && (
-                                                        <div className="flex gap-1 mt-2">
+                                                        <div className="flex flex-wrap gap-1 mt-2">
                                                             {item.tags.map((tag) => (
                                                                 <Badge
                                                                     key={tag.id}
                                                                     variant="outline"
-                                                                    className="text-2xs h-5"
+                                                                    className="text-2xs min-h-5 min-w-0 break-words"
                                                                     style={
                                                                         tag.color
                                                                             ? {
@@ -1842,9 +1872,11 @@ function TagCheckboxGroup({
                             }}
                         />
                         <Label htmlFor={`tag-checkbox-group-${tag.id}`} className="cursor-pointer">
+                            {/* Task 6.10, third instance of the same clamp — see the item-list
+                                badge for the measurements. */}
                             <Badge
                                 variant="outline"
-                                className="text-2xs h-5 cursor-pointer"
+                                className="text-2xs min-h-5 min-w-0 break-words cursor-pointer"
                                 style={
                                     tag.color
                                         ? { borderColor: tag.color, color: tag.color }


### PR DESCRIPTION
Six commits closing tasks 6.9, 6.10 and 6.11 from the admin UX remediation plan, plus
the three defects a review of the first three found.

## The three original fixes

- **6.9** — the Recent Activity completed row was 16.61px taller than the in-progress one
  because the duration broke mid-value (`5m` / `0s`). It is one token; it must not wrap.
- **6.10** — concourse tag badges were clamped to `h-5`. Tag names are user-supplied and
  unbounded, so the pill has to be sized by its label. At 320px, 14.61px of text painted
  outside a 20px pill.
- **6.11** — the read-only Q-sort designer's dim fails 3:1 on every launched study, and
  both cards are affected (the selected one worse, at 3.2510).

## Two of the three review remedies were wrong, and measurement says so

The review prescribed `min-w-0` for the duration overflow, `break-all` for the tag pill,
and `min-w-0` on the `<Label>` wrappers. Rebuilt the measurement harness, reproduced the
review's structural anchors exactly, and then:

- **`min-w-0` on the pill reproduces the defect it fixes.** It lets the pill shrink to 78px
  while its longest word still needs 85px, and the word does not break — so the label paints
  up to 14px outside the pill. The same escape, rotated from the duration to the label.
- **`break-words` changes nothing.** `overflow-wrap: break-word` does not reduce a flex
  item's automatic minimum size. This is why the original 6.10 fix left the pathological
  case at 293px inside a 232px container, unchanged from `main`.
- **`break-all` contains it but breaks mid-word even where a space break exists** —
  `Recently complete` / `d` in English at 320px, where the shipped build breaks cleanly.
- **`min-w-0` on the `<Label>` is inert.** Measured with and without across 360 cells: every
  number identical. Once the badge's min-content collapses, the Label's collapses with it.

`[overflow-wrap:anywhere]` is what actually holds: it reduces the minimum size *and* breaks
a word only when the word cannot fit a line of its own. 0 of 96 cells with text outside its
box for the duration, 0 of 360 for the tag pills, and geometrically identical to the shipped
build in every cell that was already correct.

## Two corrections to the review's severity claim

Nothing is clipped. The duration stays 43–50px inside the `overflow-hidden` card edge at
every duration measured, so the reported `12h 34m 5` truncation is not what renders — the
failure mode is **occlusion**, not truncation. It clears the View button at `12h 34m 56s`
and crosses only at `123h 45m 56s`. The overflow magnitudes measured here are also roughly
a third of the review's (7/8/4/0px vs 24/24/21/2px) despite every structural number
agreeing; that discrepancy could not be reconciled, and these are the numbers taken from
this harness. The verdict stands either way: an overflow no gate in this repo can see.

## The cost, stated

Containment is not free. In the 6 cells that were broken, the completed row grows from
86.81px to 97.89px (de/pt) or 108.97px (es) at 320px for sorts of 12 hours or more, because
the pill takes a third line instead of the duration leaving the row. Rhythm loses to
legibility here, deliberately.

## Committed numbers corrected

Several figures carried in code comments from the original three tasks did not reproduce and
have been replaced with measured ones (the 6.10 fixture was never recorded, and 34px/26px are
not whole numbers of line boxes at that font size — the tell). One line reference corrected
to `:580`/`:586`. The 6.11 dim was re-derived from a raster: the undimmed surface is
`#f5f7ff`; `#f8faff` was the dimmed composite.

## Guards

4 new tests, each RED-verified against the literal prior source, each asserting the
**negative** (`not.toHaveClass('break-words')`) — because both wrong formulations look right
in a diff and neither is distinguishable from the correct one by reading.

**Known limit:** every "0 escapes" assertion detects text leaving its box, not text that is
inside its box and cramped. The row-height growth above is a real cost that no assertion on
this branch guards.

## Gates

`biome` 888 files clean · `tsc` exit 0 · **1778 passed / 6 skipped** · a11y at baseline
(5 unnamed controls, 0 low-contrast) · i18n in sync. `make ci-fast` still fails only the
known local way — ~340 `asyncpg.exceptions.InvalidPasswordError`, one class, unrelated to
this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
