### PR TITLE
fix(admin): one label per section, and a breadcrumb that can tell two pages apart (5.2)

### DIFF
--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -937,15 +937,16 @@
             "participants": "Teilnehmer",
             "team": "Team",
             "recruitment": "Zugang",
-            "exports": "Daten",
             "data": "Daten",
             "privacy": "Datenschutz",
             "account": "Kontoeinstellungen",
             "participant_n": "Teilnehmer {{code}}",
             "analysis": "Analyse",
-            "settings": "Einstellungen",
+            "project_settings": "Projekteinstellungen",
+            "study_settings": "Studieneinstellungen",
             "concourse": "Aussagenpool",
             "members": "Teammitglieder",
+            "users": "Benutzer",
             "nav_label": "Brotkrümelnavigation"
         },
         "command_menu": {
@@ -971,7 +972,7 @@
             "switched_project": "Zu {{name}} gewechselt"
         },
         "dashboard": {
-            "title": "Projekt-Dashboard",
+            "title": "Dashboard",
             "welcome": "Willkommen zurück,",
             "snapshot": "Hier ist ein Überblick über Ihre Forschungsaktivitäten.",
             "create_study": "Studie erstellen",
@@ -1249,7 +1250,7 @@
             }
         },
         "design": {
-            "title": "Studiendesign",
+            "title": "Design",
             "translation_needed": "Überprüfung erforderlich (Kopie)",
             "reset_defaults": "Auf Standard zurücksetzen",
             "editing_language_banner": "Sie bearbeiten die {{language}}-Version. Verwenden Sie die Sprachauswahl in der Werkzeugleiste, um zu wechseln.",
@@ -2005,7 +2006,7 @@
             "draft": "Entwurf"
         },
         "settings": {
-            "title": "Einstellungen",
+            "title": "Studieneinstellungen",
             "description": "Datenspeicherung, Archivierung und Studienlöschung.",
             "lifecycle": {
                 "title": "Archivierung",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -947,15 +947,16 @@
             "participants": "Participants",
             "team": "Team",
             "recruitment": "Access",
-            "exports": "Data",
             "data": "Data",
             "privacy": "Data privacy",
             "account": "Account settings",
             "participant_n": "Participant {{code}}",
             "analysis": "Analysis",
-            "settings": "Settings",
+            "project_settings": "Project settings",
+            "study_settings": "Study settings",
             "concourse": "Concourse",
             "members": "Team members",
+            "users": "Users",
             "nav_label": "breadcrumb"
         },
         "command_menu": {
@@ -981,7 +982,7 @@
             "switched_project": "Switched to {{name}}"
         },
         "dashboard": {
-            "title": "Project dashboard",
+            "title": "Dashboard",
             "welcome": "Welcome back,",
             "snapshot": "Here's a snapshot of your research activity.",
             "create_study": "Create study",
@@ -1262,7 +1263,7 @@
             }
         },
         "design": {
-            "title": "Study design",
+            "title": "Design",
             "translation_needed": "Review required (copy)",
             "reset_defaults": "Reset to defaults",
             "editing_language_banner": "Editing the {{language}} version. Use the language selector in the toolbar to switch.",
@@ -2020,7 +2021,7 @@
             "draft": "Draft"
         },
         "settings": {
-            "title": "Settings",
+            "title": "Study settings",
             "description": "Data retention, archiving, and study deletion.",
             "lifecycle": {
                 "title": "Archiving",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -937,15 +937,16 @@
             "participants": "Participantes",
             "team": "Equipo",
             "recruitment": "Acceso",
-            "exports": "Datos",
             "data": "Datos",
             "privacy": "Privacidad de datos",
             "account": "Configuración de cuenta",
             "participant_n": "Participante {{code}}",
             "analysis": "Análisis",
-            "settings": "Configuración",
+            "project_settings": "Configuración del proyecto",
+            "study_settings": "Configuración del estudio",
             "concourse": "Concurso",
             "members": "Miembros del equipo",
+            "users": "Usuarios",
             "nav_label": "ruta de navegación"
         },
         "command_menu": {
@@ -971,7 +972,7 @@
             "switched_project": "Cambiado a {{name}}"
         },
         "dashboard": {
-            "title": "Panel del proyecto",
+            "title": "Panel",
             "welcome": "Bienvenido de nuevo,",
             "snapshot": "Aquí tiene un resumen de su actividad de investigación.",
             "create_study": "Crear estudio",
@@ -1249,7 +1250,7 @@
             }
         },
         "design": {
-            "title": "Diseño del estudio",
+            "title": "Diseño",
             "translation_needed": "Revisión requerida (texto)",
             "reset_defaults": "Restablecer valores predeterminados",
             "editing_language_banner": "Editando la versión en {{language}}. Use el selector de idioma en la barra de herramientas para cambiar.",
@@ -2005,7 +2006,7 @@
             "draft": "Borrador"
         },
         "settings": {
-            "title": "Configuración",
+            "title": "Configuración del estudio",
             "description": "Retención de datos, archivado y eliminación del estudio.",
             "lifecycle": {
                 "title": "Archivado",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -846,15 +846,16 @@
             "participants": "Osallistujat",
             "team": "Tiimi",
             "recruitment": "Pääsy",
-            "exports": "Tiedot",
             "data": "Tiedot",
             "privacy": "Tietosuoja",
             "account": "Tilin asetukset",
             "participant_n": "Osallistuja {{code}}",
             "analysis": "Analyysi",
-            "settings": "Asetukset",
+            "project_settings": "Projektin asetukset",
+            "study_settings": "Asetukset",
             "concourse": "Concourse",
             "members": "Tiimin jäsenet",
+            "users": "Käyttäjät",
             "nav_label": "murupolku"
         },
         "command_menu": {
@@ -880,7 +881,7 @@
             "switched_project": "Vaihdettu projektiin {{name}}"
         },
         "dashboard": {
-            "title": "Projektin yhteenveto",
+            "title": "Hallintapaneeli",
             "welcome": "Tervetuloa takaisin,",
             "snapshot": "Tässä on yhteenveto tutkimustoiminnastasi.",
             "create_study": "Luo tutkimus",
@@ -1653,7 +1654,7 @@
                     "remove_default": "Poista kuva"
                 }
             },
-            "title": "Tutkimuksen suunnittelu",
+            "title": "Suunnittelu",
             "activate_dialog": {
                 "title": "Aktivoidaanko tämä tutkimus?",
                 "description": "Aktivointi avaa rekrytoinnin ja vapauttaa julkiset linkit. Todelliset osallistujat voivat alkaa vastata.",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -846,15 +846,16 @@
             "participants": "Participants",
             "team": "Équipe",
             "recruitment": "Accès",
-            "exports": "Données",
             "data": "Données",
             "privacy": "Confidentialité",
             "account": "Paramètres du compte",
             "participant_n": "Participant {{code}}",
             "analysis": "Analyse",
-            "settings": "Réglages",
+            "project_settings": "Réglages du projet",
+            "study_settings": "Réglages",
             "concourse": "Concours",
             "members": "Membres de l'équipe",
+            "users": "Utilisateurs",
             "nav_label": "fil d'Ariane"
         },
         "command_menu": {
@@ -880,7 +881,7 @@
             "switched_project": "Basculé vers {{name}}"
         },
         "dashboard": {
-            "title": "Tableau de bord du projet",
+            "title": "Tableau de bord",
             "welcome": "Bon retour,",
             "snapshot": "Voici un aperçu de votre activité de recherche.",
             "create_study": "Créer une étude",
@@ -1691,7 +1692,7 @@
                     "remove_default": "Retirer l'image"
                 }
             },
-            "title": "Conception de l'étude",
+            "title": "Conception",
             "activate_dialog": {
                 "title": "Activer cette étude ?",
                 "description": "L’activation ouvre le recrutement et déverrouille les liens publics. De vrais participants peuvent commencer à répondre.",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -937,15 +937,16 @@
             "participants": "Partecipanti",
             "team": "Team",
             "recruitment": "Accesso",
-            "exports": "Dati",
             "data": "Dati",
             "privacy": "Privacy dei dati",
             "account": "Impostazioni account",
             "participant_n": "Partecipante {{code}}",
             "analysis": "Analisi",
-            "settings": "Impostazioni",
+            "project_settings": "Impostazioni progetto",
+            "study_settings": "Impostazioni studio",
             "concourse": "Concorso",
             "members": "Membri del team",
+            "users": "Utenti",
             "nav_label": "percorso di navigazione"
         },
         "command_menu": {
@@ -971,7 +972,7 @@
             "switched_project": "Passato a {{name}}"
         },
         "dashboard": {
-            "title": "Dashboard del progetto",
+            "title": "Dashboard",
             "welcome": "Bentornato,",
             "snapshot": "Ecco un riepilogo della sua attività di ricerca.",
             "create_study": "Crea studio",
@@ -1249,7 +1250,7 @@
             }
         },
         "design": {
-            "title": "Progettazione studio",
+            "title": "Progettazione",
             "translation_needed": "Revisione richiesta (testo)",
             "reset_defaults": "Ripristina valori predefiniti",
             "editing_language_banner": "Modifica della versione {{language}}. Utilizzi il selettore lingua nella barra degli strumenti per cambiare.",
@@ -2005,7 +2006,7 @@
             "draft": "Bozza"
         },
         "settings": {
-            "title": "Impostazioni",
+            "title": "Impostazioni studio",
             "description": "Conservazione dei dati, archiviazione ed eliminazione dello studio.",
             "lifecycle": {
                 "title": "Archiviazione",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -937,15 +937,16 @@
             "participants": "Deelnemers",
             "team": "Team",
             "recruitment": "Toegang",
-            "exports": "Data",
             "data": "Data",
             "privacy": "Gegevensprivacy",
             "account": "Accountinstellingen",
             "participant_n": "Deelnemer {{code}}",
             "analysis": "Analyse",
-            "settings": "Instellingen",
+            "project_settings": "Projectinstellingen",
+            "study_settings": "Onderzoeksinstellingen",
             "concourse": "Concours",
             "members": "Teamleden",
+            "users": "Gebruikers",
             "nav_label": "kruimelpad"
         },
         "command_menu": {
@@ -971,7 +972,7 @@
             "switched_project": "Overgeschakeld naar {{name}}"
         },
         "dashboard": {
-            "title": "Projectdashboard",
+            "title": "Dashboard",
             "welcome": "Welkom terug,",
             "snapshot": "Een overzicht van uw onderzoeksactiviteit.",
             "create_study": "Onderzoek aanmaken",
@@ -1249,7 +1250,7 @@
             }
         },
         "design": {
-            "title": "Onderzoeksopzet",
+            "title": "Opzet",
             "translation_needed": "Controle vereist (kopie)",
             "reset_defaults": "Standaardinstellingen herstellen",
             "editing_language_banner": "U bewerkt de {{language}}-versie. Gebruik de taalkiezer in de werkbalk om te wisselen.",
@@ -2005,7 +2006,7 @@
             "draft": "Concept"
         },
         "settings": {
-            "title": "Instellingen",
+            "title": "Onderzoeksinstellingen",
             "description": "Gegevensbewaring, archivering en verwijdering van onderzoeken.",
             "lifecycle": {
                 "title": "Archivering",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -937,15 +937,16 @@
       "participants": "Participants",
       "team": "Team",
       "recruitment": "Access",
-      "exports": "Data",
       "data": "Data",
       "privacy": "Data privacy",
       "account": "Account settings",
       "participant_n": "Participant {{code}}",
       "analysis": "Analysis",
-      "settings": "Settings",
+      "project_settings": "Ustawienia projektu",
+      "study_settings": "Ustawienia badania",
       "concourse": "Concourse",
       "members": "Team members",
+      "users": "Użytkownicy",
       "nav_label": "ścieżka nawigacji"
     },
     "command_menu": {
@@ -971,7 +972,7 @@
       "switched_project": "Przełączono na {{name}}"
     },
     "dashboard": {
-      "title": "Panel projektu",
+      "title": "Panel",
       "welcome": "Witamy z powrotem,",
       "snapshot": "Oto migawka aktywności badawczej.",
       "create_study": "Utwórz badanie",
@@ -1249,7 +1250,7 @@
       }
     },
     "design": {
-      "title": "Projekt badania",
+      "title": "Projekt",
       "translation_needed": "Wymaga weryfikacji (kopia)",
       "reset_defaults": "Przywróć wartości domyślne",
       "editing_language_banner": "Edytowanie wersji {{language}}. Aby przełączyć, użyj selektora języka na pasku narzędzi.",
@@ -2005,7 +2006,7 @@
       "draft": "Draft"
     },
     "settings": {
-      "title": "Ustawienia",
+      "title": "Ustawienia badania",
       "description": "Przechowywanie danych, archiwizacja i usuwanie badania.",
       "lifecycle": {
         "title": "Archiwizacja",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -937,15 +937,16 @@
             "participants": "Participantes",
             "team": "Equipa",
             "recruitment": "Acesso",
-            "exports": "Dados",
             "data": "Dados",
             "privacy": "Privacidade de dados",
             "account": "Definições da conta",
             "participant_n": "Participante {{code}}",
             "analysis": "Análise",
-            "settings": "Definições",
+            "project_settings": "Definições do projeto",
+            "study_settings": "Definições do estudo",
             "concourse": "Concurso",
             "members": "Membros da equipa",
+            "users": "Utilizadores",
             "nav_label": "rasto de navegação"
         },
         "command_menu": {
@@ -971,7 +972,7 @@
             "switched_project": "Mudou para {{name}}"
         },
         "dashboard": {
-            "title": "Painel do projeto",
+            "title": "Painel",
             "welcome": "Bem-vindo/a de volta,",
             "snapshot": "Aqui está um resumo da sua atividade de investigação.",
             "create_study": "Criar estudo",
@@ -1249,7 +1250,7 @@
             }
         },
         "design": {
-            "title": "Desenho do estudo",
+            "title": "Desenho",
             "translation_needed": "Revisão necessária (cópia)",
             "reset_defaults": "Repor valores predefinidos",
             "editing_language_banner": "A editar a versão em {{language}}. Use o seletor de idioma na barra de ferramentas para mudar.",
@@ -2005,7 +2006,7 @@
             "draft": "Rascunho"
         },
         "settings": {
-            "title": "Definições",
+            "title": "Definições do estudo",
             "description": "Retenção de dados, arquivamento e eliminação de estudos.",
             "lifecycle": {
                 "title": "Arquivamento",

--- a/frontend/src/components/admin/AppSidebar.tsx
+++ b/frontend/src/components/admin/AppSidebar.tsx
@@ -258,19 +258,19 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                       show: true,
                   },
                   {
-                      title: t('admin.sidebar.design'),
+                      title: t('admin.sidebar.design', 'Design'),
                       url: `/app/${projectSlug}/studies/${params.studySlug}/design`,
                       icon: PencilRuler,
                       show: can('study:edit_design'),
                   },
                   {
-                      title: t('admin.sidebar.recruit'),
+                      title: t('admin.sidebar.recruit', 'Access'),
                       url: `/app/${projectSlug}/studies/${params.studySlug}/recruitment`,
                       icon: Link2,
                       show: can('study:launch_recruitment'),
                   },
                   {
-                      title: t('admin.sidebar.data'),
+                      title: t('admin.sidebar.data', 'Data'),
                       url: `/app/${projectSlug}/studies/${params.studySlug}/data`,
                       icon: Download,
                       show: can('study:view_data'),
@@ -332,7 +332,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                                 >
                                     <Search className="size-3.5 mr-2" />
                                     <span className="text-xs">
-                                        {t('admin.sidebar.search', 'Search')}
+                                        {t('admin.sidebar.search', 'Search...')}
                                     </span>
                                     <kbd className="ml-auto pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-background px-1.5 font-mono text-2xs font-medium text-muted-foreground opacity-100">
                                         <span className="text-xs">⌘</span>K
@@ -372,7 +372,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                                     }}
                                 >
                                     <Search className="size-3.5 mr-2" />
-                                    <span className="text-xs">{t('admin.sidebar.search')}</span>
+                                    <span className="text-xs">
+                                        {t('admin.sidebar.search', 'Search...')}
+                                    </span>
                                     <kbd className="ml-auto pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-background px-1.5 font-mono text-2xs font-medium text-muted-foreground opacity-100">
                                         <span className="text-xs">⌘</span>K
                                     </kbd>

--- a/frontend/src/components/admin/CommandMenu.tsx
+++ b/frontend/src/components/admin/CommandMenu.tsx
@@ -217,7 +217,7 @@ export const CommandMenu = () => {
                                     missed in that pass and still showed the project-scope
                                     "Tableau de bord" / "Dashboard" / "Hallintapaneeli" label
                                     for the same target. */}
-                                <span>{t('admin.sidebar.overview')}</span>
+                                <span>{t('admin.sidebar.overview', 'Overview')}</span>
                             </Command.Item>
                             <Command.Item
                                 value="design study"
@@ -233,7 +233,7 @@ export const CommandMenu = () => {
                                 <div className="flex h-6 w-6 items-center justify-center rounded bg-emerald-100 dark:bg-emerald-900/40">
                                     <PencilRuler className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
                                 </div>
-                                <span>{t('admin.sidebar.design')}</span>
+                                <span>{t('admin.sidebar.design', 'Design')}</span>
                             </Command.Item>
                             <Command.Item
                                 value="access recruit recruitment"
@@ -249,7 +249,7 @@ export const CommandMenu = () => {
                                 <div className="flex h-6 w-6 items-center justify-center rounded bg-pink-100 dark:bg-pink-900/40">
                                     <UserPlus className="h-3.5 w-3.5 text-pink-600 dark:text-pink-400" />
                                 </div>
-                                <span>{t('admin.sidebar.recruit')}</span>
+                                <span>{t('admin.sidebar.recruit', 'Access')}</span>
                             </Command.Item>
                             <Command.Item
                                 value="data exports stats analytics"
@@ -265,7 +265,7 @@ export const CommandMenu = () => {
                                 <div className="flex h-6 w-6 items-center justify-center rounded bg-amber-100 dark:bg-amber-900/40">
                                     <BarChart3 className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
                                 </div>
-                                <span>{t('admin.sidebar.data')}</span>
+                                <span>{t('admin.sidebar.data', 'Data')}</span>
                             </Command.Item>
                             <Command.Item
                                 value="settings configuration"
@@ -281,7 +281,7 @@ export const CommandMenu = () => {
                                 <div className="flex h-6 w-6 items-center justify-center rounded bg-slate-100 dark:bg-slate-800 border">
                                     <Settings className="h-3.5 w-3.5 text-slate-500" />
                                 </div>
-                                <span>{t('admin.sidebar.settings')}</span>
+                                <span>{t('admin.sidebar.settings', 'Study settings')}</span>
                             </Command.Item>
                             <Command.Item
                                 value="copy share link"

--- a/frontend/src/components/admin/FocusModeHeader.tsx
+++ b/frontend/src/components/admin/FocusModeHeader.tsx
@@ -33,7 +33,7 @@ export function FocusModeHeader({
                 className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
                 <ArrowLeft className="h-4 w-4" />
-                <span>{projectTitle || t('admin.sidebar.project')}</span>
+                <span>{projectTitle || t('admin.sidebar.project', 'Project')}</span>
             </button>
             <div className="px-2">
                 <Badge variant="outline" className="font-semibold" title={title}>

--- a/frontend/src/components/admin/ProjectSwitcher.tsx
+++ b/frontend/src/components/admin/ProjectSwitcher.tsx
@@ -80,7 +80,7 @@ export function ProjectSwitcher() {
                                 <span className="truncate font-bold tracking-tight text-slate-900">
                                     {currentProject
                                         ? currentProject.title
-                                        : t('admin.sidebar.select_project')}
+                                        : t('admin.sidebar.select_project', 'Select project')}
                                 </span>
                             </div>
                             <ChevronsUpDown className="ml-auto size-4 text-slate-500" />

--- a/frontend/src/layouts/AdminLayout.breadcrumb-coverage.test.tsx
+++ b/frontend/src/layouts/AdminLayout.breadcrumb-coverage.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Qualis - Open-source platform for conducting Q-methodology research
+ * Copyright (C) 2025 Julien Vastenekels
+ * Licensed under the GNU Affero General Public License v3.0 or later.
+ */
+
+/**
+ * Breadcrumb coverage over the REAL route table.
+ *
+ * CLAUDE.md's admin header policy: "Every static URL segment must have an entry
+ * in the `mapping` table (no fallback to `last.charAt(0).toUpperCase()`)."
+ *
+ * That rule is only enforceable if something checks the mapping against the
+ * routes that actually exist. This walks the exported `routes` array from
+ * App.tsx, collects every static leaf segment rendered inside an <AdminLayout>,
+ * and asserts each one resolves to a real label rather than to the raw segment.
+ *
+ * A new admin route whose segment is missing from SEGMENT_LABEL_KEYS fails here.
+ */
+
+import type { ReactElement } from 'react';
+import type { RouteObject } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import type { TFunction } from 'i18next';
+import { routes } from '../App';
+import AdminLayout from './AdminLayout';
+import { resolveBreadcrumbLabel } from './AdminLayout.helpers';
+
+/** Stub `t`: returns the fallback when given, otherwise the key. */
+const t = ((key: string, fallback?: unknown) =>
+    typeof fallback === 'string' ? fallback : key) as unknown as TFunction;
+
+function isAdminLayout(route: RouteObject): boolean {
+    const element = route.element as ReactElement | undefined;
+    return !!element && typeof element === 'object' && element.type === AdminLayout;
+}
+
+/**
+ * Collect the full path of every leaf route rendered under an <AdminLayout>.
+ * `parent` is the accumulated path prefix; `inAdmin` flips true once an
+ * AdminLayout route is entered and stays true for its whole subtree.
+ */
+function collectAdminPaths(
+    routeList: RouteObject[],
+    parent: string,
+    inAdmin: boolean,
+    out: string[]
+): void {
+    for (const route of routeList) {
+        const here = inAdmin || isAdminLayout(route);
+        const path = route.path ? `${parent}/${route.path}`.replace(/\/+/g, '/') : parent;
+        if (route.children) {
+            collectAdminPaths(route.children, path, here, out);
+        } else if (here && route.path) {
+            out.push(path);
+        }
+    }
+}
+
+const adminPaths: string[] = [];
+collectAdminPaths(routes, '', false, adminPaths);
+
+describe('breadcrumb mapping covers the real admin route table', () => {
+    it('finds the admin routes at all (guards against a vacuous pass)', () => {
+        expect(adminPaths.length).toBeGreaterThan(8);
+        expect(adminPaths).toContain('/app/:projectSlug/settings');
+        expect(adminPaths).toContain('/app/:projectSlug/studies/:studySlug/settings');
+        expect(adminPaths).toContain('/app/users');
+    });
+
+    it.each(adminPaths)('resolves a label for %s', (routePath: string) => {
+        // Substitute concrete values for the dynamic segments so the helper
+        // sees a realistic pathname.
+        const pathname = routePath
+            .replace(':projectSlug', 'example-project')
+            .replace(':studySlug', 'study-abc')
+            .replace(':concourseId', '42')
+            .replace(':participantId', '7');
+        const segments = pathname.split('/').filter(Boolean);
+        const last = segments[segments.length - 1];
+
+        const label = resolveBreadcrumbLabel(pathname, 'study-abc', { code: 'ABCDEF01' }, t);
+
+        expect(label).toBeTruthy();
+        // The raw segment coming back means the mapping has no entry for it.
+        expect(label).not.toBe(last);
+        // A dotted i18n key coming back means the entry has no fallback.
+        expect(label).not.toMatch(/^admin\./);
+    });
+});

--- a/frontend/src/layouts/AdminLayout.helpers.test.ts
+++ b/frontend/src/layouts/AdminLayout.helpers.test.ts
@@ -29,24 +29,22 @@ const t = ((key: string, fallbackOrOpts?: unknown, opts?: Record<string, unknown
 
 describe('resolveBreadcrumbLabel', () => {
     it('returns dashboard for empty pathname', () => {
-        expect(resolveBreadcrumbLabel('/', null, undefined, t)).toBe('admin.breadcrumbs.dashboard');
+        expect(resolveBreadcrumbLabel('/', null, undefined, t)).toBe('Dashboard');
     });
 
     it('returns dashboard for /admin tail', () => {
-        expect(resolveBreadcrumbLabel('/admin', null, undefined, t)).toBe(
-            'admin.breadcrumbs.dashboard'
-        );
+        expect(resolveBreadcrumbLabel('/admin', null, undefined, t)).toBe('Dashboard');
     });
 
     it('returns study_dashboard when last segment matches activeStudyId', () => {
         expect(
             resolveBreadcrumbLabel('/app/proj1/studies/study-abc', 'study-abc', undefined, t)
-        ).toBe('admin.breadcrumbs.study_dashboard');
+        ).toBe('Overview');
     });
 
     it('returns project.create.title for /new tail', () => {
         expect(resolveBreadcrumbLabel('/app/proj1/projects/new', null, undefined, t)).toBe(
-            'admin.project.create.title'
+            'Create project'
         );
     });
 
@@ -73,7 +71,10 @@ describe('resolveBreadcrumbLabel', () => {
         ).toBe('Participant 7');
     });
 
-    it('maps known segments via the mapping table (with fallback)', () => {
+    it('maps known segments via the mapping table', () => {
+        expect(resolveBreadcrumbLabel('/app/proj1/dashboard', null, undefined, t)).toBe(
+            'Dashboard'
+        );
         expect(resolveBreadcrumbLabel('/app/proj1/data', null, undefined, t)).toBe('Data');
         expect(resolveBreadcrumbLabel('/app/proj1/privacy', null, undefined, t)).toBe(
             'Data privacy'
@@ -84,21 +85,74 @@ describe('resolveBreadcrumbLabel', () => {
         expect(resolveBreadcrumbLabel('/app/proj1/concourses', null, undefined, t)).toBe(
             'Concourse'
         );
+        expect(resolveBreadcrumbLabel('/app/proj1/members', null, undefined, t)).toBe(
+            'Team members'
+        );
+        expect(resolveBreadcrumbLabel('/app/proj1/studies/s/design', 's', undefined, t)).toBe(
+            'Design'
+        );
+        expect(resolveBreadcrumbLabel('/app/proj1/studies/s/recruitment', 's', undefined, t)).toBe(
+            'Access'
+        );
+        expect(resolveBreadcrumbLabel('/app/proj1/studies/s/analysis', 's', undefined, t)).toBe(
+            'Analysis'
+        );
     });
 
-    it('maps known segments via the mapping table (no fallback)', () => {
-        expect(resolveBreadcrumbLabel('/app/proj1/dashboard', null, undefined, t)).toBe(
-            'admin.breadcrumbs.dashboard'
-        );
-        expect(resolveBreadcrumbLabel('/app/proj1/exports', null, undefined, t)).toBe(
-            'admin.breadcrumbs.exports'
-        );
+    // --- Naming canon (CLAUDE.md) -------------------------------------------
+    // One label per section, propagated to admin.sidebar.<s>,
+    // admin.breadcrumbs.<s> and admin.<s>.title. The `settings` URL segment is
+    // used by two different pages, so it must resolve by context: a bare
+    // "Settings" leaf makes the breadcrumb — the single source of truth for
+    // hierarchy — unable to say which page you are on.
+
+    it('labels the project settings breadcrumb "Project settings", matching admin.sidebar.project_settings', () => {
         expect(resolveBreadcrumbLabel('/app/proj1/settings', null, undefined, t)).toBe(
-            'admin.breadcrumbs.settings'
+            'Project settings'
         );
     });
 
-    it('Title-cases unknown segments as fallback', () => {
-        expect(resolveBreadcrumbLabel('/app/proj1/banana', null, undefined, t)).toBe('Banana');
+    it('labels the study settings breadcrumb "Study settings", matching admin.sidebar.settings', () => {
+        expect(
+            resolveBreadcrumbLabel(
+                '/app/proj1/studies/study-abc/settings',
+                'study-abc',
+                undefined,
+                t
+            )
+        ).toBe('Study settings');
+    });
+
+    it('distinguishes study settings from project settings in the breadcrumb', () => {
+        const project = resolveBreadcrumbLabel('/app/proj1/settings', null, undefined, t);
+        const study = resolveBreadcrumbLabel(
+            '/app/proj1/studies/study-abc/settings',
+            'study-abc',
+            undefined,
+            t
+        );
+        expect(project).not.toBe(study);
+    });
+
+    it('resolves the study settings breadcrumb from the URL, not from the active-study store', () => {
+        // activeStudyId is store state and can lag a route change by a render.
+        // The URL is authoritative for hierarchy.
+        expect(
+            resolveBreadcrumbLabel('/app/proj1/studies/study-abc/settings', null, undefined, t)
+        ).toBe('Study settings');
+    });
+
+    it('has a mapping entry for the superuser /app/users segment', () => {
+        // Previously this fell through to the Title-case fallback and only
+        // *looked* right because "users" title-cases to "Users".
+        expect(resolveBreadcrumbLabel('/app/users', null, undefined, t)).toBe('Users');
+    });
+
+    it('never fabricates a Title-cased label for an unmapped segment', () => {
+        // CLAUDE.md: every static URL segment must have a `mapping` entry, with
+        // no fallback to `last.charAt(0).toUpperCase()`. AdminLayout.breadcrumb-coverage
+        // .test.ts proves the mapping is exhaustive over the real route table;
+        // this pins that the fabricating fallback is gone.
+        expect(resolveBreadcrumbLabel('/app/proj1/banana', null, undefined, t)).toBe('banana');
     });
 });

--- a/frontend/src/layouts/AdminLayout.helpers.ts
+++ b/frontend/src/layouts/AdminLayout.helpers.ts
@@ -4,19 +4,28 @@ interface BreadcrumbParticipant {
     code?: string;
 }
 
-const SEGMENT_LABEL_KEYS: Record<string, [string, string?]> = {
-    dashboard: ['admin.breadcrumbs.dashboard'],
-    design: ['admin.breadcrumbs.design'],
-    recruitment: ['admin.breadcrumbs.recruitment'],
+/**
+ * One entry per static URL segment reachable inside `<AdminLayout>`, per
+ * CLAUDE.md's admin header policy. Each fallback is the canonical English
+ * label for that section — the same string carried by `admin.sidebar.<s>` and
+ * `admin.<s>.title` (the naming canon).
+ *
+ * Exhaustiveness over the real route table is enforced by
+ * `AdminLayout.breadcrumb-coverage.test.tsx`. `settings` is deliberately absent:
+ * two different pages own that segment, so it is resolved by context below.
+ */
+const SEGMENT_LABEL_KEYS: Record<string, [string, string]> = {
+    dashboard: ['admin.breadcrumbs.dashboard', 'Dashboard'],
+    design: ['admin.breadcrumbs.design', 'Design'],
+    recruitment: ['admin.breadcrumbs.recruitment', 'Access'],
     data: ['admin.breadcrumbs.data', 'Data'],
     privacy: ['admin.breadcrumbs.privacy', 'Data privacy'],
     account: ['admin.breadcrumbs.account', 'Account settings'],
     analysis: ['admin.breadcrumbs.analysis', 'Analysis'],
-    exports: ['admin.breadcrumbs.exports'],
-    settings: ['admin.breadcrumbs.settings'],
-    participants: ['admin.breadcrumbs.participants'],
+    participants: ['admin.breadcrumbs.participants', 'Participants'],
     concourses: ['admin.breadcrumbs.concourse', 'Concourse'],
     members: ['admin.breadcrumbs.members', 'Team members'],
+    users: ['admin.breadcrumbs.users', 'Users'],
 };
 
 /**
@@ -29,6 +38,11 @@ const SEGMENT_LABEL_KEYS: Record<string, [string, string?]> = {
  *  - `/participants/:id` (digit-only id) → "Participant <CODE>" where CODE is
  *    the participant's short display code (session_token[:8], computed
  *    server-side); falls back to the URL id while the fetch is in flight.
+ *
+ * Context-sensitive segment:
+ *  - `settings` → "Study settings" inside `/studies/:slug/…`, "Project settings"
+ *    otherwise. A bare "Settings" leaf on both would make the breadcrumb — the
+ *    single source of truth for hierarchy — unable to say which page you are on.
  */
 export function resolveBreadcrumbLabel(
     pathname: string,
@@ -38,11 +52,19 @@ export function resolveBreadcrumbLabel(
 ): string {
     const segments = pathname.split('/').filter(Boolean);
     const last = segments[segments.length - 1];
-    if (!last) return t('admin.breadcrumbs.dashboard');
+    if (!last) return t('admin.breadcrumbs.dashboard', 'Dashboard');
 
-    if (last === 'admin') return t('admin.breadcrumbs.dashboard');
-    if (last === activeStudyId) return t('admin.breadcrumbs.study_dashboard');
-    if (last === 'new') return t('admin.project.create.title');
+    if (last === 'admin') return t('admin.breadcrumbs.dashboard', 'Dashboard');
+    if (last === activeStudyId) return t('admin.breadcrumbs.study_dashboard', 'Overview');
+    if (last === 'new') return t('admin.project.create.title', 'Create project');
+
+    // `settings` is owned by two pages. Resolve it from the URL rather than from
+    // `activeStudyId`, which is store state and can lag a route change.
+    if (last === 'settings') {
+        return segments.includes('studies')
+            ? t('admin.breadcrumbs.study_settings', 'Study settings')
+            : t('admin.breadcrumbs.project_settings', 'Project settings');
+    }
 
     const prev = segments[segments.length - 2];
     if (prev === 'concourses' && /^\d+$/.test(last)) {
@@ -56,8 +78,13 @@ export function resolveBreadcrumbLabel(
     const labelKey = SEGMENT_LABEL_KEYS[last];
     if (labelKey) {
         const [key, fallback] = labelKey;
-        return fallback ? t(key, fallback) : t(key);
+        return t(key, fallback);
     }
 
-    return last.charAt(0).toUpperCase() + last.slice(1);
+    // Unreachable for any route that exists: the mapping's exhaustiveness over
+    // the real route table is asserted by AdminLayout.breadcrumb-coverage.test.tsx.
+    // Deliberately returns the segment verbatim rather than Title-casing it —
+    // a fabricated "Banana" reads like a real section name and hid the missing
+    // `users` entry for as long as the fallback existed (CLAUDE.md forbids it).
+    return last;
 }

--- a/frontend/src/pages/admin/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/admin/GeneralSettingsPage.tsx
@@ -256,7 +256,7 @@ export default function GeneralSettingsPage() {
     return (
         <div className="flex flex-1 flex-col gap-6 p-4 sm:p-6 pt-2">
             <StudyPageHeader
-                title={t('admin.settings.title')}
+                title={t('admin.settings.title', 'Study settings')}
                 description={t('admin.settings.description')}
                 icon={Settings}
             />


### PR DESCRIPTION
Task 5.2 of the admin UX remediation plan — restoring the naming canon `CLAUDE.md` specifies:
one label per section, propagated to `admin.sidebar.<s>`, `admin.breadcrumbs.<s>` and
`admin.<s>.title`.

## The defect

The `settings` URL segment is owned by **two different pages**, and both rendered the
breadcrumb leaf "Settings". Since `CLAUDE.md` makes the breadcrumb the single source of truth
for hierarchy, the one piece of chrome that is supposed to tell you where you are could not
distinguish project settings from study settings.

It now resolves by context — `admin.breadcrumbs.project_settings` /
`admin.breadcrumbs.study_settings` — derived from the **URL**, deliberately not from
`activeStudyId`, which is store state and lags a route change by a render.

`admin.settings.title` "Settings" → "Study settings" to match its sidebar label, plus two
drifted (currently unrendered) `.title` keys realigned: `admin.dashboard.title` → "Dashboard",
`admin.design.title` → "Design".

## The title-case fallback still existed, and a live route depended on it

`CLAUDE.md` requires every static URL segment to have a `mapping` entry, with **no** fallback
to `last.charAt(0).toUpperCase()`. That fallback was still there — and `/app/users`, the
superuser platform page, had no mapping entry at all. It only *looked* correct because
"users" happens to title-case to "Users".

That is the plan's own failure shape in miniature: a defect that renders a plausible string,
so nothing flags it. The entry is added, the fallback deleted, and the residual branch now
returns the segment **verbatim**, so a future miss is visibly wrong instead of plausibly
right.

Also removed a stale `exports` mapping entry — a mapping, plus a JSON key in all nine
locales, for a route that no longer exists.

## Counts re-derived, not inherited

- Naming-canon fallback/JSON divergences: **1 → 0** (`admin.sidebar.search` said `Search`,
  the JSON says `Search...`). That is 1 of the 114 task 4.4 handed on; the other 113 stay
  with task 5.1.
- Naming-canon `t()` calls with no fallback at all: **12 → 0**.
- Case-sensitive Playwright matchers in `e2e/`: **12** — confirming task 4.3's recount and
  refuting the 16 an earlier brief claimed. None touches a changed string; the only
  settings-shaped locators are a case-insensitive sidebar regex and an "Account settings"
  menuitem, both unaffected.

## The i18n warning delta is 0, not the large positive number the brief predicted

The brief assumed adding keys to `en/admin.json` would inevitably make eight locales report
them missing (it was 16 → 200 on task 4.4). Not here: every new key names a label the other
eight locales have **already translated** — `admin.sidebar.project_settings`,
`admin.sidebar.settings`, `admin.users.title` — so their own existing translations were
copied across rather than adding English-only keys.

Nothing machine-translated, and it avoids a real regression in which eight locales would have
shown English breadcrumbs. **`pl` actually improves**: its breadcrumb value was the
untranslated string "Settings".

## The guard

`AdminLayout.breadcrumb-coverage.test.tsx` walks the **real exported `routes` array** from
`App.tsx` and asserts every static admin segment resolves to something that is neither the
raw segment nor a dotted key — so a new route cannot ship without a breadcrumb label.

Verified adversarially with exit codes read directly: deleting the `users` entry → **1**,
deleting a fallback → **1**, clean → **0**.

## Brief errors, all mine

Every file path in the brief was wrong. The mapping table lives at
`src/layouts/AdminLayout.helpers.ts`, not `components/admin/AdminLayout.tsx`, and
`AdminLayout.test.tsx` — where the plan says to write the test — does not exist. The
assertions went into the existing pure helper test rather than into a new render harness
built to match a wrong path.

## Handed on

- `admin.layout.platform_settings` ("Platform settings") points at a page titled "Users".
- Two `DataPrivacyPage` strings still say "Edit in Study design".

## Gates

lint 893 files · `tsc --noEmit` clean · **202 files / 1828 passed / 6 skipped / 0 failed** ·
a11y, `i18n-check`, `check-interpolations`, `check-orphan-keys` all exit 0. `backend/uv.lock`
untouched. Re-verified after rebase onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
