### PR TITLE
fix(i18n): give every t() key a home, and a gate that says so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,8 @@ jobs:
           echo "All high+ advisories are within the SECURITY.md allowlist."
       - name: Localization Check (i18n)
         run: npm run i18n-check
+      - name: Localization Check (orphan t() keys)
+        run: npm run check-orphan-keys
       - name: API Sync Check
         run: npm run check:api
 

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ check:
 	cd frontend && npm run type-check
 	cd frontend && npm run i18n-check
 	cd frontend && npm run check-interpolations
+	cd frontend && npm run check-orphan-keys
 	cd frontend && npm run lint:a11y
 
 test:

--- a/frontend/e2e/admin/roles.spec.ts
+++ b/frontend/e2e/admin/roles.spec.ts
@@ -209,8 +209,8 @@ test.describe('owner can manage team', () => {
         await memberRow.getByRole('combobox').click();
         await page.getByRole('option', { name: /^viewer$/i }).click();
 
-        // Re-read row and assert new value (the role_update_success toast key
-        // has no en translation yet, so we don't wait for the toast string).
+        // Re-read row and assert new value. The role_update_success toast now
+        // has an en string, but asserting on the row is the stabler signal.
         await expect(memberRow.getByRole('combobox')).toContainText(/viewer/i);
     });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
         "test:e2e:study": "playwright test --project='Study E2E' --project='Study Mobile'",
         "i18n-check": "python3 scripts/check_i18n.py",
         "check-interpolations": "python3 scripts/i18n/check_interpolations.py",
+        "check-orphan-keys": "python3 scripts/check_orphan_keys.py",
         "lint:duplication": "jscpd --config ../.jscpd.json",
         "lint:deadcode": "knip",
         "lint:a11y": "node scripts/check-a11y-names.mjs",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -19,7 +19,8 @@
             "two_factor_app_prompt": "Enter the 6-digit code from your authenticator app.",
             "two_factor_submit": "Verify",
             "two_factor_invalid": "Invalid code. Try again.",
-            "lost_2fa_link": "Lost access to your 2FA?"
+            "lost_2fa_link": "Lost access to your 2FA?",
+            "back_to_home": "Back to home"
         },
         "twofa": {
             "recovery": {
@@ -485,7 +486,9 @@
             "status_for": "Status for {{code}}",
             "create_tag": "Create tag",
             "delete_tag": "Delete {{tag}}",
-            "cancel_delete_tag": "Cancel deleting {{tag}}"
+            "cancel_delete_tag": "Cancel deleting {{tag}}",
+            "viewer_empty_state": "No concourse yet. Ask the project owner or a member to create one.",
+            "retry": "Retry"
         },
         "concourse_import": {
             "title": "Import from concourse",
@@ -657,7 +660,8 @@
                 "deleted": "Analysis run deleted.",
                 "delete_error": "Failed to delete the run.",
                 "viewing_banner": "Viewing run from {{date}}: {{extraction}} · {{n}}F · {{rotation}}",
-                "back_to_current": "Back to current"
+                "back_to_current": "Back to current",
+                "run_label": "Run #{{id}}"
             },
             "factor_voices": {
                 "title": "Voices on Factor {{n}}",
@@ -747,7 +751,8 @@
                 "delta_z_aria": "Δz {{delta}} vs compare run",
                 "delta_loading_aria": "Δloading {{delta}} vs compare run"
             },
-            "quote_insert_format": "> {{text}}\n> {{p}}, on statement {{code}}: \"{{stmt}}\""
+            "quote_insert_format": "> {{text}}\n> {{p}}, on statement {{code}}: \"{{stmt}}\"",
+            "loading_run": "Loading run…"
         },
         "project": {
             "remove_member": "Remove member",
@@ -906,7 +911,10 @@
                 "revoked": "Link revoked",
                 "revoke_failed": "Could not revoke this link. It may already be in use.",
                 "copied": "Copied to clipboard"
-            }
+            },
+            "copied": "Copied",
+            "copy_url": "Copy URL",
+            "generating": "Generating..."
         },
         "analytics": {
             "charts": {
@@ -1136,7 +1144,9 @@
                     "external_partner_logo": "Partner logo for '{{name}}' uses an external URL: {{url}}",
                     "external_logo": "Logo URL references external resource - may not be accessible"
                 }
-            }
+            },
+            "error": "Could not import configuration. See details below and retry.",
+            "invalid_type": "Invalid file type. Please upload a JSON file."
         },
         "dialogs": {
             "create_study": {
@@ -1157,7 +1167,8 @@
         "validation": {
             "required": "Required",
             "slug_min": "Slug must be at least 3 characters",
-            "slug_regex": "Slug must contain only lowercase letters, numbers, and hyphens"
+            "slug_regex": "Slug must contain only lowercase letters, numbers, and hyphens",
+            "language_required": "Select at least one language"
         },
         "study_overview": {
             "title": "Overview",
@@ -1390,7 +1401,8 @@
                         "title": "Step title",
                         "description": "Short description",
                         "icon": "Icon",
-                        "toggle": "Toggle"
+                        "toggle": "Toggle",
+                        "color": "Color"
                     },
                     "defaults": {
                         "new_step": "New study step",
@@ -1810,7 +1822,8 @@
                 "clear_all": "Reset all data",
                 "clear_all_confirm": "DANGER: This will permanently delete ALL participant data for this study. This cannot be undone.",
                 "clear_all_success": "All data cleared",
-                "clear_all_error": "Could not clear data. Check your permissions and try again."
+                "clear_all_error": "Could not clear data. Check your permissions and try again.",
+                "confirm_delete": "Delete"
             },
             "confirm_discard": {
                 "title": "Discard participant?",
@@ -2182,7 +2195,9 @@
                         "copy_link": "Copy link",
                         "copied": "Copied"
                     },
-                    "role_for": "Role for {{name}}"
+                    "role_for": "Role for {{name}}",
+                    "role_update_success": "Role updated",
+                    "role_update_error": "Could not update role. Please try again."
                 }
             }
         },
@@ -2214,7 +2229,8 @@
                 "no_comment": "No comment provided.",
                 "select_instruction": "Select a card on the grid to view details.",
                 "read_only_mode": "Viewer mode",
-                "score": "Score"
+                "score": "Score",
+                "no_response": "No response provided."
             },
             "metadata": {
                 "title": "Session metadata",
@@ -2231,7 +2247,8 @@
                     "mobile": "Mobile",
                     "tablet": "Tablet",
                     "desktop": "Desktop"
-                }
+                },
+                "recruitment_link": "Recruitment link"
             },
             "status": {
                 "started": "Started",
@@ -2250,8 +2267,10 @@
                     "questions": "Questionnaire responses",
                     "comments": "Card comments",
                     "feedback": "General feedback"
-                }
-            }
+                },
+                "audio_recordings": "Audio recordings"
+            },
+            "previous": "Previous"
         },
         "users": {
             "title": "Users",
@@ -2334,7 +2353,17 @@
             "recording": "Audio recording",
             "play": "Play audio",
             "pause": "Pause audio",
-            "seek": "Seek audio position"
+            "seek": "Seek audio position",
+            "file_size": "File size"
+        },
+        "sync": {
+            "saving": "Saving..."
+        },
+        "errors": {
+            "access_denied": {
+                "title": "Access denied",
+                "message": "You do not have access to the researcher area. Ask a project owner to add you to a project."
+            }
         }
     }
 }

--- a/frontend/scripts/check_orphan_keys.py
+++ b/frontend/scripts/check_orphan_keys.py
@@ -1,0 +1,302 @@
+"""Fail when a `t()` key in src/ resolves in no locale file at all.
+
+`check_i18n.py` compares the locale files **against each other**. A key that is
+absent from every one of them — including `en/` — is, to that tool, perfectly in
+sync: nothing is missing relative to the master. What actually renders in that
+case is the developer-written second argument (`t('a.b', 'Fallback')`), or, when
+there is no second argument, the raw dotted key. Either way the string is
+English for every locale and invisible to translators, because there is no key
+for them to translate.
+
+This script closes that gap: it parses every `t(` call site in `src/`, resolves
+each key against the union of all locale files, and fails on the ones that
+resolve nowhere.
+
+Read the COVERAGE block it prints before trusting a green run: it states exactly
+which call-site forms it can and cannot see, and lists the deferred keys by name
+and reason. There is no silent escape hatch.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "i18n"))
+
+from i18n_utils import get_keys  # noqa: E402
+from namespace_partition import NAMESPACES  # noqa: E402
+
+REPO_FRONTEND = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+
+# ---------------------------------------------------------------------------
+# Deferred keys.
+#
+# Every entry here is a key that resolves in NO locale file and is therefore a
+# known defect, not an approved state. It is listed — by name, with a reason —
+# because fixing it needs work this checker cannot do on its own, not because it
+# is acceptable. The list is printed on every run, pass or fail. Shrink it; do
+# not grow it. Adding an entry to silence a new failure defeats the check.
+#
+# All current entries share one cause: the key lives in the `participant`
+# namespace, whose parity policy is *strict* (see check_i18n.py). Adding it to
+# `en/participant.json` alone makes the other eight locales fail CI, so each one
+# needs a real translation in nine files — a translation task, not this one.
+# ---------------------------------------------------------------------------
+DEFERRED: dict[str, str] = {
+    "common.edit": "participant ns is strict-parity; needs 9-locale translation (admin-only call sites in ConcourseDetailPage, in flight on another branch)",
+    "common.save": "participant ns is strict-parity; needs 9-locale translation (admin-only call sites in ConcourseDetailPage, in flight on another branch)",
+    "common.remove": "participant ns is strict-parity; needs 9-locale translation",
+    "common.retry": "participant ns is strict-parity; needs 9-locale translation",
+    "common.status.offline": "participant ns is strict-parity; needs 9-locale translation",
+    "common.errors.component_error": "participant ns is strict-parity; needs 9-locale translation",
+    "common.errors.conflict_title": "participant ns is strict-parity; needs 9-locale translation; renders the raw key today",
+    "common.errors.conflict_message": "participant ns is strict-parity; needs 9-locale translation; renders the raw key today",
+    "common.errors.timeout.title": "participant ns is strict-parity; needs 9-locale translation",
+    "common.errors.timeout.message": "participant ns is strict-parity; needs 9-locale translation",
+    "common.errors.validation_title": "participant ns is strict-parity; needs 9-locale translation; renders the raw key today",
+    "common.errors.validation_message": "participant ns is strict-parity; needs 9-locale translation; renders the raw key today",
+    "fine.deck.confirm_reset": "participant ns is strict-parity; needs 9-locale translation; renders the raw key today",
+    "fine.grid.slot_label": "participant ns is strict-parity; needs 9-locale translation",
+    "post.extreme.required": "participant ns is strict-parity; needs 9-locale translation",
+    "post.submit_error.hint": "participant ns is strict-parity; needs 9-locale translation",
+    "study.access.password_label": "participant ns is strict-parity; needs 9-locale translation",
+    "study.access.protected_desc": "participant ns is strict-parity; needs 9-locale translation",
+    "study.access.unlock_btn": "participant ns is strict-parity; needs 9-locale translation",
+    "study.access.wrong_password": "participant ns is strict-parity; needs 9-locale translation",
+}
+
+PLURAL_SUFFIXES = ("_zero", "_one", "_two", "_few", "_many", "_other")
+
+
+# ---------------------------------------------------------------------------
+# Minimal TS/TSX scanner
+# ---------------------------------------------------------------------------
+def read_string_literal(s: str, i: int, keep: bool = False):
+    """If s[i] opens a string/template literal, return (quote, body, end).
+
+    With keep=False the body of a template literal has each `${...}` hole
+    replaced by the placeholder `${*}` so it can be turned into a glob.
+    """
+    q = s[i] if i < len(s) else ""
+    if q not in "\"'`":
+        return None
+    j = i + 1
+    body: list[str] = []
+    while j < len(s):
+        c = s[j]
+        if c == "\\":
+            body.append(s[j : j + 2])
+            j += 2
+            continue
+        if q == "`" and c == "$" and j + 1 < len(s) and s[j + 1] == "{":
+            k = j + 2
+            depth = 1
+            while k < len(s) and depth:
+                if s[k] == "{":
+                    depth += 1
+                elif s[k] == "}":
+                    depth -= 1
+                k += 1
+            body.append(s[j:k] if keep else "${*}")
+            j = k
+            continue
+        if c == q:
+            return (q, s[i : j + 1] if keep else "".join(body), j + 1)
+        if q != "`" and c == "\n":
+            return None
+        body.append(c)
+        j += 1
+    return None
+
+
+def strip_comments(s: str) -> str:
+    """Blank out // and /* */ comments, preserving offsets and line numbers.
+
+    Without this, prose such as `// the t() call above` is mistaken for a call
+    site — which is how a naive scan reports phantom orphans.
+    """
+    out: list[str] = []
+    i, n = 0, len(s)
+    while i < n:
+        c = s[i]
+        if c in "\"'`":
+            lit = read_string_literal(s, i, keep=True)
+            if lit:
+                out.append(lit[1])
+                i = lit[2]
+                continue
+        if c == "/" and i + 1 < n and s[i + 1] == "/":
+            j = s.find("\n", i)
+            j = n if j < 0 else j
+            out.append(" " * (j - i))
+            i = j
+            continue
+        if c == "/" and i + 1 < n and s[i + 1] == "*":
+            j = s.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            out.append("".join(ch if ch == "\n" else " " for ch in s[i:j]))
+            i = j
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+# `t(` not preceded by an identifier character or a dot, so `.t(` (i18n.t) and
+# `format(` do not match. i18n.t is not used in src/; if it ever is, this
+# regex must be widened.
+CALL_RE = re.compile(r"(?<![\w$.])t\(")
+
+
+def collect_sites(src_dir: str):
+    """Return (sites, opaque) over src_dir.
+
+    sites  : (relpath, line, key, is_template)
+    opaque : (relpath, line, snippet) — the first argument is not a literal, so
+             the key is unknowable statically. Reported, never hidden.
+    """
+    files: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(src_dir):
+        dirnames[:] = [
+            d for d in dirnames if d not in ("test-utils", "__tests__", "__mocks__")
+        ]
+        files.extend(
+            os.path.join(dirpath, fn)
+            for fn in filenames
+            if fn.endswith((".ts", ".tsx")) and ".test." not in fn and ".spec." not in fn
+        )
+    files.sort()
+
+    sites, opaque = [], []
+    for path in files:
+        with open(path, encoding="utf-8") as f:
+            src = strip_comments(f.read())
+        rel = os.path.relpath(path, REPO_FRONTEND)
+        for m in CALL_RE.finditer(src):
+            i = m.end()
+            while i < len(src) and src[i] in " \t\n\r":
+                i += 1
+            line = src.count("\n", 0, m.start()) + 1
+            lit = read_string_literal(src, i)
+            if lit is None:
+                snippet = " ".join(src[m.start() : m.start() + 60].split())
+                opaque.append((rel, line, snippet))
+                continue
+            quote, key, _ = lit
+            sites.append((rel, line, key, quote == "`" and "${*}" in key))
+    return files, sites, opaque
+
+
+def load_locale_keys(locales_dir: str):
+    """Union of every key in every locale file, plus the language list."""
+    keys: set[str] = set()
+    langs = sorted(
+        d for d in os.listdir(locales_dir) if os.path.isdir(os.path.join(locales_dir, d))
+    )
+    files = 0
+    for lang in langs:
+        for ns in NAMESPACES:
+            path = os.path.join(locales_dir, lang, f"{ns}.json")
+            if os.path.exists(path):
+                with open(path, encoding="utf-8") as f:
+                    keys |= get_keys(json.load(f))
+                files += 1
+    return keys, langs, files
+
+
+def make_resolver(locale_keys: set[str]):
+    """A key resolves if it is present, or is the stem of a plural/context key.
+
+    i18next appends `_one`/`_other` (plurals) and `_<context>` (context) to the
+    key the developer writes, so `t('a.n_items', {count})` is live when only
+    `a.n_items_one` / `a.n_items_other` exist in the JSON.
+    """
+    stems = {k.rsplit("_", 1)[0] for k in locale_keys if k.endswith(PLURAL_SUFFIXES)}
+    context_stems = set()
+    for k in locale_keys:
+        head, _, leaf = k.rpartition(".")
+        if head and "_" in leaf:
+            context_stems.add(f"{head}.{leaf.split('_')[0]}")
+
+    def resolves(key: str, is_template: bool) -> bool:
+        if is_template:
+            glob = key.replace("${*}", "*")
+            return any(
+                fnmatch.fnmatchcase(k, glob) or fnmatch.fnmatchcase(k, glob + "_*")
+                for k in locale_keys
+            )
+        return key in locale_keys or key in stems or key in context_stems
+
+    return resolves
+
+
+def check_orphan_keys(src_dir: str | None = None, locales_dir: str | None = None) -> int:
+    src_dir = src_dir or os.path.join(REPO_FRONTEND, "src")
+    locales_dir = locales_dir or os.path.join(REPO_FRONTEND, "public", "locales")
+
+    locale_keys, langs, locale_files = load_locale_keys(locales_dir)
+    resolves = make_resolver(locale_keys)
+    files, sites, opaque = collect_sites(src_dir)
+
+    orphans: dict[str, list[tuple[str, int]]] = {}
+    for rel, line, key, is_tpl in sites:
+        if not resolves(key, is_tpl):
+            orphans.setdefault(key, []).append((rel, line))
+
+    print("Checking for t() keys that resolve in no locale file")
+    print("\nCOVERAGE — what this check inspects, and what it cannot")
+    print(f"  ✓ inspected  {len(files)} .ts/.tsx files under {os.path.relpath(src_dir, REPO_FRONTEND)}")
+    print(f"  ✓ inspected  {len(sites)} t() call sites with a literal or template-literal key")
+    print(f"  ✓ resolved   against {len(locale_keys)} keys from {locale_files} files "
+          f"across {len(langs)} locales ({', '.join(langs)})")
+    print("  ✓ understands i18next plural (_one/_other/…) and context (_suffix) key stems")
+    print("  ✓ understands template-literal keys: `a.b.${x}` is matched as the glob a.b.*")
+    print("  ✓ comments are blanked before scanning, so prose mentioning t() is not a call site")
+    print("  ✗ SKIPS *.test.*, *.spec.*, test-utils/, __tests__/, __mocks__/ — test copy is not shipped UI")
+    print(f"  ✗ BLIND to {len(opaque)} call sites whose first argument is not a literal")
+    print("      (t(key), t(step.labelKey), t(...tuple) — the key is only known at runtime):")
+    for rel, line, snippet in opaque:
+        print(f"        {rel}:{line}  {snippet}")
+    print("  ✗ BLIND to keys reached only through i18next's own fallbackLng chain at runtime")
+
+    print(f"\nDEFERRED — {len(DEFERRED)} known-orphan keys carried as debt, never silent:")
+    stale: list[str] = []
+    for key in sorted(DEFERRED):
+        hits = orphans.pop(key, [])
+        if not hits:
+            stale.append(key)
+        where = ", ".join(f"{r}:{n}" for r, n in hits) or "no live call site"
+        print(f"  ⚠️  {key}  — {DEFERRED[key]}")
+        print(f"        at {where}")
+
+    if stale:
+        print("\n  ℹ️  deferred entries that are no longer orphaned or no longer")
+        print("      referenced — delete them from DEFERRED in this file:")
+        for key in stale:
+            print(f"        {key}")
+
+    n_sites = sum(len(v) for v in orphans.values())
+    if orphans:
+        print(f"\n❌ FAIL: {len(orphans)} key(s) / {n_sites} call site(s) resolve in no locale file.")
+        for key in sorted(orphans):
+            for rel, line in orphans[key]:
+                print(f"  ❌ {key}\n        {rel}:{line}")
+        print(
+            "\nFix by adding the key to public/locales/en/admin.json with the call site's\n"
+            "own fallback text as its value (admin parity is best-effort — the other\n"
+            "locales fall back to English). Participant-namespace keys need all nine\n"
+            "locales, because that namespace is strict-parity."
+        )
+        return 1
+
+    print("\n✅ PASS: every statically visible t() key resolves in at least one locale file.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check_orphan_keys())

--- a/frontend/scripts/i18n/test_check_orphan_keys.py
+++ b/frontend/scripts/i18n/test_check_orphan_keys.py
@@ -1,0 +1,126 @@
+"""Unit tests for the orphan-key gate.
+
+Builds a synthetic src/ + locales/ tree in tmpdir and runs
+check_orphan_keys() programmatically (no subprocess), so the tests state
+exactly which call-site shapes the scanner is expected to see and to miss.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "frontend" / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "frontend" / "scripts" / "i18n"))
+
+import check_orphan_keys  # noqa: E402
+
+
+@pytest.fixture
+def tree(tmp_path):
+    """Return (write_src, write_locale, run)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    locales = tmp_path / "locales"
+
+    def write_src(name: str, body: str) -> None:
+        (src / name).write_text(body, encoding="utf-8")
+
+    def write_locale(lang: str, namespace: str, data: dict) -> None:
+        d = locales / lang
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{namespace}.json").write_text(
+            json.dumps(data, ensure_ascii=False, indent=4), encoding="utf-8"
+        )
+
+    def run() -> int:
+        return check_orphan_keys.check_orphan_keys(str(src), str(locales))
+
+    write_locale("en", "participant", {"common": {"next": "Next"}})
+    write_locale("en", "admin", {"admin": {"x": {"y": "Y"}}})
+    return write_src, write_locale, run
+
+
+def test_resolvable_key_passes(tree):
+    write_src, _, run = tree
+    write_src("A.tsx", "export const A = () => <p>{t('admin.x.y', 'Y')}</p>;")
+    assert run() == 0
+
+
+def test_orphan_key_fails(tree):
+    write_src, _, run = tree
+    write_src("A.tsx", "export const A = () => <p>{t('admin.x.gone', 'Gone')}</p>;")
+    assert run() == 1
+
+
+def test_key_only_in_a_non_en_locale_still_resolves(tree):
+    """The gate asks 'does this resolve anywhere', not 'is en complete'."""
+    write_src, write_locale, run = tree
+    write_locale("fr", "admin", {"admin": {"only_fr": "Seulement"}})
+    write_src("A.tsx", "export const A = () => <p>{t('admin.only_fr')}</p>;")
+    assert run() == 0
+
+
+def test_plural_stem_resolves(tree):
+    write_src, write_locale, run = tree
+    write_locale(
+        "en", "admin", {"admin": {"n_items_one": "1 item", "n_items_other": "{{count}} items"}}
+    )
+    write_src("A.tsx", "export const A = () => <p>{t('admin.n_items', { count: 2 })}</p>;")
+    assert run() == 0
+
+
+def test_template_literal_key_resolves_as_a_glob(tree):
+    write_src, write_locale, run = tree
+    write_locale("en", "admin", {"admin": {"tabs": {"grid": "Grid", "list": "List"}}})
+    write_src("A.tsx", "export const A = () => <p>{t(`admin.tabs.${which}`)}</p>;")
+    assert run() == 0
+
+
+def test_template_literal_key_with_no_match_fails(tree):
+    write_src, _, run = tree
+    write_src("A.tsx", "export const A = () => <p>{t(`admin.nope.${which}`)}</p>;")
+    assert run() == 1
+
+
+def test_t_inside_a_comment_is_not_a_call_site(tree):
+    write_src, _, run = tree
+    write_src(
+        "A.tsx",
+        "// the t('admin.x.ghost') call below was removed\n"
+        "/* also t('admin.x.ghost2') */\n"
+        "export const A = () => <p>{t('admin.x.y')}</p>;",
+    )
+    assert run() == 0
+
+
+def test_dotted_t_is_not_a_call_site(tree):
+    write_src, _, run = tree
+    write_src("A.tsx", "export const A = () => i18n.t('admin.x.ghost');")
+    assert run() == 0
+
+
+def test_test_files_are_skipped(tree):
+    write_src, _, run = tree
+    write_src("A.test.tsx", "it('x', () => { t('admin.x.ghost'); });")
+    assert run() == 0
+
+
+def test_deferred_key_does_not_fail_but_is_reported(tree, capsys, monkeypatch):
+    write_src, _, run = tree
+    monkeypatch.setitem(check_orphan_keys.DEFERRED, "admin.x.gone", "test reason")
+    write_src("A.tsx", "export const A = () => <p>{t('admin.x.gone', 'Gone')}</p>;")
+    assert run() == 0
+    out = capsys.readouterr().out
+    assert "admin.x.gone" in out
+    assert "test reason" in out
+
+
+def test_non_literal_first_arg_is_reported_as_blind(tree, capsys):
+    write_src, _, run = tree
+    write_src("A.tsx", "export const A = () => <p>{t(dynamicKey, fallback)}</p>;")
+    assert run() == 0
+    out = capsys.readouterr().out
+    assert "BLIND to 1 call sites" in out
+    assert "A.tsx:1" in out

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -816,7 +816,7 @@ export default function InteractiveDataView({
                                 onClick={handleClearAllParticipants}
                                 className="rounded-2xl font-bold h-12 bg-rose-600 hover:bg-rose-700"
                             >
-                                {t('common.confirm_delete')}
+                                {t('admin.data.actions.confirm_delete')}
                             </AlertDialogAction>
                         </AlertDialogFooter>
                     </AlertDialogContent>

--- a/frontend/src/components/admin/designer/LanguageManagerModal.tsx
+++ b/frontend/src/components/admin/designer/LanguageManagerModal.tsx
@@ -122,7 +122,7 @@ const LanguageManagerModal = ({ isOpen, onClose }: LanguageManagerModalProps) =>
                                                 className="bg-indigo-100 text-indigo-700 border-none"
                                             >
                                                 <Check className="h-3 w-3 mr-1" />{' '}
-                                                {t('common.active', 'Active')}
+                                                {t('admin.status.active', 'Active')}
                                             </Badge>
                                         </div>
                                     ) : (

--- a/frontend/src/components/auth/RequireAdmin.tsx
+++ b/frontend/src/components/auth/RequireAdmin.tsx
@@ -50,8 +50,8 @@ const RequireAdmin = () => {
             <div className="flex h-screen w-full items-center justify-center p-4">
                 <Alert variant="destructive" className="max-w-md">
                     <ShieldAlert className="h-4 w-4" />
-                    <AlertTitle>{t('common.errors.access_denied.title')}</AlertTitle>
-                    <AlertDescription>{t('common.errors.access_denied.message')}</AlertDescription>
+                    <AlertTitle>{t('admin.errors.access_denied.title')}</AlertTitle>
+                    <AlertDescription>{t('admin.errors.access_denied.message')}</AlertDescription>
                 </Alert>
             </div>
         );

--- a/frontend/src/hooks/admin/useStudyDesignPage.ts
+++ b/frontend/src/hooks/admin/useStudyDesignPage.ts
@@ -481,7 +481,7 @@ export function useStudyDesignPage(): StudyDesignPageApi {
                 params: { new_state: 'active' },
             });
 
-            toast.success(t('admin.study.state_changed_active') || 'Study is now active!');
+            toast.success(t('admin.study_status.notifications.state_changed_active'));
             window.location.reload();
         } catch (error) {
             toast.error(

--- a/frontend/src/pages/admin/ConcourseListPage.tsx
+++ b/frontend/src/pages/admin/ConcourseListPage.tsx
@@ -99,7 +99,7 @@ export default function ConcourseListPage() {
                     ) : (
                         <RefreshCw className="size-4 mr-2" />
                     )}
-                    {t('common.retry', 'Retry')}
+                    {t('admin.concourse.retry', 'Retry')}
                 </Button>
             </div>
         );

--- a/frontend/src/pages/admin/ParticipantDetailsPage.tsx
+++ b/frontend/src/pages/admin/ParticipantDetailsPage.tsx
@@ -267,7 +267,7 @@ export default function ParticipantDetailsPage() {
                                 size="icon"
                                 disabled={prevId === null}
                                 onClick={() => navigate(`${baseUrl}/participants/${prevId}`)}
-                                aria-label={t('common.previous', 'Previous')}
+                                aria-label={t('admin.participant.previous', 'Previous')}
                             >
                                 <ChevronLeft className="w-4 h-4" />
                             </Button>

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -808,7 +808,7 @@ const RecruitmentPage = () => {
                                             className="bg-indigo-600 hover:bg-indigo-700 font-bold px-8 rounded-xl shadow-lg shadow-indigo-200"
                                         >
                                             {isCreatingLink
-                                                ? t('common.generating', 'Generating...')
+                                                ? t('admin.recruitment.generating', 'Generating...')
                                                 : t(
                                                       'admin.recruitment.generate_links',
                                                       'Generate Links'


### PR DESCRIPTION
Task 4.4 of the admin UX remediation plan. This one is a gap in the instrument, not one
more item on the list.

## The gap

`check_i18n.py` compares locale files **against each other**. A key that exists in none of
them is, to that tool, perfectly in sync. So `t('some.key', 'Some fallback')` where
`some.key` exists nowhere renders the developer-written fallback, passes every i18n gate
in the repo, and is invisible to translators — nine locales cannot translate a string that
has no key.

`check_orphan_keys.py` asks the other question: does every `t()` key resolve *somewhere*?

## The count is 44 keys / 49 call sites, not the 38 / 33 the plan carried

Re-derived rather than inherited. Three things move the number, and each was a real error
in the original count:

- **Plural stems.** Four keys were called dead that are alive as i18next plurals
  (`admin.dashboard.n_participants` resolves via `_one`/`_other`).
- **Comments.** Five phantom sites came from `t(` inside commented-out code. The scanner
  now blanks comments while preserving byte offsets, so line numbers stay true.
- **Namespace scope.** 26 of the 44 are participant-namespace, which the original framing
  did not anticipate at all.

## The finding nobody was looking for: 11 sites render a raw dotted key

Eleven call sites pass **no fallback**, or use `t('key') || 'Fallback'` — an idiom that
never fires, because i18next returns the truthy key itself on a miss. `'common.retry' ||
'Retry'` is always `'common.retry'`.

So these did not render English. They rendered the key:

- a destructive confirm button labelled `common.confirm_delete`
- the entire access-denied alert in `RequireAdmin` — title *and* body
- two toasts and a `window.confirm`

`e2e/admin/roles.spec.ts:212` already carried a comment noting one of them and routing its
assertion around it. The workaround outlived the memory of what it was working around.

## Triage — 0 dead, 0 deliberate

- **14 keys** added to `en/admin.json` with each call site's fallback verbatim → zero render change.
- **2 keys** were simply wrong, repointed to existing already-translated siblings.
- **6 keys** lived in the participant namespace but are only ever rendered by admin-only
  components; moved to `admin.*`.
- **6 of the above had no fallback at all**, so minimal sentence-case copy was authored.
  That is the one place in this PR where new user-facing wording was written, and it is
  called out as such in the report rather than buried.
- **Dead: 0.** Reachability proven for all 44 — the ~7 expected dead keys do not survive
  handling plural stems and comments.

## 20 keys are deferred, loudly

These are participant-namespace (`common.*`, `fine.*`, `post.*`, `study.*`), and that
namespace is **strict parity**. Adding them to `en` alone makes eight locales fail and CI
exit 1. Closing them honestly needs nine real translations, and machine-translating them
was not on the table. They are carried in a `DEFERRED` list printed on **every** run, with
each reason and each live call site — debt with a name rather than silence.

Largest hole: `study.access.*` — the entire participant password gate, four keys,
untranslated in every locale. That is participant-facing, so it is worth its own task.

## The gate, and what it admits it cannot see

`frontend/scripts/check_orphan_keys.py`, wired into `package.json`, the `Makefile` `check`
target, and `ci.yml`. 11 unit tests.

Two constraints, both learned the hard way on this plan:

1. **It states its own coverage.** Every run prints a COVERAGE block: `✓` for what it
   inspects (682 files, 1941 sites, 2175 keys, 9 locales, template literals, plural stems)
   and `✗` for what it cannot — **including the full file:line list of all 17 non-literal
   `t()` call sites**. A checker that silently skips a category certifies its own blind
   spot; this one prints the size of it on a green run.
2. **Its escape hatch is not silent.** Task 6.7's gate could be silenced by the very thing
   that task was adding. The only hatch here is `DEFERRED`, and it is printed every run
   with stale entries flagged for deletion.

Stated limitation: stale `DEFERRED` entries warn, they do not fail.

## Verified adversarially

Injecting one orphan key makes the gate exit **1**; removing it exits **0**. A gate that
prints `FAIL` and exits 0 is decorative, so the exit code was checked directly rather than
through a pipeline that would mask it.

## Divergences handed to Phase 5: 114 call sites / 102 keys

Casing-only divergence is **0**, confirming task 4.2's fix held. The rest is classified —
72 materially different, 39 one-contains-the-other, 3 punctuation-only — and handed on
rather than resolved here.

## Gates

lint 888 files · `tsc` exit 0 · **1778 passed / 6 skipped** · a11y at baseline ·
`i18n-check` · `check-interpolations` · `check-orphan-keys` — all clean.

**i18n-check warnings go from 16 to 200** (+184). Expected and correct: adding 23 keys to
`en/admin.json` makes eight locales report them missing, admin parity is best-effort per
CLAUDE.md, and a missing key falls back to English. Nothing was machine-translated. The two
pre-existing `admin.analysis.*` warnings were verified against `main` by stashing — they
predate this work and are reported, not silenced.

**E2E:** six strings change (the ex-raw-key ones). All six old keys and all six new strings
were grepped across `frontend/e2e/` — no spec asserts on any of them. The only hit was the
stale comment above, now corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
