### PR TITLE
fix(dx): check the configuration, not just that a config file exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: install preflight run-backend run-frontend seed demo-up demo-seed demo-lipset validate-lipset demo-smoke demo-down lint check test ci run-ci ci-full run-ci-full
+.PHONY: install preflight db-check run-backend run-frontend seed demo-up demo-seed demo-lipset validate-lipset demo-smoke demo-down lint check test ci run-ci ci-full run-ci-full
 
 # Toolchain versions CI exercises. Keep in sync with .python-version, .nvmrc,
 # backend/Dockerfile, docker-compose.yml and .github/workflows/ci.yml.
@@ -28,8 +28,39 @@ preflight:
 		pg=$$(psql --version | sed 's/[^0-9]*\([0-9]*\).*/\1/'); \
 		[ "$$pg" = "$(POSTGRES_MAJOR)" ] || echo "WARN     psql client $$pg, expected $(POSTGRES_MAJOR) — the server major is what matters"; \
 	fi; \
-	[ -f .env ] || echo "WARN     no .env — copy .env.example and fill SECRET_KEY, IP_HASH_SALT, DATABASE_URL"; \
+	if [ ! -f .env ]; then \
+		echo "WARN     no .env — copy .env.example and fill SECRET_KEY, IP_HASH_SALT, DATABASE_URL"; \
+	else \
+		for k in ENVIRONMENT DATABASE_URL SECRET_KEY IP_HASH_SALT TEST_DATABASE_URL; do \
+			grep -qE "^$$k=." .env || echo "WARN     .env has no $$k — see .env.example for what it does"; \
+		done; \
+		grep -qE "^(SECRET_KEY|IP_HASH_SALT)=CHANGEME-insecure-dev-only" .env \
+			&& echo "WARN     .env still holds a CHANGEME placeholder — generate one: python3 -c 'import secrets; print(secrets.token_urlsafe(48))'"; \
+		url=$$(grep -E "^DATABASE_URL=." .env | head -1 | cut -d= -f2- | sed 's/+asyncpg//'); \
+		if [ -z "$$url" ]; then :; \
+		elif ! command -v psql >/dev/null 2>&1; then \
+			echo "SKIPPED  DATABASE_URL not tested (no psql client on PATH)"; \
+		elif psql "$$url" -c 'select 1' >/dev/null 2>&1; then :; \
+		else \
+			echo "WARN     DATABASE_URL does not connect. Is PostgreSQL running, and did you"; \
+			echo "         run README.md step 2 (CREATE USER qualis_user / CREATE DATABASE"; \
+			echo "         qualis_dev + qualis_test)? Diagnose with: make db-check"; \
+		fi; \
+	fi; \
 	[ "$$fail" = "0" ] || { echo; echo "Prerequisites missing. See README.md > Local development setup."; exit 1; }
+
+# Print the database error instead of swallowing it. `preflight` only reports
+# that DATABASE_URL does not connect — deliberately, so it never leaks the
+# password into a build log. Run this by hand when you need to know why:
+# "password authentication failed" means the role exists with a different
+# password, "role ... does not exist" means README step 2 was skipped, and
+# "could not connect" means the server is not running.
+db-check:
+	@if [ ! -f .env ]; then echo "No .env — copy .env.example first."; exit 1; fi; \
+	url=$$(grep -E "^DATABASE_URL=." .env | head -1 | cut -d= -f2- | sed 's/+asyncpg//'); \
+	if [ -z "$$url" ]; then echo ".env has no DATABASE_URL."; exit 1; fi; \
+	command -v psql >/dev/null 2>&1 || { echo "No psql client on PATH — install postgresql-client."; exit 1; }; \
+	psql "$$url" -c 'select current_user, current_database()' || exit 1
 
 install: preflight
 	cd backend && uv sync

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Use this path when you want hot reload, local tests, or direct backend/frontend 
 - Python 3.14 — the version CI and the backend image use. `pyproject.toml`
   declares 3.13 as the floor, but only 3.14 is exercised.
 - [uv](https://docs.astral.sh/uv/) (Python package manager)
-- [Node.js](https://nodejs.org/) v24 (the active LTS line, pinned in `.nvmrc`)
+- [Node.js](https://nodejs.org/) v26 — pinned in `.nvmrc`, and the version CI installs
 - PostgreSQL 18 — the version CI and `docker-compose.yml` use. Earlier majors
   are untested.
 
@@ -281,6 +281,23 @@ cd backend && uv run python seed.py data/example-study.json && cd ..
 Visit [http://localhost:5173](http://localhost:5173). Log in with the `ADMIN_EMAIL` / `ADMIN_PASSWORD` you set in `.env`.
 
 If you seeded the example study, you can also visit `http://localhost:5173/study/bioeconomy-futures` to walk the participant flow. (For the full demo — concourse plus filled Q-sorts — run `uv run python seed_demo.py` from `backend/` instead, with the backend running.)
+
+#### Local-setup troubleshooting
+
+Almost every failure here is step 2 or step 3, and the error usually surfaces two
+commands later. `make preflight` (which `make install` runs for you) checks the
+toolchain, every key `.env` is expected to hold, and whether `DATABASE_URL` actually
+connects — run it on its own any time.
+
+| What you see | What it means |
+| ------------ | ------------- |
+| `WARN .env has no ENVIRONMENT` | Step 3 was skipped or partial. Without `ENVIRONMENT=development` the `/api/test/*` routes are not mounted, so the E2E suite cannot run at all. |
+| `WARN .env has no SECRET_KEY` / `IP_HASH_SALT`, or `still holds a CHANGEME placeholder` | Generate each with `python3 -c 'import secrets; print(secrets.token_urlsafe(48))'`. |
+| `WARN DATABASE_URL does not connect` | Run `make db-check` for the real error — `preflight` hides it so no password reaches a build log. `role "…" does not exist` means step 2 was skipped; `password authentication failed` means the role exists with a different password; `could not connect` means PostgreSQL is not running. |
+| `make migrate` → `password authentication failed` | Same cause. `make db-check` confirms it in one line. |
+| `make test` → hundreds of `asyncpg … InvalidPasswordError` | `TEST_DATABASE_URL`, not `DATABASE_URL`. Step 2 creates `qualis_test` as a second database; the test suite resets it between runs. |
+| E2E fails on `The test router is not mounted` | `ENVIRONMENT` is missing or set to `production`. `TESTING=true` does **not** substitute — that variable only disables rate limiting. |
+| A spec fails locally but passes in CI | CI retries twice (`retries: process.env.CI ? 2 : 0`), so it absorbs flakes that a local run surfaces on the first attempt. Re-run the spec alone before assuming a regression. |
 
 ### Verifying your setup
 


### PR DESCRIPTION
Four fixes to the local-setup experience, all found by running it end to end for the first time.

## The gap

`make preflight` verified the toolchain and that `.env` was **present**. It never looked inside it, and never touched the database — so the two failures that actually stop a new setup were the two it could not see.

Demonstrated rather than asserted: the `.env` that cost this session an entire diagnosis — three keys, no `ENVIRONMENT`, no `SECRET_KEY` — passed preflight **silently, exit 0**. The failure then surfaced two commands later as an alembic auth error, or as ~340 identical `asyncpg … InvalidPasswordError` from `make test`, or as an E2E suite that could not mount `/api/test/*` at all.

A green check that verified nothing is the same defect this repo's UX plan spent seven phases removing from the product. It was in the onboarding too.

## 1 & 2 — preflight now checks contents and connectivity

Same `.env`, after:

```
WARN     .env has no ENVIRONMENT — see .env.example for what it does
WARN     .env has no SECRET_KEY — see .env.example for what it does
WARN     DATABASE_URL does not connect. Is PostgreSQL running, and did you
         run README.md step 2 (CREATE USER qualis_user / CREATE DATABASE
         qualis_dev + qualis_test)? Diagnose with: make db-check
```

It also catches a `SECRET_KEY`/`IP_HASH_SALT` still holding the `CHANGEME-insecure-dev-only` sentinel (the app only logs that in non-development, so a dev environment never hears about it).

Three deliberate choices:

- **Everything warns, nothing fails.** `make install` still works on a fresh clone where the database does not exist yet — preflight runs *before* `uv sync`, so it cannot depend on backend packages either.
- **When `psql` is absent it prints `SKIPPED`**, not nothing. A clean run should never overstate what it verified.
- **It does not print the database error.** The URL carries a password and preflight output ends up in build logs.

## 3 — `make db-check` prints what preflight withholds

On demand, so the password stays out of automated logs:

| exit | output |
|---|---|
| 0 | ` qualis_user | qualis_dev` |
| 2 | `FATAL: password authentication failed for user "qualis_user"` |

Exit codes read directly, not through a pipe — this session already found one gate that printed `FAIL` while the shell reported 0.

The README maps each of the three usual messages to its cause: `role "…" does not exist` → step 2 skipped; `password authentication failed` → role exists with another password; `could not connect` → server not running.

## 4 — README: the version was wrong, and the troubleshooting was for the wrong path

**Prerequisites declared Node v24**, and justified it as "the active LTS line, pinned in `.nvmrc`". `.nvmrc` says **26** — as do `NODE_MAJOR`, `CLAUDE.md`, and all three CI setup steps. The one list a newcomer reads first was the only wrong one, and its rationale pointed at a file that contradicted it.

The **Quick-start troubleshooting** table covered the Docker demo path only (daemon missing, `--wait` flag, port allocation). The local path had none. It now has one, including the two traps found while getting the E2E suite to run locally for the first time:

- `ENVIRONMENT` gates the test router, and **`TESTING=true` does not substitute** — that variable only disables rate limiting.
- **CI retries twice** (`retries: process.env.CI ? 2 : 0`) while a local run does not, so a spec that fails locally and passes in CI is a flake before it is a regression. Verified: with `--retries=2` the local Admin E2E suite reports 24 passed / 1 flaky, matching CI.

## Verified by running each path

| path | before | after |
|---|---|---|
| 3-key `.env` | silence, exit 0 | 3 precise warnings |
| `CHANGEME` sentinel | silence | caught |
| `db-check`, bad password | — | exit **2**, real error |
| `db-check`, good | — | exit **0**, role + database |
| correct `.env` | exit 0 | exit 0, no output |

Stray `backend/uv.lock` bump reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)