### PR TITLE
fix(admin): one date and time format, driven by the app's language

### DIFF
--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -14,7 +14,6 @@ import {
     Library,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { formatDistanceToNow, format } from 'date-fns';
 import { cn } from '@/lib/utils';
 
 import { Button } from '@/components/ui/button';
@@ -27,6 +26,7 @@ import { CreateStudyDialog } from '@/components/admin/CreateStudyDialog';
 import { ImportStudyDialog } from '@/components/admin/ImportStudyDialog';
 import { useTranslation } from 'react-i18next';
 import { useAdminDashboard } from '@/hooks/admin/useAdminDashboard';
+import { useDateFormat } from '@/hooks/useDateFormat';
 import type { StudyRead } from '@/api/model/studyRead';
 import type { ConcourseRead } from '@/api/model/concourseRead';
 
@@ -122,7 +122,6 @@ export function AdminDashboard() {
         concourse,
         isConcourseLoading,
         alerts,
-        currentLocale,
         showCreateDialog,
         showImportDialog,
         setShowCreateDialog,
@@ -362,7 +361,6 @@ export function AdminDashboard() {
                     study={studies[0]}
                     title={getStudyTitle(studies[0])}
                     projectSlug={projectSlug}
-                    locale={currentLocale}
                     t={t}
                     onCreateStudy={canCreateStudy ? () => setShowCreateDialog(true) : undefined}
                 />
@@ -374,7 +372,6 @@ export function AdminDashboard() {
                     closedStudies={closedStudies}
                     getTitle={getStudyTitle}
                     onOpen={handleOpenStudy}
-                    locale={currentLocale}
                     t={t}
                 />
             )}
@@ -507,19 +504,17 @@ function SingleStudyCard({
     study,
     title,
     projectSlug,
-    locale,
     t,
     onCreateStudy,
 }: {
     study: StudyRead;
     title: string;
     projectSlug: string;
-    // biome-ignore lint/suspicious/noExplicitAny: date-fns locale type
-    locale: any;
     t: TranslateFn;
     onCreateStudy?: () => void; // omitted for viewers — Add-study CTA hides
 }) {
     const navigate = useNavigate();
+    const { formatDate, formatRelative } = useDateFormat();
     const participants = study.participant_count ?? 0;
     const languageCodes =
         study.translations?.map((tr) => tr.language_code.toUpperCase()).join(', ') ?? '';
@@ -593,18 +588,13 @@ function SingleStudyCard({
                                 </span>
                                 <span className="inline-flex items-center gap-1">
                                     <Calendar className="h-3 w-3" />
-                                    {formatDistanceToNow(new Date(study.created_at), {
-                                        addSuffix: true,
-                                        locale,
-                                    })}
+                                    {formatRelative(study.created_at)}
                                 </span>
                                 {study.end_date && (
                                     <span className="inline-flex items-center gap-1">
                                         <Clock className="h-3 w-3" />
                                         {t('admin.dashboard.closes', 'Closes')}{' '}
-                                        {format(new Date(study.end_date as string), 'PP', {
-                                            locale,
-                                        })}
+                                        {formatDate(study.end_date)}
                                     </span>
                                 )}
                             </div>
@@ -630,7 +620,6 @@ function StudyGroups({
     closedStudies,
     getTitle,
     onOpen,
-    locale,
     t,
 }: {
     activeStudies: StudyRead[];
@@ -639,8 +628,6 @@ function StudyGroups({
     closedStudies: StudyRead[];
     getTitle: (s: StudyRead) => string;
     onOpen: (slug: string) => void;
-    // biome-ignore lint/suspicious/noExplicitAny: date-fns locale type
-    locale: any;
     t: TranslateFn;
 }) {
     return (
@@ -651,7 +638,6 @@ function StudyGroups({
                     studies={activeStudies}
                     getTitle={getTitle}
                     onOpen={onOpen}
-                    locale={locale}
                     t={t}
                 />
             )}
@@ -661,7 +647,6 @@ function StudyGroups({
                     studies={pausedStudies}
                     getTitle={getTitle}
                     onOpen={onOpen}
-                    locale={locale}
                     t={t}
                 />
             )}
@@ -671,7 +656,6 @@ function StudyGroups({
                     studies={draftStudies}
                     getTitle={getTitle}
                     onOpen={onOpen}
-                    locale={locale}
                     t={t}
                 />
             )}
@@ -681,7 +665,6 @@ function StudyGroups({
                     studies={closedStudies}
                     getTitle={getTitle}
                     onOpen={onOpen}
-                    locale={locale}
                     t={t}
                     collapsed
                 />
@@ -695,7 +678,6 @@ function StudyGroup({
     studies,
     getTitle,
     onOpen,
-    locale,
     t,
     collapsed = false,
 }: {
@@ -703,8 +685,6 @@ function StudyGroup({
     studies: StudyRead[];
     getTitle: (s: StudyRead) => string;
     onOpen: (slug: string) => void;
-    // biome-ignore lint/suspicious/noExplicitAny: date-fns locale type
-    locale: any;
     t: TranslateFn;
     collapsed?: boolean;
 }) {
@@ -734,7 +714,6 @@ function StudyGroup({
                             study={study}
                             title={getTitle(study)}
                             onOpen={() => onOpen(study.slug)}
-                            locale={locale}
                             t={t}
                         />
                     ))}
@@ -748,16 +727,14 @@ function StudyRow({
     study,
     title,
     onOpen,
-    locale,
     t,
 }: {
     study: StudyRead;
     title: string;
     onOpen: () => void;
-    // biome-ignore lint/suspicious/noExplicitAny: date-fns locale type
-    locale: any;
     t: TranslateFn;
 }) {
+    const { formatDate, formatRelative } = useDateFormat();
     const languageCodes =
         study.translations?.map((tr) => tr.language_code.toUpperCase()).join(', ') ?? '';
     const participants = study.participant_count ?? 0;
@@ -805,16 +782,13 @@ function StudyRow({
                             </span>
                             <span className="inline-flex items-center gap-1">
                                 <Calendar className="h-3 w-3" />
-                                {formatDistanceToNow(new Date(study.created_at), {
-                                    addSuffix: true,
-                                    locale,
-                                })}
+                                {formatRelative(study.created_at)}
                             </span>
                             {study.end_date && (
                                 <span className="inline-flex items-center gap-1">
                                     <Clock className="h-3 w-3" />
                                     {t('admin.dashboard.closes', 'Closes')}{' '}
-                                    {format(new Date(study.end_date as string), 'PP', { locale })}
+                                    {formatDate(study.end_date)}
                                 </span>
                             )}
                         </div>

--- a/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '@/hooks/useDateFormat';
 import { toast } from 'sonner';
 import { ClipboardList, Pencil, Trash2, Check, X, ChevronDown, ChevronUp } from 'lucide-react';
 import {
@@ -45,20 +46,6 @@ interface AnalysisHistoryPanelProps {
     onLoadRun: (result: AnalysisResult, run: AnalysisRunSummary) => void;
 }
 
-function formatDateTime(iso: string): string {
-    try {
-        return new Date(iso).toLocaleString(undefined, {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit',
-        });
-    } catch {
-        return iso;
-    }
-}
-
 function truncate(str: string, maxLen: number): string {
     if (str.length <= maxLen) return str;
     return `${str.slice(0, maxLen)}…`;
@@ -71,6 +58,7 @@ export function AnalysisHistoryPanel({
     onLoadRun,
 }: AnalysisHistoryPanelProps) {
     const { t } = useTranslation();
+    const { formatDateTime } = useDateFormat();
     const queryClient = useQueryClient();
 
     const [collapsed, setCollapsed] = useState(false);

--- a/frontend/src/components/admin/concourse/ItemDetailSheet.tsx
+++ b/frontend/src/components/admin/concourse/ItemDetailSheet.tsx
@@ -22,6 +22,7 @@ import {
 import type { ConcourseItemVersionRead, ConcourseItemCommentRead } from '@/api/model';
 import { useQueryClient } from '@tanstack/react-query';
 import { parseApiErrorSync } from '@/lib/error-utils';
+import { useDateFormat } from '@/hooks/useDateFormat';
 import { diffVersionFields } from './ItemDetailSheet.helpers';
 
 interface ItemDetailSheetProps {
@@ -97,16 +98,7 @@ export function ItemDetailSheet({
         }
     };
 
-    const formatDate = (dateStr: string) => {
-        const d = new Date(dateStr);
-        return d.toLocaleDateString(undefined, {
-            month: 'short',
-            day: 'numeric',
-            year: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit',
-        });
-    };
+    const { formatDateTime: formatDate } = useDateFormat();
 
     return (
         <Sheet open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -63,10 +63,9 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/datetime';
 import { parseUA } from '@/utils/uaParser';
 import { useTranslation } from 'react-i18next';
-import { format } from 'date-fns';
-import type { Locale } from 'date-fns/locale';
 import type { DumpParticipant } from './types';
 import type {
     ConsentType,
@@ -235,7 +234,8 @@ export function ParticipantCell({
 
 export interface BuildColumnsParams {
     t: TFunction;
-    currentLocale: Locale;
+    /** Active i18n language; see `lib/datetime`. */
+    language: string;
     duplicateIpGroups: Map<string, number>;
     showLanguageColumn: boolean;
     statusFilter: StatusFilter;
@@ -263,7 +263,7 @@ export interface BuildColumnsParams {
 
 export function buildColumns({
     t,
-    currentLocale,
+    language,
     duplicateIpGroups,
     showLanguageColumn,
     statusFilter,
@@ -779,31 +779,29 @@ export function buildColumns({
                 const val = info.getValue();
                 if (!val) return <span className="text-slate-500">—</span>;
                 const date = new Date(val);
-                const shortLabel = format(date, 'MMM d, HH:mm', { locale: currentLocale });
-                const fullLabel = format(date, 'PPpp', { locale: currentLocale });
+                const label = formatDateTime(date, language);
                 // Plain span, no role (Task 6.7i review finding 2): the
-                // short date is already the accessible name via its own
-                // visible text, sitting in a sorted temporal column —
-                // role="img" would make a screen reader announce it as
-                // "graphic, Jan 1, 01:10" instead of a date.
+                // date is already the accessible name via its own visible
+                // text, sitting in a sorted temporal column — role="img"
+                // would make a screen reader announce it as "graphic, Jan 1,
+                // 01:10" instead of a date.
                 //
-                // One channel, not two (re-review, 2026-07-28): no `title`
-                // here alongside the sr-only span — keeping both would
-                // double-announce the full timestamp on any AT/browser
-                // pairing that surfaces the accessible description
-                // alongside the name (see the duplicate-IP badge above for
-                // the full HTML-AAM reasoning; identical trade here). The
-                // sr-only span is the one reliable channel to a screen
-                // reader; the trade-off accepted, not solved, is that a
-                // sighted mouse user no longer gets a hover tooltip for the
-                // full timestamp, and neither they nor a sighted
-                // keyboard-only/touch user without AT can reach it at all
-                // now — there is no longer any focusable trigger to reveal
-                // it on demand.
+                // One channel, not two (re-review, 2026-07-28): no `title`,
+                // which would double-announce on any AT/browser pairing that
+                // surfaces the accessible description alongside the name (see
+                // the duplicate-IP badge above for the full HTML-AAM
+                // reasoning; identical trade here).
+                //
+                // Task 4.3 removed the sr-only companion span that used to
+                // carry a *longer* form of the same timestamp. It existed
+                // because the visible label was the year-less `MMM d, HH:mm`
+                // while screen readers got the full `PPpp`. Now that
+                // `formatDateTime` is the single format, the visible text
+                // already carries day, month, year and 24-hour time, so the
+                // second span was announcing the identical string twice.
                 return (
                     <span className="flex flex-col text-xs text-slate-500 font-medium">
-                        {shortLabel}
-                        <span className="sr-only"> {fullLabel}</span>
+                        {label}
                     </span>
                 );
             },

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.stopPropagation.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.stopPropagation.test.tsx
@@ -54,7 +54,6 @@
 import { useMemo } from 'react';
 import { useReactTable, getCoreRowModel, flexRender } from '@tanstack/react-table';
 import type { TFunction } from 'i18next';
-import { enUS } from 'date-fns/locale';
 import { render, renderWithProviders, screen } from '@/test-utils/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
@@ -176,7 +175,7 @@ function GuardlessRowHarness({ participant, onView, onRowClick }: GuardlessRowHa
         () =>
             buildColumns({
                 t: fakeT,
-                currentLocale: enUS,
+                language: 'en',
                 duplicateIpGroups: new Map(),
                 showLanguageColumn: false,
                 statusFilter: 'all',

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -30,24 +30,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { Routes, Route } from 'react-router-dom';
 import type { ReactElement } from 'react';
-import { format } from 'date-fns';
-import { enUS } from 'date-fns/locale';
+import { formatDateTime } from '@/lib/datetime';
 import type { DumpParticipant, DumpResponse } from './types';
 import InteractiveDataView from './InteractiveDataView';
 
-// The submitted_at cell renders `format(date, 'MMM d, HH:mm', { locale })`
+// The submitted_at cell renders `formatDateTime(date, language)`
 // (InteractiveDataView.columns.tsx) in the *local* timezone of whatever
 // machine runs the test — computing the expected label the same way the
-// component does (rather than hardcoding a string like "Jan 1, 00:10")
+// component does (rather than hardcoding a string like "01 Jan 2026, 00:10")
 // keeps these assertions correct regardless of the runner's TZ.
+//
+// Task 4.3 collapsed this cell's two labels into one: it used to render a
+// year-less visible label plus an sr-only long form, which under a single
+// format would have announced the same string twice.
 function expectedSubmittedLabel(iso: string): string {
-    return format(new Date(iso), 'MMM d, HH:mm', { locale: enUS });
-}
-
-// The submitted_at cell's `title` carries the full timestamp (Task 6.7i) —
-// same local-timezone-independence reasoning as expectedSubmittedLabel above.
-function expectedFullSubmittedLabel(iso: string): string {
-    return format(new Date(iso), 'PPpp', { locale: enUS });
+    return formatDateTime(iso, 'en');
 }
 
 const { mockDumpQuery } = vi.hoisted(() => ({ mockDumpQuery: vi.fn() }));
@@ -285,16 +282,11 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         // tab stop (Task 6.7i). It carries no role at all now (review
         // finding 2): it already has an accessible name from its own
         // visible text, so role="img" would have turned it into a graphic
-        // node instead. The visible short label and the sr-only full
-        // timestamp are two separate text-node-owning elements (RTL's
-        // getByText matches an element's own direct text nodes, not its
-        // descendants' — no `title` any more, single channel, see
-        // columns.tsx), so both are queried independently.
+        // node instead. Since Task 4.3 there is one label, not a short
+        // visible one plus an sr-only long one — under a single format the
+        // two were the same string, announced twice.
         expect(
             within(row).getByText(expectedSubmittedLabel('2026-01-01T00:10:19Z'))
-        ).toBeInTheDocument();
-        expect(
-            within(row).getByText(expectedFullSubmittedLabel('2026-01-01T00:10:19Z'))
         ).toBeInTheDocument();
     });
 
@@ -335,14 +327,11 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         expect(within(row).queryByRole('button', { name: /Duplicate IP/ })).not.toBeInTheDocument();
 
         // Same for the submitted_at date: was a TooltipTrigger button
-        // revealing the full timestamp on hover, now plain text, split
-        // across a visible short label and an sr-only full timestamp — not
-        // a role="img" either, for the same reason.
+        // revealing the full timestamp on hover, now a single plain-text
+        // label carrying the whole timestamp — not a role="img" either, for
+        // the same reason.
         expect(
             within(row).getByText(expectedSubmittedLabel('2026-01-01T00:10:19Z'))
-        ).toBeInTheDocument();
-        expect(
-            within(row).getByText(expectedFullSubmittedLabel('2026-01-01T00:10:19Z'))
         ).toBeInTheDocument();
         expect(
             within(row).queryByRole('img', { name: expectedSubmittedLabel('2026-01-01T00:10:19Z') })

--- a/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
@@ -28,9 +28,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import { useTranslation } from 'react-i18next';
-import { formatDistanceToNow } from 'date-fns';
-import { de, enUS, fr, fi } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 interface ParticipantMetadataCardProps {
     participant: {
@@ -58,20 +57,12 @@ export function ParticipantMetadataCard({
     onToggleDiscard,
     isDiscardPending,
 }: ParticipantMetadataCardProps) {
-    const { t, i18n } = useTranslation();
+    const { t } = useTranslation();
+    const { formatRelative } = useDateFormat();
     const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
     const [discardReason, setDiscardReason] = useState(participant.discard_reason || '');
     const uaInfo = parseUA(participant.user_agent || '');
     const isDiscarded = !!participant.is_discarded;
-
-    // biome-ignore lint/suspicious/noExplicitAny: library locale types are complex
-    const dateLocales: Record<string, any> = {
-        en: enUS,
-        fr: fr,
-        fi: fi,
-        de: de,
-    };
-    const currentLocale = dateLocales[i18n.language] || enUS;
 
     const DeviceIcon = {
         mobile: Smartphone,
@@ -227,10 +218,7 @@ export function ParticipantMetadataCard({
                             </div>
                             <div>
                                 <p className="text-xs font-black text-slate-900 leading-none">
-                                    {formatDistanceToNow(new Date(participant.created_at), {
-                                        addSuffix: true,
-                                        locale: currentLocale,
-                                    })}
+                                    {formatRelative(participant.created_at)}
                                 </p>
                                 <p className="text-2xs text-slate-500 font-bold mt-1">
                                     {t('admin.participant.metadata.started', 'Started')}
@@ -244,10 +232,7 @@ export function ParticipantMetadataCard({
                                 </div>
                                 <div>
                                     <p className="text-xs font-black text-slate-900 leading-none">
-                                        {formatDistanceToNow(new Date(participant.submitted_at), {
-                                            addSuffix: true,
-                                            locale: currentLocale,
-                                        })}
+                                        {formatRelative(participant.submitted_at)}
                                     </p>
                                     <p className="text-2xs text-slate-500 font-bold mt-1">
                                         {t('admin.participant.metadata.submitted', 'Submitted')}

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -1,8 +1,5 @@
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import type { Locale } from 'date-fns';
-import { formatDistanceToNow, format } from 'date-fns';
-import { de, enUS, fr, fi } from 'date-fns/locale';
 import { useTranslation } from 'react-i18next';
 
 import type { ParticipantRead } from '@/api/model';
@@ -14,13 +11,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { TrendingUp, Eye, Link as LinkIcon, Table as TableIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { getStepInfo } from '@/utils/studySteps';
-
-const dateLocales: Record<string, Locale> = {
-    en: enUS,
-    fr: fr,
-    fi: fi,
-    de: de,
-};
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 function getParticipantColor(id: string) {
     const hue = (id.charCodeAt(0) + id.charCodeAt(1)) % 360;
@@ -48,7 +39,6 @@ function computeDurationSeconds(p: ParticipantRead): number | null {
 
 interface ParticipantRowProps {
     participant: ParticipantRead;
-    locale: Locale;
     showLanguage: boolean;
     roughSortEnabled: boolean;
     onView: () => void;
@@ -56,12 +46,12 @@ interface ParticipantRowProps {
 
 function ParticipantRow({
     participant,
-    locale,
     showLanguage,
     roughSortEnabled,
     onView,
 }: ParticipantRowProps) {
     const { t } = useTranslation();
+    const { formatRelative, formatDateTime } = useDateFormat();
     const colors = getParticipantColor(participant.code);
     const isCompleted = participant.status === 'completed';
     const activityTime = getActivityTime(participant);
@@ -172,14 +162,11 @@ function ParticipantRow({
                                             : 'admin.study_overview.started',
                                         isCompleted ? 'Submitted' : 'Started'
                                     )}{' '}
-                                    {formatDistanceToNow(new Date(activityTime), {
-                                        addSuffix: true,
-                                        locale,
-                                    })}
+                                    {formatRelative(activityTime)}
                                 </span>
                             </TooltipTrigger>
                             <TooltipContent className="text-xs">
-                                {format(new Date(activityTime), 'PPpp', { locale })}
+                                {formatDateTime(activityTime)}
                             </TooltipContent>
                         </Tooltip>
                     </TooltipProvider>
@@ -226,9 +213,8 @@ export default function RecentActivityCard({
     studySlug,
     roughSortEnabled = true,
 }: RecentActivityCardProps) {
-    const { t, i18n } = useTranslation();
+    const { t } = useTranslation();
     const navigate = useNavigate();
-    const currentLocale = dateLocales[i18n.language] || enUS;
 
     const recentParticipants = useMemo(() => {
         const active = participants.filter(
@@ -273,7 +259,6 @@ export default function RecentActivityCard({
                             <ParticipantRow
                                 key={p.id}
                                 participant={p}
-                                locale={currentLocale}
                                 showLanguage={isMultiLang}
                                 roughSortEnabled={roughSortEnabled}
                                 onView={() =>

--- a/frontend/src/components/admin/memo/CommentThread.tsx
+++ b/frontend/src/components/admin/memo/CommentThread.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '@/hooks/useDateFormat';
 import { Button } from '@/components/ui/button';
 import type { MemoCommentRead } from '@/api/model';
 import { MentionAutocomplete } from './MentionAutocomplete';
@@ -39,6 +40,7 @@ export function CommentThread({
     onToggleResolve,
 }: Props) {
     const { t } = useTranslation();
+    const { formatDate } = useDateFormat();
     const [draft, setDraft] = useState('');
     const [mentions, setMentions] = useState<number[]>([]);
     const [editingId, setEditingId] = useState<number | null>(null);
@@ -92,8 +94,7 @@ export function CommentThread({
                 return (
                     <div key={c.id} className="border rounded-xl p-3 bg-white text-sm">
                         <div className="text-xs text-slate-500 mb-1">
-                            {displayNameFor(c.user_id, members)} ·{' '}
-                            {new Date(c.created_at).toLocaleDateString()}
+                            {displayNameFor(c.user_id, members)} · {formatDate(c.created_at)}
                             {c.resolved && (
                                 <span className="ml-2 text-emerald-600">
                                     {t('admin.memo.resolved_label', '[resolved]')}

--- a/frontend/src/hooks/admin/useAdminDashboard.ts
+++ b/frontend/src/hooks/admin/useAdminDashboard.ts
@@ -17,8 +17,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { de, enUS, fr, fi } from 'date-fns/locale';
-import type { Locale } from 'date-fns';
 import {
     useListConcoursesApiAdminConcoursesGet,
     useListStudiesApiAdminStudiesGet,
@@ -26,8 +24,6 @@ import {
 import type { ConcourseRead, StudyRead } from '@/api/model';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useAdminStore } from '@/store/useAdminStore';
-
-const DATE_LOCALES: Record<string, Locale> = { en: enUS, fr, fi, de };
 
 export interface DashboardAlert {
     key: string;
@@ -49,7 +45,6 @@ export interface AdminDashboardApi {
     concourse: ConcourseRead | undefined;
     isConcourseLoading: boolean;
     alerts: DashboardAlert[];
-    currentLocale: Locale;
     showCreateDialog: boolean;
     showImportDialog: boolean;
     setShowCreateDialog: (open: boolean) => void;
@@ -72,7 +67,6 @@ export function useAdminDashboard(): AdminDashboardApi {
     const [showImportDialog, setShowImportDialog] = useState(false);
 
     const projectSlug = currentProject?.slug ?? '';
-    const currentLocale = DATE_LOCALES[i18n.language] ?? enUS;
 
     const { data: allStudiesData, isLoading } = useListStudiesApiAdminStudiesGet(undefined, {
         query: { enabled: !!currentProject?.id },
@@ -175,7 +169,6 @@ export function useAdminDashboard(): AdminDashboardApi {
         concourse,
         isConcourseLoading,
         alerts,
-        currentLocale,
         showCreateDialog,
         showImportDialog,
         setShowCreateDialog,

--- a/frontend/src/hooks/admin/useInteractiveDataView.ts
+++ b/frontend/src/hooks/admin/useInteractiveDataView.ts
@@ -31,7 +31,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { de, enUS, fr, fi, type Locale } from 'date-fns/locale';
 import {
     useGetStudyDumpApiAdminStudiesSlugDumpGet,
     getGetStudyDumpApiAdminStudiesSlugDumpGetQueryKey,
@@ -75,7 +74,7 @@ export interface UseInteractiveDataViewResult {
     liveParticipants: DumpParticipant[];
     submittedParticipants: DumpParticipant[];
     stepLabels: ReturnType<typeof getStepLabels>;
-    currentLocale: Locale;
+    language: string;
     metrics: {
         liveCount: number;
         newsletterCount: number;
@@ -123,8 +122,7 @@ export function useInteractiveDataView({
     const { projectSlug } = useParams<{ projectSlug: string }>();
     const queryClient = useQueryClient();
 
-    const dateLocales: Record<string, Locale> = { en: enUS, fr, fi, de };
-    const currentLocale = dateLocales[i18n.language] || enUS;
+    const language = i18n.language;
 
     const { data: rawData, isLoading, error } = useGetStudyDumpApiAdminStudiesSlugDumpGet(slug);
 
@@ -355,7 +353,7 @@ export function useInteractiveDataView({
         () =>
             buildColumns({
                 t,
-                currentLocale,
+                language,
                 duplicateIpGroups,
                 showLanguageColumn,
                 statusFilter,
@@ -372,7 +370,7 @@ export function useInteractiveDataView({
             }),
         [
             t,
-            currentLocale,
+            language,
             duplicateIpGroups,
             showLanguageColumn,
             statusFilter,
@@ -406,7 +404,7 @@ export function useInteractiveDataView({
         liveParticipants,
         submittedParticipants,
         stepLabels,
-        currentLocale,
+        language,
         metrics: {
             liveCount,
             newsletterCount,

--- a/frontend/src/hooks/useDateFormat.ts
+++ b/frontend/src/hooks/useDateFormat.ts
@@ -1,0 +1,47 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+    formatDate,
+    formatDateTime,
+    formatRelative,
+    type DateFormatOptions,
+    type DateInput,
+    type RelativeFormatOptions,
+} from '@/lib/datetime';
+
+export interface DateFormatters {
+    /** `26 Jul 2026` */
+    formatDate: (value: DateInput, options?: DateFormatOptions) => string;
+    /** `26 Jul 2026, 17:25` */
+    formatDateTime: (value: DateInput, options?: DateFormatOptions) => string;
+    /** `2 hours ago`, falling back to `formatDate` past a week. */
+    formatRelative: (value: DateInput, options?: RelativeFormatOptions) => string;
+}
+
+/**
+ * `lib/datetime` bound to the active i18n language.
+ *
+ * Going through `useTranslation()` is what makes a language switch re-render
+ * the dates — reading the `i18n` singleton directly inside a component would
+ * format correctly on mount and then go stale.
+ */
+export function useDateFormat(): DateFormatters {
+    const { i18n } = useTranslation();
+    const language = i18n.language;
+
+    return useMemo(
+        () => ({
+            formatDate: (value, options) => formatDate(value, language, options),
+            formatDateTime: (value, options) => formatDateTime(value, language, options),
+            formatRelative: (value, options) => formatRelative(value, language, options),
+        }),
+        [language]
+    );
+}

--- a/frontend/src/lib/datetime.test.ts
+++ b/frontend/src/lib/datetime.test.ts
@@ -1,0 +1,213 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Every exact string in this file was produced by running the implementation
+ * on this repo's Node/ICU, not copied from a spec. Where output is not stable
+ * enough to pin (nine locales × separator × month abbreviation × ordering),
+ * the assertion is on the property that matters instead.
+ *
+ * Every call passes `timeZone: 'UTC'`, so the suite is `TZ`-independent.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { SUPPORTED_LANGUAGES } from '@/constants/languages';
+import {
+    INVALID_DATE_PLACEHOLDER,
+    RELATIVE_CUTOVER_DAYS,
+    formatDate,
+    formatDateTime,
+    formatRelative,
+    resolveLocale,
+} from './datetime';
+
+const UTC = { timeZone: 'UTC' } as const;
+const REF = '2026-07-26T17:25:00Z';
+const CODES = SUPPORTED_LANGUAGES.map((l) => l.code);
+
+describe('resolveLocale', () => {
+    it('maps bare `en` to en-GB so English is day-first like the other eight', () => {
+        expect(resolveLocale('en')).toBe('en-GB');
+    });
+
+    it('strips a region i18next may have left on the tag', () => {
+        expect(resolveLocale('en-US')).toBe('en-GB');
+        expect(resolveLocale('pt-BR')).toBe('pt');
+        expect(resolveLocale('FR')).toBe('fr');
+    });
+
+    it('falls back to English for unknown, empty and nullish input', () => {
+        expect(resolveLocale('kl')).toBe('en-GB');
+        expect(resolveLocale('')).toBe('en-GB');
+        expect(resolveLocale(null)).toBe('en-GB');
+        expect(resolveLocale(undefined)).toBe('en-GB');
+    });
+
+    it('passes every supported language through to a usable Intl tag', () => {
+        for (const code of CODES) {
+            expect(() => new Intl.DateTimeFormat(resolveLocale(code))).not.toThrow();
+        }
+    });
+});
+
+describe('formatDate', () => {
+    // Run, not assumed: bare `'en'` yields `Jul 26, 2026` (US, month-first).
+    // `26 Jul 2026` is the en-GB ordering, which is why resolveLocale maps to it.
+    it('renders English day-first with an abbreviated month', () => {
+        expect(formatDate(REF, 'en', UTC)).toBe('26 Jul 2026');
+    });
+
+    it('is not the browser default: `en-US` still renders day-first', () => {
+        expect(formatDate(REF, 'en-US', UTC)).toBe('26 Jul 2026');
+    });
+
+    it('actually applies the locale rather than falling back to English', () => {
+        expect(formatDate(REF, 'fr', UTC)).toBe('26 juil. 2026');
+        expect(formatDate(REF, 'de', UTC)).toBe('26. Juli 2026');
+        expect(formatDate(REF, 'fi', UTC)).toBe('26.7.2026');
+        expect(formatDate(REF, 'pl', UTC)).toBe('26 lip 2026');
+    });
+
+    it('produces a distinct, non-empty rendering for every supported language', () => {
+        const rendered = CODES.map((c) => formatDate(REF, c, UTC));
+        for (const s of rendered) {
+            expect(s).not.toBe(INVALID_DATE_PLACEHOLDER);
+            // Day and year are digits in all nine; the month word is not pinned.
+            expect(s).toMatch(/26/);
+            expect(s).toMatch(/2026/);
+        }
+        // At least Finnish (numeric) and German (full month) differ from English.
+        expect(new Set(rendered).size).toBeGreaterThan(1);
+    });
+
+    it('accepts Date, epoch millis and ISO strings alike', () => {
+        const d = new Date(REF);
+        expect(formatDate(d, 'en', UTC)).toBe('26 Jul 2026');
+        expect(formatDate(d.getTime(), 'en', UTC)).toBe('26 Jul 2026');
+        expect(formatDate(REF, 'en', UTC)).toBe('26 Jul 2026');
+    });
+
+    it('renders a placeholder instead of throwing on bad input', () => {
+        expect(formatDate(undefined, 'en', UTC)).toBe(INVALID_DATE_PLACEHOLDER);
+        expect(formatDate(null, 'en', UTC)).toBe(INVALID_DATE_PLACEHOLDER);
+        expect(formatDate('', 'en', UTC)).toBe(INVALID_DATE_PLACEHOLDER);
+        expect(formatDate('not-a-date', 'en', UTC)).toBe(INVALID_DATE_PLACEHOLDER);
+        expect(formatDate(Number.NaN, 'en', UTC)).toBe(INVALID_DATE_PLACEHOLDER);
+        expect(() => formatDate('not-a-date', 'en', UTC)).not.toThrow();
+    });
+});
+
+describe('formatDateTime', () => {
+    it('renders 24-hour time in English', () => {
+        expect(formatDateTime(REF, 'en', UTC)).toBe('26 Jul 2026, 17:25');
+    });
+
+    it('never emits an AM/PM marker in any supported language', () => {
+        for (const code of CODES) {
+            const s = formatDateTime(REF, code, UTC);
+            expect(s).not.toMatch(/\b[AP]\.?M\.?\b/i);
+            expect(s).toMatch(/17[:.]25/);
+        }
+    });
+
+    it('renders midnight as 00:00, never 24:00, in every supported language', () => {
+        // `hour12: false` resolves to hour cycle h24 in some ICU builds, which
+        // renders midnight as 24:00. `hourCycle: 'h23'` is why this holds.
+        for (const code of CODES) {
+            const s = formatDateTime('2026-07-26T00:00:00Z', code, UTC);
+            expect(s).toMatch(/00[:.]00/);
+            expect(s).not.toMatch(/24[:.]00/);
+        }
+    });
+
+    it('renders the last minute of the day as 23:59 in every supported language', () => {
+        for (const code of CODES) {
+            expect(formatDateTime('2026-07-26T23:59:00Z', code, UTC)).toMatch(/23[:.]59/);
+        }
+    });
+
+    it('applies the locale', () => {
+        expect(formatDateTime(REF, 'fr', UTC)).toBe('26 juil. 2026, 17:25');
+        expect(formatDateTime(REF, 'de', UTC)).toBe('26. Juli 2026, 17:25');
+    });
+
+    it('honours an explicit timezone rather than the runtime zone', () => {
+        expect(formatDateTime(REF, 'en', { timeZone: 'UTC' })).toBe('26 Jul 2026, 17:25');
+        expect(formatDateTime(REF, 'en', { timeZone: 'Asia/Tokyo' })).toBe('27 Jul 2026, 02:25');
+    });
+
+    it('renders a placeholder instead of throwing on bad input', () => {
+        expect(formatDateTime(undefined, 'en', UTC)).toBe(INVALID_DATE_PLACEHOLDER);
+        expect(formatDateTime('not-a-date', 'en', UTC)).toBe(INVALID_DATE_PLACEHOLDER);
+    });
+});
+
+describe('formatRelative', () => {
+    // The clock is injected, never `Date.now()`.
+    const now = new Date('2026-07-26T12:00:00Z');
+    const ago = (ms: number) => new Date(now.getTime() - ms).toISOString();
+    const ahead = (ms: number) => new Date(now.getTime() + ms).toISOString();
+
+    const MIN = 60_000;
+    const HOUR = 60 * MIN;
+    const DAY = 24 * HOUR;
+
+    it('collapses anything under a minute to the locale word for "now"', () => {
+        expect(formatRelative(ago(0), 'en', { now, ...UTC })).toBe('now');
+        expect(formatRelative(ago(30_000), 'en', { now, ...UTC })).toBe('now');
+        expect(formatRelative(ago(30_000), 'fr', { now, ...UTC })).toBe('maintenant');
+    });
+
+    it('counts minutes, hours and days', () => {
+        expect(formatRelative(ago(MIN), 'en', { now, ...UTC })).toBe('1 minute ago');
+        expect(formatRelative(ago(45 * MIN), 'en', { now, ...UTC })).toBe('45 minutes ago');
+        expect(formatRelative(ago(3 * HOUR), 'en', { now, ...UTC })).toBe('3 hours ago');
+        expect(formatRelative(ago(3 * DAY), 'en', { now, ...UTC })).toBe('3 days ago');
+    });
+
+    it('uses each locale’s own idiom, which a hand-rolled ladder could not', () => {
+        expect(formatRelative(ago(3 * HOUR), 'fr', { now, ...UTC })).toBe('il y a 3 heures');
+        expect(formatRelative(ago(2 * DAY), 'fr', { now, ...UTC })).toBe('avant-hier');
+        expect(formatRelative(ago(2 * DAY), 'pl', { now, ...UTC })).toBe('przedwczoraj');
+        expect(formatRelative(ago(3 * HOUR), 'de', { now, ...UTC })).toBe('vor 3 Stunden');
+    });
+
+    it('hands over to an absolute date at the cutover', () => {
+        const justInside = formatRelative(ago(RELATIVE_CUTOVER_DAYS * DAY - MIN), 'en', {
+            now,
+            ...UTC,
+        });
+        expect(justInside).toBe('6 days ago');
+
+        const atCutover = formatRelative(ago(RELATIVE_CUTOVER_DAYS * DAY), 'en', { now, ...UTC });
+        expect(atCutover).toBe(formatDate(ago(RELATIVE_CUTOVER_DAYS * DAY), 'en', UTC));
+        expect(atCutover).toBe('19 Jul 2026');
+
+        expect(formatRelative(ago(120 * DAY), 'en', { now, ...UTC })).toBe('28 Mar 2026');
+    });
+
+    it('renders forward for future timestamps and clock skew', () => {
+        expect(formatRelative(ahead(2 * HOUR), 'en', { now, ...UTC })).toBe('in 2 hours');
+        // Sub-minute skew still reads as "now" rather than "in 0 seconds".
+        expect(formatRelative(ahead(5_000), 'en', { now, ...UTC })).toBe('now');
+        expect(formatRelative(ahead(30 * DAY), 'en', { now, ...UTC })).toBe('25 Aug 2026');
+    });
+
+    it('produces a non-placeholder rendering for every supported language', () => {
+        for (const code of CODES) {
+            const s = formatRelative(ago(3 * HOUR), code, { now, ...UTC });
+            expect(s).not.toBe(INVALID_DATE_PLACEHOLDER);
+            expect(s.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('renders a placeholder instead of throwing on bad input', () => {
+        expect(formatRelative(undefined, 'en', { now, ...UTC })).toBe(INVALID_DATE_PLACEHOLDER);
+        expect(formatRelative(null, 'en', { now, ...UTC })).toBe(INVALID_DATE_PLACEHOLDER);
+        expect(formatRelative('not-a-date', 'en', { now, ...UTC })).toBe(INVALID_DATE_PLACEHOLDER);
+    });
+});

--- a/frontend/src/lib/datetime.ts
+++ b/frontend/src/lib/datetime.ts
@@ -1,0 +1,210 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Single source of truth for rendering dates and times in the admin UI.
+ *
+ * Before this module the app shipped four mutually inconsistent formats —
+ * `1 minute ago`, `7/26/2026`, `Jul 26, 17:25` (24h) and
+ * `Jul 26, 2026, 05:38 PM` (12h) — the last two on the same Analysis screen.
+ * Every call site now routes through `formatDate` / `formatDateTime` /
+ * `formatRelative`.
+ *
+ * Four decisions are load-bearing; change them here, not at a call site.
+ *
+ * 1. **Locale = the active i18n language, never the browser's.** A researcher
+ *    who set the admin UI to French must not get US month-first dates because
+ *    their laptop is `en-US`. Call sites pass `i18n.language`; `useDateFormat()`
+ *    binds it for them and re-renders on a language switch.
+ *
+ * 2. **`en` resolves to `en-GB`, not bare `en`.** Bare `'en'` resolves to US
+ *    conventions: `{day:'2-digit', month:'short', year:'numeric'}` renders
+ *    `Jul 26, 2026` — month first. Every one of the other eight supported
+ *    locales is day-first. The product is British-spelled throughout
+ *    ("anonymised", "serialisation") and `SUPPORTED_LANGUAGES` flies 🇬🇧 for
+ *    `en`, so `en-GB` is both the coherent choice and the one that makes the
+ *    day-first ordering uniform across all nine languages: `26 Jul 2026`.
+ *
+ * 3. **24-hour clock via `hourCycle: 'h23'`, not `hour12: false`.** They are
+ *    not synonyms: `hour12: false` historically resolved to hour cycle `h24`
+ *    in some locales, which renders midnight as `24:00`. Modern V8/ICU has
+ *    converged on `h23` for `hour12: false` (verified across all nine locales
+ *    plus ja/ko/zh/da on Node 26), but `h23` states the intent and is immune
+ *    to a future ICU change.
+ *
+ * 4. **Timezone = the runtime zone.** Backend timestamps are
+ *    `DateTime(timezone=True)` columns serialised with a UTC offset, so
+ *    `new Date(iso)` is unambiguous; rendering them in the viewer's own zone is
+ *    what a researcher reading their own study data expects. Tests must pass an
+ *    explicit `timeZone` rather than depend on the machine's `TZ`.
+ *
+ * No function in this module throws. These strings come off the API and land
+ * inside table cells; a `RangeError` from an unparseable value would blank the
+ * page, so bad input renders `INVALID_DATE_PLACEHOLDER` instead.
+ */
+
+// Deliberately `constants/languages`, not `@/i18n`: importing the latter runs
+// i18next's `.init()` side effect, which a pure formatting module (and its
+// unit test) has no business triggering. `SUPPORTED_LANGUAGES` is the canonical
+// source per CLAUDE.md and is kept in step with `SUPPORTED_I18N_LANGUAGES` by
+// an existing cross-consistency test.
+import { SUPPORTED_LANGUAGES } from '@/constants/languages';
+
+const KNOWN_LANGUAGE_CODES = new Set(SUPPORTED_LANGUAGES.map((l) => l.code));
+
+/** Anything a call site might hand us, including what the API omits. */
+export type DateInput = string | number | Date | null | undefined;
+
+/** Rendered in place of a missing or unparseable timestamp. */
+export const INVALID_DATE_PLACEHOLDER = '—';
+
+/**
+ * Beyond this many days, `formatRelative` hands over to an absolute date.
+ * "3 months ago" is strictly less informative than "26 Jul 2026", and the
+ * elapsed-time framing stops being useful about the point it stops being
+ * countable in days.
+ */
+export const RELATIVE_CUTOVER_DAYS = 7;
+
+export interface DateFormatOptions {
+    /** IANA zone. Omitted = the runtime zone. Tests should pass `'UTC'`. */
+    timeZone?: string;
+}
+
+export interface RelativeFormatOptions extends DateFormatOptions {
+    /** Injected clock, so tests never race `Date.now()`. */
+    now?: Date;
+}
+
+/**
+ * Maps an i18next language to the BCP-47 tag `Intl` should use.
+ *
+ * i18next's `supportedLngs` allow-list normally hands us a bare code, but a
+ * region-qualified detection (`en-US`, `pt-BR`) can survive, so we strip the
+ * region and re-resolve. Anything unrecognised falls back to `en`, matching
+ * i18next's own `fallbackLng`.
+ */
+export function resolveLocale(language: string | null | undefined): string {
+    const base = ((language ?? '').split('-')[0] ?? '').toLowerCase();
+    const known = KNOWN_LANGUAGE_CODES.has(base) ? base : 'en';
+    // See decision 2 in the module docstring.
+    return known === 'en' ? 'en-GB' : known;
+}
+
+/** `null` for anything we must not hand to `Intl`. */
+function toDate(value: DateInput): Date | null {
+    if (value === null || value === undefined || value === '') return null;
+    const d = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d;
+}
+
+// Intl constructors are expensive and the Data table renders one call per row
+// per render; memoise per (locale, option-set).
+const dateTimeFormatters = new Map<string, Intl.DateTimeFormat>();
+const relativeFormatters = new Map<string, Intl.RelativeTimeFormat>();
+
+function dateTimeFormatter(locale: string, options: Intl.DateTimeFormatOptions) {
+    const key = `${locale}|${JSON.stringify(options)}`;
+    let fmt = dateTimeFormatters.get(key);
+    if (!fmt) {
+        fmt = new Intl.DateTimeFormat(locale, options);
+        dateTimeFormatters.set(key, fmt);
+    }
+    return fmt;
+}
+
+function relativeFormatter(locale: string) {
+    let fmt = relativeFormatters.get(locale);
+    if (!fmt) {
+        fmt = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+        relativeFormatters.set(locale, fmt);
+    }
+    return fmt;
+}
+
+/**
+ * Calendar date, no time. `26 Jul 2026` in `en`.
+ */
+export function formatDate(
+    value: DateInput,
+    language: string | null | undefined,
+    options: DateFormatOptions = {}
+): string {
+    const date = toDate(value);
+    if (!date) return INVALID_DATE_PLACEHOLDER;
+    return dateTimeFormatter(resolveLocale(language), {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        ...(options.timeZone ? { timeZone: options.timeZone } : {}),
+    }).format(date);
+}
+
+/**
+ * Date and time to the minute, 24-hour. `26 Jul 2026, 17:25` in `en`.
+ */
+export function formatDateTime(
+    value: DateInput,
+    language: string | null | undefined,
+    options: DateFormatOptions = {}
+): string {
+    const date = toDate(value);
+    if (!date) return INVALID_DATE_PLACEHOLDER;
+    return dateTimeFormatter(resolveLocale(language), {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hourCycle: 'h23',
+        ...(options.timeZone ? { timeZone: options.timeZone } : {}),
+    }).format(date);
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Elapsed time in words — `2 hours ago`, `il y a 2 heures` — via
+ * `Intl.RelativeTimeFormat`, which carries every locale's plural rules and
+ * idioms ("avant-hier", "przedwczoraj") that a hand-rolled ladder cannot.
+ *
+ * Past `RELATIVE_CUTOVER_DAYS` it returns `formatDate(value)` instead, so old
+ * records read as dates rather than as a vague "3 months ago".
+ *
+ * Future timestamps (clock skew, a study end date) render forward — `in 2
+ * days` — and use the same cutover.
+ */
+export function formatRelative(
+    value: DateInput,
+    language: string | null | undefined,
+    options: RelativeFormatOptions = {}
+): string {
+    const date = toDate(value);
+    if (!date) return INVALID_DATE_PLACEHOLDER;
+
+    const now = options.now ?? new Date();
+    const deltaMs = date.getTime() - now.getTime();
+    const absMs = Math.abs(deltaMs);
+
+    if (absMs >= RELATIVE_CUTOVER_DAYS * DAY_MS) {
+        return formatDate(date, language, options);
+    }
+
+    const fmt = relativeFormatter(resolveLocale(language));
+    if (absMs < MINUTE_MS) {
+        // `numeric: 'auto'` turns 0 seconds into the locale's "now"/"maintenant".
+        return fmt.format(0, 'second');
+    }
+    if (absMs < HOUR_MS) {
+        return fmt.format(Math.trunc(deltaMs / MINUTE_MS), 'minute');
+    }
+    if (absMs < DAY_MS) {
+        return fmt.format(Math.trunc(deltaMs / HOUR_MS), 'hour');
+    }
+    return fmt.format(Math.trunc(deltaMs / DAY_MS), 'day');
+}

--- a/frontend/src/pages/admin/AdminUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminUsersPage.tsx
@@ -57,6 +57,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import { resolveApiErrorKey } from '@/lib/error-utils';
+import { formatDate } from '@/lib/datetime';
 import {
     useAdminUsersPage,
     deriveRiskBadges,
@@ -102,9 +103,9 @@ type ActionKind =
 // Pure presentational helpers (no business logic — formatting only)
 // ────────────────────────────────────────────────────────────────
 
-function formatLastSeen(value: string | null | undefined): string | null {
+function formatLastSeen(value: string | null | undefined, language: string): string | null {
     if (!value) return null;
-    return new Date(value).toLocaleDateString();
+    return formatDate(value, language);
 }
 
 // Deliberately surfaces the server's human-readable message and ignores the
@@ -544,9 +545,9 @@ function UserRow({
     onGenerateLink: (user: AdminUser) => void;
     onSetEmail: (user: AdminUser) => void;
 }) {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const badges = deriveRiskBadges(user, now);
-    const lastSeen = formatLastSeen(user.last_login_at);
+    const lastSeen = formatLastSeen(user.last_login_at, i18n.language);
 
     return (
         <li

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '@/hooks/useDateFormat';
 import { toast } from 'sonner';
 import type { TFunction } from 'i18next';
 import {
@@ -840,6 +841,7 @@ function InterpretShell({
     onPin,
     onUnpin,
 }: InterpretShellProps) {
+    const { formatDateTime } = useDateFormat();
     const [searchParams, setSearchParams] = useSearchParams();
     const activeTab = searchParams.get('tab') ?? 'loadings';
     const setActiveTab = useCallback(
@@ -1145,13 +1147,7 @@ function InterpretShell({
                             'admin.analysis.history.viewing_banner',
                             'Viewing run from {{date}}: {{extraction}} · {{n}}F · {{rotation}}',
                             {
-                                date: new Date(run.ran_at).toLocaleString(undefined, {
-                                    year: 'numeric',
-                                    month: 'short',
-                                    day: 'numeric',
-                                    hour: '2-digit',
-                                    minute: '2-digit',
-                                }),
+                                date: formatDateTime(run.ran_at),
                                 extraction: run.extraction_method.toUpperCase(),
                                 n: run.n_factors,
                                 rotation: run.rotation_method,

--- a/frontend/src/pages/admin/DataPrivacyPage.tsx
+++ b/frontend/src/pages/admin/DataPrivacyPage.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useDateFormat } from '@/hooks/useDateFormat';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
@@ -82,15 +83,6 @@ function defaultCutoff(retentionMonths: number | null | undefined): string {
     const d = new Date();
     d.setMonth(d.getMonth() - retentionMonths);
     return d.toISOString().slice(0, 10);
-}
-
-function formatDate(iso: string | null | undefined): string {
-    if (!iso) return '—';
-    return new Date(iso).toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-    });
 }
 
 // ─── loading skeleton ──────────────────────────────────────────────────────────
@@ -234,6 +226,7 @@ function ConsentLocaleRow({
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: P5 — declarative data-privacy page shell with anonymisation preview + bulk-mutation chain + per-row action handlers; better fit for a useDataPrivacyPage hook (Phase 5G pattern in CLAUDE.md) but out of cognitive-complexity remediation scope
 export default function DataPrivacyPage() {
     const { t } = useTranslation();
+    const { formatDate } = useDateFormat();
     const { studySlug, projectSlug } = useParams<{ studySlug: string; projectSlug: string }>();
     const effectiveSlug = studySlug ?? projectSlug ?? '';
 

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -53,10 +53,12 @@ import {
     useCreateInvitationApiAdminProjectsSlugInvitationsPost,
 } from '@/api/generated';
 import { parseApiErrorSync, resolveApiErrorKey } from '@/lib/error-utils';
+import { useDateFormat } from '@/hooks/useDateFormat';
 
 export default function ProjectMembersPage() {
     const { slug } = useLoaderData() as { slug: string };
     const { t } = useTranslation();
+    const { formatDate } = useDateFormat();
     const { user: currentUser } = useAuthStore();
 
     const { data: project, isLoading: isProjectLoading } =
@@ -296,7 +298,7 @@ export default function ProjectMembersPage() {
                                                 )}
                                             </TableCell>
                                             <TableCell className="text-xs font-medium text-slate-500">
-                                                {new Date(member.joined_at).toLocaleDateString()}
+                                                {formatDate(member.joined_at)}
                                             </TableCell>
                                             <TableCell className="text-right px-6">
                                                 <Button


### PR DESCRIPTION
Task 4.3 of the admin UX remediation plan.

## The defect

Four formats shipped: `1 minute ago`, `7/26/2026`, `Jul 26, 17:25` (24h) and
`Jul 26, 2026, 05:38 PM` (12h) — **the last two on the same Analysis screen**.

Both engines keyed off the wrong thing. `toLocale*(undefined, …)` follows the **browser's**
locale, so a researcher who set the admin UI to French still got US month-first dates.

## The sweep found a second engine the plan never mentioned

Beyond the 7 raw `toLocale*` sites the plan listed, **date-fns** was formatting dates across
5 components and 2 hooks. Its locale map covered only `{en, fr, fi, de}` — **5 of the 9
supported languages silently fell back to `enUS`**, so a Spanish researcher's dashboard read
"2 hours ago" in English. The map also keyed on `i18n.language` unstripped, so `en-US` and
`pt-BR` missed it entirely and fell back too.

Neither failure was visible to any gate: the strings were real English, just the wrong
language.

## Three decisions made by running the code, not by reading the plan

**1. The plan's expected string was wrong.** It asserted `formatDate(d, 'en')` →
`'26 Jul 2026'`. Bare `'en'` resolves to US conventions and actually yields `Jul 26, 2026`.
Rather than bend the implementation to the plan's assertion, `en` now resolves to **`en-GB`**
— every other supported locale is day-first, the product is British-spelled throughout, and
`SUPPORTED_LANGUAGES` flies 🇬🇧 for `en`. That reaches the plan's string, but by a decision
taken after running it.

**2. The `24:00` hazard I warned about does not reproduce.** All nine locales (plus
ja/ko/zh/da/no as a control) return `00:00` under `hour12: false`, with
`resolvedOptions().hourCycle === 'h23'` in every case — modern V8/ICU has converged.
`hourCycle: 'h23'` is used anyway because it states the intent and is immune to ICU drift,
but the brief should not be cited as evidence the bug is live today. Midnight and 23:59 are
asserted in all nine locales regardless.

**3. My e2e count was off — 12 case-sensitive matchers, not 16.** All 12 were read: **none
assert on a formatted date.** The closest, `toContainText(/viewing run from/i)`, stops before
the `{{date}}` interpolation.

## Built

`lib/datetime.ts` (pure, no i18next init side effect) + `hooks/useDateFormat.ts` + 24 tests.
The hook is what makes a language switch actually re-render the dates.

- `formatRelative` uses `Intl.RelativeTimeFormat`, which carries idioms a hand-rolled ladder
  cannot ("avant-hier", "przedwczoraj"), and hands over to an absolute date past 7 days —
  "3 months ago" is worse than a date.
- Its clock is **injected**, so the suite never races `Date.now()`.
- Timestamps are UTC-anchored on the wire (`DateTime(timezone=True)`) and render in the
  viewer's zone; every test passes an explicit `timeZone`. The suite was re-run under
  `TZ=UTC`, `Pacific/Kiritimati`, `America/Los_Angeles` and `Asia/Kolkata` — 24/24 each.
- **Nothing throws.** These strings come off the API and a `RangeError` in a table cell
  blanks the page; bad input renders `—`.

## Two collateral wins

Four `locale: any` biome-ignores deleted from `AdminDashboard` — the prop chain they typed is
gone. And the Data table's sr-only companion timestamp is removed: it existed only because
the visible label was a *shorter* format than the screen-reader one, so under a single format
it announced the identical string twice.

## Not reached, stated plainly

- **E2E could not be executed here.** The conclusion above is a static read of all 12
  matchers, not a run.
- **No browser screenshots.** The Data-table cell grows ~6 characters; that is the one change
  with a plausible visual regression at 320–375px, and it is unverified.
- `SubmissionsTimelineChart`'s axis tick was deliberately left alone — unifying it would
  wreck the axis. Flagged separately: **that chart passes no locale at all**, so its axis and
  tooltip are hardcoded English in all nine languages. Different defect, not fixed here.

## Gates

`npm run lint` clean · `type-check` clean · **199 files / 1790 passed, 6 skipped, 0 failed** ·
`lint:a11y` at baseline · `i18n-check` exit 0. `backend/uv.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
