### PR TITLE
style(i18n): one word per concept across the admin (5.1)

### DIFF
--- a/frontend/e2e/admin/recruitment-funnel.spec.ts
+++ b/frontend/e2e/admin/recruitment-funnel.spec.ts
@@ -54,7 +54,7 @@ test.describe('Recruitment funnel', () => {
         await expect(page).toHaveURL(/recruitment/, { timeout: 15_000 });
 
         // Verify the empty state is shown initially
-        await expect(page.getByText(/no recruitment links yet/i)).toBeVisible({ timeout: 10_000 });
+        await expect(page.getByText(/no access links yet/i)).toBeVisible({ timeout: 10_000 });
 
         // ------------------------------------------------------------------ //
         // 3. Create a public recruitment link via the UI                       //
@@ -102,15 +102,15 @@ test.describe('Recruitment funnel', () => {
         // en.json key admin.status.active = "Active" (or similar)
         await expect(linkRow.getByText(/active/i)).toBeVisible({ timeout: 5_000 });
 
-        // Verify the link has a security token displayed (non-empty <code> element)
+        // Verify the link has a link token displayed (non-empty <code> element)
         const tokenCell = linkRow.locator('code');
         await expect(tokenCell).toBeVisible({ timeout: 5_000 });
         const tokenText = await tokenCell.textContent();
         expect(tokenText).toBeTruthy();
         expect(tokenText?.length).toBeGreaterThan(4);
 
-        // The "no recruitment links yet" empty state should be gone
-        await expect(page.getByText(/no recruitment links yet/i)).not.toBeVisible();
+        // The "no access links yet" empty state should be gone
+        await expect(page.getByText(/no access links yet/i)).not.toBeVisible();
 
         // ------------------------------------------------------------------ //
         // 5. Verify the public study URL is live for this link                 //

--- a/frontend/e2e/admin/roles.spec.ts
+++ b/frontend/e2e/admin/roles.spec.ts
@@ -175,7 +175,7 @@ test.describe('owner can manage team', () => {
         await expect(page.getByRole('heading', { name: /team members/i })).toBeVisible();
 
         // Open invite modal
-        await page.getByRole('button', { name: /invite collaborator/i }).click();
+        await page.getByRole('button', { name: /invite member/i }).click();
 
         // Fill email (label isn't bound via htmlFor; target the textbox by placeholder).
         const dialog = page.getByRole('dialog');
@@ -269,7 +269,7 @@ test.describe('member cannot manage team', () => {
         await expect(ownRow).toBeVisible();
 
         // Invite button must be disabled for non-owners.
-        const inviteBtn = page.getByRole('button', { name: /invite collaborator/i });
+        const inviteBtn = page.getByRole('button', { name: /invite member/i });
         await expect(inviteBtn).toBeDisabled();
 
         // Role selects in every data row should be disabled — the page gates
@@ -403,7 +403,7 @@ test.describe('owner role is never offered in dropdowns', () => {
         const projectSlug = testDb.getWorkspaceSlug();
 
         await page.goto(`/app/${projectSlug}/members`);
-        await page.getByRole('button', { name: /invite collaborator/i }).click();
+        await page.getByRole('button', { name: /invite member/i }).click();
 
         // Open the role select inside the dialog. Two combobox elements exist
         // (the Radix portal duplicates them) — the visible trigger is first.

--- a/frontend/public/locales/de/admin.json
+++ b/frontend/public/locales/de/admin.json
@@ -276,7 +276,7 @@
             "logout": "Abmelden",
             "account": "Kontoeinstellungen",
             "admin_user": "Admin-Benutzer",
-            "platform_settings": "Plattformeinstellungen"
+            "platform_settings": "Benutzer"
         },
         "account": {
             "title": "Kontoeinstellungen",
@@ -836,7 +836,6 @@
             "link_count": "Chargengröße",
             "capacity_label": "Max. Einreichungen",
             "generate_links": "Links bereitstellen",
-            "no_links": "Noch keine Rekrutierungslinks erstellt.",
             "unnamed": "Unbenannter Kanal",
             "revoked": "Zugang widerrufen",
             "qr_title": "Per QR teilen",
@@ -873,16 +872,6 @@
                 "public": "Am besten für hohe Teilnehmerzahlen. Eine einzige URL für alle Teilnehmer.",
                 "individual": "Maximale Sicherheit. Erzeugt eindeutige Links, die nach einer erfolgreichen Teilnahme verfallen.",
                 "limited": "Kontrollierter Zugang. Ein Link, der nach einer festgelegten Anzahl von Einreichungen nicht mehr funktioniert."
-            },
-            "stats": {
-                "total_links": "Kanäle gesamt",
-                "active_channels": "Aktive Rekrutierungschargen",
-                "started": "Sitzungen gesamt",
-                "engagements": "Teilnehmer, die gestartet haben",
-                "submitted": "Gültige Daten",
-                "completions": "Abgeschlossene Einreichungen",
-                "conversion": "Erfassungsrate",
-                "efficiency": "Endgültige Datenausbeute"
             },
             "table": {
                 "name": "Kampagne / Charge",
@@ -930,12 +919,10 @@
             }
         },
         "breadcrumbs": {
-            "admin": "Admin",
             "dashboard": "Dashboard",
             "study_dashboard": "Übersicht",
             "design": "Design",
             "participants": "Teilnehmer",
-            "team": "Team",
             "recruitment": "Zugang",
             "data": "Daten",
             "privacy": "Datenschutz",
@@ -960,7 +947,6 @@
             "no_studies": "Keine Studien in diesem Projekt.",
             "open_dashboard": "Dashboard öffnen",
             "design_study": "Studiendesign",
-            "collaborators": "Mitarbeiter",
             "copy_link": "Öffentlichen Link kopieren",
             "toggle_theme": "Design umschalten",
             "logout": "Abmelden",
@@ -1030,7 +1016,6 @@
             "alert_deadline": "{{study}}: Schließt in {{days}} Tagen mit {{count}} Teilnehmern",
             "view": "Anzeigen",
             "open_study": "Studie öffnen",
-            "add_study": "Studie hinzufügen",
             "closes": "Schließt",
             "timeline": {
                 "title": "Einreichungszeitlinie",
@@ -1050,13 +1035,7 @@
             },
             "n_studies_help": "Gesamtzahl der Studien in diesem Projekt, einschließlich Entwürfe und abgeschlossene.",
             "n_active_help": "Studien, die derzeit Teilnehmereinreichungen akzeptieren (Status = aktiv).",
-            "n_participants_total_help": "Summe der abgeschlossenen Teilnehmer über alle Studien in diesem Projekt.",
-            "tool_help": {
-                "design": "Studie konfigurieren: Verteilungsraster, Anweisungen, Aussagen, Einwilligung.",
-                "recruit": "Rekrutierungslinks, Zugriffsregeln und Studien-URL-Einstellungen.",
-                "data": "Teilnehmerantworten und Exporte (CSV, Q-Sortierungen).",
-                "analysis": "Faktoranalyse-Konfiguration und Verlaufsläufe."
-            }
+            "n_participants_total_help": "Summe der abgeschlossenen Teilnehmer über alle Studien in diesem Projekt."
         },
         "export": {
             "config": "Konfiguration exportieren",
@@ -1942,44 +1921,6 @@
                 "next": "Nächste Seite"
             }
         },
-        "team": {
-            "title": "Studienteam",
-            "description": "Mitarbeiter und Zugriffsberechtigungen auf Studienebene verwalten.",
-            "invite_title": "Mitarbeiter einladen",
-            "invite_description": "Einen sicheren Link erstellen, um ein neues Mitglied zu dieser Studie einzuladen.",
-            "email_label": "E-Mail-Adresse",
-            "role_label": "Rolle",
-            "select_role": "Rolle auswählen",
-            "generate_link": "Link erstellen",
-            "invite_success": "Einladungslink erstellt!",
-            "invite_error": "Einladung konnte nicht erstellt werden",
-            "copy_success": "Link in die Zwischenablage kopiert",
-            "share_label": "Diesen Link mit dem Eingeladenen teilen:",
-            "collab_overview": "Zusammenarbeitsübersicht",
-            "active_members": "Aktive Mitglieder",
-            "permissions_info": "Berechtigungsinfo",
-            "list_title": "Forschungsteam",
-            "list_description": "Zugriff für bestehende Mitarbeiter verwalten.",
-            "added_on": "Hinzugefügt am",
-            "headers": {
-                "collaborator": "Mitarbeiter",
-                "role": "Rolle",
-                "actions": "Aktionen"
-            },
-            "roles": {
-                "owner": "Eigentümer (volle Kontrolle)",
-                "editor": "Bearbeiter (Design & Analyse)",
-                "viewer": "Betrachter (nur lesen)",
-                "owner_badge": "EIGENTÜMER",
-                "editor_badge": "BEARBEITER",
-                "viewer_badge": "BETRACHTER"
-            },
-            "permissions": {
-                "owner": "Kann die Studie löschen und das Team verwalten.",
-                "editor": "Kann das Design ändern und Ergebnisse einsehen.",
-                "viewer": "Nur-Lese-Zugriff auf alle Module."
-            }
-        },
         "empty_states": {
             "participants": {
                 "title": "Bereit zum Start?",
@@ -1987,11 +1928,6 @@
                 "action": "Studienlink kopieren",
                 "hint": "Oder QR-Code scannen",
                 "copy_success": "Studienlink in die Zwischenablage kopiert!"
-            },
-            "team": {
-                "title": "Sie arbeiten alleine",
-                "desc": "Laden Sie Mitarbeiter ein, um diese Studie gemeinsam zu verwalten. Sie können Daten einsehen, das Design bearbeiten oder nur beobachten.",
-                "action": "Ersten Mitarbeiter einladen"
             },
             "designer": {
                 "title": "Tabula rasa",
@@ -2132,9 +2068,7 @@
                     "save_error": "Projekt konnte nicht aktualisiert werden."
                 },
                 "team_growth_title": "Teamverwaltung",
-                "team_growth_desc": "Weitere Forscher benötigt? Sie können Mitarbeiter zu Ihrem Projekt einladen. Diese können alle Studien innerhalb dieses Projekts verwalten.",
                 "team": {
-                    "title": "Teammitglieder",
                     "desc": "Liste der Benutzer mit Zugriff auf dieses Projekt.",
                     "col_user": "Benutzer",
                     "col_role": "Rolle",

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -113,7 +113,7 @@
             "n_studies_other": "{{count}} studies",
             "n_active_one": "{{count}} active",
             "n_active_other": "{{count}} active",
-            "collecting": "Collecting data",
+            "collecting": "Active studies",
             "no_studies": "No studies yet",
             "no_projects": "No projects yet. Create your first project to get started.",
             "no_projects_title": "Start your first research project",
@@ -276,7 +276,7 @@
             "beta": "Research beta",
             "logout": "Log out",
             "account": "Account settings",
-            "platform_settings": "Platform settings",
+            "platform_settings": "Users",
             "admin_user": "Admin user"
         },
         "account": {
@@ -792,7 +792,7 @@
         },
         "recruitment": {
             "title": "Access",
-            "description": "Configure the study URL, manage participant access, and track recruitment efficiency.",
+            "description": "Configure the study URL, manage participant access, and track how each access link performs.",
             "study_url": {
                 "title": "Study URL",
                 "description": "The public address where participants access your study.",
@@ -803,8 +803,8 @@
             },
             "state_draft": "Draft mode. Links will work once you activate the study.",
             "state_closed": "This study is closed. Existing links remain visible but new participants cannot start.",
-            "state_archived": "This study is archived. All recruitment data is read-only.",
-            "empty_title": "No recruitment links yet",
+            "state_archived": "This study is archived. Access links are read-only.",
+            "empty_title": "No access links yet",
             "empty_description": "Create your first link to start inviting participants.",
             "empty_cta": "Create access link",
             "stats_summary": {
@@ -837,18 +837,17 @@
             "new_link": "New access link",
             "create_title": "Create access links",
             "link_type": "Access strategy",
-            "select_type": "Choose a recruitment type...",
+            "select_type": "Choose an access strategy...",
             "campaign_name": "Channel / campaign name",
             "name_placeholder": "E.g. LinkedIn, email batch a, student list...",
             "link_count": "Batch size",
             "capacity_label": "Max submissions",
             "generate_links": "Provision links",
-            "no_links": "No recruitment links generated yet.",
             "unnamed": "Unnamed channel",
             "revoked": "Access revoked",
             "qr_title": "Share via QR",
             "copy_link": "Copy URL",
-            "table_title": "Recruitment links",
+            "table_title": "Access links",
             "share_title": "Share study",
             "share_desc": "Distribute your study URL to invite participants.",
             "public_url_label": "Public participation URL",
@@ -856,7 +855,7 @@
             "show_qr": "Show QR code",
             "delete_link": "Delete link",
             "qr_alt": "QR code for {{url}}",
-            "table_caption": "Recruitment links",
+            "table_caption": "Access links",
             "progress_label": "{{count}} of {{max}} responses",
             "usage": {
                 "started": "started",
@@ -881,20 +880,10 @@
                 "individual": "Maximum security. Generates unique links that expire after one successful completion.",
                 "limited": "Controlled access. One link that stops working after a fixed number of submissions."
             },
-            "stats": {
-                "total_links": "Total channels",
-                "active_channels": "Active recruitment lots",
-                "started": "Total sessions",
-                "engagements": "Participants who started",
-                "submitted": "Valid data",
-                "completions": "Finished submissions",
-                "conversion": "Capture rate",
-                "efficiency": "Final data yield"
-            },
             "table": {
                 "name": "Campaign / lot",
                 "type": "Entry type",
-                "token": "Security token",
+                "token": "Link token",
                 "usage": "Capacity",
                 "status": "State",
                 "actions": "Manage",
@@ -906,8 +895,8 @@
                 "limited": "Limited"
             },
             "toasts": {
-                "created": "Recruitment links created successfully",
-                "failed": "Could not create recruitment links. Check the inputs and try again.",
+                "created": "Access links created successfully",
+                "failed": "Could not create access links. Check the inputs and try again.",
                 "revoked": "Link revoked",
                 "revoke_failed": "Could not revoke this link. It may already be in use.",
                 "copied": "Copied to clipboard"
@@ -940,12 +929,10 @@
             }
         },
         "breadcrumbs": {
-            "admin": "Admin",
             "dashboard": "Dashboard",
             "study_dashboard": "Overview",
             "design": "Design",
             "participants": "Participants",
-            "team": "Team",
             "recruitment": "Access",
             "data": "Data",
             "privacy": "Data privacy",
@@ -970,7 +957,6 @@
             "no_studies": "No studies in this project.",
             "open_dashboard": "Open dashboard",
             "design_study": "Study design",
-            "collaborators": "Collaborators",
             "copy_link": "Copy public link",
             "toggle_theme": "Toggle theme",
             "logout": "Log out",
@@ -1040,7 +1026,6 @@
             "alert_deadline": "{{study}}: closing in {{days}} days with {{count}} participants",
             "view": "View",
             "open_study": "Open study",
-            "add_study": "Add study",
             "closes": "Closes",
             "timeline": {
                 "title": "Submissions timeline",
@@ -1060,13 +1045,7 @@
             },
             "n_studies_help": "Total number of studies in this project, including drafts and closed.",
             "n_active_help": "Studies currently accepting participant submissions (state = active).",
-            "n_participants_total_help": "Sum of completed participants across all studies in this project.",
-            "tool_help": {
-                "design": "Configure the study: distribution grid, conditions of instruction, statements, consent.",
-                "recruit": "Recruitment links, access rules, and study URL settings.",
-                "data": "Participant responses and exports (CSV, Q-sort dumps).",
-                "analysis": "Factor analysis configuration and historical runs."
-            }
+            "n_participants_total_help": "Sum of completed participants across all studies in this project."
         },
         "export": {
             "config": "Export configuration",
@@ -1235,7 +1214,7 @@
                 },
                 "active": {
                     "label": "Active",
-                    "description": "Collecting responses"
+                    "description": "Data collection"
                 },
                 "paused": {
                     "label": "Paused",
@@ -1874,7 +1853,7 @@
                 "email_provided": "Email provided",
                 "newsletter_consent": "Wants results",
                 "interview_consent": "Accepts follow-up",
-                "recruitment_link": "Recruitment link",
+                "recruitment_link": "Access link",
                 "device_info": "Device: {{os}}, {{browser}}"
             },
             "toast": {
@@ -1924,7 +1903,7 @@
                 "all_steps": "All steps",
                 "has_comments": "Has comments",
                 "has_audio": "Has audio",
-                "has_recruitment": "Has recruitment link"
+                "has_recruitment": "Has access link"
             },
             "charts": {
                 "section_title": "Response distributions",
@@ -1936,7 +1915,7 @@
                 "count": "Count"
             },
             "search": {
-                "placeholder": "Search by ID or recruitment token...",
+                "placeholder": "Search by ID or link token...",
                 "records_found": "Records detected",
                 "no_results": "No records match your query"
             },
@@ -1957,44 +1936,6 @@
                 "next": "Next page"
             }
         },
-        "team": {
-            "title": "Study team",
-            "description": "Manage collaborators and study-level access control.",
-            "invite_title": "Invite collaborator",
-            "invite_description": "Generate a secure link to invite a new member to this study.",
-            "email_label": "Email address",
-            "role_label": "Role",
-            "select_role": "Select a role",
-            "generate_link": "Generate link",
-            "invite_success": "Invitation link generated!",
-            "invite_error": "Failed to generate invitation",
-            "copy_success": "Link copied to clipboard",
-            "share_label": "Share this link with the invitee:",
-            "collab_overview": "Collaboration overview",
-            "active_members": "Active members",
-            "permissions_info": "Permissions info",
-            "list_title": "Research team",
-            "list_description": "Manage access for existing collaborators.",
-            "added_on": "Added on",
-            "headers": {
-                "collaborator": "Collaborator",
-                "role": "Role",
-                "actions": "Actions"
-            },
-            "roles": {
-                "owner": "Owner (full control)",
-                "editor": "Editor (design & analysis)",
-                "viewer": "Viewer (read-only)",
-                "owner_badge": "OWNER",
-                "editor_badge": "EDITOR",
-                "viewer_badge": "VIEWER"
-            },
-            "permissions": {
-                "owner": "Can delete the study and manage team.",
-                "editor": "Can modify design and view results.",
-                "viewer": "Read-only access to all modules."
-            }
-        },
         "empty_states": {
             "participants": {
                 "title": "Ready to launch?",
@@ -2002,11 +1943,6 @@
                 "action": "Copy study link",
                 "hint": "Or scan the QR code",
                 "copy_success": "Study link copied to clipboard!"
-            },
-            "team": {
-                "title": "You're flying solo",
-                "desc": "Invite collaborators to help manage this study. They can view data, edit the design, or just observe.",
-                "action": "Invite your first collaborator"
             },
             "designer": {
                 "title": "Tabula rasa",
@@ -2089,10 +2025,10 @@
             "audio_title": "Audio storage",
             "audio_count": "Recordings",
             "audio_mb": "Total size",
-            "locale_title": "Locale breakdown",
+            "locale_title": "Language breakdown",
             "locale_col": "Language",
             "locale_count_col": "Participants",
-            "locale_empty": "No locale data yet.",
+            "locale_empty": "No language data yet.",
             "timeline_title": "Timeline",
             "tl_first": "First submission",
             "tl_last": "Last submission",
@@ -2121,11 +2057,11 @@
             },
             "consent": {
                 "title": "Consent form",
-                "description": "What participants see before they enter the study. Edited in Study design.",
+                "description": "What participants see before they enter the study. Edited in Design.",
                 "no_text": "No consent text set yet.",
                 "no_title": "(no title)",
                 "no_body": "(empty)",
-                "edit_in_design": "Edit in Study design",
+                "edit_in_design": "Edit in Design",
                 "view": "View"
             }
         },
@@ -2147,24 +2083,22 @@
                     "save_error": "Failed to update project."
                 },
                 "team_growth_title": "Team management",
-                "team_growth_desc": "Need more researchers? You can invite collaborators to your project. They will be able to manage all studies within this project.",
                 "team": {
-                    "title": "Team members",
-                    "desc": "List of users with access to this project.",
-                    "col_user": "User",
+                    "desc": "List of members with access to this project.",
+                    "col_user": "Member",
                     "col_role": "Role",
                     "col_joined": "Joined",
                     "col_actions": "Actions",
                     "remove_confirm": "Are you sure you want to remove this member?",
-                    "remove_dialog_title": "Remove team member?",
+                    "remove_dialog_title": "Remove member?",
                     "remove_dialog_body": "{{name}} will lose access to this project. They can be re-invited later.",
                     "remove_dialog_action": "Remove",
                     "remove_member_aria": "Remove {{name}}",
                     "remove_success": "Member removed successfully",
                     "remove_error": "Failed to remove member",
                     "growth_title": "Team growth",
-                    "growth_desc": "Need more researchers? You can invite collaborators to your project. They will be able to manage all studies within this project.",
-                    "invite_button": "Invite collaborator",
+                    "growth_desc": "Need more members? Invite them to your project. They will be able to manage all studies within this project.",
+                    "invite_button": "Invite member",
                     "permissions_matrix": {
                         "title": "Permissions matrix",
                         "admin": {
@@ -2186,8 +2120,8 @@
                     },
                     "coming_soon": "Coming soon",
                     "invite_modal": {
-                        "title": "Invite collaborator",
-                        "email_label": "Collaborator email",
+                        "title": "Invite member",
+                        "email_label": "Member email",
                         "role_label": "Assigned role",
                         "success": "Invitation link generated!",
                         "error": "Failed to create invitation.",
@@ -2243,13 +2177,13 @@
                 "submitted": "Submitted",
                 "id": "Internal ID",
                 "ip_hash": "IP hash",
-                "recruitment_token": "Recruitment token",
+                "recruitment_token": "Link token",
                 "device": {
                     "mobile": "Mobile",
                     "tablet": "Tablet",
                     "desktop": "Desktop"
                 },
-                "recruitment_link": "Recruitment link"
+                "recruitment_link": "Access link"
             },
             "status": {
                 "started": "Started",

--- a/frontend/public/locales/es/admin.json
+++ b/frontend/public/locales/es/admin.json
@@ -276,7 +276,7 @@
             "logout": "Cerrar sesión",
             "account": "Configuración de cuenta",
             "admin_user": "Usuario administrador",
-            "platform_settings": "Configuración de la plataforma"
+            "platform_settings": "Usuarios"
         },
         "account": {
             "title": "Configuración de cuenta",
@@ -836,7 +836,6 @@
             "link_count": "Tamaño del lote",
             "capacity_label": "Máx. de envíos",
             "generate_links": "Generar enlaces",
-            "no_links": "Aún no se han generado enlaces de reclutamiento.",
             "unnamed": "Canal sin nombre",
             "revoked": "Acceso revocado",
             "qr_title": "Compartir por QR",
@@ -873,16 +872,6 @@
                 "public": "Ideal para reclutamiento de gran volumen. Una URL única para todos los participantes.",
                 "individual": "Máxima seguridad. Genera enlaces únicos que expiran después de una finalización exitosa.",
                 "limited": "Acceso controlado. Un enlace que deja de funcionar después de un número fijo de envíos."
-            },
-            "stats": {
-                "total_links": "Canales totales",
-                "active_channels": "Lotes de reclutamiento activos",
-                "started": "Sesiones totales",
-                "engagements": "Participantes que comenzaron",
-                "submitted": "Datos válidos",
-                "completions": "Envíos finalizados",
-                "conversion": "Tasa de captura",
-                "efficiency": "Rendimiento final de datos"
             },
             "table": {
                 "name": "Campaña / lote",
@@ -930,12 +919,10 @@
             }
         },
         "breadcrumbs": {
-            "admin": "Administración",
             "dashboard": "Panel",
             "study_dashboard": "Resumen",
             "design": "Diseño",
             "participants": "Participantes",
-            "team": "Equipo",
             "recruitment": "Acceso",
             "data": "Datos",
             "privacy": "Privacidad de datos",
@@ -960,7 +947,6 @@
             "no_studies": "No hay estudios en este proyecto.",
             "open_dashboard": "Abrir panel",
             "design_study": "Diseño del estudio",
-            "collaborators": "Colaboradores",
             "copy_link": "Copiar enlace público",
             "toggle_theme": "Cambiar tema",
             "logout": "Cerrar sesión",
@@ -1030,7 +1016,6 @@
             "alert_deadline": "{{study}}: cierra en {{days}} días con {{count}} participantes",
             "view": "Ver",
             "open_study": "Abrir estudio",
-            "add_study": "Añadir estudio",
             "closes": "Cierra",
             "timeline": {
                 "title": "Cronología de envíos",
@@ -1050,13 +1035,7 @@
             },
             "n_studies_help": "Número total de estudios en este proyecto, incluyendo borradores y cerrados.",
             "n_active_help": "Estudios que actualmente aceptan envíos de participantes (estado = activo).",
-            "n_participants_total_help": "Suma de participantes completados en todos los estudios de este proyecto.",
-            "tool_help": {
-                "design": "Configure el estudio: cuadrícula de distribución, condiciones de instrucción, enunciados, consentimiento.",
-                "recruit": "Enlaces de reclutamiento, reglas de acceso y configuración de URL del estudio.",
-                "data": "Respuestas de participantes y exportaciones (CSV, volcados de clasificación Q).",
-                "analysis": "Configuración del análisis factorial y ejecuciones históricas."
-            }
+            "n_participants_total_help": "Suma de participantes completados en todos los estudios de este proyecto."
         },
         "export": {
             "config": "Exportar configuración",
@@ -1942,44 +1921,6 @@
                 "next": "Página siguiente"
             }
         },
-        "team": {
-            "title": "Equipo del estudio",
-            "description": "Gestione los colaboradores y el control de acceso a nivel de estudio.",
-            "invite_title": "Invitar colaborador",
-            "invite_description": "Genere un enlace seguro para invitar a un nuevo miembro a este estudio.",
-            "email_label": "Dirección de correo electrónico",
-            "role_label": "Rol",
-            "select_role": "Seleccione un rol",
-            "generate_link": "Generar enlace",
-            "invite_success": "¡Enlace de invitación generado!",
-            "invite_error": "Error al generar la invitación",
-            "copy_success": "Enlace copiado al portapapeles",
-            "share_label": "Comparta este enlace con el invitado:",
-            "collab_overview": "Resumen de la colaboración",
-            "active_members": "Miembros activos",
-            "permissions_info": "Información sobre permisos",
-            "list_title": "Equipo de investigación",
-            "list_description": "Gestione el acceso de los colaboradores existentes.",
-            "added_on": "Añadido el",
-            "headers": {
-                "collaborator": "Colaborador",
-                "role": "Rol",
-                "actions": "Acciones"
-            },
-            "roles": {
-                "owner": "Propietario (control total)",
-                "editor": "Editor (diseño y análisis)",
-                "viewer": "Observador (solo lectura)",
-                "owner_badge": "PROPIETARIO",
-                "editor_badge": "EDITOR",
-                "viewer_badge": "OBSERVADOR"
-            },
-            "permissions": {
-                "owner": "Puede eliminar el estudio y gestionar el equipo.",
-                "editor": "Puede modificar el diseño y ver los resultados.",
-                "viewer": "Acceso de solo lectura a todos los módulos."
-            }
-        },
         "empty_states": {
             "participants": {
                 "title": "¿Listo para lanzar?",
@@ -1987,11 +1928,6 @@
                 "action": "Copiar enlace del estudio",
                 "hint": "O escanee el código QR",
                 "copy_success": "¡Enlace del estudio copiado al portapapeles!"
-            },
-            "team": {
-                "title": "Trabaja en solitario",
-                "desc": "Invite colaboradores para ayudar a gestionar este estudio. Pueden ver datos, editar el diseño u observar.",
-                "action": "Invite a su primer colaborador"
             },
             "designer": {
                 "title": "Tabula rasa",
@@ -2132,9 +2068,7 @@
                     "save_error": "Error al actualizar el proyecto."
                 },
                 "team_growth_title": "Gestión del equipo",
-                "team_growth_desc": "¿Necesita más investigadores? Puede invitar colaboradores a su proyecto. Podrán gestionar todos los estudios dentro de este proyecto.",
                 "team": {
-                    "title": "Miembros del equipo",
                     "desc": "Lista de usuarios con acceso a este proyecto.",
                     "col_user": "Usuario",
                     "col_role": "Rol",

--- a/frontend/public/locales/fi/admin.json
+++ b/frontend/public/locales/fi/admin.json
@@ -185,7 +185,7 @@
             "logout": "Kirjaudu ulos",
             "account": "Tilin asetukset",
             "admin_user": "Ylläpitäjä",
-            "platform_settings": "Alustan asetukset"
+            "platform_settings": "Käyttäjät"
         },
         "account": {
             "title": "Tilin asetukset",
@@ -745,7 +745,6 @@
             "link_count": "Erän koko",
             "capacity_label": "Maksimilähetykset",
             "generate_links": "Luo linkit",
-            "no_links": "Ei vielä luotuja rekrytointilinkkejä.",
             "unnamed": "Nimetön kanava",
             "revoked": "Pääsy peruutettu",
             "qr_title": "Jaa QR-koodina",
@@ -782,16 +781,6 @@
                 "public": "Paras suurten määrien rekrytointiin. Yksi URL kaikille osallistujille.",
                 "individual": "Maksimaalinen turvallisuus. Luo yksilöllisiä linkkejä, jotka vanhenevat yhden onnistuneen suorituksen jälkeen.",
                 "limited": "Hallittu pääsy. Yksi linkki, joka lakkaa toimimasta tietyn lähetysmäärän jälkeen."
-            },
-            "stats": {
-                "total_links": "Kanavat",
-                "active_channels": "Aktiiviset erät",
-                "started": "Istunnot",
-                "engagements": "Osallistujat",
-                "submitted": "Tiedot",
-                "completions": "Valmiit",
-                "conversion": "Konversio",
-                "efficiency": "Tehokkuus"
             },
             "table": {
                 "name": "Kampanja",
@@ -839,12 +828,10 @@
             }
         },
         "breadcrumbs": {
-            "admin": "Ylläpito",
             "dashboard": "Hallintapaneeli",
             "study_dashboard": "Yleisnäkymä",
             "design": "Suunnittelu",
             "participants": "Osallistujat",
-            "team": "Tiimi",
             "recruitment": "Pääsy",
             "data": "Tiedot",
             "privacy": "Tietosuoja",
@@ -869,7 +856,6 @@
             "no_studies": "Ei tutkimuksia tässä projektissa.",
             "open_dashboard": "Avaa kojelauta",
             "design_study": "Tutkimuksen suunnittelu",
-            "collaborators": "Yhteistyökumppanit",
             "copy_link": "Kopioi julkinen linkki",
             "toggle_theme": "Vaihda teemaa",
             "logout": "Kirjaudu ulos",
@@ -939,7 +925,6 @@
             "alert_deadline": "{{study}}: sulkeutuu {{days}} päivän kuluttua, {{count}} osallistujaa",
             "view": "Näytä",
             "open_study": "Avaa tutkimus",
-            "add_study": "Lisää tutkimus",
             "closes": "Sulkeutuu",
             "timeline": {
                 "title": "Vastausten aikajana",
@@ -959,13 +944,7 @@
             },
             "n_studies_help": "Tämän projektin tutkimusten kokonaismäärä, mukaan lukien luonnokset ja suljetut.",
             "n_active_help": "Tutkimukset, jotka ottavat parhaillaan vastaan osallistujien vastauksia (tila = active).",
-            "n_participants_total_help": "Loppuun saaneiden osallistujien summa kaikissa projektin tutkimuksissa.",
-            "tool_help": {
-                "design": "Tutkimuksen asetukset: jakaumaruudukko, ohjeet, lauseet, suostumus.",
-                "recruit": "Rekrytointilinkit, käyttöoikeussäännöt ja URL-asetukset.",
-                "data": "Osallistujien vastaukset ja viennit (CSV, Q-sort-tuonnit).",
-                "analysis": "Faktorianalyysin asetukset ja aiempien ajojen historia."
-            }
+            "n_participants_total_help": "Loppuun saaneiden osallistujien summa kaikissa projektin tutkimuksissa."
         },
         "export": {
             "config": "Vie asetukset",
@@ -1851,44 +1830,6 @@
                 "next": "Seuraava sivu"
             }
         },
-        "team": {
-            "title": "Tutkimustiimi",
-            "description": "Hallitse yhteistyökumppaneita ja tutkimustason pääsynhallintaa.",
-            "invite_title": "Kutsu yhteistyökumppani",
-            "invite_description": "Luo turvallinen linkki uuden jäsenen kutsumiseksi tähän tutkimukseen.",
-            "email_label": "Sähköpostiosoite",
-            "role_label": "Rooli",
-            "select_role": "Valitse rooli",
-            "generate_link": "Luo linkki",
-            "invite_success": "Kutsulinkki luotu!",
-            "invite_error": "Kutsun luominen epäonnistui",
-            "copy_success": "Linkki kopioitu leikepöydälle",
-            "share_label": "Jaa tämä linkki kutsuttavan kanssa:",
-            "collab_overview": "Yhteistyön yleiskatsaus",
-            "active_members": "Aktiiviset jäsenet",
-            "permissions_info": "Lupatiedot",
-            "list_title": "Tutkimustiimi",
-            "list_description": "Hallitse olemassa olevien yhteistyökumppaneiden pääsyä.",
-            "added_on": "Lisätty",
-            "headers": {
-                "collaborator": "Yhteistyökumppani",
-                "role": "Rooli",
-                "actions": "Toiminnot"
-            },
-            "roles": {
-                "owner": "Omistaja (Täydet oikeudet)",
-                "editor": "Muokkaja (Suunnittelu ja analyysi)",
-                "viewer": "Katsoja (Vain luku)",
-                "owner_badge": "OMISTAJA",
-                "editor_badge": "MUOKKAAJA",
-                "viewer_badge": "KATSOJA"
-            },
-            "permissions": {
-                "owner": "Voi poistaa tutkimuksen ja hallinnoida tiimiä.",
-                "editor": "Voi muokata suunnitelmaa ja tarkastella tuloksia.",
-                "viewer": "Vain luku -pääsy kaikkiin moduuleihin."
-            }
-        },
         "empty_states": {
             "participants": {
                 "title": "Valmiina julkaisuun?",
@@ -1896,11 +1837,6 @@
                 "action": "Kopioi tutkimuslinkki",
                 "hint": "Tai skannaa QR-koodi",
                 "copy_success": "Tutkimuslinkki kopioitu leikepöydälle!"
-            },
-            "team": {
-                "title": "Työskentelet yksin",
-                "desc": "Kutsu yhteistyökumppaneita auttamaan tämän tutkimuksen hallinnassa. He voivat tarkastella tietoja, muokata suunnitelmaa tai vain seurata.",
-                "action": "Kutsu ensimmäinen yhteistyökumppanisi"
             },
             "designer": {
                 "title": "Tabula Rasa",
@@ -1987,9 +1923,7 @@
                     "save_error": "Projektin päivitys epäonnistui"
                 },
                 "team_growth_title": "Tiimin hallinta",
-                "team_growth_desc": "Tarvitsetko lisää tutkijoita? Voit kutsua yhteistyökumppaneita projektiisi. He voivat hallinnoida kaikkia projektin tutkimuksia.",
                 "team": {
-                    "title": "Tiimin jäsenet",
                     "desc": "Luettelo käyttäjistä, joilla on pääsy tähän projektiin.",
                     "col_user": "Käyttäjä",
                     "col_role": "Rooli",
@@ -2212,10 +2146,10 @@
             "audio_title": "Audio storage",
             "audio_count": "Recordings",
             "audio_mb": "Total size",
-            "locale_title": "Locale breakdown",
+            "locale_title": "Language breakdown",
             "locale_col": "Language",
             "locale_count_col": "Participants",
-            "locale_empty": "No locale data yet.",
+            "locale_empty": "No language data yet.",
             "timeline_title": "Timeline",
             "tl_first": "First submission",
             "tl_last": "Last submission",

--- a/frontend/public/locales/fr/admin.json
+++ b/frontend/public/locales/fr/admin.json
@@ -694,7 +694,7 @@
         },
         "recruitment": {
             "title": "Accès",
-            "description": "Configurez l'URL de l'étude, gérez l'accès des participants et suivez l'efficacité du recrutement.",
+            "description": "Configurez l'URL de l'étude, gérez l'accès des participants et suivez les performances de chaque lien d'accès.",
             "study_url": {
                 "title": "URL de l'étude",
                 "description": "L'adresse publique par laquelle les participants accèdent à votre étude.",
@@ -705,8 +705,8 @@
             },
             "state_draft": "Mode brouillon. Les liens fonctionneront une fois l'étude activée.",
             "state_closed": "Cette étude est fermée. Les liens existants restent visibles mais les nouveaux participants ne peuvent pas commencer.",
-            "state_archived": "Cette étude est archivée. Toutes les données de recrutement sont en lecture seule.",
-            "empty_title": "Aucun lien de recrutement",
+            "state_archived": "Cette étude est archivée. Les liens d'accès sont en lecture seule.",
+            "empty_title": "Aucun lien d'accès",
             "empty_description": "Créez votre premier lien pour commencer à inviter des participants.",
             "empty_cta": "Créer un lien d'accès",
             "stats_summary": {
@@ -739,18 +739,17 @@
             "new_link": "Nouveau lien d'accès",
             "create_title": "Créer des liens d'accès",
             "link_type": "Stratégie d'accès",
-            "select_type": "Choisir le type de recrutement...",
+            "select_type": "Choisir une stratégie d'accès...",
             "campaign_name": "Nom du canal / de la campagne",
             "name_placeholder": "ex: LinkedIn, Email Lot A, Liste étudiants...",
             "link_count": "Taille du lot",
             "capacity_label": "Soumissions max",
             "generate_links": "Provisionner les liens",
-            "no_links": "Aucun lien de recrutement généré pour le moment.",
             "unnamed": "Canal sans nom",
             "revoked": "Accès révoqué",
             "qr_title": "Partager via QR",
             "copy_link": "Copier l'URL",
-            "table_title": "Liens de recrutement",
+            "table_title": "Liens d'accès",
             "share_title": "Partager l'étude",
             "share_desc": "Distribuez l'URL de votre étude pour inviter des participants.",
             "public_url_label": "URL publique de participation",
@@ -758,7 +757,7 @@
             "show_qr": "Afficher le code QR",
             "delete_link": "Supprimer le lien",
             "qr_alt": "Code QR pour {{url}}",
-            "table_caption": "Liens de recrutement",
+            "table_caption": "Liens d'accès",
             "progress_label": "{{count}} sur {{max}} réponses",
             "usage": {
                 "started": "démarrés",
@@ -783,20 +782,10 @@
                 "individual": "Sécurité maximale. Génère des liens uniques qui expirent après une participation validée.",
                 "limited": "Accès contrôlé. Un seul lien qui cesse de fonctionner après un nombre fixe de participations."
             },
-            "stats": {
-                "total_links": "Canaux",
-                "active_channels": "Lots de recrutement actifs",
-                "started": "Sessions",
-                "engagements": "Participants ayant commencé",
-                "submitted": "Données",
-                "completions": "Soumissions terminées",
-                "conversion": "Taux de conversion",
-                "efficiency": "Efficacité"
-            },
             "table": {
                 "name": "Campagne / Lot",
                 "type": "Type d'entrée",
-                "token": "Jeton",
+                "token": "Jeton du lien",
                 "usage": "Capacité",
                 "status": "État",
                 "actions": "Gérer",
@@ -808,8 +797,8 @@
                 "limited": "Limité"
             },
             "toasts": {
-                "created": "Liens de recrutement créés avec succès",
-                "failed": "Impossible de créer les liens de recrutement. Vérifiez les paramètres et réessayez.",
+                "created": "Liens d'accès créés avec succès",
+                "failed": "Impossible de créer les liens d'accès. Vérifiez les paramètres et réessayez.",
                 "revoked": "Lien révoqué",
                 "revoke_failed": "Impossible de révoquer ce lien. Il est peut-être déjà utilisé.",
                 "copied": "Copié dans le presse-papiers"
@@ -839,12 +828,10 @@
             }
         },
         "breadcrumbs": {
-            "admin": "Admin",
             "dashboard": "Tableau de bord",
             "study_dashboard": "Vue d'ensemble",
             "design": "Conception",
             "participants": "Participants",
-            "team": "Équipe",
             "recruitment": "Accès",
             "data": "Données",
             "privacy": "Confidentialité",
@@ -869,7 +856,6 @@
             "no_studies": "Aucune étude dans cet espace.",
             "open_dashboard": "Ouvrir le tableau de bord",
             "design_study": "Conception",
-            "collaborators": "Collaborateurs",
             "copy_link": "Copier le lien public",
             "toggle_theme": "Changer de thème",
             "logout": "Déconnexion",
@@ -939,7 +925,6 @@
             "alert_deadline": "{{study}} : fermeture dans {{days}} jours avec {{count}} participants",
             "view": "Voir",
             "open_study": "Ouvrir l'étude",
-            "add_study": "Ajouter une étude",
             "closes": "Fermeture le",
             "timeline": {
                 "title": "Chronologie des participations",
@@ -959,13 +944,7 @@
             },
             "n_studies_help": "Nombre total d’études dans ce projet, brouillons et fermées comprises.",
             "n_active_help": "Études actuellement ouvertes aux participants (état = actif).",
-            "n_participants_total_help": "Somme des participants ayant terminé, toutes études confondues dans ce projet.",
-            "tool_help": {
-                "design": "Configurer l’étude : grille de distribution, consignes, énoncés, consentement.",
-                "recruit": "Liens de recrutement, règles d’accès et configuration de l’URL.",
-                "data": "Réponses des participants et exports (CSV, dumps Q-sort).",
-                "analysis": "Configuration de l’analyse factorielle et runs historiques."
-            }
+            "n_participants_total_help": "Somme des participants ayant terminé, toutes études confondues dans ce projet."
         },
         "export": {
             "config": "Exporter la configuration",
@@ -1131,7 +1110,7 @@
                 },
                 "active": {
                     "label": "Active",
-                    "description": "Collecte de réponses"
+                    "description": "Collecte de données"
                 },
                 "paused": {
                     "label": "En pause",
@@ -1156,44 +1135,6 @@
                 "activate": "Activer l'étude",
                 "switch_to_draft": "Mode brouillon",
                 "manage": "Gérer le statut"
-            }
-        },
-        "team": {
-            "title": "Équipe de l'étude",
-            "description": "Gérez les collaborateurs et le contrôle d'accès au niveau de l'étude.",
-            "invite_title": "Inviter un collaborateur",
-            "invite_description": "Générez un lien sécurisé pour inviter un nouveau membre à cette étude.",
-            "email_label": "Adresse E-mail",
-            "role_label": "Rôle",
-            "select_role": "Sélectionner un rôle",
-            "generate_link": "Générer le lien",
-            "invite_success": "Lien d'invitation généré !",
-            "invite_error": "Échec de la génération de l'invitation",
-            "copy_success": "Lien copié dans le presse-papiers",
-            "share_label": "Partagez ce lien avec l'invité :",
-            "collab_overview": "Aperçu de la collaboration",
-            "active_members": "Membres actifs",
-            "permissions_info": "Infos sur les permissions",
-            "list_title": "Équipe de recherche",
-            "list_description": "Gérez l'accès des collaborateurs existants.",
-            "added_on": "Ajouté le",
-            "headers": {
-                "collaborator": "Collaborateur",
-                "role": "Rôle",
-                "actions": "Actions"
-            },
-            "roles": {
-                "owner": "Propriétaire (Contrôle total)",
-                "editor": "Éditeur (Conception & Analyse)",
-                "viewer": "Lecteur (Lecture seule)",
-                "owner_badge": "PROPRIÉTAIRE",
-                "editor_badge": "ÉDITEUR",
-                "viewer_badge": "LECTEUR"
-            },
-            "permissions": {
-                "owner": "Peut supprimer l'étude et gérer l'équipe.",
-                "editor": "Peut modifier la conception et voir les résultats.",
-                "viewer": "Accès en lecture seule à tous les modules."
             }
         },
         "design": {
@@ -1806,7 +1747,7 @@
                 "email_provided": "Email fourni",
                 "newsletter_consent": "Souhaite les résultats",
                 "interview_consent": "Accepte suivi",
-                "recruitment_link": "Lien de recrutement",
+                "recruitment_link": "Lien d'accès",
                 "device_info": "Appareil : {{os}}, {{browser}}"
             },
             "toast": {
@@ -1856,7 +1797,7 @@
                 "all_steps": "Toutes les étapes",
                 "has_comments": "Avec commentaires",
                 "has_audio": "Avec audio",
-                "has_recruitment": "Avec lien de recrutement"
+                "has_recruitment": "Avec lien d'accès"
             },
             "charts": {
                 "section_title": "Répartition des réponses",
@@ -1868,7 +1809,7 @@
                 "count": "Nombre"
             },
             "search": {
-                "placeholder": "Chercher par ID, email...",
+                "placeholder": "Chercher par ID ou jeton du lien...",
                 "records_found": "enregistrements détectés",
                 "no_results": "Aucun enregistrement ne correspond à votre requête"
             },
@@ -1896,11 +1837,6 @@
                 "action": "Copier le lien de l'étude",
                 "hint": "Ou scannez le code QR",
                 "copy_success": "Lien de l'étude copié dans le presse-papiers !"
-            },
-            "team": {
-                "title": "Aucun collaborateur identifié",
-                "desc": "Invitez des collaborateurs pour aider à gérer cette étude. Ils peuvent consulter les données, modifier la conception ou simplement observer.",
-                "action": "Ajouter un collaborateur"
             },
             "designer": {
                 "title": "Configuration initiale (Vierge)",
@@ -2041,24 +1977,22 @@
                     "save_error": "Échec de la mise à jour du projet"
                 },
                 "team_growth_title": "Gérer l'équipe",
-                "team_growth_desc": "Besoin de plus de chercheurs ? Vous pouvez inviter des collaborateurs à votre projet. Ils pourront gérer toutes les études au sein de ce projet.",
                 "team": {
-                    "title": "Membres de l'équipe",
-                    "desc": "Liste des utilisateurs ayant accès à ce projet.",
-                    "col_user": "Utilisateur",
+                    "desc": "Liste des membres ayant accès à ce projet.",
+                    "col_user": "Membre",
                     "col_role": "Rôle",
                     "col_joined": "Rejoint le",
                     "col_actions": "Actions",
                     "remove_confirm": "Êtes-vous sûr de vouloir supprimer ce membre ?",
-                    "remove_dialog_title": "Retirer ce membre de l'équipe ?",
+                    "remove_dialog_title": "Retirer ce membre ?",
                     "remove_dialog_body": "{{name}} perdra l'accès à ce projet. Vous pourrez l'inviter à nouveau plus tard.",
                     "remove_dialog_action": "Retirer",
                     "remove_member_aria": "Retirer {{name}}",
                     "remove_success": "Membre supprimé avec succès",
                     "remove_error": "Échec de la suppression du membre",
                     "growth_title": "Gestion des accès",
-                    "growth_desc": "Gérez les accès institutionnels en ajoutant des chercheurs à ce projet. Ils pourront gérer toutes les études au sein de ce projet.",
-                    "invite_button": "Inviter un collaborateur",
+                    "growth_desc": "Besoin de plus de membres ? Invitez-les à rejoindre ce projet. Ils pourront gérer toutes les études au sein de ce projet.",
+                    "invite_button": "Inviter un membre",
                     "permissions_matrix": {
                         "title": "Matrice des permissions",
                         "admin": {
@@ -2080,8 +2014,8 @@
                     },
                     "coming_soon": "Bientôt disponible",
                     "invite_modal": {
-                        "title": "Inviter un collaborateur",
-                        "email_label": "E-mail du collaborateur",
+                        "title": "Inviter un membre",
+                        "email_label": "E-mail du membre",
                         "role_label": "Rôle assigné",
                         "success": "Lien d'invitation généré !",
                         "error": "Échec de la création de l'invitation.",
@@ -2109,7 +2043,7 @@
             "n_studies_other": "{{count}} études",
             "n_active_one": "{{count}} active",
             "n_active_other": "{{count}} actives",
-            "collecting": "Collecte en cours",
+            "collecting": "Études actives",
             "no_studies": "Aucune étude",
             "no_projects": "Aucun projet. Créez votre premier projet pour commencer.",
             "no_projects_title": "Lancer votre premier projet de recherche",
@@ -2225,12 +2159,13 @@
                 "submitted": "Soumis",
                 "id": "ID interne",
                 "ip_hash": "Hash IP",
-                "recruitment_token": "Jeton de recrutement",
+                "recruitment_token": "Jeton du lien",
                 "device": {
                     "mobile": "Mobile",
                     "tablet": "Tablette",
                     "desktop": "Ordinateur"
-                }
+                },
+                "recruitment_link": "Lien d'accès"
             },
             "status": {
                 "started": "Commencé",

--- a/frontend/public/locales/it/admin.json
+++ b/frontend/public/locales/it/admin.json
@@ -276,7 +276,7 @@
             "logout": "Esci",
             "account": "Impostazioni account",
             "admin_user": "Utente admin",
-            "platform_settings": "Impostazioni della piattaforma"
+            "platform_settings": "Utenti"
         },
         "account": {
             "title": "Impostazioni account",
@@ -836,7 +836,6 @@
             "link_count": "Dimensione batch",
             "capacity_label": "Invii massimi",
             "generate_links": "Genera link",
-            "no_links": "Nessun link di reclutamento generato ancora.",
             "unnamed": "Canale senza nome",
             "revoked": "Accesso revocato",
             "qr_title": "Condividi tramite QR",
@@ -873,16 +872,6 @@
                 "public": "Ideale per un reclutamento ad alto volume. Un singolo URL per tutti i partecipanti.",
                 "individual": "Sicurezza massima. Genera link univoci che scadono dopo un completamento riuscito.",
                 "limited": "Accesso controllato. Un link che smette di funzionare dopo un numero fisso di invii."
-            },
-            "stats": {
-                "total_links": "Canali totali",
-                "active_channels": "Lotti di reclutamento attivi",
-                "started": "Sessioni totali",
-                "engagements": "Partecipanti che hanno iniziato",
-                "submitted": "Dati validi",
-                "completions": "Invii completati",
-                "conversion": "Tasso di acquisizione",
-                "efficiency": "Rendimento finale dei dati"
             },
             "table": {
                 "name": "Campagna / lotto",
@@ -930,12 +919,10 @@
             }
         },
         "breadcrumbs": {
-            "admin": "Admin",
             "dashboard": "Dashboard",
             "study_dashboard": "Panoramica",
             "design": "Progettazione",
             "participants": "Partecipanti",
-            "team": "Team",
             "recruitment": "Accesso",
             "data": "Dati",
             "privacy": "Privacy dei dati",
@@ -960,7 +947,6 @@
             "no_studies": "Nessuno studio in questo progetto.",
             "open_dashboard": "Apri dashboard",
             "design_study": "Progettazione studio",
-            "collaborators": "Collaboratori",
             "copy_link": "Copia link pubblico",
             "toggle_theme": "Cambia tema",
             "logout": "Esci",
@@ -1030,7 +1016,6 @@
             "alert_deadline": "{{study}}: chiusura tra {{days}} giorni con {{count}} partecipanti",
             "view": "Visualizza",
             "open_study": "Apri studio",
-            "add_study": "Aggiungi studio",
             "closes": "Chiude",
             "timeline": {
                 "title": "Timeline degli invii",
@@ -1050,13 +1035,7 @@
             },
             "n_studies_help": "Numero totale di studi in questo progetto, incluse bozze e chiusi.",
             "n_active_help": "Studi che accettano attualmente invii di partecipanti (stato = attivo).",
-            "n_participants_total_help": "Somma dei partecipanti completati in tutti gli studi di questo progetto.",
-            "tool_help": {
-                "design": "Configura lo studio: griglia di distribuzione, condizioni di istruzione, affermazioni, consenso.",
-                "recruit": "Link di reclutamento, regole di accesso e impostazioni URL dello studio.",
-                "data": "Risposte dei partecipanti ed esportazioni (CSV, dump classificazione Q).",
-                "analysis": "Configurazione dell'analisi fattoriale e esecuzioni storiche."
-            }
+            "n_participants_total_help": "Somma dei partecipanti completati in tutti gli studi di questo progetto."
         },
         "export": {
             "config": "Esporta configurazione",
@@ -1942,44 +1921,6 @@
                 "next": "Pagina successiva"
             }
         },
-        "team": {
-            "title": "Team dello studio",
-            "description": "Gestisca i collaboratori e il controllo degli accessi a livello di studio.",
-            "invite_title": "Invita collaboratore",
-            "invite_description": "Generi un link sicuro per invitare un nuovo membro in questo studio.",
-            "email_label": "Indirizzo e-mail",
-            "role_label": "Ruolo",
-            "select_role": "Seleziona un ruolo",
-            "generate_link": "Genera link",
-            "invite_success": "Link di invito generato!",
-            "invite_error": "Generazione dell'invito non riuscita",
-            "copy_success": "Link copiato negli appunti",
-            "share_label": "Condivida questo link con l'invitato:",
-            "collab_overview": "Panoramica della collaborazione",
-            "active_members": "Membri attivi",
-            "permissions_info": "Informazioni sui permessi",
-            "list_title": "Team di ricerca",
-            "list_description": "Gestisca l'accesso per i collaboratori esistenti.",
-            "added_on": "Aggiunto il",
-            "headers": {
-                "collaborator": "Collaboratore",
-                "role": "Ruolo",
-                "actions": "Azioni"
-            },
-            "roles": {
-                "owner": "Proprietario (controllo completo)",
-                "editor": "Editor (progettazione e analisi)",
-                "viewer": "Osservatore (sola lettura)",
-                "owner_badge": "PROPRIETARIO",
-                "editor_badge": "EDITOR",
-                "viewer_badge": "OSSERVATORE"
-            },
-            "permissions": {
-                "owner": "Può eliminare lo studio e gestire il team.",
-                "editor": "Può modificare la progettazione e visualizzare i risultati.",
-                "viewer": "Accesso in sola lettura a tutti i moduli."
-            }
-        },
         "empty_states": {
             "participants": {
                 "title": "Pronto al lancio?",
@@ -1987,11 +1928,6 @@
                 "action": "Copia link studio",
                 "hint": "Oppure scansi il codice QR",
                 "copy_success": "Link dello studio copiato negli appunti!"
-            },
-            "team": {
-                "title": "È solo",
-                "desc": "Inviti dei collaboratori ad aiutare a gestire questo studio. Possono visualizzare i dati, modificare la progettazione o semplicemente osservare.",
-                "action": "Inviti il primo collaboratore"
             },
             "designer": {
                 "title": "Tabula rasa",
@@ -2132,9 +2068,7 @@
                     "save_error": "Aggiornamento del progetto non riuscito."
                 },
                 "team_growth_title": "Gestione del team",
-                "team_growth_desc": "Ha bisogno di più ricercatori? Può invitare collaboratori nel suo progetto. Potranno gestire tutti gli studi all'interno di questo progetto.",
                 "team": {
-                    "title": "Membri del team",
                     "desc": "Elenco degli utenti con accesso a questo progetto.",
                     "col_user": "Utente",
                     "col_role": "Ruolo",

--- a/frontend/public/locales/nl/admin.json
+++ b/frontend/public/locales/nl/admin.json
@@ -276,7 +276,7 @@
             "logout": "Uitloggen",
             "account": "Accountinstellingen",
             "admin_user": "Beheerder",
-            "platform_settings": "Platforminstellingen"
+            "platform_settings": "Gebruikers"
         },
         "account": {
             "title": "Accountinstellingen",
@@ -836,7 +836,6 @@
             "link_count": "Batchgrootte",
             "capacity_label": "Max. inzendingen",
             "generate_links": "Links aanmaken",
-            "no_links": "Nog geen wervingslinks aangemaakt.",
             "unnamed": "Naamloos kanaal",
             "revoked": "Toegang ingetrokken",
             "qr_title": "Delen via QR",
@@ -873,16 +872,6 @@
                 "public": "Ideaal voor grootschalige werving. Één URL voor alle deelnemers.",
                 "individual": "Maximale beveiliging. Genereert unieke links die verlopen na één succesvolle voltooiing.",
                 "limited": "Gecontroleerde toegang. Één link die stopt na een vast aantal inzendingen."
-            },
-            "stats": {
-                "total_links": "Totaal kanalen",
-                "active_channels": "Actieve wervingslots",
-                "started": "Totaal sessies",
-                "engagements": "Gestarte deelnemers",
-                "submitted": "Geldige data",
-                "completions": "Voltooide inzendingen",
-                "conversion": "Vastleggingspercentage",
-                "efficiency": "Uiteindelijke dataopbrengst"
             },
             "table": {
                 "name": "Campagne / lot",
@@ -930,12 +919,10 @@
             }
         },
         "breadcrumbs": {
-            "admin": "Beheer",
             "dashboard": "Dashboard",
             "study_dashboard": "Overzicht",
             "design": "Opzet",
             "participants": "Deelnemers",
-            "team": "Team",
             "recruitment": "Toegang",
             "data": "Data",
             "privacy": "Gegevensprivacy",
@@ -960,7 +947,6 @@
             "no_studies": "Geen onderzoeken in dit project.",
             "open_dashboard": "Dashboard openen",
             "design_study": "Onderzoeksopzet",
-            "collaborators": "Medewerkers",
             "copy_link": "Openbare link kopiëren",
             "toggle_theme": "Thema wisselen",
             "logout": "Uitloggen",
@@ -1030,7 +1016,6 @@
             "alert_deadline": "{{study}}: sluit over {{days}} dagen met {{count}} deelnemers",
             "view": "Bekijken",
             "open_study": "Onderzoek openen",
-            "add_study": "Onderzoek toevoegen",
             "closes": "Sluit",
             "timeline": {
                 "title": "Inzendingtijdlijn",
@@ -1050,13 +1035,7 @@
             },
             "n_studies_help": "Totaal aantal onderzoeken in dit project, inclusief concepten en gesloten.",
             "n_active_help": "Onderzoeken die momenteel deelnemersinzendingen accepteren (status = actief).",
-            "n_participants_total_help": "Som van voltooide deelnemers over alle onderzoeken in dit project.",
-            "tool_help": {
-                "design": "Configureer het onderzoek: verdeelgrid, instructieomstandigheden, stellingen, toestemming.",
-                "recruit": "Wervingslinks, toegangsregels en URL-instellingen.",
-                "data": "Deelnemersantwoorden en exports (CSV, Q-sorteringsdumps).",
-                "analysis": "Factoranalyseconfiguratie en historische runs."
-            }
+            "n_participants_total_help": "Som van voltooide deelnemers over alle onderzoeken in dit project."
         },
         "export": {
             "config": "Configuratie exporteren",
@@ -1942,44 +1921,6 @@
                 "next": "Volgende pagina"
             }
         },
-        "team": {
-            "title": "Onderzoeksteam",
-            "description": "Beheer medewerkers en toegangsrechten op onderzoeksniveau.",
-            "invite_title": "Medewerker uitnodigen",
-            "invite_description": "Genereer een beveiligde link om een nieuw lid uit te nodigen voor dit onderzoek.",
-            "email_label": "E-mailadres",
-            "role_label": "Rol",
-            "select_role": "Selecteer een rol",
-            "generate_link": "Link genereren",
-            "invite_success": "Uitnodigingslink gegenereerd!",
-            "invite_error": "Uitnodiging genereren mislukt",
-            "copy_success": "Link gekopieerd naar klembord",
-            "share_label": "Deel deze link met de genodigde:",
-            "collab_overview": "Samenwerkingsoverzicht",
-            "active_members": "Actieve leden",
-            "permissions_info": "Rechtenoverzicht",
-            "list_title": "Onderzoeksteam",
-            "list_description": "Beheer toegang voor bestaande medewerkers.",
-            "added_on": "Toegevoegd op",
-            "headers": {
-                "collaborator": "Medewerker",
-                "role": "Rol",
-                "actions": "Acties"
-            },
-            "roles": {
-                "owner": "Eigenaar (volledige controle)",
-                "editor": "Redacteur (opzet & analyse)",
-                "viewer": "Kijker (alleen-lezen)",
-                "owner_badge": "EIGENAAR",
-                "editor_badge": "REDACTEUR",
-                "viewer_badge": "KIJKER"
-            },
-            "permissions": {
-                "owner": "Kan het onderzoek verwijderen en het team beheren.",
-                "editor": "Kan de opzet aanpassen en resultaten bekijken.",
-                "viewer": "Alleen-lezentoegang tot alle modules."
-            }
-        },
         "empty_states": {
             "participants": {
                 "title": "Klaar om te starten?",
@@ -1987,11 +1928,6 @@
                 "action": "Onderzoekslink kopiëren",
                 "hint": "Of scan de QR-code",
                 "copy_success": "Onderzoekslink gekopieerd naar klembord!"
-            },
-            "team": {
-                "title": "U werkt alleen",
-                "desc": "Nodig medewerkers uit om dit onderzoek te helpen beheren. Zij kunnen data bekijken, de opzet bewerken of gewoon meekijken.",
-                "action": "Uw eerste medewerker uitnodigen"
             },
             "designer": {
                 "title": "Tabula rasa",
@@ -2132,9 +2068,7 @@
                     "save_error": "Project bijwerken mislukt."
                 },
                 "team_growth_title": "Teambeheer",
-                "team_growth_desc": "Meer onderzoekers nodig? U kunt medewerkers uitnodigen voor uw project. Zij kunnen alle onderzoeken in dit project beheren.",
                 "team": {
-                    "title": "Teamleden",
                     "desc": "Lijst van gebruikers met toegang tot dit project.",
                     "col_user": "Gebruiker",
                     "col_role": "Rol",

--- a/frontend/public/locales/pl/admin.json
+++ b/frontend/public/locales/pl/admin.json
@@ -276,7 +276,7 @@
       "logout": "Wyloguj",
       "account": "Ustawienia konta",
       "admin_user": "Użytkownik administracyjny",
-      "platform_settings": "Ustawienia platformy"
+      "platform_settings": "Użytkownicy"
     },
     "account": {
       "title": "Ustawienia konta",
@@ -836,7 +836,6 @@
       "link_count": "Rozmiar partii",
       "capacity_label": "Maks. zgłoszeń",
       "generate_links": "Generuj linki",
-      "no_links": "Nie wygenerowano jeszcze żadnych linków rekrutacyjnych.",
       "unnamed": "Kanał bez nazwy",
       "revoked": "Dostęp odwołany",
       "qr_title": "Udostępnij przez QR",
@@ -873,16 +872,6 @@
         "public": "Najlepszy do rekrutacji na dużą skalę. Jeden URL dla wszystkich uczestników.",
         "individual": "Maksymalne bezpieczeństwo. Generuje unikalne linki wygasające po jednym pomyślnym ukończeniu.",
         "limited": "Kontrolowany dostęp. Jeden link, który przestaje działać po określonej liczbie zgłoszeń."
-      },
-      "stats": {
-        "total_links": "Łącznie kanałów",
-        "active_channels": "Aktywne partie rekrutacyjne",
-        "started": "Łącznie sesji",
-        "engagements": "Uczestnicy, którzy rozpoczęli",
-        "submitted": "Prawidłowe dane",
-        "completions": "Ukończone zgłoszenia",
-        "conversion": "Wskaźnik przechwycenia",
-        "efficiency": "Ostateczny wynik danych"
       },
       "table": {
         "name": "Kampania / partia",
@@ -930,12 +919,10 @@
       }
     },
     "breadcrumbs": {
-      "admin": "Admin",
       "dashboard": "Dashboard",
       "study_dashboard": "Overview",
       "design": "Design",
       "participants": "Participants",
-      "team": "Team",
       "recruitment": "Access",
       "data": "Data",
       "privacy": "Data privacy",
@@ -960,7 +947,6 @@
       "no_studies": "Brak badań w tym projekcie.",
       "open_dashboard": "Otwórz panel",
       "design_study": "Projekt badania",
-      "collaborators": "Współpracownicy",
       "copy_link": "Kopiuj publiczny link",
       "toggle_theme": "Przełącz motyw",
       "logout": "Wyloguj",
@@ -1030,7 +1016,6 @@
       "alert_deadline": "{{study}}: zamknięcie za {{days}} dni, {{count}} uczestników",
       "view": "Pokaż",
       "open_study": "Otwórz badanie",
-      "add_study": "Dodaj badanie",
       "closes": "Zamknięcie",
       "timeline": {
         "title": "Oś czasu zgłoszeń",
@@ -1050,13 +1035,7 @@
       },
       "n_studies_help": "Łączna liczba badań w tym projekcie, w tym szkice i zamknięte.",
       "n_active_help": "Badania aktualnie przyjmujące zgłoszenia uczestników (stan = aktywne).",
-      "n_participants_total_help": "Suma ukończonych uczestników we wszystkich badaniach tego projektu.",
-      "tool_help": {
-        "design": "Konfiguruj badanie: siatka rozkładu, warunki instrukcji, stwierdzenia, zgoda.",
-        "recruit": "Linki rekrutacyjne, reguły dostępu i ustawienia URL badania.",
-        "data": "Odpowiedzi uczestników i eksporty (CSV, zrzuty sortowania Q).",
-        "analysis": "Konfiguracja analizy czynnikowej i historia przebiegów."
-      }
+      "n_participants_total_help": "Suma ukończonych uczestników we wszystkich badaniach tego projektu."
     },
     "export": {
       "config": "Eksportuj konfigurację",
@@ -1942,44 +1921,6 @@
         "next": "Następna strona"
       }
     },
-    "team": {
-      "title": "Zespół badania",
-      "description": "Zarządzaj współpracownikami i kontrolą dostępu na poziomie badania.",
-      "invite_title": "Zaproś współpracownika",
-      "invite_description": "Wygeneruj bezpieczny link, aby zaprosić nowego członka do tego badania.",
-      "email_label": "Adres e-mail",
-      "role_label": "Rola",
-      "select_role": "Wybierz rolę",
-      "generate_link": "Generuj link",
-      "invite_success": "Link zaproszenia wygenerowany!",
-      "invite_error": "Nie udało się wygenerować zaproszenia",
-      "copy_success": "Link skopiowany do schowka",
-      "share_label": "Udostępnij ten link zaproszonej osobie:",
-      "collab_overview": "Przegląd współpracy",
-      "active_members": "Aktywni członkowie",
-      "permissions_info": "Informacje o uprawnieniach",
-      "list_title": "Zespół badawczy",
-      "list_description": "Zarządzaj dostępem dla istniejących współpracowników.",
-      "added_on": "Dodano",
-      "headers": {
-        "collaborator": "Współpracownik",
-        "role": "Rola",
-        "actions": "Akcje"
-      },
-      "roles": {
-        "owner": "Właściciel (pełna kontrola)",
-        "editor": "Redaktor (projekt i analiza)",
-        "viewer": "Obserwator (tylko odczyt)",
-        "owner_badge": "WŁAŚCICIEL",
-        "editor_badge": "REDAKTOR",
-        "viewer_badge": "OBSERWATOR"
-      },
-      "permissions": {
-        "owner": "Może usunąć badanie i zarządzać zespołem.",
-        "editor": "Może modyfikować projekt i przeglądać wyniki.",
-        "viewer": "Dostęp tylko do odczytu do wszystkich modułów."
-      }
-    },
     "empty_states": {
       "participants": {
         "title": "Gotowe do uruchomienia?",
@@ -1987,11 +1928,6 @@
         "action": "Kopiuj link do badania",
         "hint": "Lub zeskanuj kod QR",
         "copy_success": "Link do badania skopiowany do schowka!"
-      },
-      "team": {
-        "title": "Działasz samodzielnie",
-        "desc": "Zaproś współpracowników, aby pomogli zarządzać tym badaniem. Mogą przeglądać dane, edytować projekt lub jedynie obserwować.",
-        "action": "Zaproś pierwszego współpracownika"
       },
       "designer": {
         "title": "Tabula rasa",
@@ -2132,9 +2068,7 @@
           "save_error": "Nie udało się zaktualizować projektu."
         },
         "team_growth_title": "Zarządzanie zespołem",
-        "team_growth_desc": "Potrzeba więcej badaczy? Możesz zaprosić współpracowników do projektu. Będą mogli zarządzać wszystkimi badaniami w tym projekcie.",
         "team": {
-          "title": "Członkowie zespołu",
           "desc": "Lista użytkowników mających dostęp do tego projektu.",
           "col_user": "Użytkownik",
           "col_role": "Rola",

--- a/frontend/public/locales/pt/admin.json
+++ b/frontend/public/locales/pt/admin.json
@@ -276,7 +276,7 @@
             "logout": "Terminar sessão",
             "account": "Definições da conta",
             "admin_user": "Utilizador administrador",
-            "platform_settings": "Definições da plataforma"
+            "platform_settings": "Utilizadores"
         },
         "account": {
             "title": "Definições da conta",
@@ -836,7 +836,6 @@
             "link_count": "Tamanho do lote",
             "capacity_label": "Máximo de submissões",
             "generate_links": "Criar links",
-            "no_links": "Ainda não foram gerados links de recrutamento.",
             "unnamed": "Canal sem nome",
             "revoked": "Acesso revogado",
             "qr_title": "Partilhar via QR",
@@ -873,16 +872,6 @@
                 "public": "Ideal para recrutamento de grande volume. Um único URL para todos os participantes.",
                 "individual": "Segurança máxima. Gera links únicos que expiram após uma conclusão bem-sucedida.",
                 "limited": "Acesso controlado. Um link que deixa de funcionar após um número fixo de submissões."
-            },
-            "stats": {
-                "total_links": "Total de canais",
-                "active_channels": "Lotes de recrutamento ativos",
-                "started": "Total de sessões",
-                "engagements": "Participantes que iniciaram",
-                "submitted": "Dados válidos",
-                "completions": "Submissões concluídas",
-                "conversion": "Taxa de captação",
-                "efficiency": "Rendimento final de dados"
             },
             "table": {
                 "name": "Campanha / lote",
@@ -930,12 +919,10 @@
             }
         },
         "breadcrumbs": {
-            "admin": "Administração",
             "dashboard": "Painel",
             "study_dashboard": "Visão geral",
             "design": "Desenho",
             "participants": "Participantes",
-            "team": "Equipa",
             "recruitment": "Acesso",
             "data": "Dados",
             "privacy": "Privacidade de dados",
@@ -960,7 +947,6 @@
             "no_studies": "Nenhum estudo neste projeto.",
             "open_dashboard": "Abrir painel",
             "design_study": "Desenho do estudo",
-            "collaborators": "Colaboradores",
             "copy_link": "Copiar link público",
             "toggle_theme": "Alternar tema",
             "logout": "Terminar sessão",
@@ -1030,7 +1016,6 @@
             "alert_deadline": "{{study}}: fecha em {{days}} dias com {{count}} participantes",
             "view": "Ver",
             "open_study": "Abrir estudo",
-            "add_study": "Adicionar estudo",
             "closes": "Fecha",
             "timeline": {
                 "title": "Cronograma de submissões",
@@ -1050,13 +1035,7 @@
             },
             "n_studies_help": "Número total de estudos neste projeto, incluindo rascunhos e fechados.",
             "n_active_help": "Estudos atualmente a aceitar submissões de participantes (estado = ativo).",
-            "n_participants_total_help": "Soma de participantes que concluíram em todos os estudos deste projeto.",
-            "tool_help": {
-                "design": "Configure o estudo: grelha de distribuição, condições de instrução, afirmações, consentimento.",
-                "recruit": "Links de recrutamento, regras de acesso e definições do URL do estudo.",
-                "data": "Respostas dos participantes e exportações (CSV, dumps de classificação Q).",
-                "analysis": "Configuração da análise fatorial e execuções anteriores."
-            }
+            "n_participants_total_help": "Soma de participantes que concluíram em todos os estudos deste projeto."
         },
         "export": {
             "config": "Exportar configuração",
@@ -1942,44 +1921,6 @@
                 "next": "Página seguinte"
             }
         },
-        "team": {
-            "title": "Equipa do estudo",
-            "description": "Gira colaboradores e o controlo de acesso ao nível do estudo.",
-            "invite_title": "Convidar colaborador",
-            "invite_description": "Gere um link seguro para convidar um novo membro para este estudo.",
-            "email_label": "Endereço de email",
-            "role_label": "Função",
-            "select_role": "Selecione uma função",
-            "generate_link": "Gerar link",
-            "invite_success": "Link de convite gerado!",
-            "invite_error": "Falha ao gerar o convite",
-            "copy_success": "Link copiado para a área de transferência",
-            "share_label": "Partilhe este link com o convidado:",
-            "collab_overview": "Visão geral da colaboração",
-            "active_members": "Membros ativos",
-            "permissions_info": "Informações sobre permissões",
-            "list_title": "Equipa de investigação",
-            "list_description": "Gira o acesso dos colaboradores existentes.",
-            "added_on": "Adicionado em",
-            "headers": {
-                "collaborator": "Colaborador",
-                "role": "Função",
-                "actions": "Ações"
-            },
-            "roles": {
-                "owner": "Proprietário (controlo total)",
-                "editor": "Editor (desenho e análise)",
-                "viewer": "Visualizador (apenas leitura)",
-                "owner_badge": "PROPRIETÁRIO",
-                "editor_badge": "EDITOR",
-                "viewer_badge": "VISUALIZADOR"
-            },
-            "permissions": {
-                "owner": "Pode eliminar o estudo e gerir a equipa.",
-                "editor": "Pode modificar o desenho e ver os resultados.",
-                "viewer": "Acesso de leitura a todos os módulos."
-            }
-        },
         "empty_states": {
             "participants": {
                 "title": "Pronto para lançar?",
@@ -1987,11 +1928,6 @@
                 "action": "Copiar link do estudo",
                 "hint": "Ou digitalize o código QR",
                 "copy_success": "Link do estudo copiado para a área de transferência!"
-            },
-            "team": {
-                "title": "Está a trabalhar sozinho",
-                "desc": "Convide colaboradores para ajudar a gerir este estudo. Podem ver dados, editar o desenho ou apenas observar.",
-                "action": "Convidar o primeiro colaborador"
             },
             "designer": {
                 "title": "Tabula rasa",
@@ -2132,9 +2068,7 @@
                     "save_error": "Falha ao atualizar o projeto."
                 },
                 "team_growth_title": "Gestão da equipa",
-                "team_growth_desc": "Precisa de mais investigadores? Pode convidar colaboradores para o seu projeto. Eles poderão gerir todos os estudos dentro deste projeto.",
                 "team": {
-                    "title": "Membros da equipa",
                     "desc": "Lista de utilizadores com acesso a este projeto.",
                     "col_user": "Utilizador",
                     "col_role": "Função",

--- a/frontend/src/components/GridSort.tsx
+++ b/frontend/src/components/GridSort.tsx
@@ -895,7 +895,7 @@ const GridSort: React.FC<GridSortProps> = React.memo(
                                     <div
                                         className="flex flex-row gap-2 items-end flex-nowrap outline-none"
                                         role="grid"
-                                        aria-label={t('fine.grid.label', 'Sorting grid')}
+                                        aria-label={t('fine.grid.label', 'Q-Sort grid')}
                                         tabIndex={-1}
                                         onKeyDown={handleGridKeyDown}
                                     >

--- a/frontend/src/components/admin/AdminDashboard.tsx
+++ b/frontend/src/components/admin/AdminDashboard.tsx
@@ -184,7 +184,7 @@ export function AdminDashboard() {
                                 size="sm"
                             >
                                 <Upload className="mr-2 h-3.5 w-3.5" />
-                                {t('admin.dashboard.import_study', 'Import')}
+                                {t('admin.dashboard.import_study', 'Import study')}
                             </Button>
                         </div>
                     )}
@@ -305,7 +305,7 @@ export function AdminDashboard() {
                         </Button>
                         <Button onClick={() => setShowImportDialog(true)} variant="ghost" size="sm">
                             <Upload className="mr-2 h-3.5 w-3.5" />
-                            {t('admin.dashboard.import_study', 'Import')}
+                            {t('admin.dashboard.import_study', 'Import study')}
                         </Button>
                     </div>
                 )}

--- a/frontend/src/components/admin/AppSidebar.tsx
+++ b/frontend/src/components/admin/AppSidebar.tsx
@@ -166,7 +166,7 @@ function NavUser({
                             {isSuperuser && (
                                 <DropdownMenuItem onSelect={() => navigate('/app/users')}>
                                     <ShieldCheck className="mr-2 h-4 w-4" />
-                                    {t('admin.layout.platform_settings', 'Platform settings')}
+                                    {t('admin.layout.platform_settings', 'Users')}
                                 </DropdownMenuItem>
                             )}
                         </DropdownMenuGroup>

--- a/frontend/src/components/admin/CommandMenu.tsx
+++ b/frontend/src/components/admin/CommandMenu.tsx
@@ -309,7 +309,7 @@ export const CommandMenu = () => {
                             <div className="flex h-6 w-6 items-center justify-center rounded bg-red-100 dark:bg-red-900/40">
                                 <LogOut className="h-3.5 w-3.5 text-red-600" />
                             </div>
-                            <span>{t('admin.command_menu.logout', 'Logout')}</span>
+                            <span>{t('admin.command_menu.logout', 'Log out')}</span>
                         </Command.Item>
                     </Command.Group>
                 </Command.List>

--- a/frontend/src/components/admin/CreateStudyDialog.tsx
+++ b/frontend/src/components/admin/CreateStudyDialog.tsx
@@ -221,7 +221,7 @@ export function CreateStudyDialog({ open, onOpenChange, projectSlug }: CreateStu
                                         <p className="text-xs font-medium text-slate-500 mt-1">
                                             {t(
                                                 'admin.dialogs.create_study.languages_desc',
-                                                'Select languages to enable for this study. Content will be initialized with localized defaults.'
+                                                'Select the languages to enable. Content will be initialized with localized defaults.'
                                             )}
                                         </p>
                                     </div>

--- a/frontend/src/components/admin/ImportStudyDialog.tsx
+++ b/frontend/src/components/admin/ImportStudyDialog.tsx
@@ -126,7 +126,7 @@ export function ImportStudyDialog({ open, onOpenChange, projectSlug }: ImportStu
             await handleConfigLoaded(json);
         } catch (error: unknown) {
             const errorMsg = error instanceof Error ? error.message : 'Unknown error';
-            toast.error(t('admin.import.invalid_json', 'Invalid JSON'), {
+            toast.error(t('admin.import.invalid_json', 'Invalid JSON file'), {
                 description: errorMsg,
             });
         }

--- a/frontend/src/components/admin/ProjectSwitcher.tsx
+++ b/frontend/src/components/admin/ProjectSwitcher.tsx
@@ -93,7 +93,7 @@ export function ProjectSwitcher() {
                         sideOffset={4}
                     >
                         <DropdownMenuLabel className="px-2 py-1.5 text-xs font-semibold text-slate-500">
-                            {t('admin.command_menu.switch_project', 'Projects')}
+                            {t('admin.command_menu.switch_project', 'Switch project')}
                         </DropdownMenuLabel>
                         <div className="space-y-1 my-1">
                             {projects?.map((project) => {

--- a/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
+++ b/frontend/src/components/admin/analysis/AnalysisHistoryPanel.tsx
@@ -226,7 +226,7 @@ export function AnalysisHistoryPanel({
                             )}
                             body={t(
                                 'admin.analysis.history.empty_explainer',
-                                'Documenting analytical choices supports reproducibility, a core requirement of careful Q-methodological practice (Watts & Stenner 2012; Sneegas 2020). Each run is logged here so you can document and revisit every decision.'
+                                'Each run is logged here so you can document and revisit every decision.'
                             )}
                             variant="inline"
                             headingLevel={3}

--- a/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
+++ b/frontend/src/components/admin/analysis/FactorVoicesPanel.tsx
@@ -285,7 +285,7 @@ export function FactorVoicesPanel({
                         <div className="absolute left-0 top-6 z-20 w-72 rounded-lg bg-white border border-slate-200 shadow-lg p-3 text-xs text-slate-600 leading-relaxed">
                             {t(
                                 'admin.analysis.factor_voices.context',
-                                "Grounding factor interpretation in participants' own words (their audio rationales and their written card comments) is a core element of careful Q-methodological practice (Watts & Stenner 2012; Sneegas 2020)."
+                                "Ground factor interpretation in participants' own words: their audio rationales and their written card comments."
                             )}
                         </div>
                     )}

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.columns.tsx
@@ -366,7 +366,7 @@ export function buildColumns({
                                     setStepFilter('all');
                                 }}
                             >
-                                {t('admin.data.filters.all_statuses', 'All')}
+                                {t('admin.data.filters.all_statuses', 'All statuses')}
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
                             <DropdownMenuLabel className="text-2xs text-slate-500">
@@ -524,7 +524,7 @@ export function buildColumns({
                                 )}
                             >
                                 <MessagesSquare className="w-3.5 h-3.5 mr-2" />
-                                {t('admin.data.filters.interview', 'Follow-up')}
+                                {t('admin.data.filters.interview', 'Accepts follow-up')}
                             </DropdownMenuItem>
                         </DropdownMenuContent>
                     </DropdownMenu>
@@ -620,7 +620,7 @@ export function buildColumns({
                                 )}
                             >
                                 <AlertTriangle className="w-3.5 h-3.5 mr-2" />
-                                {t('admin.data.filters.flagged', 'Flagged')}
+                                {t('admin.data.filters.flagged', 'Flagged only')}
                             </DropdownMenuItem>
                             <DropdownMenuItem
                                 onClick={() => setQualityFilter('has_comments')}
@@ -648,7 +648,7 @@ export function buildColumns({
                                 )}
                             >
                                 <Tag className="w-3.5 h-3.5 mr-2" />
-                                {t('admin.data.filters.has_recruitment', 'Has recruitment link')}
+                                {t('admin.data.filters.has_recruitment', 'Has access link')}
                             </DropdownMenuItem>
                         </DropdownMenuContent>
                     </DropdownMenu>
@@ -664,7 +664,7 @@ export function buildColumns({
 
                 const recruitmentLinkLabel = `${t(
                     'admin.data.tooltips.recruitment_link',
-                    'Recruitment link'
+                    'Access link'
                 )}: ${p.recruitment_token}`;
                 const suspectLabel = t('admin.data.tooltips.suspect');
                 const hasCommentsLabel = t('admin.data.tooltips.has_comments');

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.test.tsx
@@ -186,7 +186,7 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
         expect(screen.getByRole('img', { name: 'Email provided' })).toBeInTheDocument();
         expect(screen.getByRole('img', { name: 'Wants results' })).toBeInTheDocument();
         expect(screen.getByRole('img', { name: 'Accepts follow-up' })).toBeInTheDocument();
-        expect(screen.getByRole('img', { name: 'Recruitment link: REF123' })).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: 'Access link: REF123' })).toBeInTheDocument();
         expect(
             screen.getByRole('img', {
                 name: 'Potentially suspect: session duration < 2 minutes',
@@ -214,7 +214,7 @@ describe('InteractiveDataView — control names (Task 6.7c)', () => {
             'Email provided',
             'Wants results',
             'Accepts follow-up',
-            'Recruitment link: REF123',
+            'Access link: REF123',
             'Potentially suspect: session duration < 2 minutes',
             'Contains participant comments on cards',
             'Has audio responses',

--- a/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
+++ b/frontend/src/components/admin/dashboard/InteractiveDataView.tsx
@@ -306,7 +306,7 @@ export default function InteractiveDataView({
                         </div>
 
                         <div className="mt-2 sm:mt-4 hidden sm:flex items-center text-xs font-semibold text-emerald-600 gap-1 opacity-0 group-hover:opacity-100 transition-opacity translate-y-1 group-hover:translate-y-0 duration-300">
-                            {t('admin.data.stats.click_to_filter', 'Filter table')}
+                            {t('admin.data.stats.click_to_filter', 'Click to filter')}
                             <ArrowRight className="w-3 h-3" />
                         </div>
                     </button>
@@ -355,7 +355,7 @@ export default function InteractiveDataView({
                         </div>
 
                         <div className="mt-2 sm:mt-4 hidden sm:flex items-center text-xs font-semibold text-sky-600 gap-1 opacity-0 group-hover:opacity-100 transition-opacity translate-y-1 group-hover:translate-y-0 duration-300">
-                            {t('admin.data.stats.click_to_filter', 'Filter table')}
+                            {t('admin.data.stats.click_to_filter', 'Click to filter')}
                             <ArrowRight className="w-3 h-3" />
                         </div>
                     </button>
@@ -403,7 +403,7 @@ export default function InteractiveDataView({
                         </div>
 
                         <div className="mt-2 sm:mt-4 hidden sm:flex items-center text-xs font-semibold text-amber-600 gap-1 opacity-0 group-hover:opacity-100 transition-opacity translate-y-1 group-hover:translate-y-0 duration-300">
-                            {t('admin.data.stats.click_to_filter', 'Filter table')}
+                            {t('admin.data.stats.click_to_filter', 'Click to filter')}
                             <ArrowRight className="w-3 h-3" />
                         </div>
                     </button>
@@ -523,14 +523,14 @@ export default function InteractiveDataView({
                             >
                                 <AlertTriangle className="w-3 h-3" />
                                 {qualityFilter === 'flagged'
-                                    ? t('admin.data.filters.flagged', 'Flagged')
+                                    ? t('admin.data.filters.flagged', 'Flagged only')
                                     : qualityFilter === 'has_comments'
                                       ? t('admin.data.filters.has_comments', 'Has comments')
                                       : qualityFilter === 'has_audio'
                                         ? t('admin.data.filters.has_audio', 'Has audio')
                                         : t(
                                               'admin.data.filters.has_recruitment',
-                                              'Has recruitment link'
+                                              'Has access link'
                                           )}
                                 <button
                                     type="button"
@@ -630,7 +630,7 @@ export default function InteractiveDataView({
                             className="h-7 text-xs font-semibold text-slate-600 gap-1.5"
                         >
                             <FilterX className="w-3.5 h-3.5" />
-                            {t('admin.data.filters.clear_all', 'Clear all')}
+                            {t('admin.data.filters.clear_all', 'Clear filters')}
                         </Button>
                     </div>
                 )}
@@ -643,11 +643,11 @@ export default function InteractiveDataView({
                             <Input
                                 placeholder={t(
                                     'admin.data.search.placeholder',
-                                    'Search by ID, email...'
+                                    'Search by ID or link token...'
                                 )}
                                 aria-label={t(
                                     'admin.data.search.placeholder',
-                                    'Search by ID, email...'
+                                    'Search by ID or link token...'
                                 )}
                                 value={globalFilter ?? ''}
                                 onChange={(e) => setGlobalFilter(e.target.value)}
@@ -663,7 +663,7 @@ export default function InteractiveDataView({
                                 <Button
                                     className="h-10 w-10 sm:w-auto sm:h-9 font-bold shadow-sm gap-2 text-xs"
                                     disabled={isExportLoading}
-                                    aria-label={t('admin.export.label', 'Export')}
+                                    aria-label={t('admin.export.label', 'Export data')}
                                 >
                                     {isExportLoading ? (
                                         <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -671,7 +671,7 @@ export default function InteractiveDataView({
                                         <Download className="h-3.5 w-3.5" />
                                     )}
                                     <span className="hidden sm:inline">
-                                        {t('admin.export.label', 'Export')}
+                                        {t('admin.export.label', 'Export data')}
                                     </span>
                                 </Button>
                             </DropdownMenuTrigger>

--- a/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantDetailContent.tsx
@@ -241,7 +241,7 @@ export function ParticipantDetailContent({
                             <div className="flex items-center justify-between">
                                 <Badge variant="outline" className="font-mono text-xs">
                                     {detailStatement.code ||
-                                        `${t('admin.participant.metadata.id', 'ID')}: ${detailStatement.id}`}
+                                        `${t('admin.participant.metadata.id', 'Internal ID')}: ${detailStatement.id}`}
                                 </Badge>
                                 <span className="text-xs font-medium text-slate-500">
                                     {t('common.score', 'Score')}:{' '}

--- a/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
+++ b/frontend/src/components/admin/dashboard/ParticipantMetadataCard.tsx
@@ -265,7 +265,7 @@ export function ParticipantMetadataCard({
                                     <p className="text-2xs text-slate-500 font-bold mt-1">
                                         {t(
                                             'admin.participant.metadata.recruitment_link',
-                                            'Recruitment link'
+                                            'Access link'
                                         )}
                                     </p>
                                 </div>

--- a/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
+++ b/frontend/src/components/admin/dashboard/RecentActivityCard.tsx
@@ -311,7 +311,7 @@ export default function RecentActivityCard({
                         {t('admin.study_overview.latest_participants', {
                             count: recentParticipants.length,
                             total: totalParticipantCount,
-                            defaultValue: `Latest participants (${recentParticipants.length} of ${totalParticipantCount})`,
+                            defaultValue: 'Latest participants (last {{count}} of {{total}})',
                         })}
                     </CardDescription>
                 </div>

--- a/frontend/src/components/admin/dashboard/RecruitmentModule.tsx
+++ b/frontend/src/components/admin/dashboard/RecruitmentModule.tsx
@@ -110,7 +110,7 @@ const RecruitmentModule: React.FC<RecruitmentModuleProps> = ({ slug }) => {
                         <span className="min-w-0 break-words">
                             {showQR
                                 ? t('admin.recruitment.hide_qr', 'Hide QR')
-                                : t('admin.recruitment.show_qr', 'Show QR')}
+                                : t('admin.recruitment.show_qr', 'Show QR code')}
                         </span>
                     </Button>
                     <Button

--- a/frontend/src/components/admin/dashboard/StudyStatusControl.tsx
+++ b/frontend/src/components/admin/dashboard/StudyStatusControl.tsx
@@ -199,7 +199,7 @@ const StudyStatusControl: React.FC<StudyStatusControlProps> = ({
             id: 'active',
             label: t('admin.study_status.steps.active.label', 'Active'),
             icon: Rocket,
-            description: t('admin.study_status.steps.active.description', 'Collecting responses'),
+            description: t('admin.study_status.steps.active.description', 'Data collection'),
             color: 'text-emerald-600',
             bg: 'bg-emerald-100',
             border: 'border-emerald-200',

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.test.ts
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.test.ts
@@ -27,19 +27,23 @@ describe('resolveAnswerLabel', () => {
     });
 
     it('returns t() fallback for special key "email"', () => {
-        expect(resolveAnswerLabel({}, 'email', 'en', t)).toBe('Email Address');
+        expect(resolveAnswerLabel({}, 'email', 'en', t)).toBe('Your email address (optional)');
     });
 
     it('returns t() fallback for "interview_consent"', () => {
-        expect(resolveAnswerLabel({}, 'interview_consent', 'en', t)).toBe('Follow-up');
+        expect(resolveAnswerLabel({}, 'interview_consent', 'en', t)).toBe(
+            'I agree to be contacted by the researcher for follow-up.'
+        );
     });
 
     it('returns t() fallback for "newsletter_consent"', () => {
-        expect(resolveAnswerLabel({}, 'newsletter_consent', 'en', t)).toBe('Results');
+        expect(resolveAnswerLabel({}, 'newsletter_consent', 'en', t)).toBe(
+            'I wish to be informed about the study results.'
+        );
     });
 
     it('returns t() fallback for "_recruitment_token"', () => {
-        expect(resolveAnswerLabel({}, '_recruitment_token', 'en', t)).toBe('Recruitment token');
+        expect(resolveAnswerLabel({}, '_recruitment_token', 'en', t)).toBe('Link token');
     });
 
     it('returns t() fallback for "missing_statement"', () => {

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.ts
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.helpers.ts
@@ -31,11 +31,19 @@ export function resolveAnswerLabel(
         // both are valid inputs for getLocalizedText.
         return getLocalizedText(q.label || q.text, language, genericFallback);
     }
-    if (key === 'email') return t('post.contact.email_label', 'Email Address');
-    if (key === 'interview_consent') return t('post.contact.interview_consent', 'Follow-up');
-    if (key === 'newsletter_consent') return t('post.contact.newsletter_consent', 'Results');
+    if (key === 'email') return t('post.contact.email_label', 'Your email address (optional)');
+    if (key === 'interview_consent')
+        return t(
+            'post.contact.interview_consent',
+            'I agree to be contacted by the researcher for follow-up.'
+        );
+    if (key === 'newsletter_consent')
+        return t(
+            'post.contact.newsletter_consent',
+            'I wish to be informed about the study results.'
+        );
     if (key === '_recruitment_token')
-        return t('admin.participant.metadata.recruitment_token', 'Recruitment token');
+        return t('admin.participant.metadata.recruitment_token', 'Link token');
     if (key === 'missing_statement')
         return t('post.extreme.missing_statement', 'Missing Statement');
     if (key === 'general_comment') return t('post.extreme.general_comment', 'General Comment');

--- a/frontend/src/components/admin/dashboard/SurveyResponseTable.tsx
+++ b/frontend/src/components/admin/dashboard/SurveyResponseTable.tsx
@@ -210,7 +210,7 @@ export function SurveyResponseTable({
                         ? statement.translations?.find((t) => t.language_code === language)?.text ||
                           statement.translations?.[0]?.text ||
                           statement.code
-                        : `${t('admin.participant.metadata.id', 'ID')}: ${sId}`;
+                        : `${t('admin.participant.metadata.id', 'Internal ID')}: ${sId}`;
 
                     // Build translations array for MultiLangFieldIcon
                     const stmtTranslations = statement?.translations?.map((tr) => ({
@@ -306,7 +306,7 @@ export function SurveyResponseTable({
                                                 over white resolves to #929eae → 2.72:1, so the
                                                 colour promotion alone would not have landed. */}
                                             <p className="text-2xs font-mono text-slate-500 mt-1 tracking-tighter">
-                                                {t('admin.participant.metadata.id', 'ID')}:{' '}
+                                                {t('admin.participant.metadata.id', 'Internal ID')}:{' '}
                                                 {item.id || item.key}
                                             </p>
                                         </div>

--- a/frontend/src/components/admin/designer/BrandingEditor.tsx
+++ b/frontend/src/components/admin/designer/BrandingEditor.tsx
@@ -219,7 +219,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                         <p className="text-blue-800/80 text-xs leading-relaxed font-medium">
                                             {t(
                                                 'admin.design.theme.logo.help_desc',
-                                                'The logo is displayed at the top of every study page and on the welcome page.'
+                                                "The logo is displayed at the top of every study page (navigation bar) and on the welcome page. It reinforces your project's visual identity."
                                             )}
                                         </p>
                                     </div>
@@ -253,7 +253,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                             <p className="text-xs">
                                                 {t(
                                                     'admin.design.theme.partners.desc',
-                                                    'Add logos of universities, labs, or funders supporting this study.'
+                                                    'Add logos of supporting institutions or partners.'
                                                 )}
                                             </p>
                                         </TooltipContent>
@@ -296,7 +296,7 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                                         >
                                                             {t(
                                                                 'admin.design.theme.partners.name_placeholder',
-                                                                'Name'
+                                                                'Institution name'
                                                             )}
                                                         </Label>
                                                         <Input
@@ -397,13 +397,13 @@ const BrandingEditor = ({ readOnly = false }: { readOnly?: boolean }) => {
                                         <p className="font-bold mb-1 text-indigo-900">
                                             {t(
                                                 'admin.design.theme.partners.help_title',
-                                                'Credibility & Trust'
+                                                'Display of logos'
                                             )}
                                         </p>
                                         <p className="text-indigo-800/80 text-xs leading-relaxed font-medium">
                                             {t(
                                                 'admin.design.theme.partners.help_desc',
-                                                'Partner logos are prominently displayed on the study home page.'
+                                                'Partner logos are displayed on the landing page as well as in the study header, next to the main logo.'
                                             )}
                                         </p>
                                     </div>

--- a/frontend/src/components/admin/designer/ConditionOfInstructionEditor.tsx
+++ b/frontend/src/components/admin/designer/ConditionOfInstructionEditor.tsx
@@ -226,7 +226,7 @@ const ConditionOfInstructionEditor = ({
                                 )}
                                 placeholder={t(
                                     'admin.design.condition.pre_placeholder',
-                                    'e.g. Based on your personal point of view...'
+                                    'E.g. Based on your personal point of view; divide the cards into three piles...'
                                 )}
                                 value={translation?.pre_instruction || ''}
                                 translations={preInstructionTranslations}
@@ -248,7 +248,7 @@ const ConditionOfInstructionEditor = ({
                             )}
                             placeholder={t(
                                 'admin.design.condition.placeholder',
-                                'e.g. Please rank the following statements...'
+                                'E.g. Please rank the following statements from those you most agree with to those you most disagree with'
                             )}
                             value={translation?.condition_of_instruction || ''}
                             translations={conditionTranslations}

--- a/frontend/src/components/admin/designer/ImageUploadInput.tsx
+++ b/frontend/src/components/admin/designer/ImageUploadInput.tsx
@@ -69,10 +69,10 @@ const ImageUploadInput: React.FC<ImageUploadInputProps> = ({
         if (file.size > maxFileSize) {
             const maxSizeKB = Math.round(maxFileSize / 1024);
             setError(
-                t(
-                    'admin.design.theme.upload.file_too_large',
-                    `File too large. Maximum size: ${maxSizeKB}KB.`
-                )
+                t('admin.design.theme.upload.file_too_large', {
+                    size: maxSizeKB,
+                    defaultValue: 'File too large. Maximum size: {{size}}kb.',
+                })
             );
             return;
         }

--- a/frontend/src/components/admin/designer/QSortEditor.tsx
+++ b/frontend/src/components/admin/designer/QSortEditor.tsx
@@ -870,7 +870,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                                   ? t('admin.design.qsort.bulk.process_append')
                                                   : t(
                                                         'admin.design.qsort.bulk.process_sync',
-                                                        'Sync statements'
+                                                        'Process & sync translations'
                                                     )}
                                         </Button>
                                     </div>
@@ -1381,7 +1381,7 @@ const QSortEditor = ({ readOnly, structureLocked }: QSortEditorProps) => {
                                         <p className="mt-1 text-xs text-slate-500 leading-relaxed">
                                             {t(
                                                 'admin.study_design.distribution_mode.helper',
-                                                'Choose how strictly the Q-sort grid is enforced. Forced: each column must be filled to its declared capacity (the most common choice; Brown 1980; Watts & Stenner 2012). Free: any number of cards per column, total = Q-set size (Brown et al. 2015 argue distribution shape barely affects results). Flexible: total enforced, columns are soft hints.'
+                                                'Choose how strictly the Q-sort grid is enforced. Forced: each column must be filled to its declared capacity (the most common choice). Free: any number of cards per column, total = Q-set size. Flexible: total enforced, columns are soft hints.'
                                             )}
                                         </p>
                                     </div>

--- a/frontend/src/components/admin/memo/MemoEntry.tsx
+++ b/frontend/src/components/admin/memo/MemoEntry.tsx
@@ -102,7 +102,7 @@ export function MemoEntry({
                                                 window.confirm(
                                                     t(
                                                         'admin.memo.delete_entry_confirm',
-                                                        'Delete this entry?'
+                                                        'Delete this entry and all its comments?'
                                                     )
                                                 )
                                             ) {

--- a/frontend/src/components/audio/AudioRecorder.test.tsx
+++ b/frontend/src/components/audio/AudioRecorder.test.tsx
@@ -920,7 +920,7 @@ describe('AudioRecorder', () => {
         await simulateRecordingComplete();
 
         await waitFor(() => {
-            expect(screen.getByLabelText('Uploaded')).toBeInTheDocument();
+            expect(screen.getByLabelText('Audio uploaded successfully')).toBeInTheDocument();
         });
     });
 

--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -177,7 +177,10 @@ export const AudioRecorder: React.FC<AudioRecorderProps> = (props) => {
                         {uploadStatus === 'success' && (
                             <Check
                                 className="w-3.5 h-3.5 text-emerald-500 shrink-0"
-                                aria-label={t('audio.upload_success', 'Uploaded')}
+                                aria-label={t(
+                                    'audio.upload_success',
+                                    'Audio uploaded successfully'
+                                )}
                             />
                         )}
                         {uploadStatus === 'failed' && (

--- a/frontend/src/components/postsort/Step1_Feedback.tsx
+++ b/frontend/src/components/postsort/Step1_Feedback.tsx
@@ -472,7 +472,10 @@ export const Step1_Feedback: React.FC<Step1Props> = ({ onNext }) => {
                             defaultValue=""
                         >
                             <option value="" disabled>
-                                {t('post.optional.select_placeholder', 'Select a statement...')}
+                                {t(
+                                    'post.optional.select_placeholder',
+                                    'Select a statement to comment...'
+                                )}
                             </option>
                             {qsort
                                 .filter((s) => {

--- a/frontend/src/components/postsort/Step2_Questionnaire.tsx
+++ b/frontend/src/components/postsort/Step2_Questionnaire.tsx
@@ -265,7 +265,7 @@ export const Step2_Questionnaire: React.FC<Step2Props> = ({ onBack, onSubmit, is
                     if (!hasText && !hasAudio) {
                         newTextAudioErrors[key] = t(
                             'post.text_audio_required',
-                            'Please provide either a text or audio response.'
+                            'A few words or an audio recording will help us understand your viewpoint.'
                         );
                     }
                 }
@@ -364,7 +364,7 @@ export const Step2_Questionnaire: React.FC<Step2Props> = ({ onBack, onSubmit, is
                 <Card className="border-blue-100 bg-blue-50/50 shadow-sm">
                     <CardHeader className="pb-3">
                         <CardTitle className="text-lg font-black text-blue-900 flex items-center gap-2">
-                            ✉️ {t('post.contact.title', 'Contact')}
+                            ✉️ {t('post.contact.title', 'Results & contact')}
                         </CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-4">
@@ -471,7 +471,7 @@ export const Step2_Questionnaire: React.FC<Step2Props> = ({ onBack, onSubmit, is
                         </>
                     ) : (
                         <>
-                            <span>{t('post.submit', 'Submit Study')}</span>
+                            <span>{t('post.submit', 'Share my perspective')}</span>
                             <Check size={20} className="ml-2" strokeWidth={3} />
                         </>
                     )}

--- a/frontend/src/components/survey/SurveyField.tsx
+++ b/frontend/src/components/survey/SurveyField.tsx
@@ -123,7 +123,7 @@ export const SurveyField: React.FC<SurveyFieldProps> = ({ id, fieldConfig, regis
             }
             return (
                 <select id={id} {...register(id)} className={commonClasses}>
-                    <option value="">{t('presort.select_placeholder', 'Select an option')}</option>
+                    <option value="">{t('presort.select_placeholder', 'Select...')}</option>
                     {fieldConfig.options.map((opt) => {
                         const optValue = typeof opt === 'object' ? opt.value : opt;
                         const optLabel =

--- a/frontend/src/hooks/admin/useImportExportConfig.tsx
+++ b/frontend/src/hooks/admin/useImportExportConfig.tsx
@@ -56,7 +56,7 @@ export function useImportConfig() {
                 }
 
                 importConfig(config);
-                toast.success(t('admin.import.success', 'Configuration imported successfully'));
+                toast.success(t('admin.import.success', 'Study imported successfully'));
             } catch (error: unknown) {
                 console.error('Import failed:', error);
                 const errorMsg = error instanceof Error ? error.message : 'Unknown error';

--- a/frontend/src/hooks/admin/useInteractiveDataView.ts
+++ b/frontend/src/hooks/admin/useInteractiveDataView.ts
@@ -211,9 +211,7 @@ export function useInteractiveDataView({
                 url: `/api/admin/studies/${slug}/participants`,
                 method: 'DELETE',
             });
-            toast.success(
-                t('admin.data.actions.clear_all_success', 'All participants successfully cleared!')
-            );
+            toast.success(t('admin.data.actions.clear_all_success', 'All data cleared'));
             queryClient.invalidateQueries({
                 queryKey: getGetStudyDumpApiAdminStudiesSlugDumpGetQueryKey(slug),
             });
@@ -316,7 +314,7 @@ export function useInteractiveDataView({
                 await exportFn();
                 toast.success(t('admin.export.success', 'Export successful'));
             } catch (_e) {
-                toast.error(t('admin.export.error', 'Export failed'));
+                toast.error(t('admin.export.error', 'Export failed. Try again.'));
             } finally {
                 setIsExportLoading(false);
             }

--- a/frontend/src/hooks/admin/useRecruitmentPage.ts
+++ b/frontend/src/hooks/admin/useRecruitmentPage.ts
@@ -227,7 +227,7 @@ export function useRecruitmentPage(): RecruitmentPageApi {
         mutation: {
             onSuccess: () => {
                 toast.success(
-                    t('admin.recruitment.toasts.created', 'Recruitment links created successfully')
+                    t('admin.recruitment.toasts.created', 'Access links created successfully')
                 );
                 setIsCreateModalOpen(false);
                 revalidator.revalidate();
@@ -238,7 +238,7 @@ export function useRecruitmentPage(): RecruitmentPageApi {
                 toast.error(
                     t(
                         'admin.recruitment.toasts.failed',
-                        'Could not create recruitment links. Check the inputs and try again.'
+                        'Could not create access links. Check the inputs and try again.'
                     )
                 );
             },

--- a/frontend/src/pages/ConsentPage.tsx
+++ b/frontend/src/pages/ConsentPage.tsx
@@ -105,7 +105,7 @@ const ConsentPage: React.FC = () => {
                     toast.error(
                         t(
                             'consent.record_error',
-                            'Could not save consent record. Please try again.'
+                            'Could not save consent record. You may continue.'
                         )
                     );
                     return; // Block navigation — consent must be recorded
@@ -133,10 +133,10 @@ const ConsentPage: React.FC = () => {
         <div className="w-full max-w-2xl min-w-0 mx-auto py-6 sm:py-12 px-4 animate-in fade-in duration-500">
             <div className="mb-8 text-center">
                 <h1 className="text-2xl font-bold text-gray-900 mb-2">
-                    {t('consent.title', 'Consent to Participate')}
+                    {t('consent.title', 'Informed consent and data processing agreement')}
                 </h1>
                 <p className="text-gray-600">
-                    {t('consent.subtitle', 'Please review the following information carefully.')}
+                    {t('consent.subtitle', 'Please read the following information carefully.')}
                 </p>
             </div>
 
@@ -184,7 +184,10 @@ const ConsentPage: React.FC = () => {
                             </label>
                             {errors.consent && (
                                 <p className="text-red-600 mt-2 text-sm">
-                                    {t('welcome.consent.error', 'Consent is required to proceed.')}
+                                    {t(
+                                        'welcome.consent.error',
+                                        'Please accept the terms to continue.'
+                                    )}
                                 </p>
                             )}
                         </div>

--- a/frontend/src/pages/RegistrationPage.tsx
+++ b/frontend/src/pages/RegistrationPage.tsx
@@ -72,7 +72,7 @@ const RegistrationPage = () => {
     const handleRegister = async (e: React.FormEvent) => {
         e.preventDefault();
         if (password !== confirmPassword) {
-            toast.error(t('auth.register.errors.password_mismatch', 'Passwords do not match.'));
+            toast.error(t('auth.register.errors.password_mismatch', 'Passwords do not match'));
             return;
         }
 
@@ -91,20 +91,11 @@ const RegistrationPage = () => {
         } catch (error: unknown) {
             const message = parseApiErrorSync(
                 error,
-                t(
-                    'auth.register.errors.generic_fail',
-                    'Could not create account. Check the form and try again.'
-                )
+                t('auth.register.errors.generic_fail', 'Registration failed')
             );
-            toast.error(
-                t(
-                    'auth.register.errors.generic_fail',
-                    'Could not create account. Check the form and try again.'
-                ),
-                {
-                    description: message,
-                }
-            );
+            toast.error(t('auth.register.errors.generic_fail', 'Registration failed'), {
+                description: message,
+            });
         }
     };
 

--- a/frontend/src/pages/ResearcherHub.tsx
+++ b/frontend/src/pages/ResearcherHub.tsx
@@ -156,7 +156,7 @@ export default function ResearcherHub() {
                                     {activeStudies.length > 0 && (
                                         <div className="border-t mx-5 pt-3 pb-4 space-y-2">
                                             <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                                                {t('admin.hub.collecting', 'Collecting data')}
+                                                {t('admin.hub.collecting', 'Active studies')}
                                             </p>
                                             {activeStudies.map((study) => {
                                                 const title = getStudyTitle(study);

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -145,7 +145,7 @@ const WelcomePage: React.FC<WelcomePageProps> = ({ highlightKey }) => {
                         ></div>
                         <h2 className="text-xs font-bold text-slate-500 mb-4 flex items-center gap-2">
                             <Target size={16} style={{ color: 'var(--brand-accent)' }} />
-                            {t('welcome.objective_label', 'Objective of the study')}
+                            {t('welcome.objective_label', 'Study objective')}
                         </h2>
                         <div className="prose prose-slate prose-base max-w-none text-slate-800 leading-relaxed">
                             <SafeMarkdown>{config.objective}</SafeMarkdown>
@@ -196,7 +196,7 @@ const WelcomePage: React.FC<WelcomePageProps> = ({ highlightKey }) => {
                         }}
                     >
                         <div className="text-xs font-bold mb-4 w-fit px-3 py-1.5 rounded-md border text-slate-700 bg-slate-50 border-slate-200">
-                            {t('welcome.how_it_works', 'How it works')}
+                            {t('welcome.how_it_works', 'Process')}
                         </div>
 
                         {config.instructions && (
@@ -264,7 +264,7 @@ const WelcomePage: React.FC<WelcomePageProps> = ({ highlightKey }) => {
                     {/* Visual Column */}
                     <div className="md:col-span-12 lg:col-span-5 p-4 sm:p-8 md:px-10 md:pt-10 md:pb-6 bg-slate-100 flex flex-col items-start min-h-[250px] sm:min-h-[350px] md:min-h-[500px] relative overflow-hidden">
                         <div className="text-xs font-bold text-slate-600 bg-slate-200/80 backdrop-blur-sm w-fit px-3 py-1.5 rounded-md border border-slate-300 shadow-sm mb-4">
-                            {t('welcome.preview_title', "It's child's play!")}
+                            {t('welcome.preview_title', 'Preview')}
                         </div>
 
                         <div

--- a/frontend/src/pages/admin/AccountSettingsPage.tsx
+++ b/frontend/src/pages/admin/AccountSettingsPage.tsx
@@ -262,7 +262,7 @@ const AccountSettingsPage = () => {
                                 >
                                     {isUpdating
                                         ? t('admin.account.personal.saving', 'Saving...')
-                                        : t('admin.account.personal.save', 'Save changes')}
+                                        : t('admin.account.personal.save', 'Save')}
                                 </Button>
                             </CardFooter>
                         </form>
@@ -382,7 +382,7 @@ const AccountSettingsPage = () => {
                                         >
                                             {t(
                                                 'admin.account.security.enter_code',
-                                                '2. Enter the 6-digit code'
+                                                'Enter 6-digit code'
                                             )}
                                         </Label>
                                         <div className="flex gap-3">

--- a/frontend/src/pages/admin/AnalysisPage.tsx
+++ b/frontend/src/pages/admin/AnalysisPage.tsx
@@ -371,7 +371,7 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                                 <p className="text-xs text-muted-foreground leading-snug">
                                     {t(
                                         'admin.analysis.help_extraction',
-                                        'PCA maximizes explained variance across factors. Centroid produces less mathematically constrained factors, which some Q researchers prefer for theoretical reasons.'
+                                        'PCA maximises explained variance. Centroid is less mathematically constrained.'
                                     )}
                                 </p>
                             </div>
@@ -402,7 +402,7 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                                 <p className="text-xs text-muted-foreground leading-snug">
                                     {t(
                                         'admin.analysis.help_n_factors',
-                                        'Each factor represents a distinct viewpoint. More factors capture more nuance but may split coherent views; fewer factors give broader groupings.'
+                                        'Each factor represents a distinct viewpoint.'
                                     )}
                                 </p>
                             </div>
@@ -517,7 +517,7 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                                                 <p className="text-xs text-muted-foreground leading-snug">
                                                     {t(
                                                         'admin.analysis.help_rotation',
-                                                        'Varimax maximizes the separation between factors, producing simpler structure. No rotation preserves the original mathematical solution. Judgmental lets you specify rotation angles manually.'
+                                                        'Varimax separates factors for simpler structure.'
                                                     )}
                                                 </p>
                                             </div>
@@ -554,7 +554,7 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                                                 <p className="text-xs text-muted-foreground leading-snug">
                                                     {t(
                                                         'admin.analysis.help_flagging',
-                                                        'Auto flags participants whose loading exceeds the significance threshold on exactly one factor. Manual lets you override flagging based on your own judgment.'
+                                                        'Auto: flag participants loading on exactly one factor. Manual: override per participant.'
                                                     )}
                                                 </p>
                                             </div>
@@ -573,7 +573,7 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                                                     <p className="text-xs text-muted-foreground leading-snug mt-1">
                                                         {t(
                                                             'admin.analysis.manual_rotations.helper',
-                                                            "Specify rotations as 'rotate factor F by Δ° around factor G'. Rotations are applied in order. Used to align factors with substantively-meaningful positions (Brown 1980; Watts & Stenner 2012)."
+                                                            "Specify rotations as 'rotate factor F by Δ° around factor G'. Rotations are applied in order."
                                                         )}
                                                     </p>
                                                 </div>
@@ -751,7 +751,7 @@ function ExploreShell({ slug, explore, t, onSelectHistoricalRun }: ExploreShellP
                                                     <p className="text-xs text-muted-foreground leading-snug">
                                                         {t(
                                                             'admin.analysis.bootstrap.helper',
-                                                            'Optional. Bootstrap resamples your Q-sorts with replacement and re-runs the analysis B times to estimate standard errors on z-scores. Useful when you want confidence intervals on factor scores (Zabala & Pascual 2016).'
+                                                            'Optional. Resamples Q-sorts B times to estimate percentile confidence intervals on factor scores.'
                                                         )}
                                                     </p>
                                                 </div>
@@ -1098,14 +1098,14 @@ function InterpretShell({
                                     aria-hidden="true"
                                 />
                             )}
-                            {t('admin.analysis.export_xlsx', 'XLSX: Complete Analysis')}
+                            {t('admin.analysis.export_xlsx', 'Complete analysis (XLSX)')}
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem onClick={() => void handleExport('loadings')}>
-                            {t('admin.analysis.export_loadings', 'CSV: Factor Loadings')}
+                            {t('admin.analysis.export_loadings', 'Factor loadings (CSV)')}
                         </DropdownMenuItem>
                         <DropdownMenuItem onClick={() => void handleExport('scores')}>
-                            {t('admin.analysis.export_scores', 'CSV: Statement Scores')}
+                            {t('admin.analysis.export_scores', 'Statement scores (CSV)')}
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                 </DropdownMenu>

--- a/frontend/src/pages/admin/ConcourseDetailPage.tsx
+++ b/frontend/src/pages/admin/ConcourseDetailPage.tsx
@@ -240,7 +240,7 @@ export default function ConcourseDetailPage() {
     if (!concourse) {
         return (
             <div className="p-8 text-center text-slate-500">
-                {t('common.errors.not_found', 'Not found')}
+                {t('common.errors.not_found', 'Study not found.')}
             </div>
         );
     }
@@ -918,7 +918,7 @@ export default function ConcourseDetailPage() {
                                                         }
                                                         placeholder={t(
                                                             'admin.concourse.source_placeholder',
-                                                            'Source (optional)'
+                                                            'e.g. Interview #3, Literature review'
                                                         )}
                                                         className="h-8 text-xs rounded-lg"
                                                     />
@@ -1346,7 +1346,7 @@ export default function ConcourseDetailPage() {
                                         <SelectValue
                                             placeholder={t(
                                                 'admin.concourse.select_language',
-                                                'Select language'
+                                                'Language'
                                             )}
                                         />
                                     </SelectTrigger>
@@ -1851,10 +1851,7 @@ export default function ConcourseDetailPage() {
                     <Select value={newLangCode} onValueChange={(val) => setNewLangCode(val)}>
                         <SelectTrigger className="h-10 rounded-xl">
                             <SelectValue
-                                placeholder={t(
-                                    'admin.concourse.select_language',
-                                    'Select language'
-                                )}
+                                placeholder={t('admin.concourse.select_language', 'Language')}
                             />
                         </SelectTrigger>
                         <SelectContent className="rounded-xl max-h-60">

--- a/frontend/src/pages/admin/CreateProjectPage.tsx
+++ b/frontend/src/pages/admin/CreateProjectPage.tsx
@@ -101,14 +101,11 @@ export default function CreateProjectPage() {
             } else {
                 const message = parseApiErrorSync(
                     error,
-                    t('admin.project.create.error', 'Could not create project. Try again.')
+                    t('admin.project.create.error', 'Failed to create project')
                 );
-                toast.error(
-                    t('admin.project.create.error', 'Could not create project. Try again.'),
-                    {
-                        description: message,
-                    }
-                );
+                toast.error(t('admin.project.create.error', 'Failed to create project'), {
+                    description: message,
+                });
             }
         } finally {
             setIsSubmitting(false);

--- a/frontend/src/pages/admin/DataExportsPage.tsx
+++ b/frontend/src/pages/admin/DataExportsPage.tsx
@@ -23,7 +23,7 @@ export default function DataExportsPage() {
                     title={t('admin.data.title', 'Data')}
                     description={t(
                         'admin.data.description',
-                        'Browse responses, export raw data, and inspect submission metadata'
+                        'Monitor real-time participation, analyze data quality, and manage research sessions.'
                     )}
                     icon={Database}
                 />

--- a/frontend/src/pages/admin/DataPrivacyPage.tsx
+++ b/frontend/src/pages/admin/DataPrivacyPage.tsx
@@ -128,14 +128,14 @@ function ConsentSummaryCard({ designHref }: { designHref: string }) {
                     >
                         <Link to={`${designHref}#consent`}>
                             <PencilLine className="size-4 mr-2" />
-                            {t('admin.privacy.consent.edit_in_design', 'Edit in Study design')}
+                            {t('admin.privacy.consent.edit_in_design', 'Edit in Design')}
                         </Link>
                     </Button>
                 </div>
                 <CardDescription className="text-sm font-medium text-slate-500">
                     {t(
                         'admin.privacy.consent.description',
-                        'What participants see before they enter the study. Edited in Study design.'
+                        'What participants see before they enter the study. Edited in Design.'
                     )}
                 </CardDescription>
             </CardHeader>
@@ -486,7 +486,7 @@ export default function DataPrivacyPage() {
                         <div className="flex items-center gap-2 mb-1">
                             <Globe className="h-5 w-5 text-emerald-500" />
                             <CardTitle className="text-lg font-black text-slate-900">
-                                {t('admin.privacy.locale_title', 'Locale breakdown')}
+                                {t('admin.privacy.locale_title', 'Language breakdown')}
                             </CardTitle>
                         </div>
                     </CardHeader>
@@ -521,7 +521,7 @@ export default function DataPrivacyPage() {
                             </table>
                         ) : (
                             <EmptyState
-                                title={t('admin.privacy.locale_empty', 'No locale data yet.')}
+                                title={t('admin.privacy.locale_empty', 'No language data yet.')}
                                 variant="compact"
                             />
                         )}

--- a/frontend/src/pages/admin/GeneralSettingsPage.tsx
+++ b/frontend/src/pages/admin/GeneralSettingsPage.tsx
@@ -100,20 +100,11 @@ export default function GeneralSettingsPage() {
         } catch (error) {
             const message = parseApiErrorSync(
                 error,
-                t(
-                    'admin.settings.archive_error',
-                    'Could not archive study. Make sure the study is closed first.'
-                )
+                t('admin.settings.archive_error', 'Error archiving study')
             );
-            toast.error(
-                t(
-                    'admin.settings.archive_error',
-                    'Could not archive study. Make sure the study is closed first.'
-                ),
-                {
-                    description: message,
-                }
-            );
+            toast.error(t('admin.settings.archive_error', 'Error archiving study'), {
+                description: message,
+            });
         }
     };
     const handleDelete = async () => {
@@ -285,7 +276,7 @@ export default function GeneralSettingsPage() {
                                     <AlertDescription className="text-red-800">
                                         {t(
                                             'admin.settings.storage.error',
-                                            'Failed to load storage usage'
+                                            'Failed to load storage usage.'
                                         )}
                                     </AlertDescription>
                                 </Alert>

--- a/frontend/src/pages/admin/ParticipantDetailsPage.tsx
+++ b/frontend/src/pages/admin/ParticipantDetailsPage.tsx
@@ -243,7 +243,7 @@ export default function ParticipantDetailsPage() {
                     }
                 >
                     <ArrowLeft className="w-4 h-4 mr-2" />
-                    {t('common.back', 'Back to Study')}
+                    {t('common.back', 'Back')}
                 </Button>
             </div>
         );
@@ -280,7 +280,7 @@ export default function ParticipantDetailsPage() {
                                 size="icon"
                                 disabled={nextId === null}
                                 onClick={() => navigate(`${baseUrl}/participants/${nextId}`)}
-                                aria-label={t('common.next', 'Next')}
+                                aria-label={t('common.next', 'Next step')}
                             >
                                 <ChevronRight className="w-4 h-4" />
                             </Button>

--- a/frontend/src/pages/admin/ProjectMembersPage.test.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.test.tsx
@@ -155,10 +155,10 @@ describe('ProjectMembersPage invite modal accessible names (Task 6.7b)', () => {
         const user = userEvent.setup();
         renderWithProviders(<ProjectMembersPage />);
 
-        await user.click(await screen.findByRole('button', { name: /invite collaborator/i }));
+        await user.click(await screen.findByRole('button', { name: /invite member/i }));
 
-        const emailField = screen.getByRole('textbox', { name: /collaborator email/i });
-        await user.click(screen.getByText('Collaborator email'));
+        const emailField = screen.getByRole('textbox', { name: /member email/i });
+        await user.click(screen.getByText('Member email'));
         expect(emailField).toHaveFocus();
     });
 
@@ -166,7 +166,7 @@ describe('ProjectMembersPage invite modal accessible names (Task 6.7b)', () => {
         const user = userEvent.setup();
         renderWithProviders(<ProjectMembersPage />);
 
-        await user.click(await screen.findByRole('button', { name: /invite collaborator/i }));
+        await user.click(await screen.findByRole('button', { name: /invite member/i }));
 
         // The trigger's own content is the selected role's value ("Member");
         // pairing the Label overrides that with the field's purpose, per
@@ -182,7 +182,8 @@ describe('ProjectMembersPage invite modal accessible names (Task 6.7b)', () => {
     it('does not repeat the page title as a card title (task 5.3)', () => {
         // `admin.members.title` and `admin.projects.settings.team.title` were both
         // "Team members", rendered ~120px apart with the same icon. The H1 stays;
-        // the card keeps only its descriptive sub-line.
+        // the card keeps only its descriptive sub-line. Task 5.1 then deleted the
+        // orphaned `…team.title` key outright, so only one now exists.
         renderWithProviders(<ProjectMembersPage />);
 
         expect(screen.getAllByText('Team members')).toHaveLength(1);
@@ -198,8 +199,8 @@ describe('ProjectMembersPage invite modal accessible names (Task 6.7b)', () => {
         });
         renderWithProviders(<ProjectMembersPage />);
 
-        await user.click(await screen.findByRole('button', { name: /invite collaborator/i }));
-        await user.type(screen.getByRole('textbox', { name: /collaborator email/i }), 'x@y.io');
+        await user.click(await screen.findByRole('button', { name: /invite member/i }));
+        await user.type(screen.getByRole('textbox', { name: /member email/i }), 'x@y.io');
         await user.click(screen.getByRole('button', { name: /create & send invitation/i }));
 
         const copyButton = await screen.findByRole('button', { name: 'Copy link' });

--- a/frontend/src/pages/admin/ProjectMembersPage.tsx
+++ b/frontend/src/pages/admin/ProjectMembersPage.tsx
@@ -394,7 +394,7 @@ export default function ProjectMembersPage() {
                                     <p className="text-2xs text-slate-500 leading-tight">
                                         {t(
                                             'admin.projects.settings.team.permissions_matrix.member.desc',
-                                            'Can manage studies, concourses, and participants.'
+                                            'Can create and manage all studies. Restricted from project settings.'
                                         )}
                                     </p>
                                 </div>
@@ -425,7 +425,7 @@ export default function ProjectMembersPage() {
                         <AlertDialogTitle>
                             {t(
                                 'admin.projects.settings.team.remove_dialog_title',
-                                'Remove team member?'
+                                'Remove member?'
                             )}
                         </AlertDialogTitle>
                         <AlertDialogDescription>

--- a/frontend/src/pages/admin/RecruitmentPage.tsx
+++ b/frontend/src/pages/admin/RecruitmentPage.tsx
@@ -123,7 +123,7 @@ const RecruitmentPage = () => {
                 title={t('admin.recruitment.title', 'Access')}
                 description={t(
                     'admin.recruitment.description',
-                    'Configure the study URL, manage participant access, and track recruitment efficiency.'
+                    'Configure the study URL, manage participant access, and track how each access link performs.'
                 )}
                 icon={Link2}
             />
@@ -165,7 +165,7 @@ const RecruitmentPage = () => {
                     <Archive className="size-4 shrink-0" />
                     {t(
                         'admin.recruitment.state_archived',
-                        'This study is archived. All recruitment data is read-only.'
+                        'This study is archived. Access links are read-only.'
                     )}
                 </div>
             )}
@@ -339,7 +339,7 @@ const RecruitmentPage = () => {
                                     ) : (
                                         <Save className="w-4 h-4 mr-2" />
                                     )}
-                                    {t('admin.settings.save_button', 'Save changes')}
+                                    {t('admin.settings.save_button', 'Save')}
                                 </Button>
                             </div>
                         </form>
@@ -629,7 +629,7 @@ const RecruitmentPage = () => {
                     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                         <div>
                             <CardTitle className="text-sm font-black text-slate-500">
-                                {t('admin.recruitment.table_title', 'Recruitment links')}
+                                {t('admin.recruitment.table_title', 'Access links')}
                             </CardTitle>
                         </div>
                         <div className="flex items-center gap-3">
@@ -661,7 +661,10 @@ const RecruitmentPage = () => {
                                                 htmlFor="type"
                                                 className="text-2xs font-black text-slate-500"
                                             >
-                                                {t('admin.recruitment.link_type', 'Link Type')}
+                                                {t(
+                                                    'admin.recruitment.link_type',
+                                                    'Access strategy'
+                                                )}
                                             </Label>
                                             <Select
                                                 value={newLinkType}
@@ -676,7 +679,7 @@ const RecruitmentPage = () => {
                                                     <SelectValue
                                                         placeholder={t(
                                                             'admin.recruitment.select_type',
-                                                            'Select type'
+                                                            'Choose an access strategy...'
                                                         )}
                                                     />
                                                 </SelectTrigger>
@@ -686,7 +689,7 @@ const RecruitmentPage = () => {
                                                             <Globe className="h-4 w-4 text-blue-500 flex-shrink-0" />
                                                             {t(
                                                                 'admin.recruitment.types.public',
-                                                                'Public (Multiple usage)'
+                                                                'Open access (public)'
                                                             )}
                                                         </span>
                                                     </SelectItem>
@@ -695,7 +698,7 @@ const RecruitmentPage = () => {
                                                             <Users className="h-4 w-4 text-indigo-500 flex-shrink-0" />
                                                             {t(
                                                                 'admin.recruitment.types.individual',
-                                                                'Individual (Single usage)'
+                                                                'Single-use passcode'
                                                             )}
                                                         </span>
                                                     </SelectItem>
@@ -704,7 +707,7 @@ const RecruitmentPage = () => {
                                                             <Lock className="h-4 w-4 text-orange-500 flex-shrink-0" />
                                                             {t(
                                                                 'admin.recruitment.types.limited',
-                                                                'Limited (Set capacity)'
+                                                                'Capped participation'
                                                             )}
                                                         </span>
                                                     </SelectItem>
@@ -714,17 +717,17 @@ const RecruitmentPage = () => {
                                                 {newLinkType === 'public' &&
                                                     t(
                                                         'admin.recruitment.guidance.public',
-                                                        'Ideal for social media or generic newsletters. Anyone with this link can participate multiple times.'
+                                                        'Best for high-volume recruitment. A single URL for all participants.'
                                                     )}
                                                 {newLinkType === 'individual' &&
                                                     t(
                                                         'admin.recruitment.guidance.individual',
-                                                        'Each link is unique and expires after one submission. Best for controlled samples.'
+                                                        'Maximum security. Generates unique links that expire after one successful completion.'
                                                     )}
                                                 {newLinkType === 'limited' &&
                                                     t(
                                                         'admin.recruitment.guidance.limited',
-                                                        'Set a maximum number of submissions for a single link. Good for small target groups.'
+                                                        'Controlled access. One link that stops working after a fixed number of submissions.'
                                                     )}
                                             </div>
                                         </div>
@@ -735,7 +738,7 @@ const RecruitmentPage = () => {
                                             >
                                                 {t(
                                                     'admin.recruitment.campaign_name',
-                                                    'Campaign Name (Optional)'
+                                                    'Channel / campaign name'
                                                 )}
                                             </Label>
                                             <div className="relative">
@@ -744,7 +747,7 @@ const RecruitmentPage = () => {
                                                     id="name"
                                                     placeholder={t(
                                                         'admin.recruitment.name_placeholder',
-                                                        'e.g. Social Media, Batch A'
+                                                        'E.g. LinkedIn, email batch a, student list...'
                                                     )}
                                                     value={newLinkName}
                                                     onChange={(e) => setNewLinkName(e.target.value)}
@@ -761,11 +764,11 @@ const RecruitmentPage = () => {
                                                     {newLinkType === 'individual'
                                                         ? t(
                                                               'admin.recruitment.link_count',
-                                                              'Number of links to generate'
+                                                              'Batch size'
                                                           )
                                                         : t(
                                                               'admin.recruitment.capacity_label',
-                                                              'Participant Capacity'
+                                                              'Max submissions'
                                                           )}
                                                 </Label>
                                                 <div className="relative">
@@ -808,7 +811,7 @@ const RecruitmentPage = () => {
                                                 ? t('admin.recruitment.generating', 'Generating...')
                                                 : t(
                                                       'admin.recruitment.generate_links',
-                                                      'Generate Links'
+                                                      'Provision links'
                                                   )}
                                         </Button>
                                     </DialogFooter>
@@ -820,7 +823,7 @@ const RecruitmentPage = () => {
                 <CardContent className="p-0">
                     <Table>
                         <caption className="sr-only">
-                            {t('admin.recruitment.table_caption', 'Recruitment links')}
+                            {t('admin.recruitment.table_caption', 'Access links')}
                         </caption>
                         <TableHeader>
                             <TableRow className="hover:bg-transparent border-slate-100">
@@ -828,41 +831,41 @@ const RecruitmentPage = () => {
                                     scope="col"
                                     className="py-4 text-2xs font-black text-slate-600 pl-6"
                                 >
-                                    {t('admin.recruitment.table.name', 'Name / Cohort')}
+                                    {t('admin.recruitment.table.name', 'Campaign / lot')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
                                     className="py-4 text-2xs font-black text-slate-600 cursor-help"
                                     title={t(
                                         'admin.recruitment.table.type_help',
-                                        'Public, Single-use, or Capacity-limited. See strategy descriptions in the “New access link” dialog.'
+                                        'Public, Single-use, or Capacity-limited. See strategy descriptions in the "New access link" dialog.'
                                     )}
                                 >
-                                    {t('admin.recruitment.table.type', 'Type')}
+                                    {t('admin.recruitment.table.type', 'Entry type')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
                                     className="py-4 text-2xs font-black text-slate-600"
                                 >
-                                    {t('admin.recruitment.table.token', 'Token')}
+                                    {t('admin.recruitment.table.token', 'Link token')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
                                     className="py-4 text-2xs font-black text-slate-600"
                                 >
-                                    {t('admin.recruitment.table.usage', 'Usage')}
+                                    {t('admin.recruitment.table.usage', 'Capacity')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
                                     className="py-4 text-2xs font-black text-slate-600"
                                 >
-                                    {t('admin.recruitment.table.status', 'Status')}
+                                    {t('admin.recruitment.table.status', 'State')}
                                 </TableHead>
                                 <TableHead
                                     scope="col"
                                     className="py-4 text-2xs font-black text-slate-600 text-right pr-6"
                                 >
-                                    {t('admin.recruitment.table.actions', 'Actions')}
+                                    {t('admin.recruitment.table.actions', 'Manage')}
                                 </TableHead>
                             </TableRow>
                         </TableHeader>
@@ -876,7 +879,7 @@ const RecruitmentPage = () => {
                                                 icon={Link2}
                                                 title={t(
                                                     'admin.recruitment.empty_title',
-                                                    'No recruitment links yet'
+                                                    'No access links yet'
                                                 )}
                                                 body={t(
                                                     'admin.recruitment.empty_description',
@@ -907,7 +910,10 @@ const RecruitmentPage = () => {
                                         <TableCell className="font-bold text-slate-900 pl-6">
                                             {link.name || (
                                                 <span className="text-slate-500 italic font-normal">
-                                                    {t('admin.recruitment.unnamed', 'Unnamed')}
+                                                    {t(
+                                                        'admin.recruitment.unnamed',
+                                                        'Unnamed channel'
+                                                    )}
                                                 </span>
                                             )}
                                         </TableCell>
@@ -1052,7 +1058,10 @@ const RecruitmentPage = () => {
                                                     variant="secondary"
                                                     className="bg-slate-50 text-slate-600 border-slate-200 px-2 py-0 shadow-none text-2xs font-black"
                                                 >
-                                                    {t('admin.recruitment.revoked', 'Revoked')}
+                                                    {t(
+                                                        'admin.recruitment.revoked',
+                                                        'Access revoked'
+                                                    )}
                                                 </Badge>
                                             )}
                                         </TableCell>
@@ -1112,7 +1121,7 @@ const RecruitmentPage = () => {
                                                                 <Copy className="h-3.5 w-3.5" />
                                                                 {t(
                                                                     'admin.recruitment.copy_link',
-                                                                    'Copy Link'
+                                                                    'Copy URL'
                                                                 )}
                                                             </Button>
                                                         </div>

--- a/frontend/src/pages/admin/StudyDesignPage.tsx
+++ b/frontend/src/pages/admin/StudyDesignPage.tsx
@@ -814,7 +814,7 @@ const StudyDesignPage = () => {
                                         <h3 className="font-black text-sm text-rose-500">
                                             {t(
                                                 'admin.design.translation_needed',
-                                                'Translation Required'
+                                                'Review required (copy)'
                                             )}
                                         </h3>
                                     </div>
@@ -914,7 +914,7 @@ const StudyDesignPage = () => {
                                         )}
                                         description={t(
                                             'admin.design.guidance.qsort_desc',
-                                            'Ensure your grid capacity exactly matches the number of statements. A balanced Q-set usually has between 30 and 60 items for robust factor analysis.'
+                                            'Ensure your grid capacity exactly matches the number of statements. A balanced Q-set usually follows a quasi-normal (bell curve) distribution.'
                                         )}
                                     />
                                 )}

--- a/frontend/src/pages/admin/StudyOverviewPage.tsx
+++ b/frontend/src/pages/admin/StudyOverviewPage.tsx
@@ -98,7 +98,10 @@ const StudyOverviewPage = () => {
                                     <Users className="w-5 h-5" aria-hidden="true" />
                                 </div>
                                 <span className="min-w-0 text-xs font-bold text-slate-500 leading-tight break-words">
-                                    {t('admin.study_overview.sample_size', 'Sample size (N)')}
+                                    {t(
+                                        'admin.study_overview.sample_size',
+                                        'Number of participants (P-Set)'
+                                    )}
                                 </span>
                             </div>
                             <div className="text-xl sm:text-4xl font-black text-slate-900 tracking-tight">


### PR DESCRIPTION
Task 5.1 — the last task on the admin UX remediation plan.

## The defect

Four words for people (*Team members*, *collaborators*, *researchers*, *users* — all four on
the Team members screen alone). Five names for the access screen. Three for collection state.
And *Locale breakdown* as a heading over a *Language* column.

The canon lands on **member / Access link / Active / Language**, across 28 `en` keys and 23
`fr` keys. Route paths, API fields, `data-testid`s and the role enum are untouched.

## Both rename traps were checked before acting, and both were already clean

- **`ProjectRole` is already `owner | member | viewer`.** The code never drifted; only the
  copy did. (PR #347's E2E log happened to show the backend rejecting a `researcher` role,
  which is what prompted the check.) No enum rename was needed, so none was made.
- **The CSV export header already reads `Language`, never `Locale`**, and has no
  recruitment-token column — so `Locale → Language` has zero downstream exposure for the
  scripts that consume exports.

## The 113 divergences were 112, and closing them surfaced a live bug

Re-derived by extending `check_orphan_keys.py`'s own scanner to read the second argument
rather than trusting the inherited list — task 4.4's contains at least two escape-sequence
false positives (`±`, `\n`).

Since tests load the real `en` JSON, syncing all 128 fallbacks is a no-op in both the app and
the suite, so they were **closed rather than merely reported**. The scanner now reports 0.

Doing that surfaced `ImageUploadInput.tsx:72`: a template-literal fallback passed with **no
interpolation options**, so the size-limit error rendered the literal `"{{size}}kb"` to users.
Fixed. That is the same class this plan keeps finding — a string that looks like copy, is
never resolved, and no gate reads.

## Unused keys: 396 of 2176 (18%), not 2

The brief said two. 52 dead keys carrying retired terms were deleted across all nine locales —
including the entire dead `admin.team.*` block, which invented an `owner/editor/viewer` role
taxonomy **the enum does not have**. 345 unused keys remain.

### Recommendation on wiring the reverse gate into CI: not yet

The brief asked whether the missing half of 4.4's gate (JSON→code) should be wired in. It
should not be, yet:

- `find_unused_keys.py` as it stands cannot be blocking — it is plural-blind and would fail on
  live keys.
- Even a **correct** scanner starts at 345 failures, which would mean a 345-entry `DEFERRED`
  list — precisely the anti-pattern that file's own comment warns against.

Proposed order: land the scanner reporting-only in `make check`, run one deletion wave, then
flip it to blocking. It is deliberately **not committed here** — adding a gate that cannot be
zero, on the plan's last task, would hand you a red build.

## The E2E warning was justified — two specs did break

The brief called this the most exposed task on the plan. It was right, though not where the
count suggested:

- 12 case-sensitive matchers (recounted; confirms 4.3 and 5.2, refutes the earlier 16) — **none
  affected.**
- But two specs broke on **case-insensitive regex locators**: `roles.spec.ts` (×3
  `/invite collaborator/i`) and `recruitment-funnel.spec.ts` (×2
  `/no recruitment links yet/i`). Both fixed, plus five Vitest assertions.

## Locales

`en` and `fr` carry the full canon; all nine agree on `platform_settings` (set from each
locale's own `admin.users.title`, so the i18n delta is **zero** — the technique task 5.2
established). Seven locales (de/es/fi/it/nl/pl/pt) retain pre-canon wording on 25 keys, listed
explicitly in the report and **not machine-translated**.

One exception: `fi` held untranslated English `"Locale breakdown"`, updated to the renamed
English rather than shipping the retired word.

Both hand-offs from 5.2 are fixed: `admin.layout.platform_settings` no longer says "Platform
settings" over a page titled "Users", and the two `DataPrivacyPage` "Edit in Study design"
strings now match.

## Two judgement calls, flagged for easy reversal

- The link token unifies on **"Link token"**, not "Access token" — that phrase already means
  the auth JWT in this codebase, and reusing it would have created a new collision while
  removing an old one.
- The active-step *description* becomes a phase noun rather than substituting "Active" under a
  label already reading "Active".

## Where the brief was off

113 → 112 with false positives in the inherited list; the divergences were closable rather
than only reportable, and the one that mattered was hiding a rendering bug; "two now-unused
keys" was 2 of 396; and the plan's file list (two locale files) understates the blast radius
by roughly 60 files.

## Gates

lint 894 files · `tsc --noEmit` clean · **203 files / 1840 passed / 6 skipped** · a11y at
baseline · `i18n-check` (199 warnings, was 200) · `check-interpolations` ·
`check-orphan-keys` — all green with real counts, re-verified after rebase.

61 files changed, +264 / −849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
