### PR TITLE
fix(admin): give the product one primary button colour (4.1)

### DIFF
--- a/frontend/src/components/admin/CreateStudyDialog.tsx
+++ b/frontend/src/components/admin/CreateStudyDialog.tsx
@@ -287,7 +287,7 @@ export function CreateStudyDialog({ open, onOpenChange, projectSlug }: CreateStu
                             <Button
                                 type="submit"
                                 disabled={createStudyMutation.isPending}
-                                className="h-11 rounded-xl px-8 font-black bg-indigo-600 hover:bg-indigo-700 shadow-sm"
+                                className="h-11 rounded-xl px-8 font-black shadow-sm"
                             >
                                 {createStudyMutation.isPending && (
                                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/frontend/src/components/admin/concourse/ItemDetailSheet.tsx
+++ b/frontend/src/components/admin/concourse/ItemDetailSheet.tsx
@@ -157,7 +157,7 @@ export function ItemDetailSheet({
                             />
                             <Button
                                 size="sm"
-                                className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white"
+                                className="rounded-xl"
                                 disabled={!newComment.trim() || createCommentMutation.isPending}
                                 onClick={handleAddComment}
                             >

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -661,7 +661,7 @@ export default function InteractiveDataView({
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                                 <Button
-                                    className="h-10 w-10 sm:w-auto sm:h-9 bg-indigo-600 hover:bg-indigo-700 text-white font-bold shadow-sm gap-2 text-xs"
+                                    className="h-10 w-10 sm:w-auto sm:h-9 font-bold shadow-sm gap-2 text-xs"
                                     disabled={isExportLoading}
                                     aria-label={t('admin.export.label', 'Export')}
                                 >

--- a/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
@@ -361,9 +361,10 @@ export function ParticipantMetadataCard({
                             }
                             className={cn(
                                 'rounded-2xl font-bold h-12',
-                                isDiscarded
-                                    ? 'bg-emerald-600 hover:bg-emerald-700'
-                                    : 'bg-rose-600 hover:bg-rose-700'
+                                // Restore inherits the single primary fill. Discard keeps a
+                                // destructive fill: white on rose-600 is 4.70:1 (AA), where the
+                                // emerald-600 it replaced sat at 3.77:1 and failed.
+                                !isDiscarded && 'bg-rose-600 text-white hover:bg-rose-700'
                             )}
                         >
                             {isDiscarded

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -250,7 +250,7 @@ function ParticipantRow({
             <Button
                 variant="default"
                 size="icon"
-                className="h-7 w-7 bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm shrink-0 rounded-lg"
+                className="h-7 w-7 shadow-sm shrink-0 rounded-lg"
                 onClick={onView}
                 aria-label={t('admin.study_overview.view_data', 'View')}
             >

--- a/frontend/src/components/admin/designer/ActivateStudyDialog.tsx
+++ b/frontend/src/components/admin/designer/ActivateStudyDialog.tsx
@@ -186,11 +186,7 @@ export function ActivateStudyDialog({
                     >
                         {t('common.cancel', 'Cancel')}
                     </Button>
-                    <Button
-                        onClick={handleConfirm}
-                        disabled={!canConfirm}
-                        className="bg-indigo-600 hover:bg-indigo-700 text-white"
-                    >
+                    <Button onClick={handleConfirm} disabled={!canConfirm}>
                         {isActivating ? (
                             <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                         ) : (

--- a/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
+++ b/frontend/src/components/admin/designer/ImportFromConcourseDialog.tsx
@@ -339,10 +339,10 @@ export function ImportFromConcourseDialog({
                         onClick={handleImport}
                         disabled={selectedItemIds.size === 0 || importMutation.isPending}
                         className={cn(
-                            'h-10 rounded-xl px-6 font-bold text-white',
-                            replaceExisting
-                                ? 'bg-red-600 hover:bg-red-700'
-                                : 'bg-indigo-600 hover:bg-indigo-700'
+                            'h-10 rounded-xl px-6 font-bold',
+                            // Destructive branch only; the non-destructive branch
+                            // inherits the single primary fill from the default variant.
+                            replaceExisting && 'bg-red-600 text-white hover:bg-red-700'
                         )}
                     >
                         {importMutation.isPending ? (

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -1334,7 +1334,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                     <Button
                                         size="sm"
                                         onClick={autoShapeGrid}
-                                        className="h-11 px-6 rounded-2xl bg-indigo-600 text-white shadow-lg shadow-indigo-200 hover:bg-indigo-700 hover:shadow-indigo-300 transition-all font-bold gap-2"
+                                        className="h-11 px-6 rounded-2xl shadow-lg shadow-indigo-200 hover:shadow-indigo-300 transition-all font-bold gap-2"
                                     >
                                         <Wand2 className="h-4 w-4" />
                                         {t('admin.design.qsort.grid.auto_balance')}

--- a/frontend/src/components/ui/button.test.tsx
+++ b/frontend/src/components/ui/button.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Button } from './button';
+
+// Vitest's root is `frontend/`; jsdom rewrites import.meta.url to an http URL,
+// so cwd is the only reliable anchor here.
+const SRC = join(process.cwd(), 'src');
+
+describe('Button variants', () => {
+    it('renders the default variant with the single primary fill', () => {
+        render(<Button>Go</Button>);
+        expect(screen.getByRole('button')).toHaveClass('bg-indigo-600');
+    });
+
+    it('darkens rather than lightens on hover', () => {
+        render(<Button>Go</Button>);
+        expect(screen.getByRole('button')).toHaveClass('hover:bg-indigo-700');
+    });
+
+    it('gives the warning variant an AA-passing amber (amber-500 + white is 2.15:1)', () => {
+        render(<Button variant="warning">Unlock</Button>);
+        const btn = screen.getByRole('button');
+        expect(btn).toHaveClass('bg-amber-600');
+        expect(btn).toHaveClass('text-slate-900');
+        // Resting white-on-amber is the failure mode; hover:text-white is fine
+        // because the hover fill darkens to amber-700 (5.02:1).
+        expect(btn.className).not.toMatch(/(?:^|\s)text-white(?:\s|$)/);
+    });
+});
+
+/**
+ * Task 4.1 guard. The defect this task fixed lived at the CALL SITES, not in
+ * the variant: four primary fills coexisted across the admin because pages
+ * hand-wrote `bg-indigo-600` / `bg-slate-900` / `bg-emerald-600` on `<Button>`
+ * instead of letting the default variant supply the fill.
+ *
+ * This budget test fails when a new RESTING primary-looking fill appears in
+ * `pages/admin` or `components/admin`. The allowlist below is the exhaustive
+ * set of remaining occurrences, every one of which is deliberately NOT a
+ * button. Adding a fill to a button raises a count and trips the test; the
+ * fix is to delete the class, not to bump the number.
+ *
+ * Anchoring note: the token regex rejects any match preceded by a word char,
+ * `:`, `/` or `-`, so state prefixes (`hover:bg-*`, `active:bg-*`,
+ * `group-hover/bar:bg-*`, `data-[state=active]:bg-*`) are not counted, and
+ * `disabled:opacity-50` cannot false-positive.
+ */
+const RESTING_FILL = /(?<![\w:/-])bg-(?:indigo-600|slate-900|emerald-600|amber-500)(?![\w-])/g;
+
+/** file (relative to src/) -> number of allowed resting fills, with the reason. */
+const ALLOWED: Record<string, { count: number; reason: string }> = {
+    'components/admin/ProjectSwitcher.tsx': {
+        count: 1,
+        reason: 'selected-project icon tile, not a button fill',
+    },
+    'components/admin/UserAvatar.tsx': {
+        count: 1,
+        reason: 'avatar background',
+    },
+    'components/admin/designer/QSortEditor.tsx': {
+        count: 3,
+        reason: 'hover tooltip surface + invalid-grid status dot + status medallion',
+    },
+    'pages/admin/ConcourseDetailPage.tsx': {
+        count: 2,
+        reason: 'two count badges pinned to a tab',
+    },
+    'pages/admin/RecruitmentPage.tsx': {
+        count: 1,
+        reason: 'at-capacity segment of the usage progress bar',
+    },
+};
+
+function walk(dir: string, acc: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+        const p = join(dir, entry);
+        if (statSync(p).isDirectory()) walk(p, acc);
+        else if (p.endsWith('.tsx') && !p.endsWith('.test.tsx')) acc.push(p);
+    }
+    return acc;
+}
+
+describe('admin primary fill budget', () => {
+    it('has no ad-hoc resting primary fill beyond the documented non-button sites', () => {
+        const files = [join(SRC, 'pages', 'admin'), join(SRC, 'components', 'admin')].flatMap((d) =>
+            walk(d)
+        );
+        const offenders: string[] = [];
+        for (const file of files) {
+            const rel = file.slice(SRC.length + 1);
+            const found = readFileSync(file, 'utf8').match(RESTING_FILL) ?? [];
+            const budget = ALLOWED[rel]?.count ?? 0;
+            if (found.length > budget) {
+                offenders.push(`${rel}: ${found.length} resting fill(s), budget ${budget}`);
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    it('keeps the allowlist honest — no stale entry', () => {
+        const stale = Object.keys(ALLOWED).filter((rel) => {
+            const found = readFileSync(join(SRC, rel), 'utf8').match(RESTING_FILL) ?? [];
+            return found.length !== ALLOWED[rel].count;
+        });
+        expect(stale).toEqual([]);
+    });
+});

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -9,7 +9,23 @@ const buttonVariants = cva(
     {
         variants: {
             variant: {
-                default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+                // The single primary fill for the whole product (task 4.1).
+                // Written as literal indigo rather than `bg-primary` so the
+                // invariant is greppable and testable: `--primary` is the
+                // near-black slate token, which is what produced the two-colour
+                // split (an indigo hand-rolled button next to a black
+                // `<Button>` default) this variant exists to end.
+                // white on indigo-600 = 6.29:1, on indigo-700 = 7.90:1 (AA).
+                default: 'bg-indigo-600 text-white shadow hover:bg-indigo-700',
+                // Warning / destructive-adjacent: design-lock and retention
+                // actions only. Measured against a white page:
+                //   rest  amber-600 fill 3.19:1 vs white (1.4.11 ≥3), label
+                //         slate-900 on amber-600 5.60:1 (1.4.3 ≥4.5)
+                //   hover amber-700 fill 5.02:1, label white on amber-700 5.02:1
+                // The amber-500 + white it replaces measured 2.15:1 on both
+                // counts and failed AA outright.
+                warning:
+                    'bg-amber-600 text-slate-900 shadow-sm hover:bg-amber-700 hover:text-white',
                 destructive:
                     'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
                 outline:

--- a/frontend/src/pages/EmailVerificationSentPage.tsx
+++ b/frontend/src/pages/EmailVerificationSentPage.tsx
@@ -50,7 +50,7 @@ export default function EmailVerificationSentPage() {
                 type="button"
                 onClick={onResend}
                 disabled={cooldown > 0 || !email}
-                className="rounded bg-slate-900 text-white px-4 py-2 disabled:opacity-50"
+                className="rounded bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 disabled:opacity-50"
             >
                 {cooldown > 0
                     ? t(

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -286,7 +286,7 @@ const LoginPage = () => {
                             <CardFooter className="pt-2 flex flex-col gap-4">
                                 <Button
                                     type="submit"
-                                    className="w-full bg-slate-900 hover:bg-slate-800 disabled:bg-slate-900 disabled:opacity-100 transition-all font-semibold"
+                                    className="w-full disabled:opacity-100 transition-all font-semibold"
                                     disabled={isCredentialsPending}
                                 >
                                     {isCredentialsPending ? (
@@ -342,7 +342,7 @@ const LoginPage = () => {
                             <CardFooter className="pt-2 flex flex-col gap-3">
                                 <Button
                                     type="submit"
-                                    className="w-full bg-slate-900 hover:bg-slate-800 disabled:bg-slate-900 disabled:opacity-100 transition-all font-semibold"
+                                    className="w-full disabled:opacity-100 transition-all font-semibold"
                                     disabled={otp.length !== 6 || isOtpPending}
                                 >
                                     {isOtpPending ? (

--- a/frontend/src/pages/PasswordResetConfirmPage.tsx
+++ b/frontend/src/pages/PasswordResetConfirmPage.tsx
@@ -105,7 +105,7 @@ export default function PasswordResetConfirmPage() {
                 <button
                     type="submit"
                     disabled={submitting}
-                    className="w-full bg-slate-900 text-white py-2 rounded disabled:opacity-50"
+                    className="w-full bg-indigo-600 hover:bg-indigo-700 text-white py-2 rounded disabled:opacity-50"
                 >
                     {t('auth.password_reset.confirm_submit', 'Reset password')}
                 </button>

--- a/frontend/src/pages/PasswordResetRequestPage.tsx
+++ b/frontend/src/pages/PasswordResetRequestPage.tsx
@@ -71,7 +71,10 @@ export default function PasswordResetRequestPage() {
                     placeholder="name@example.com"
                     autoComplete="email"
                 />
-                <button type="submit" className="w-full bg-slate-900 text-white py-2 rounded">
+                <button
+                    type="submit"
+                    className="w-full bg-indigo-600 hover:bg-indigo-700 text-white py-2 rounded"
+                >
                     {t('auth.password_reset.request_submit', 'Send reset link')}
                 </button>
             </form>

--- a/frontend/src/pages/RegistrationPage.tsx
+++ b/frontend/src/pages/RegistrationPage.tsx
@@ -294,7 +294,7 @@ const RegistrationPage = () => {
                         <CardFooter className="pt-2">
                             <Button
                                 type="submit"
-                                className="w-full h-12 text-lg font-bold shadow-lg shadow-primary/20"
+                                className="w-full h-12 text-lg font-bold shadow-lg shadow-indigo-500/20"
                                 disabled={registerMutation.isPending}
                             >
                                 {registerMutation.isPending ? (

--- a/frontend/src/pages/TwoFactorRecoveryPage.tsx
+++ b/frontend/src/pages/TwoFactorRecoveryPage.tsx
@@ -64,7 +64,10 @@ export default function TwoFactorRecoveryPage() {
                     placeholder="name@example.com"
                     autoComplete="email"
                 />
-                <button type="submit" className="w-full bg-slate-900 text-white py-2 rounded">
+                <button
+                    type="submit"
+                    className="w-full bg-indigo-600 hover:bg-indigo-700 text-white py-2 rounded"
+                >
                     {t('auth.twofa.recovery.submit', 'Send disable link')}
                 </button>
             </form>

--- a/frontend/src/pages/admin/AccountSettingsPage.tsx
+++ b/frontend/src/pages/admin/AccountSettingsPage.tsx
@@ -258,7 +258,7 @@ const AccountSettingsPage = () => {
                                 <Button
                                     type="submit"
                                     disabled={isUpdating}
-                                    className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
+                                    className="h-11 rounded-xl px-6 font-bold shadow-sm"
                                 >
                                     {isUpdating
                                         ? t('admin.account.personal.saving', 'Saving...')
@@ -298,7 +298,7 @@ const AccountSettingsPage = () => {
                             {!user?.is_totp_enabled && !is2FASetupMode && (
                                 <Button
                                     onClick={() => setIs2FASetupMode(true)}
-                                    className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
+                                    className="h-11 rounded-xl px-6 font-bold shadow-sm"
                                 >
                                     {t('admin.account.security.setup_cta', 'Set up 2FA now')}
                                 </Button>
@@ -395,7 +395,7 @@ const AccountSettingsPage = () => {
                                                 onChange={(e) => setTotpToken(e.target.value)}
                                             />
                                             <Button
-                                                className="h-12 px-8 bg-indigo-600 hover:bg-indigo-700 font-bold"
+                                                className="h-12 px-8 font-bold"
                                                 disabled={
                                                     totpToken.length !== 6 ||
                                                     enableMutation.isPending
@@ -541,7 +541,7 @@ const AccountSettingsPage = () => {
                                         <Button
                                             type="submit"
                                             disabled={isChangingPassword}
-                                            className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
+                                            className="h-11 rounded-xl px-6 font-bold shadow-sm"
                                         >
                                             {isChangingPassword
                                                 ? t(

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -256,7 +256,7 @@ export default function ConcourseDetailPage() {
                         {canEdit && (
                             <Button
                                 size="sm"
-                                className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white"
+                                className="rounded-xl"
                                 onClick={openAddItemDialog}
                                 aria-label={t('admin.concourse.add_item', 'Add item')}
                             >
@@ -1430,7 +1430,7 @@ export default function ConcourseDetailPage() {
                                 (!activeLocale && !newItemLocale) ||
                                 isCreatingItem
                             }
-                            className="h-10 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white"
+                            className="h-10 rounded-xl px-6 font-bold"
                         >
                             {isCreatingItem ? (
                                 <Loader2 className="size-4 animate-spin mr-2" />
@@ -1475,7 +1475,7 @@ export default function ConcourseDetailPage() {
                             {t('common.cancel', 'Cancel')}
                         </Button>
                         <Button
-                            className="rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white"
+                            className="rounded-xl"
                             disabled={bulkActionPending}
                             onClick={async () => {
                                 if (bulkConfirm) {
@@ -1705,7 +1705,7 @@ export default function ConcourseDetailPage() {
                         <Button
                             onClick={handleImport}
                             disabled={!importText.trim() || isImporting}
-                            className="h-10 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white"
+                            className="h-10 rounded-xl px-6 font-bold"
                         >
                             {isImporting ? (
                                 <Loader2 className="size-4 animate-spin mr-2" />
@@ -1747,7 +1747,7 @@ export default function ConcourseDetailPage() {
                             />
                             <Button
                                 size="sm"
-                                className="h-9 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white"
+                                className="h-9 rounded-xl"
                                 disabled={!newTagName.trim() || isCreatingTag}
                                 onClick={handleCreateTag}
                                 aria-label={t('admin.concourse.create_tag', 'Create tag')}
@@ -1869,7 +1869,7 @@ export default function ConcourseDetailPage() {
                         <Button
                             onClick={confirmAddLanguage}
                             disabled={!newLangCode}
-                            className="h-10 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white"
+                            className="h-10 rounded-xl px-6 font-bold"
                         >
                             {t('common.add', 'Add')}
                         </Button>

--- a/frontend/src/pages/admin/CreateProjectPage.tsx
+++ b/frontend/src/pages/admin/CreateProjectPage.tsx
@@ -189,7 +189,7 @@ export default function CreateProjectPage() {
                                     </Button>
                                     <Button
                                         type="submit"
-                                        className="h-11 rounded-xl px-8 font-black bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm border-none"
+                                        className="h-11 rounded-xl px-8 font-black shadow-sm border-none"
                                         disabled={isSubmitting}
                                     >
                                         {isSubmitting ? (

--- a/frontend/src/pages/admin/DataPrivacyPage.tsx
+++ b/frontend/src/pages/admin/DataPrivacyPage.tsx
@@ -38,7 +38,7 @@ import {
 import type { BulkAnonymiseResult } from '@/api/model';
 import { StudyPageHeader } from '@/components/admin/layout/StudyPageHeader';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import { Button, buttonVariants } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
     AlertDialog,
@@ -632,7 +632,8 @@ export default function DataPrivacyPage() {
                         <Button
                             disabled={candidateCount === 0 || anonymiseMutation.isPending}
                             onClick={() => setConfirmOpen(true)}
-                            className="rounded-xl px-6 font-black bg-amber-500 hover:bg-amber-600 text-white active:scale-[0.98] transition-all shadow-sm disabled:opacity-50"
+                            variant="warning"
+                            className="rounded-xl px-6 font-black active:scale-[0.98] transition-all shadow-sm disabled:opacity-50"
                         >
                             {anonymiseMutation.isPending ? (
                                 <Loader2 className="w-4 h-4 animate-spin mr-2" />
@@ -688,7 +689,7 @@ export default function DataPrivacyPage() {
                                     },
                                 })
                             }
-                            className="bg-amber-500 hover:bg-amber-600"
+                            className={buttonVariants({ variant: 'warning' })}
                         >
                             {anonymiseMutation.isPending
                                 ? t('admin.privacy.confirm_in_progress', 'Anonymising…')

--- a/frontend/src/pages/admin/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/admin/GeneralSettingsPage.tsx
@@ -374,7 +374,7 @@ export default function GeneralSettingsPage() {
                                 <Button
                                     onClick={handleSaveQuota}
                                     disabled={isSavingQuota || isArchived}
-                                    className="rounded-xl px-6 font-black bg-indigo-600 hover:bg-indigo-700 active:scale-[0.98] transition-all shadow-sm"
+                                    className="rounded-xl px-6 font-black active:scale-[0.98] transition-all shadow-sm"
                                 >
                                     {isSavingQuota ? (
                                         <Loader2 className="w-4 h-4 animate-spin mr-2" />
@@ -433,7 +433,7 @@ export default function GeneralSettingsPage() {
                             <Button
                                 onClick={handleSaveRetention}
                                 disabled={isSavingRetention || isArchived}
-                                className="rounded-xl px-6 font-black bg-indigo-600 hover:bg-indigo-700 active:scale-[0.98] transition-all shadow-sm"
+                                className="rounded-xl px-6 font-black active:scale-[0.98] transition-all shadow-sm"
                             >
                                 {isSavingRetention ? (
                                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -495,7 +495,7 @@ function InviteMemberModal({ slug, isOwner }: { slug: string; isOwner: boolean }
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
                 <Button
-                    className="w-full h-11 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold shadow-lg shadow-indigo-500/20 border-none"
+                    className="w-full h-11 rounded-xl font-bold shadow-lg shadow-indigo-500/20 border-none"
                     disabled={!isOwner}
                 >
                     <UserPlus className="size-4 mr-2" />
@@ -565,7 +565,7 @@ function InviteMemberModal({ slug, isOwner }: { slug: string; isOwner: boolean }
                             <DialogFooter className="pt-2">
                                 <Button
                                     type="submit"
-                                    className="w-full h-11 rounded-xl bg-slate-900 font-bold"
+                                    className="w-full h-11 rounded-xl font-bold"
                                     disabled={inviteMutation.isPending}
                                 >
                                     {inviteMutation.isPending ? (

--- a/frontend/src/pages/admin/ProjectSettingsPage.tsx
+++ b/frontend/src/pages/admin/ProjectSettingsPage.tsx
@@ -208,7 +208,7 @@ export default function ProjectSettingsPage() {
                                     <div className="flex justify-end pt-2">
                                         <Button
                                             type="submit"
-                                            className="h-11 rounded-xl px-6 font-bold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm"
+                                            className="h-11 rounded-xl px-6 font-bold shadow-sm"
                                             disabled={updateProjectMutation.isPending}
                                         >
                                             {updateProjectMutation.isPending ? (

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -332,7 +332,7 @@ const RecruitmentPage = () => {
                                         slugForm.formState.isSubmitting ||
                                         !slugForm.formState.isDirty
                                     }
-                                    className="rounded-xl px-6 font-black bg-indigo-600 hover:bg-indigo-700 active:scale-[0.98] transition-all shadow-sm"
+                                    className="rounded-xl px-6 font-black active:scale-[0.98] transition-all shadow-sm"
                                 >
                                     {slugForm.formState.isSubmitting ? (
                                         <Loader2 className="w-4 h-4 animate-spin mr-2" />
@@ -607,7 +607,7 @@ const RecruitmentPage = () => {
                                     accessForm.formState.isSubmitting ||
                                     !accessForm.formState.isDirty
                                 }
-                                className="rounded-xl px-6 font-black bg-indigo-600 hover:bg-indigo-700 active:scale-[0.98] transition-all shadow-sm"
+                                className="rounded-xl px-6 font-black active:scale-[0.98] transition-all shadow-sm"
                             >
                                 {accessForm.formState.isSubmitting ? (
                                     <Loader2 className="w-4 h-4 animate-spin mr-2" />
@@ -638,10 +638,7 @@ const RecruitmentPage = () => {
                                 onOpenChange={handleCreateModalOpenChange}
                             >
                                 <DialogTrigger asChild>
-                                    <Button
-                                        size="sm"
-                                        className="bg-indigo-600 hover:bg-indigo-700 shadow-sm font-bold rounded-xl"
-                                    >
+                                    <Button size="sm" className="shadow-sm font-bold rounded-xl">
                                         <Plus className="h-4 w-4 mr-1.5" />
                                         {t('admin.recruitment.new_link', 'New access link')}
                                     </Button>
@@ -805,7 +802,7 @@ const RecruitmentPage = () => {
                                         <Button
                                             onClick={handleCreate}
                                             disabled={isCreatingLink}
-                                            className="bg-indigo-600 hover:bg-indigo-700 font-bold px-8 rounded-xl shadow-lg shadow-indigo-200"
+                                            className="font-bold px-8 rounded-xl shadow-lg shadow-indigo-200"
                                         >
                                             {isCreatingLink
                                                 ? t('admin.recruitment.generating', 'Generating...')

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -536,9 +536,9 @@ const StudyDesignPage = () => {
                             </Button>
                             {draft.state === 'active' && (
                                 <Button
-                                    variant="default"
+                                    variant="warning"
                                     disabled={api.isSwitchingToDraft}
-                                    className="h-11 px-6 rounded-xl font-bold shadow-lg shadow-amber-200 bg-amber-500 hover:bg-amber-600 text-white"
+                                    className="h-11 px-6 rounded-xl font-bold shadow-lg shadow-amber-200"
                                     onClick={api.handleSwitchToDraft}
                                 >
                                     {api.isSwitchingToDraft && (
@@ -950,7 +950,7 @@ const StudyDesignPage = () => {
                                             api.isFullyReadOnly ||
                                             !api.isLaunchReady
                                         }
-                                        className="gap-2 h-12 px-8 rounded-xl font-black bg-indigo-600 hover:bg-indigo-700 text-white shadow-xl shadow-indigo-200 transition-all"
+                                        className="gap-2 h-12 px-8 rounded-xl font-black shadow-xl shadow-indigo-200 transition-all"
                                         data-testid="activate-button"
                                     >
                                         <Rocket className="h-5 w-5" />


### PR DESCRIPTION
Task 4.1 of the admin UX remediation plan — the last task in Phase 4.

## The counts held; the mechanism did not

The sweep was re-run rather than inherited: **32 `bg-indigo-600` / 6 `bg-amber-500` /
4 `bg-slate-900` / 1 `bg-emerald-600`, 43 hits** — exactly the audit's figures, so
"indigo is the majority" stands.

But the plan's sharpest example was diagnosed wrong, and following its prescription
literally would have **inverted the outcome**. On Access, "New access link" is a
hand-written indigo `<Button>` and the empty-state "Create access link" is near-black —
not because anything says `bg-slate-900`, but because `EmptyState` renders a **bare**
`<Button>`, which falls through to `bg-primary`, and `--primary` is `222.2 47.4% 11.2%`:
the slate token.

A grep for the four fill classes can never find that button. **15 further admin call sites
plus every EmptyState CTA were near-black and invisible to the sweep.** The plan said
"route through the default variant, delete the className" — which, with the default variant
still slate, would have turned 26 indigo buttons black.

So the fix lands on the **variant** first: `default` is now literally
`bg-indigo-600 … hover:bg-indigo-700`, and 26 call sites drop the fill they were
hand-writing on top of it. `hover:bg-primary/90` had to go too — at 90% over white, indigo
*lightens* on hover.

## Contrast, computed against each control's real background

- white on indigo-600 **6.29:1**, on indigo-700 **7.90:1** — AA. This is a genuine
  reduction from 17.85:1 on slate-900, and it is recorded as such rather than glossed.
- indigo-600 as a fill boundary: 6.29 on white, 6.01 slate-50, 5.74 slate-100, 5.62
  indigo-50, 6.06 amber-50 — all clear 1.4.11's 3:1.

**Two fills the plan wanted kept were already failing AA.** White on `amber-500` is
**2.15:1** — failing both 1.4.3 and 1.4.11 — and white on `emerald-600` is 3.77:1.
Preserving amber as the plan specified would have preserved a live accessibility failure,
so the new `warning` variant is amber-600 + slate-900 (5.60 text / 3.19 fill), darkening to
amber-700 + white on hover (5.02 both). Emerald inherits indigo.

`disabled:opacity-50` composites to 2.29:1, down from 3.41 — WCAG 1.4.3 exempts inactive
controls, so neither state has a requirement, but it is recorded rather than omitted. (The
missing opacity bucket is what produced four defects in task 6.5.)

## The guard, verified in both directions

A test over `pages/admin` and `components/admin` that fails when a resting primary fill
appears outside a documented non-button allowlist, plus a second test that fails when an
allowlist entry goes **stale**.

The token regex rejects matches preceded by a word char, `:`, `/` or `-`, so `hover:bg-*`,
`data-[state=active]:bg-*`, `group-hover/bar:bg-*` and `disabled:opacity-50` cannot
false-positive. Verified by injection both ways: a real fill fails and names the file and
count; every modifier-prefixed decoy passes.

## A warning worth more than this PR

The task's own worktree had **no `node_modules`**, so `npx biome` and `npx vitest` silently
no-opped and **exited 0** before that was noticed. Every gate below was therefore re-run
from a worktree with real dependencies. On this plan, a green gate in a fresh worktree may
mean nothing ran.

## Scope, stated

Extended to the auth family (Login, Registration, 4 password/2FA pages) — not for tidiness:
`RegistrationPage` renders bare `<Button>`s, so it flips to indigo whether or not it is
touched, and leaving `LoginPage` pinned to slate-900 would have split the auth surface
instead of the admin one. Participant sort/status pills deliberately left alone.

**E2E:** 3 `toHaveClass` assertions (all `/ring-2/`, fine-sort) and 3 class-bearing
locators — none references any token this task moves.

## Follow-up this opens

`--primary` and the button primary now **diverge**. `--primary` still drives `IconPicker`
and the `link` variant, so the token and the component disagree about what "primary" means.
Worth its own task.

## Gates (re-run with real dependencies)

`biome` 892 files clean · `tsc` exit 0 · **1807 passed / 6 skipped** · a11y at baseline ·
`i18n-check` · `check-orphan-keys` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
