### PR TITLE
fix(e2e): mount the test router locally, and stop reporting success when it is absent

### DIFF
--- a/frontend/e2e/fixtures/global-setup.ts
+++ b/frontend/e2e/fixtures/global-setup.ts
@@ -3,6 +3,50 @@
  * Ensures backend is ready and database is initialized
  */
 
+/**
+ * Prove the test router is mounted before anything relies on it.
+ *
+ * `main.py` mounts it only when `settings.ENVIRONMENT in ["test", "development"]`,
+ * and `ENVIRONMENT` defaults to `"production"`. When it is absent every
+ * `/api/test/*` call fails — and this file used to swallow that: the cleanup
+ * logged a warning and continued, and the init never checked its response at
+ * all, printing "✅ Database initialized" on a 404. The suite then announced
+ * "✅ E2E test environment ready!" and every spec failed downstream on missing
+ * data, pointing anywhere but here.
+ *
+ * Probe with GET, not POST: the SPA middleware answers unknown POST paths with
+ * 405, so a POST cannot distinguish "router absent" from "wrong method".
+ * GET /api/test/health returns a clean 404 when unmounted.
+ */
+async function assertTestRouterMounted(backendUrl: string): Promise<void> {
+    console.log('🔎 Checking the test router is mounted...');
+
+    let probe: Response;
+    try {
+        probe = await fetch(`${backendUrl}/api/test/health`);
+    } catch (error) {
+        throw new Error(
+            `Could not reach ${backendUrl}/api/test/health: ${error}\n` +
+                'The backend answered /health, so it is running but unreachable on this route.'
+        );
+    }
+
+    if (!probe.ok) {
+        throw new Error(
+            `The test router is not mounted (GET /api/test/health returned ${probe.status}).\n\n` +
+                'The backend must run with ENVIRONMENT=test (or development) — main.py gates\n' +
+                'include_router(test_router) on it, and ENVIRONMENT defaults to "production".\n' +
+                'TESTING=true does NOT mount it; that variable only disables the rate limiter.\n\n' +
+                'If Playwright started the server, playwright.config.ts webServer.env should set\n' +
+                'ENVIRONMENT: "test". If you started it yourself, restart it with that variable —\n' +
+                'note reuseExistingServer:true means Playwright will happily reuse a server that\n' +
+                'was started without it.'
+        );
+    }
+
+    console.log('✅ Test router mounted');
+}
+
 async function globalSetup() {
     const backendUrl = process.env.API_BASE_URL || 'http://localhost:8000';
     const maxRetries = 30;
@@ -28,6 +72,8 @@ async function globalSetup() {
         }
     }
 
+    await assertTestRouterMounted(backendUrl);
+
     // Clean up stale data from previous runs
     console.log('🧹 Cleaning up stale data from previous runs...');
     try {
@@ -37,6 +83,9 @@ async function globalSetup() {
         if (cleanupRes.ok) {
             console.log('✅ Previous data cleaned up');
         } else {
+            // Tolerated: the router is mounted (proven above), so a non-OK here
+            // is a data-state problem, not a wiring one — an empty database is
+            // the common case and is harmless.
             console.warn(`⚠️  Cleanup returned ${cleanupRes.status} (continuing anyway)`);
         }
     } catch (error) {
@@ -46,12 +95,22 @@ async function globalSetup() {
     // Initialize test database
     console.log('🗄️  Initializing test database...');
     try {
-        await fetch(`${backendUrl}/api/test/init`, {
+        const initRes = await fetch(`${backendUrl}/api/test/init`, {
             method: 'POST',
         });
+        // Not tolerated: every spec depends on this having run. The previous
+        // version discarded this response and printed success unconditionally.
+        if (!initRes.ok) {
+            throw new Error(
+                `POST /api/test/init returned ${initRes.status}: ${await initRes.text()}`
+            );
+        }
         console.log('✅ Database initialized');
     } catch (error) {
-        console.warn('⚠️  Database init failed (may already be initialized):', error);
+        throw new Error(
+            `Test database initialization failed: ${error}\n` +
+                'Every spec depends on this; continuing would fail them all with unrelated errors.'
+        );
     }
 
     console.log('✅ E2E test environment ready!');

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -123,14 +123,34 @@ export default defineConfig({
     /* Run both frontend and backend servers before starting tests */
     webServer: [
         {
-            command: 'cd ../backend && TESTING=true uv run uvicorn app.main:app --port 8000',
+            command: 'cd ../backend && uv run uvicorn app.main:app --port 8000',
             url: 'http://127.0.0.1:8000/health',
             reuseExistingServer: true,
             timeout: 120 * 1000,
             stdout: 'pipe',
             stderr: 'pipe',
+            /*
+             * Two variables, two different jobs — setting only one is why this
+             * suite could not run outside CI.
+             *
+             * `ENVIRONMENT=test` is what mounts the test router: `main.py`
+             * gates `include_router(test_router)` on
+             * `settings.ENVIRONMENT in ["test", "development"]`, and
+             * `ENVIRONMENT` defaults to `"production"`. Without it every
+             * `/api/test/*` call 404s and the suite dies in global setup,
+             * before a single assertion runs.
+             *
+             * `TESTING=true` is read only by `limiter.py`, to disable rate
+             * limiting. It does not gate the router, so it cannot substitute
+             * for the above — which is precisely the mistake this config made.
+             *
+             * CI passed regardless because `ci.yml` sets `ENVIRONMENT: test` at
+             * the job level. That made this config non-self-contained: green in
+             * CI, broken everywhere else, and no gate could see the difference.
+             */
             env: {
                 TESTING: 'true',
+                ENVIRONMENT: 'test',
             },
         },
         {


### PR DESCRIPTION
Playwright could not run outside CI. Two defects, and the second is the worse one.

## 1. The config set the wrong variable

`playwright.config.ts` set `TESTING=true` on the backend webServer, believing that enabled the test endpoints. **It does not.** `TESTING` is read only by `limiter.py`, to disable rate limiting. The test router is gated in `main.py:221` on `settings.ENVIRONMENT in ["test", "development"]`, and `ENVIRONMENT` defaults to `"production"`.

So every `/api/test/*` call 404'd and the suite died in global setup, before a single assertion ran.

**CI passed regardless**, because `ci.yml` sets `ENVIRONMENT: test` at the job level (lines 421, 505). That made the config non-self-contained: green in CI, broken everywhere else, and no gate could see the difference.

Verified in both directions against a real server:

| backend started with | `GET /api/test/health` |
|---|---|
| `TESTING=true` (before) | **404** |
| `TESTING=true ENVIRONMENT=test` (after) | **200** `{"status":"ok","environment":"test"}` |

`/health` returns 200 in both cases — the server is up either way, which is precisely why this was hard to see.

## 2. Global setup reported success it had not earned

This is the part worth reading. With the router absent, `global-setup.ts` printed:

```
⚠️  Cleanup returned 404 (continuing anyway)
✅ Database initialized          ← on a 404
✅ E2E test environment ready!   ← nothing was ready
```

The cleanup logged a warning and continued. The init **discarded its response entirely** — no `.ok` check — so it printed success unconditionally. Every spec then failed downstream on absent data, pointing anywhere but at the cause.

It now proves the router is mounted before relying on it, and the error names the missing variable and states that `TESTING` is not it.

Three deliberate choices:

- **The probe is a GET.** The SPA middleware answers unknown POST paths with **405**, so a POST cannot distinguish "router absent" from "wrong method". `GET /api/test/health` returns a clean 404 when unmounted — confirmed by measuring both.
- **The init failure is now fatal.** Every spec depends on it; continuing guarantees a wall of unrelated failures.
- **The cleanup stays tolerant** — but only because the router has now been *proven* present, so a non-OK there is a data-state problem (an empty database, the common case) and not a wiring one.

The message also warns about `reuseExistingServer: true`, which will happily reuse a server someone started by hand without the variable.

## Verified by running it, not by reading it

Against a real backend, both ways:

- **Unmounted** → throws at the probe, naming `ENVIRONMENT`, instead of two false successes.
- **Mounted** → proceeds, and surfaces the next real blocker in one line: `POST /api/test/init returned 500: password authentication failed for user "julien"`.

That second line is a local database credential problem, not a repo defect, and it is left alone deliberately — see the note below.

## Not fixed here: the local database

With this merged, Playwright gets past the router and stops on the next blocker: this machine's `.env` points `DATABASE_URL` at PostgreSQL role `julien`, which does not exist on the local server (roles `qualis` and `postgres` do). That is a developer-machine setup issue in a gitignored file holding a real password — not something to guess at in a PR. The repo's own `docker-compose.yml` provisions `qualis:qualis@localhost:5432/qualis`, which is the documented path.

The value of this PR is that the failure now *says so*, in one line, instead of claiming the environment is ready.

## Gates

`biome check` clean on both changed files (note `npm run lint` only covers `src`, so `e2e/` and the config were linted explicitly) · `tsc --noEmit` exit 0 · stray `backend/uv.lock` bump reverted.

Biome flagged the setup function at cognitive complexity 16 (max 15) after the addition; the probe was extracted into `assertTestRouterMounted()` rather than suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)