### PR TITLE
fix(compose): make the database probe actually prove the app can connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,25 @@ Stop the stack with:
 make demo-down
 ```
 
+This keeps your data. `make demo-down` removes the containers and the network but
+leaves the `qualis_pgdata` and `qualis_miniodata` volumes in place, so the next
+`make demo-up` comes back to the same database — which is why re-running
+`make demo-seed` reports that the study and its 18 Q-sorts already exist and skips
+them.
+
+To start over from an empty database instead — **this deletes the demo data and
+any study you built on top of it**:
+
+```bash
+docker compose down -v
+```
+
+One thing worth knowing if you edit `docker-compose.yml`: the postgres image runs
+`initdb` only on an empty data directory, so changing `POSTGRES_USER` or
+`POSTGRES_PASSWORD` against an existing volume is **silently ignored** — the old
+role stays, and the app then fails to connect. `docker compose down -v` first if
+you change either.
+
 ### Local development setup
 
 Use this path when you want hot reload, local tests, or direct backend/frontend development.

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -18,7 +18,11 @@ services:
       # /var/lib/postgresql/data and is NOT readable through this mount.
       - qualis-pgdata:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U qualis -d qualis"]
+      # A real connection as the app's own role, not `pg_isready` — see the
+      # note in docker-compose.yml: `pg_isready` returns 0 for a role that does
+      # not exist, so it cannot tell a healthy database from one the app has no
+      # account on.
+      test: ["CMD-SHELL", "psql -U $${POSTGRES_USER} -d $${POSTGRES_DB} -c 'select 1' >/dev/null"]
       interval: 5s
       timeout: 3s
       retries: 12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,19 @@ services:
       # would vanish on `docker compose down` — silently, with no error.
       - pgdata:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U qualis"]
+      # `psql`, not `pg_isready`, and the difference is the whole point:
+      # `pg_isready` only asks whether the server accepts connections. It
+      # returns 0 for a role that does not exist — measured against this very
+      # volume, with a deliberately bogus role. So the old probe could not see
+      # the one misconfiguration it most needed to: POSTGRES_USER is silently
+      # ignored against an already-populated pgdata volume (the image runs
+      # initdb only on an empty data directory), leaving Compose reporting
+      # "Healthy" while the backend failed on `role does not exist`.
+      #
+      # A real connection as the app's own role distinguishes them: exit 0
+      # when it works, exit 2 when the role is absent. $$ escapes Compose
+      # interpolation so the container shell expands it.
+      test: ["CMD-SHELL", "psql -U $${POSTGRES_USER} -d $${POSTGRES_DB} -c 'select 1' >/dev/null"]
       interval: 5s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## The probe could not see the failure it existed for

The db healthcheck ran `pg_isready -U qualis`. Two defects, and the second is the one that matters.

**The role was hardcoded** — it tested a name the configuration no longer had to be asking for.

**But reading `POSTGRES_USER` instead fixes nothing.** `pg_isready` only asks whether the server *accepts connections*. Measured directly against this volume with a deliberately bogus role:

```
$ pg_isready -U role_totalement_bidon
/var/run/postgresql:5432 - accepting connections     exit 0
```

I shipped that intermediate version before measuring it, and it was inert — the comment it carried asserted a cause that was false. Corrected here rather than left in history looking right.

## What actually distinguishes them

A real connection as the app's own role:

| role | `psql -U … -c 'select 1'` |
|---|---|
| valid | exit **0** |
| absent | exit **2**, `FATAL: role "…" does not exist` |

## Why this matters beyond tidiness

Setting `POSTGRES_USER` against an **already-populated** `pgdata` volume is **silently ignored** — the postgres image runs `initdb` only on an empty data directory. So the old probe reported **Healthy** on a database the backend could not log into at all, and the failure surfaced later as `role does not exist`, pointing anywhere but at the compose change.

Verified in both directions against the real stack:

| config | before | after |
|---|---|---|
| unchanged | Healthy | Healthy |
| `POSTGRES_USER` changed on existing volume | **Healthy** | **unhealthy**, exit 2, names the missing role |

## Also: what `make demo-down` does and does not remove

It keeps `qualis_pgdata` and `qualis_miniodata` — which is why re-running `make demo-seed` reports the study and its 18 Q-sorts already exist and skips them. Documented, along with `docker compose down -v` for a genuine reset, and the `initdb` trap above so nobody changes `POSTGRES_USER` expecting it to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
