### PR TITLE
feat(demo): make the first five minutes feel like someone was expecting you

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,24 @@ export
 
 .PHONY: install preflight db-check run-backend run-frontend seed demo-up demo-seed demo-lipset validate-lipset demo-smoke demo-down lint check test ci run-ci ci-full run-ci-full
 
+# The demo path is the first thing a newcomer runs, and its two lines that
+# matter used to be typographically identical to the several hundred BuildKit
+# lines above them. Colour only when stdout is a terminal, and never when
+# NO_COLOR is set (https://no-color.org) — `make demo-up | tee log` must not
+# embed escape codes.
+TTYCOL = if [ -t 1 ] && [ -z "$$NO_COLOR" ]; then B=$$(printf '\033[1m'); D=$$(printf '\033[2m'); G=$$(printf '\033[32m'); R=$$(printf '\033[0m'); else B=; D=; G=; R=; fi
+
+# say <headline> <next step> — the end of a step: what happened, then where to go.
+define say
+$(TTYCOL); printf '\n  %s%s%s\n' "$$G$$B" "$(1)" "$$R"; printf '  %s%s%s\n\n' "$$D" "$(2)" "$$R"
+endef
+
+# probe <what> <url> <what to do about it> — a named check that says which one
+# failed and what to try, instead of a bare curl error and a line number.
+define probe
+$(TTYCOL); printf '  %-40s' "checking $(1)"; if curl -fsS "$(2)" >/dev/null 2>&1; then printf '%sok%s\n' "$$G" "$$R"; else printf '%sfailed%s\n\n  Could not reach %s\n  %s\n\n' "$$B" "$$R" "$(2)" "$(3)"; exit 1; fi
+endef
+
 # Toolchain versions CI exercises. Keep in sync with .python-version, .nvmrc,
 # backend/Dockerfile, docker-compose.yml and .github/workflows/ci.yml.
 PYTHON_VERSION := 3.14
@@ -97,11 +115,11 @@ demo-up:
 		echo "   registry hiccup — retrying in $$((i * 5))s"; sleep $$((i * 5)); \
 	done
 	docker compose up -d --wait --wait-timeout 240
-	@printf '\nQualis services are running.\nNext: make demo-seed\n\n'
+	@$(call say,Your Qualis stack is up and healthy.,Next: make demo-seed  — loads the Bioeconomy Futures example)
 
 demo-seed:
 	docker compose exec backend .venv/bin/python seed_demo.py
-	@printf '\nDemo data is ready.\nNext: make demo-smoke\n\n'
+	@$(call say,The demo data is in place.,Next: make demo-smoke  — checks the whole path end to end)
 
 demo-lipset:
 	docker compose exec backend .venv/bin/python seed_lipset.py
@@ -109,11 +127,16 @@ demo-lipset:
 validate-lipset:
 	python3 validation/lipset/compare.py
 
+# Each check is named. Three bare `curl`s printed the same shape of error and
+# only a Makefile line number, so a 502 on the study API read exactly like a
+# dead frontend — you had to open the Makefile to tell which of the three had
+# failed.
 demo-smoke:
-	@curl -fsS http://localhost:3000/ >/dev/null
-	@curl -fsS http://localhost:3000/health >/dev/null
-	@curl -fsS http://localhost:3000/api/study/bioeconomy-futures >/dev/null
-	@printf '\nQualis demo is ready: http://localhost:3000/login\nLogin: admin@example.com / admin123\n\n'
+	@$(call probe,the frontend,http://localhost:3000/,Is the stack up? Run: make demo-up)
+	@$(call probe,the backend health endpoint,http://localhost:3000/health,The frontend answered but the backend did not. Check: docker compose logs backend)
+	@$(call probe,the demo study API,http://localhost:3000/api/study/bioeconomy-futures,The app is running but the demo data is missing. Run: make demo-seed)
+	@$(call say,Everything checks out — your demo is ready.,Open http://localhost:3000/login   ·   admin@example.com / admin123)
+	@$(TTYCOL); printf '  %sFirst stop: open "Bioeconomy Futures" then Analysis and click\n' "$$D"; printf '  "Commit and interpret" — 18 Q-sorts are waiting for you.%s\n\n' "$$R"
 
 demo-down:
 	docker compose down
@@ -125,8 +148,14 @@ migration-new:
 	@read -p "Enter migration name: " name; \
 	cd backend && uv run alembic revision --autogenerate -m "$$name"
 
+# ENVIRONMENT=production, and not by accident: main.py mounts the /api/test/*
+# router whenever ENVIRONMENT is "test" or "development", and the README tells
+# you to set development locally. Generating from that spec silently adds seven
+# test-only endpoints — cleanup-all among them — to the client the app ships.
+# Passed as a command-line variable so it beats the `-include .env` at the top
+# of this file, which would otherwise win over a plain environment variable.
 generate-api:
-	cd backend && uv run python ../export_openapi.py
+	cd backend && ENVIRONMENT=production uv run python ../export_openapi.py
 	cd frontend && npm run generate:api
 
 check-api: generate-api

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ make demo-up
 ```
 
 **Expected result:** after the images are built and the services become healthy,
-the command ends with `Qualis services are running` and tells you what to run
-next. The first build can take several minutes; later starts reuse the images.
+the command ends with `Your Qualis stack is up and healthy.` and tells you what to
+run next. The first build can take several minutes; later starts reuse the images.
 
 Load the guided example:
 
@@ -171,9 +171,9 @@ Load the guided example:
 make demo-seed
 ```
 
-**Expected result:** the final lines say that the Bioeconomy Futures demo data
-is ready and point you to the smoke test. This step reuses the Python environment
-already built into the backend image and does not install development tools.
+**Expected result:** the final lines read `The demo data is in place.` and point
+you to the smoke test. This step reuses the Python environment already built into
+the backend image and does not install development tools.
 
 Verify the complete path:
 
@@ -181,9 +181,11 @@ Verify the complete path:
 make demo-smoke
 ```
 
-**Expected result:** `Qualis demo is ready`, followed by the login URL and demo
-credentials. If any check fails, `curl` prints an error and Make stops without
-printing the success message.
+**Expected result:** each check is named as it passes, then
+`Everything checks out — your demo is ready.` followed by the login URL and demo
+credentials. If a check fails it says which one and what to do about it — a
+stopped backend reports `checking the backend health endpoint    failed` and
+points you at `docker compose logs backend`.
 
 Open [http://localhost:3000/login](http://localhost:3000/login) and log in with:
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,11 @@ psql -U postgres
 # In psql:
 CREATE USER qualis_user WITH PASSWORD 'qualis_pass';
 CREATE DATABASE qualis_dev OWNER qualis_user;
--- The test suite needs its own database; `make test` resets it between runs.
+-- The test suite does not reuse one database: it creates a throwaway
+-- `<name>_<worker>_<pid>` per pytest process so parallel workers never share
+-- storage, and drops it afterwards. That needs CREATEDB, without which
+-- `make test` stops at "permission denied to create database".
+ALTER ROLE qualis_user CREATEDB;
 CREATE DATABASE qualis_test OWNER qualis_user;
 \q
 
@@ -295,7 +299,8 @@ connects — run it on its own any time.
 | `WARN .env has no SECRET_KEY` / `IP_HASH_SALT`, or `still holds a CHANGEME placeholder` | Generate each with `python3 -c 'import secrets; print(secrets.token_urlsafe(48))'`. |
 | `WARN DATABASE_URL does not connect` | Run `make db-check` for the real error — `preflight` hides it so no password reaches a build log. `role "…" does not exist` means step 2 was skipped; `password authentication failed` means the role exists with a different password; `could not connect` means PostgreSQL is not running. |
 | `make migrate` → `password authentication failed` | Same cause. `make db-check` confirms it in one line. |
-| `make test` → hundreds of `asyncpg … InvalidPasswordError` | `TEST_DATABASE_URL`, not `DATABASE_URL`. Step 2 creates `qualis_test` as a second database; the test suite resets it between runs. |
+| `make test` → hundreds of `asyncpg … InvalidPasswordError` | `TEST_DATABASE_URL`, not `DATABASE_URL`. Step 2 creates `qualis_test` as a second database; the test suite derives its own throwaway database from that name. |
+| `make test` → `InsufficientPrivilegeError: permission denied to create database` | The role is missing `CREATEDB`. Each pytest process creates and drops its own `<name>_<worker>_<pid>` database. Fix with `ALTER ROLE qualis_user CREATEDB;` as a superuser. |
 | E2E fails on `The test router is not mounted` | `ENVIRONMENT` is missing or set to `production`. `TESTING=true` does **not** substitute — that variable only disables rate limiting. |
 | A spec fails locally but passes in CI | CI retries twice (`retries: process.env.CI ? 2 : 0`), so it absorbs flakes that a local run surfaces on the first attempt. Re-run the spec alone before assuming a regression. |
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,6 +12,18 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Qualis API"
     ENVIRONMENT: str = "production"
 
+    # Opt-in, and only ever for the throwaway `docker-compose.yml` demo stack.
+    # When true, GET /api/config reports demo_mode and the sign-in page offers
+    # to fill the published demo account for you, so nobody has to go hunting
+    # back through their terminal for credentials the README already prints.
+    #
+    # Two independent gates, because the failure mode here is advertising a
+    # real account: this flag is opt-in and defaults off, AND `is_demo_mode`
+    # refuses to report it whenever ENVIRONMENT is "production". No credential
+    # is ever served by the API — the sign-in page carries the published demo
+    # constants itself, so a misconfigured instance can leak nothing.
+    DEMO_MODE: bool = False
+
     # Security
     SECRET_KEY: str = "CHANGEME-insecure-dev-only"
     ALGORITHM: str = "HS256"
@@ -196,6 +208,20 @@ class Settings(BaseSettings):
         - SMTP is configured (otherwise users could never receive the link).
         """
         return self.EMAIL_VERIFICATION_REQUIRED and self.is_smtp_configured
+
+    @property
+    def is_demo_mode(self) -> bool:
+        """True only for the throwaway compose demo stack.
+
+        The second of DEMO_MODE's two gates, and the reason the flag alone is
+        not enough: a production deployment that inherits DEMO_MODE=true — from
+        a copied .env, a stale compose override, an image built for evaluation
+        and then promoted — must not start telling visitors there is a demo
+        account to try. ENVIRONMENT is the one setting a production operator
+        always sets deliberately, so it wins over the flag rather than the
+        other way round.
+        """
+        return self.DEMO_MODE and self.ENVIRONMENT != "production"
 
 
 settings = Settings()

--- a/backend/app/routers/config.py
+++ b/backend/app/routers/config.py
@@ -16,4 +16,5 @@ async def get_public_config() -> PublicConfig:
     return PublicConfig(
         email_delivery="smtp" if settings.is_smtp_configured else "manual",
         audio_storage=("available" if settings.is_s3_configured else "unavailable"),
+        demo_mode=settings.is_demo_mode,
     )

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -15,7 +15,14 @@ class PublicConfig(BaseModel):
     configured and "unavailable" otherwise. When "unavailable", the
     participant audio UI is suppressed and audio-enabled studies degrade to
     text-only (see docs/guides/running-without-s3.md).
+
+    ``demo_mode`` is True only for the throwaway compose demo stack, and lets
+    the sign-in page offer to fill the published demo account. It is a boolean
+    and nothing more: no credential crosses this endpoint, so an instance that
+    reports it wrongly still discloses nothing. See ``Settings.is_demo_mode``
+    for the two gates that produce it.
     """
 
     email_delivery: Literal["smtp", "manual"]
     audio_storage: Literal["available", "unavailable"]
+    demo_mode: bool = False

--- a/backend/tests/integration/test_demo_mode.py
+++ b/backend/tests/integration/test_demo_mode.py
@@ -1,0 +1,49 @@
+"""Demo mode: the capability flag, and the gate that keeps it off in production.
+
+The failure that matters here is not a missing banner. It is a real deployment
+telling every visitor there is a demo account to try — so most of these assert
+the *absence* of the flag.
+"""
+
+import pytest
+
+from app.core.config import settings
+
+
+@pytest.mark.asyncio
+class TestPublicConfigDemoMode:
+    async def test_defaults_to_false(self, client):
+        """Nobody has to opt out. An instance that never heard of DEMO_MODE
+        must report False."""
+        r = await client.get("/api/config")
+        assert r.status_code == 200
+        assert r.json()["demo_mode"] is False
+
+    async def test_reports_true_for_the_compose_demo_stack(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "DEMO_MODE", True)
+        monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+        r = await client.get("/api/config")
+        assert r.json()["demo_mode"] is True
+
+    async def test_production_overrides_the_flag(self, client, monkeypatch):
+        """The second gate. A production deployment that inherits DEMO_MODE=true
+        — copied .env, stale compose override, an evaluation image promoted to
+        real use — must not advertise a demo account. ENVIRONMENT wins."""
+        monkeypatch.setattr(settings, "DEMO_MODE", True)
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+        r = await client.get("/api/config")
+        assert r.json()["demo_mode"] is False
+
+    async def test_never_returns_a_credential(self, client, monkeypatch):
+        """The endpoint is unauthenticated. Even in demo mode its whole payload
+        must stay capability flags — the sign-in page carries the published demo
+        constants itself precisely so this response cannot leak anything."""
+        monkeypatch.setattr(settings, "DEMO_MODE", True)
+        monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+        body = await client.get("/api/config")
+        payload = body.json()
+
+        assert set(payload) == {"email_delivery", "audio_storage", "demo_mode"}
+        serialised = body.text.lower()
+        for secret in ("password", "admin123", "secret", "token"):
+            assert secret not in serialised

--- a/backend/vulture_whitelist.py
+++ b/backend/vulture_whitelist.py
@@ -409,6 +409,11 @@ email_delivery
 audio_storage
 require_audio_storage
 
+# --- Demo mode (docker-compose.yml quick start) ---
+# Same shape as the two above: a PublicConfig field vulture only ever sees
+# assigned, because it is read across the JSON wire by the sign-in page.
+demo_mode
+
 # --- app/schemas/recruitment.py (#24: public-link capacity validator) ---
 # Pydantic @model_validator invoked by the framework, not called directly.
 reject_capacity_on_public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,11 @@ services:
       IP_HASH_SALT: docker-dev-salt-change-in-production
       FRONTEND_URL: http://localhost:3000
       ENVIRONMENT: development
+      # Only ever here. This stack is disposable and its credentials are
+      # published in the README, so the sign-in page may offer to fill them.
+      # docker-compose.production.yml must never set this — and even if it
+      # somehow did, ENVIRONMENT=production overrides it (Settings.is_demo_mode).
+      DEMO_MODE: "true"
       ADMIN_EMAIL: admin@example.com
       ADMIN_PASSWORD: admin123
       # Audio storage (MinIO). Backend uploads via the internal endpoint;

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -10702,6 +10702,11 @@
               "unavailable"
             ],
             "title": "Audio Storage"
+          },
+          "demo_mode": {
+            "type": "boolean",
+            "title": "Demo Mode",
+            "default": false
           }
         },
         "type": "object",
@@ -10710,7 +10715,7 @@
           "audio_storage"
         ],
         "title": "PublicConfig",
-        "description": "Minimal client bootstrap payload.\n\n``email_delivery`` is \"smtp\" when SMTP credentials are configured and\n\"manual\" otherwise (see docs/guides/running-without-smtp.md).\n\n``audio_storage`` is \"available\" when S3/object-storage credentials are\nconfigured and \"unavailable\" otherwise. When \"unavailable\", the\nparticipant audio UI is suppressed and audio-enabled studies degrade to\ntext-only (see docs/guides/running-without-s3.md)."
+        "description": "Minimal client bootstrap payload.\n\n``email_delivery`` is \"smtp\" when SMTP credentials are configured and\n\"manual\" otherwise (see docs/guides/running-without-smtp.md).\n\n``audio_storage`` is \"available\" when S3/object-storage credentials are\nconfigured and \"unavailable\" otherwise. When \"unavailable\", the\nparticipant audio UI is suppressed and audio-enabled studies degrade to\ntext-only (see docs/guides/running-without-s3.md).\n\n``demo_mode`` is True only for the throwaway compose demo stack, and lets\nthe sign-in page offer to fill the published demo account. It is a boolean\nand nothing more: no credential crosses this endpoint, so an instance that\nreports it wrongly still discloses nothing. See ``Settings.is_demo_mode``\nfor the two gates that produce it."
       },
       "QSortEntryInput": {
         "properties": {

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -20,7 +20,13 @@
             "two_factor_submit": "Verify",
             "two_factor_invalid": "Invalid code. Try again.",
             "lost_2fa_link": "Lost access to your 2FA?",
-            "back_to_home": "Back to home"
+            "back_to_home": "Back to home",
+            "demo": {
+                "title": "Welcome — this is the Qualis demo",
+                "body": "Everything here is sample data, so explore freely — nothing you do can break anything.",
+                "fill": "Fill in the demo account for me",
+                "credentials": "{{email}} · password {{password}}"
+            }
         },
         "twofa": {
             "recovery": {

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -20270,6 +20270,7 @@ export const getGetPublicConfigApiConfigGetResponseMock = (
 ): PublicConfig => ({
     email_delivery: faker.helpers.arrayElement(['smtp', 'manual'] as const),
     audio_storage: faker.helpers.arrayElement(['available', 'unavailable'] as const),
+    demo_mode: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
     ...overrideResponse,
 });
 

--- a/frontend/src/api/model/publicConfig.ts
+++ b/frontend/src/api/model/publicConfig.ts
@@ -17,8 +17,15 @@ import type { PublicConfigAudioStorage } from './publicConfigAudioStorage';
 configured and "unavailable" otherwise. When "unavailable", the
 participant audio UI is suppressed and audio-enabled studies degrade to
 text-only (see docs/guides/running-without-s3.md).
+
+``demo_mode`` is True only for the throwaway compose demo stack, and lets
+the sign-in page offer to fill the published demo account. It is a boolean
+and nothing more: no credential crosses this endpoint, so an instance that
+reports it wrongly still discloses nothing. See ``Settings.is_demo_mode``
+for the two gates that produce it.
  */
 export interface PublicConfig {
     email_delivery: PublicConfigEmailDelivery;
     audio_storage: PublicConfigAudioStorage;
+    demo_mode?: boolean;
 }

--- a/frontend/src/components/auth/DemoAccountCard.test.tsx
+++ b/frontend/src/components/auth/DemoAccountCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DemoAccountCard } from './DemoAccountCard';
+import { usePlatformConfigStore } from '@/store/usePlatformConfigStore';
+
+describe('DemoAccountCard', () => {
+    beforeEach(() => {
+        usePlatformConfigStore.setState({ isDemo: false });
+    });
+
+    it('renders nothing when the instance is not a demo', () => {
+        const { container } = render(<DemoAccountCard onFill={vi.fn()} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    /**
+     * The defect this guards is not "the card is missing" — it is the card
+     * appearing on a real deployment and advertising an account to try. The
+     * store defaults to false and only an explicit `demo_mode: true` from
+     * /api/config flips it, so this asserts the default rather than trusting it.
+     */
+    it('stays hidden on the store default, without anything having to set it', () => {
+        usePlatformConfigStore.setState(usePlatformConfigStore.getInitialState());
+        const { container } = render(<DemoAccountCard onFill={vi.fn()} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('welcomes the visitor when the instance is a demo', () => {
+        usePlatformConfigStore.setState({ isDemo: true });
+        render(<DemoAccountCard onFill={vi.fn()} />);
+        expect(screen.getByText(/this is the Qualis demo/i)).toBeInTheDocument();
+        expect(screen.getByText(/nothing you do can break anything/i)).toBeInTheDocument();
+    });
+
+    it('hands the published demo credentials to its caller', async () => {
+        const user = userEvent.setup();
+        const onFill = vi.fn();
+        usePlatformConfigStore.setState({ isDemo: true });
+        render(<DemoAccountCard onFill={onFill} />);
+
+        await user.click(screen.getByRole('button', { name: /fill in the demo account/i }));
+
+        // Must match docker-compose.yml's ADMIN_EMAIL / ADMIN_PASSWORD and the
+        // README quick-start table. If those change, this fails — which is the
+        // point: the card would otherwise silently offer a dead account.
+        expect(onFill).toHaveBeenCalledWith('admin@example.com', 'admin123');
+    });
+
+    it('shows the credentials as well as filling them', () => {
+        usePlatformConfigStore.setState({ isDemo: true });
+        render(<DemoAccountCard onFill={vi.fn()} />);
+        // A visitor should be able to read what is about to be typed for them,
+        // and to type it themselves instead.
+        expect(screen.getByText(/admin@example\.com/)).toBeInTheDocument();
+        expect(screen.getByText(/admin123/)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/auth/DemoAccountCard.tsx
+++ b/frontend/src/components/auth/DemoAccountCard.tsx
@@ -1,0 +1,70 @@
+import { Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { usePlatformConfigStore } from '@/store/usePlatformConfigStore';
+
+/**
+ * The published credentials of the throwaway `docker-compose.yml` demo stack.
+ *
+ * They live here, in the client bundle, and deliberately NOT in the API
+ * response. `GET /api/config` returns a boolean and nothing else, so an
+ * instance that reports `demo_mode` by mistake still discloses nothing — the
+ * worst case is this card offering an account that does not exist, which is a
+ * cosmetic bug rather than a credential leak. The values match
+ * `docker-compose.yml` and the README's quick-start table; an operator who
+ * changes `ADMIN_PASSWORD` there will see the fill fail, and the card says
+ * where the values come from so that is diagnosable.
+ */
+const DEMO_EMAIL = 'admin@example.com';
+const DEMO_PASSWORD = 'admin123';
+
+interface DemoAccountCardProps {
+    onFill: (email: string, password: string) => void;
+}
+
+/**
+ * Shown only on the demo stack. Someone evaluating Qualis has just been told
+ * these credentials by `make demo-smoke`, in a terminal they have very likely
+ * scrolled past or closed — this is the one moment in the whole quick start
+ * where they would have to go and look something up again.
+ */
+export function DemoAccountCard({ onFill }: DemoAccountCardProps) {
+    const { t } = useTranslation();
+    const isDemo = usePlatformConfigStore((s) => s.isDemo);
+
+    if (!isDemo) {
+        return null;
+    }
+
+    return (
+        <div className="px-6 pb-4">
+            <div className="rounded-lg border border-indigo-200 bg-indigo-50/70 px-4 py-3">
+                <p className="flex items-center gap-2 text-sm font-semibold text-indigo-900">
+                    <Sparkles className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                    {t('auth.login.demo.title', 'Welcome — this is the Qualis demo')}
+                </p>
+                <p className="mt-1 text-sm text-indigo-900/80">
+                    {t(
+                        'auth.login.demo.body',
+                        'Everything here is sample data, so explore freely — nothing you do can break anything.'
+                    )}
+                </p>
+                <button
+                    type="button"
+                    onClick={() => onFill(DEMO_EMAIL, DEMO_PASSWORD)}
+                    className="mt-2 rounded-md text-sm font-semibold text-indigo-700 underline underline-offset-2 hover:text-indigo-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+                >
+                    {t('auth.login.demo.fill', 'Fill in the demo account for me')}
+                </button>
+                {/* The credentials stay visible rather than only being filled:
+                    a reader should be able to see what is about to be typed on
+                    their behalf, and be able to type it themselves. */}
+                <p className="mt-1 text-xs text-indigo-900/70">
+                    {t('auth.login.demo.credentials', '{{email}} · password {{password}}', {
+                        email: DEMO_EMAIL,
+                        password: DEMO_PASSWORD,
+                    })}
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/hooks/usePlatformConfigBootstrap.ts
+++ b/frontend/src/hooks/usePlatformConfigBootstrap.ts
@@ -12,6 +12,7 @@ export function usePlatformConfigBootstrap(): void {
     const { data } = useGetPublicConfigApiConfigGet();
     const setEmailDelivery = usePlatformConfigStore((s) => s.setEmailDelivery);
     const setAudioStorage = usePlatformConfigStore((s) => s.setAudioStorage);
+    const setIsDemo = usePlatformConfigStore((s) => s.setIsDemo);
 
     useEffect(() => {
         if (data?.email_delivery) {
@@ -20,5 +21,8 @@ export function usePlatformConfigBootstrap(): void {
         if (data?.audio_storage) {
             setAudioStorage(data.audio_storage);
         }
-    }, [data, setEmailDelivery, setAudioStorage]);
+        // Explicit === true, not truthiness: the field is optional in the
+        // generated client, and only a real `true` may turn the banner on.
+        setIsDemo(data?.demo_mode === true);
+    }, [data, setEmailDelivery, setAudioStorage, setIsDemo]);
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 import { Loader2, Lock, AtSign, ArrowRight, ShieldCheck, Info, ArrowLeft } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import { DemoAccountCard } from '@/components/auth/DemoAccountCard';
 import { parseApiErrorSync } from '@/lib/error-utils';
 import { ApiError } from '@/api/client';
 
@@ -189,6 +190,12 @@ const LoginPage = () => {
                                     {t('auth.login.card_title')}
                                 </h1>
                             </CardHeader>
+                            <DemoAccountCard
+                                onFill={(demoEmail, demoPassword) => {
+                                    setEmail(demoEmail);
+                                    setPassword(demoPassword);
+                                }}
+                            />
                             {resetSuccess && (
                                 <div className="px-6 pb-2">
                                     <div

--- a/frontend/src/store/usePlatformConfigStore.ts
+++ b/frontend/src/store/usePlatformConfigStore.ts
@@ -8,8 +8,10 @@ type AudioStorage = PublicConfigAudioStorage;
 interface PlatformConfigState {
     emailDelivery: EmailDelivery | null;
     audioStorage: AudioStorage | null;
+    isDemo: boolean;
     setEmailDelivery: (mode: EmailDelivery) => void;
     setAudioStorage: (mode: AudioStorage) => void;
+    setIsDemo: (isDemo: boolean) => void;
     isEmailManual: () => boolean;
     isAudioStorageAvailable: () => boolean;
 }
@@ -17,8 +19,13 @@ interface PlatformConfigState {
 export const usePlatformConfigStore = create<PlatformConfigState>((set, get) => ({
     emailDelivery: null,
     audioStorage: null,
+    // Opposite default to audioStorage below: absent or unreadable config means
+    // "not a demo". Showing a demo banner on an instance that never asked for
+    // one is the failure that matters here, so it takes an explicit true.
+    isDemo: false,
     setEmailDelivery: (mode) => set({ emailDelivery: mode }),
     setAudioStorage: (mode) => set({ audioStorage: mode }),
+    setIsDemo: (isDemo) => set({ isDemo }),
     isEmailManual: () => get().emailDelivery === 'manual',
     // null = not yet loaded: default to available so a transient /api/config
     // failure never suppresses audio on a correctly-configured instance.

--- a/openapi.json
+++ b/openapi.json
@@ -10702,6 +10702,11 @@
               "unavailable"
             ],
             "title": "Audio Storage"
+          },
+          "demo_mode": {
+            "type": "boolean",
+            "title": "Demo Mode",
+            "default": false
           }
         },
         "type": "object",
@@ -10710,7 +10715,7 @@
           "audio_storage"
         ],
         "title": "PublicConfig",
-        "description": "Minimal client bootstrap payload.\n\n``email_delivery`` is \"smtp\" when SMTP credentials are configured and\n\"manual\" otherwise (see docs/guides/running-without-smtp.md).\n\n``audio_storage`` is \"available\" when S3/object-storage credentials are\nconfigured and \"unavailable\" otherwise. When \"unavailable\", the\nparticipant audio UI is suppressed and audio-enabled studies degrade to\ntext-only (see docs/guides/running-without-s3.md)."
+        "description": "Minimal client bootstrap payload.\n\n``email_delivery`` is \"smtp\" when SMTP credentials are configured and\n\"manual\" otherwise (see docs/guides/running-without-smtp.md).\n\n``audio_storage`` is \"available\" when S3/object-storage credentials are\nconfigured and \"unavailable\" otherwise. When \"unavailable\", the\nparticipant audio UI is suppressed and audio-enabled studies degrade to\ntext-only (see docs/guides/running-without-s3.md).\n\n``demo_mode`` is True only for the throwaway compose demo stack, and lets\nthe sign-in page offer to fill the published demo account. It is a boolean\nand nothing more: no credential crosses this endpoint, so an instance that\nreports it wrongly still discloses nothing. See ``Settings.is_demo_mode``\nfor the two gates that produce it."
       },
       "QSortEntryInput": {
         "properties": {

--- a/scripts/check_installation_docs.py
+++ b/scripts/check_installation_docs.py
@@ -10,6 +10,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+# The exact lines the demo path prints on success. Changing one means changing
+# the README paragraph that quotes it; the check below enforces that pairing.
+DEMO_SUCCESS_MESSAGES = (
+    "Your Qualis stack is up and healthy.",
+    "The demo data is in place.",
+    "Everything checks out — your demo is ready.",
+)
+
+
 def _read(path: str) -> str:
     return (ROOT / path).read_text(encoding="utf-8")
 
@@ -116,13 +125,19 @@ def check_demo_make_targets() -> list[str]:
                 f"Makefile lets uv re-sync development dependencies for {script}"
             )
 
-    for message in (
-        "Qualis services are running.",
-        "Demo data is ready.",
-        "Qualis demo is ready:",
-    ):
+    # The README quotes these back to the reader as "Expected result", so the
+    # two must not drift. Pinning them in the Makefile alone let a reword make
+    # the README describe output the demo no longer prints — which is how this
+    # check first failed.
+    readme = _read("README.md")
+    for message in DEMO_SUCCESS_MESSAGES:
         if message not in makefile:
             errors.append(f"Makefile demo path is missing success feedback {message!r}")
+        if message not in readme:
+            errors.append(
+                f"README does not quote the demo success message {message!r} — "
+                "its 'Expected result' text and the Makefile have drifted"
+            )
     return errors
 
 


### PR DESCRIPTION
Three things a newcomer meets before they meet the product, measured by running the whole Docker quick start end to end.

## 1. The two lines that mattered were invisible

`make demo-up` ends with the only two lines a human needs — and they were typographically identical to the several hundred BuildKit lines above them. They are now set apart and say where to go next.

Colour only when stdout is a terminal and `NO_COLOR` is unset ([no-color.org](https://no-color.org)). Verified: `make demo-smoke | cat -v` contains **zero** escape codes.

## 2. `demo-smoke` did not say which check failed

Three bare `curl`s. Any failure printed the same shape of error plus a Makefile line number, so a 502 from the study API read exactly like a dead frontend — you had to open the Makefile to tell them apart.

Verified by stopping the backend container:

```
  checking the frontend                   ok
  checking the backend health endpoint    failed

  Could not reach http://localhost:3000/health
  The frontend answered but the backend did not. Check: docker compose logs backend
```

## 3. The sign-in page said nothing about the demo

The credentials existed in exactly one place: a terminal line the visitor has by then very likely scrolled past or closed. On a path the README itself calls "recommended for evaluation and first-time use", that was the single moment requiring them to go and look something up again.

It now welcomes them, says the data is disposable so they can explore without fear, shows the account, and offers to fill it in.

### Two independent gates, because this is the part that could hurt

The failure that matters is a real deployment advertising an account to try.

- `DEMO_MODE` is **opt-in**, defaults off, and is set only in `docker-compose.yml` — never in `docker-compose.production.yml`.
- `is_demo_mode` then **refuses** to report it whenever `ENVIRONMENT` is `production`, because that is the one setting a production operator always sets deliberately. A copied `.env`, a stale compose override, or an evaluation image promoted to real use cannot switch it on.

**No credential crosses the API.** `GET /api/config` returns a boolean; the sign-in page carries the published demo constants itself. An instance that reports the flag wrongly offers a dead account — a cosmetic bug, not a leak. A test asserts the payload never contains `password`, `admin123`, `secret` or `token`.

The frontend default is deliberately the opposite of its neighbour `audioStorage`: absent or unreadable config means *not* a demo, and only an explicit `demo_mode === true` turns the banner on.

## Two defects found while verifying, both the same kind as the rest

**README step 2 could not run the test suite.** `conftest.py:86` creates a throwaway `<name>_<worker>_<pid>` database per pytest process so parallel workers never share storage — which needs `CREATEDB`, and step 2 never granted it. Following the documentation exactly, `make test` stopped at `InsufficientPrivilegeError: permission denied to create database`. Granted in the documented steps, and added to the troubleshooting table.

With it, **`make ci-fast` passes on this machine for the first time**: 340 backend tests and 1845 frontend tests. The "~340 asyncpg InvalidPasswordError" that has been the known local failure all along is the same 340 tests, now green.

**`make generate-api` silently depended on `.env`.** `main.py` mounts `/api/test/*` when `ENVIRONMENT` is `test` or `development` — which the README tells you to set locally — so generating from that spec added **seven test-only endpoints, `cleanup-all` among them**, to the client the app ships. Caught here before commit; the target now pins `ENVIRONMENT=production` itself, passed as a command-line variable so it beats the `-include .env` at the top of the Makefile.

## Verified by running each path, not by reading it

| check | result |
|---|---|
| named probe vs a stopped container | names the right check, gives the fix |
| `GET /api/config` on the real stack | `"demo_mode":true` |
| double gate, both directions | `development`→true, `production`→**false** |
| click-to-fill in the real compose stack | filled → signed in → `/app/example-project/dashboard` |
| `make demo-smoke \| cat -v` | no escape codes |
| `make ci-fast` | 340 backend + 1845 frontend, green |

9 new tests (4 backend, 5 frontend). `i18n-check`, `check-interpolations` and `check-orphan-keys` all clean — the four new keys are in `en/admin.json` with values matching their fallbacks verbatim. Stray `backend/uv.lock` bump reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)