### PR TITLE
docs(readme): lead with how to run Qualis, not with why it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,129 +17,11 @@ Design studies, collect Q-sorts, and run factor analysis in the browser. Partici
 
 ---
 
-## Statement of need
+## Quick start (Docker)
 
-Q-methodology, introduced by Stephenson (1953) as a way of studying subjectivity through rank-ordered statements, is used across the social sciences and in applied fields including health, sustainability, education, and public policy. A growing share of recent work extends a reflexive tradition that foregrounds transparency of analytical choices, reflexivity, and the integration of participant voice into interpretation (Stainton Rogers 1997; Stenner 2011; Watts & Stenner 2012; Sneegas 2020).
+**This is how you run Qualis.** Three commands bring up PostgreSQL, the backend, and the built frontend, with a worked example study already loaded — no configuration file to write first. Use it to evaluate Qualis, to run a pilot, or as the basis of a self-hosted deployment (see [Deployment](docs/guides/deployment.md) for production settings).
 
-The studies this orientation invites tend to share a few practical needs:
-
-- running in several languages;
-- reaching participants across phones and computers;
-- building and reusing the pool of candidate statements over time, with the curatorial trail kept visible;
-- tracking how recruitment is unfolding without leaving the platform;
-- keeping what participants say about their sort attached to the analysis;
-- making the analytical choices open to discussion and revision by a research team.
-
-The open-source and freely available tools most Q researchers reach for each cover part of this workflow well — browser-based collection, desktop factor analysis, format conversion — but sit in separate systems: design, collection, analysis, interpretation, privacy operations, and export end up scattered across tools, and the research record has to be reassembled at each import and export boundary, where the audit trail can weaken. A few hosted commercial platforms (Q Method Software / Qsortware, and the now-discontinued Q-Assessor) do integrate collection and analysis in one place, but they are closed-source and vendor-hosted: the data leaves the institution's control, the analytical internals cannot be inspected, and — as Q-Assessor's 2024 shutdown shows — a study's tooling can disappear with the vendor.
-
-Qualis's central design claim is **continuity**: statements, translations, recruitment links, Q-sorts, participant responses, analytical memos, consent and withdrawal events, and export files stay linked as research objects in one self-hosted project, rather than moving between separate tools. The platform implements this through a project-scoped concourse where candidate statements are curated, versioned, and reused across studies; visual study design with sorting grids and post-sort surveys; mobile-first recruitment and data collection with funnel monitoring; built-in factor analysis; collaborative interpretation; and export to PQMethod, R, and Ken-Q formats. Researchers can use Qualis as a data-collection frontend feeding their preferred analysis tool, or as a complete platform — the export bridges to established Q-analytic tools stay open either way. What sets Qualis apart from the integrated commercial platforms is that this continuity is open-source and self-hostable, keeping data and analytical choices under the researcher's control, and that it adds reflexive-workflow affordances — audio post-sorts, shared analytical memos, and a versioned reusable concourse with item-level discussion — that none of the other Q tools surveyed here, open or commercial, provide.
-
-The choices behind each analytical step are visible and adjustable. Multiple researchers can work on the same project, with collaborative memos for analytical reflexivity, optional audio post-sorts that travel with the analysis, and a voices panel that keeps participant material adjacent to factor interpretation.
-
-Data ownership stays with the researcher, and Qualis can run on institutional infrastructure to support the GDPR-aware consent, withdrawal, and data-residency practices common in European Q research. These are technical safeguards and operational paths; compliance remains a matter for each institution's own ethics and legal process.
-
----
-
-## Comparison with existing tools
-
-| Capability | HTMLQ | Quince (Banasick) | PQMethod | Ken-Q Analysis | KADE (Banasick 2019) | qmethod (R, Zabala 2014) | Q-Assessor\* | Qsortware\* | Qualis |
-| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| Browser-based data collection | Yes | Yes | No | No | No | No | Yes | Yes | **Yes** |
-| Documented mobile & tablet support | Tablet | Yes | No | — | No | N/A | — | Yes | **Yes** |
-| Built-in factor analysis | No | No | Yes | Yes | Yes | Yes | Yes | Yes | **Yes** |
-| Participant-facing multi-language studies | No | No | No | No | No | N/A | — | — | **Yes** |
-| Audio post-sort responses | No | No | No | No | No | No | — | — | **Yes** |
-| Shared memos | No | No | No | No | No | No | — | — | **Yes** |
-| Reusable concourse with versioning and item-level discussion | No | No | No | No | No | No | — | — | **Yes** |
-| Recruitment tracking & funnels | No | No | No | No | No | No | Enrollment | — | **Yes** |
-| Team collaboration (roles) | No | No | No | No | No | No | — | — | **Yes** |
-| Interop with PQMethod / R / Ken-Q formats | CSV out | KADE / PQMethod | Native | Imports PQMethod | Imports CSV/PQMethod | Yes (import & export) | PQMethod export | Yes | **Yes** |
-| Self-hosted | Yes | Frontend only | Desktop | Yes (static site) | Desktop | Yes (local R) | No | No | **Yes** |
-| Open source | Yes (MIT) | Yes (GPL-3) | Yes (GPL) | Yes (GPL-3) | Yes (GPL-3) | Yes (GPL-2+) | No | No | **Yes (AGPL-3)** |
-
-\*Q-Assessor and Qsortware are closed-source, vendor-hosted commercial platforms that, unlike the open-source tools above, integrate collection and analysis in one system — so the **Open source** and **Self-hosted** rows, not integration itself, mark Qualis's distinction from them. Q-Assessor ceased operation in September 2024; its column reflects its last-documented feature set.
-
-*Capabilities were checked against each tool's published materials in June 2026. "—" indicates no documented support was found at the time of writing — for the closed commercial tools many internals are undocumented, so "—" is not a positive claim of absence. "Participant-facing multi-language studies" means statements, instructions, and consent are translated so a participant chooses a language and sorts in it, distinct from a localizable single-language interface (which Quince and the commercial tools offer). Sources: [Quince](https://github.com/shawnbanasick/quince), [Q Method Software / Qsortware](https://qmethodsoftware.com/), and the published materials of PQMethod, Ken-Q Analysis, KADE (Banasick), HTMLQ, and qmethod (Zabala). Corrections welcome via PR.*
-
----
-
-## Key features
-
-### Participant experience
-
-- **Clean, readable layout.** A simple interface that lets participants focus on the sorting task.
-- **Works across common devices.** Participants can open a study link on a phone, tablet, or desktop browser and start sorting without installing apps or plugins.
-- **Mobile-first drag-and-drop.** Touch-optimised sorting with auto-pan, dwell-zoom, and edge scrolling, so participants without desktop access are not excluded.
-- **Intercultural studies.** Translate statements, instructions, consent forms, and UI labels into multiple languages; participants see the study in their preferred language. Lowers the barrier to cross-cultural and multi-site Q research.
-
-### Study design
-
-- **Visual grid designer** with symmetry lock, capacity validation, and configurable score ranges.
-- **Survey builder** with 10 question types (text, long text, number, date, email, audio, dropdown, radio, checkboxes, rating), conditional visibility, reordering, and per-question validation.
-- **Markdown-formatted content** for instructions, consent forms, and condition of instruction.
-- **Import/Export configurations** to create templates, back up designs, or clone studies across projects.
-- **Optional rough-sort step.** The 3-pile triage that precedes the fine-sort grid is configurable per study, since not every protocol uses it.
-- **Pilot mode** to run through the full participant experience without persisting any data.
-
-### Concourse
-
-A reusable pool of candidate statements that lives at the project level, not the study level. Researchers can curate the concourse over time, draw on it across multiple studies, and keep the curatorial trail attached to the data.
-
-- **Project-scoped statement pool** with status workflow (proposed, accepted, rejected) so the team can see what was considered and what was excluded.
-- **Per-item provenance**: source citation, multilingual translations, free-form tags, and an editable code.
-- **Version history** on each statement so revisions are traceable.
-- **Item-level comments** for team discussion of curatorial choices, alongside concourse-level memos that travel with exports for replication and pre-registration packages.
-- **Q-set sampling** into a study with one click; the link back to the concourse is preserved.
-
-### Analysis
-
-- **Built-in factor analysis** for initial exploration without exporting to external software.
-- **PCA or Centroid extraction** (Brown 1980) with Varimax or judgmental (manual) rotation and Kaiser normalization.
-- **Scree plot** with Kaiser criterion reference line for factor selection.
-- **Auto-flagging** using significance and dominance thresholds, or manual flagging for full researcher control.
-- **Distinguishing and consensus statements** classified via Standard Error of Differences at multiple significance levels (p < 0.05, 0.01, 0.001).
-- **Factor arrays, z-scores, composite reliability** (Spearman-Brown), and factor correlation matrix.
-
-### Data collection and monitoring
-
-- **Recruitment links** (public, single-use, or capacity-limited) with QR code generation and funnel tracking (started vs. completed).
-- **Monitoring dashboard** with submission timelines, device breakdowns, and completion rates.
-- **Session review** with grid reconstruction, survey responses, and audio playback.
-- **Discard with reason** to flag problematic responses while preserving the audit trail.
-
-### Export and interoperability
-
-| Format | Description |
-| :----- | :---------- |
-| **CSV** | Wide-format, one row per participant. Compatible with Excel, SPSS, Stata. |
-| **PQMethod** | `.dat` + `.sta` files ready for PQMethod and Ken-Q Analysis. |
-| **Ken-Q JSON** | Native format for Ken-Q web analysis. |
-| **R-Kit** | CSV + auto-generated R script using the `qmethod` package. |
-| **Research Package** | ZIP with all formats, codebook, and metadata for archiving. |
-
-### Privacy and security
-
-- **Self-hosted.** Data stays on your server with no third-party analytics or tracking.
-- **IP address hashing.** Participant IPs are SHA-256 hashed with a configurable salt before storage. Plaintext IPs are never persisted.
-- **Consent audit trail.** Each participant's consent is recorded with a hash of the consent version they agreed to.
-- **Security headers** (HSTS, CSP, X-Frame-Options) and bcrypt password hashing.
-- **Two-factor authentication** — TOTP (authenticator app), with a self-serve recovery flow to disable 2FA when the authenticator is lost.
-- **Email-driven account flows** — sign-up email verification and password reset via time-limited tokens; graceful degradation when SMTP is not configured (dev-friendly).
-- **Role-based access control.** Project-level roles (Owner, Member, Viewer) control who can edit, export, or manage team members.
-
-### Collaboration
-
-- **Projects** to isolate research groups, each with its own members and studies.
-- **Shared project access** for research teams, with role-based permissions for editing, exports, and member management.
-- **Invitation system** via email, or shareable link when SMTP is not configured.
-
----
-
-## Quick start
-
-### Quick start (Docker)
-
-This is the recommended path for evaluation and first-time use. It starts PostgreSQL, the backend, and the built frontend with development demo credentials.
+The [local development setup](#local-development-setup) below is for contributing to Qualis itself.
 
 > The first `make demo-up` **builds the backend and frontend images from source** (no pre-built image is pulled), so the initial run compiles the stack and may take a few minutes; subsequent runs reuse the cached layers. Qualis is self-hosted by design — there is no third-party-hosted instance, which is the point: participant data stays on infrastructure you control.
 
@@ -209,7 +91,7 @@ For a useful first tour after login:
 
 The Docker stack includes a MinIO object store for the audio comments (console at [http://localhost:9001](http://localhost:9001), login `qualis` / `qualis-demo-secret`).
 
-#### Quick-start troubleshooting
+### Quick-start troubleshooting
 
 | What you see | What to do |
 | ------------ | ---------- |
@@ -243,11 +125,77 @@ One thing worth knowing if you edit `docker-compose.yml`: the postgres image run
 role stays, and the app then fails to connect. `docker compose down -v` first if
 you change either.
 
-### Local development setup
+## What you get
+
+| | |
+| :--- | :--- |
+| **Participants** | Sort on a phone, tablet, or desktop browser — no app, no plugin. Touch-optimised drag-and-drop; studies translated into several languages, each participant choosing their own. |
+| **Study design** | Visual grid designer with capacity validation, a 10-type survey builder with conditional visibility, Markdown instructions and consent, import/export of designs, and a pilot mode that persists nothing. |
+| **Concourse** | A project-level pool of candidate statements with a proposed/accepted/rejected workflow, per-item provenance and version history, item-level discussion, and one-click sampling into a study. |
+| **Analysis** | PCA or centroid extraction with Varimax or manual rotation, scree plot, auto- or manual flagging, distinguishing and consensus statements, factor arrays, z-scores, and composite reliability. |
+| **Monitoring** | Recruitment links (public, single-use, capacity-limited) with QR codes and funnel tracking, submission timelines, session review with audio playback. |
+| **Export** | CSV, PQMethod `.dat`/`.sta`, Ken-Q JSON, an R kit using the `qmethod` package, and a research package with codebook and metadata. |
+| **Privacy** | Self-hosted with no third-party analytics, SHA-256 hashed participant IPs, a consent audit trail, TOTP two-factor authentication, and project roles (Owner, Member, Viewer). |
+
+Full detail: [Feature reference](docs/reference/features.md).
+
+---
+
+## Statement of need
+
+Q-methodology, introduced by Stephenson (1953) as a way of studying subjectivity through rank-ordered statements, is used across the social sciences and in applied fields including health, sustainability, education, and public policy. A growing share of recent work extends a reflexive tradition that foregrounds transparency of analytical choices, reflexivity, and the integration of participant voice into interpretation (Stainton Rogers 1997; Stenner 2011; Watts & Stenner 2012; Sneegas 2020).
+
+The studies this orientation invites tend to share a few practical needs:
+
+- running in several languages;
+- reaching participants across phones and computers;
+- building and reusing the pool of candidate statements over time, with the curatorial trail kept visible;
+- tracking how recruitment is unfolding without leaving the platform;
+- keeping what participants say about their sort attached to the analysis;
+- making the analytical choices open to discussion and revision by a research team.
+
+The open-source and freely available tools most Q researchers reach for each cover part of this workflow well — browser-based collection, desktop factor analysis, format conversion — but sit in separate systems: design, collection, analysis, interpretation, privacy operations, and export end up scattered across tools, and the research record has to be reassembled at each import and export boundary, where the audit trail can weaken. A few hosted commercial platforms (Q Method Software / Qsortware, and the now-discontinued Q-Assessor) do integrate collection and analysis in one place, but they are closed-source and vendor-hosted: the data leaves the institution's control, the analytical internals cannot be inspected, and — as Q-Assessor's 2024 shutdown shows — a study's tooling can disappear with the vendor.
+
+Qualis's central design claim is **continuity**: statements, translations, recruitment links, Q-sorts, participant responses, analytical memos, consent and withdrawal events, and export files stay linked as research objects in one self-hosted project, rather than moving between separate tools. The platform implements this through a project-scoped concourse where candidate statements are curated, versioned, and reused across studies; visual study design with sorting grids and post-sort surveys; mobile-first recruitment and data collection with funnel monitoring; built-in factor analysis; collaborative interpretation; and export to PQMethod, R, and Ken-Q formats. Researchers can use Qualis as a data-collection frontend feeding their preferred analysis tool, or as a complete platform — the export bridges to established Q-analytic tools stay open either way. What sets Qualis apart from the integrated commercial platforms is that this continuity is open-source and self-hostable, keeping data and analytical choices under the researcher's control, and that it adds reflexive-workflow affordances — audio post-sorts, shared analytical memos, and a versioned reusable concourse with item-level discussion — that none of the other Q tools surveyed here, open or commercial, provide.
+
+The choices behind each analytical step are visible and adjustable. Multiple researchers can work on the same project, with collaborative memos for analytical reflexivity, optional audio post-sorts that travel with the analysis, and a voices panel that keeps participant material adjacent to factor interpretation.
+
+Data ownership stays with the researcher, and Qualis can run on institutional infrastructure to support the GDPR-aware consent, withdrawal, and data-residency practices common in European Q research. These are technical safeguards and operational paths; compliance remains a matter for each institution's own ethics and legal process.
+
+---
+
+---
+
+## Comparison with existing tools
+
+| Capability | HTMLQ | Quince (Banasick) | PQMethod | Ken-Q Analysis | KADE (Banasick 2019) | qmethod (R, Zabala 2014) | Q-Assessor\* | Qsortware\* | Qualis |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| Browser-based data collection | Yes | Yes | No | No | No | No | Yes | Yes | **Yes** |
+| Documented mobile & tablet support | Tablet | Yes | No | — | No | N/A | — | Yes | **Yes** |
+| Built-in factor analysis | No | No | Yes | Yes | Yes | Yes | Yes | Yes | **Yes** |
+| Participant-facing multi-language studies | No | No | No | No | No | N/A | — | — | **Yes** |
+| Audio post-sort responses | No | No | No | No | No | No | — | — | **Yes** |
+| Shared memos | No | No | No | No | No | No | — | — | **Yes** |
+| Reusable concourse with versioning and item-level discussion | No | No | No | No | No | No | — | — | **Yes** |
+| Recruitment tracking & funnels | No | No | No | No | No | No | Enrollment | — | **Yes** |
+| Team collaboration (roles) | No | No | No | No | No | No | — | — | **Yes** |
+| Interop with PQMethod / R / Ken-Q formats | CSV out | KADE / PQMethod | Native | Imports PQMethod | Imports CSV/PQMethod | Yes (import & export) | PQMethod export | Yes | **Yes** |
+| Self-hosted | Yes | Frontend only | Desktop | Yes (static site) | Desktop | Yes (local R) | No | No | **Yes** |
+| Open source | Yes (MIT) | Yes (GPL-3) | Yes (GPL) | Yes (GPL-3) | Yes (GPL-3) | Yes (GPL-2+) | No | No | **Yes (AGPL-3)** |
+
+\*Q-Assessor and Qsortware are closed-source, vendor-hosted commercial platforms that, unlike the open-source tools above, integrate collection and analysis in one system — so the **Open source** and **Self-hosted** rows, not integration itself, mark Qualis's distinction from them. Q-Assessor ceased operation in September 2024; its column reflects its last-documented feature set.
+
+*Capabilities were checked against each tool's published materials in June 2026. "—" indicates no documented support was found at the time of writing — for the closed commercial tools many internals are undocumented, so "—" is not a positive claim of absence. "Participant-facing multi-language studies" means statements, instructions, and consent are translated so a participant chooses a language and sorts in it, distinct from a localizable single-language interface (which Quince and the commercial tools offer). Sources: [Quince](https://github.com/shawnbanasick/quince), [Q Method Software / Qsortware](https://qmethodsoftware.com/), and the published materials of PQMethod, Ken-Q Analysis, KADE (Banasick), HTMLQ, and qmethod (Zabala). Corrections welcome via PR.*
+
+---
+
+---
+
+## Local development setup
 
 Use this path when you want hot reload, local tests, or direct backend/frontend development.
 
-#### Prerequisites
+### Prerequisites
 
 - Git and GNU Make
 - Python 3.14 — the version CI and the backend image use. `pyproject.toml`
@@ -257,7 +205,7 @@ Use this path when you want hot reload, local tests, or direct backend/frontend 
 - PostgreSQL 18 — the version CI and `docker-compose.yml` use. Earlier majors
   are untested.
 
-#### From zero
+### From zero
 
 ```bash
 # 1. Clone and enter
@@ -307,7 +255,7 @@ Visit [http://localhost:5173](http://localhost:5173). Log in with the `ADMIN_EMA
 
 If you seeded the example study, you can also visit `http://localhost:5173/study/bioeconomy-futures` to walk the participant flow. (For the full demo — concourse plus filled Q-sorts — run `uv run python seed_demo.py` from `backend/` instead, with the backend running.)
 
-#### Local-setup troubleshooting
+### Local-setup troubleshooting
 
 Almost every failure here is step 2 or step 3, and the error usually surfaces two
 commands later. `make preflight` (which `make install` runs for you) checks the

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ Dry, accurate technical descriptions of the system.
 | [API Reference](reference/api.md) | All endpoints with methods, auth requirements, and rate limits |
 | [Configuration Options](reference/configuration.md) | Study fields and application environment variables |
 | [Admin Dashboard](reference/admin-dashboard.md) | Page-by-page catalog of the admin UI |
+| [Feature Reference](reference/features.md) | Complete feature catalogue by area — participant experience, design, concourse, analysis, export, privacy |
 | [Frontend Components](reference/components.md) | Sorting primitives + component index |
 | [Study Configuration Format](reference/study-configuration-format.md) | JSON import/export format specification |
 | [GDPR Memo for Self-Hosters](reference/gdpr-self-hosters.md) | Controls the software provides, for the operator's own DPIA and DPA |

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -1,0 +1,74 @@
+# Feature reference
+
+The complete catalogue, grouped by area. The README carries a summary; this page
+is the detail.
+
+### Participant experience
+
+- **Clean, readable layout.** A simple interface that lets participants focus on the sorting task.
+- **Works across common devices.** Participants can open a study link on a phone, tablet, or desktop browser and start sorting without installing apps or plugins.
+- **Mobile-first drag-and-drop.** Touch-optimised sorting with auto-pan, dwell-zoom, and edge scrolling, so participants without desktop access are not excluded.
+- **Intercultural studies.** Translate statements, instructions, consent forms, and UI labels into multiple languages; participants see the study in their preferred language. Lowers the barrier to cross-cultural and multi-site Q research.
+
+### Study design
+
+- **Visual grid designer** with symmetry lock, capacity validation, and configurable score ranges.
+- **Survey builder** with 10 question types (text, long text, number, date, email, audio, dropdown, radio, checkboxes, rating), conditional visibility, reordering, and per-question validation.
+- **Markdown-formatted content** for instructions, consent forms, and condition of instruction.
+- **Import/Export configurations** to create templates, back up designs, or clone studies across projects.
+- **Optional rough-sort step.** The 3-pile triage that precedes the fine-sort grid is configurable per study, since not every protocol uses it.
+- **Pilot mode** to run through the full participant experience without persisting any data.
+
+### Concourse
+
+A reusable pool of candidate statements that lives at the project level, not the study level. Researchers can curate the concourse over time, draw on it across multiple studies, and keep the curatorial trail attached to the data.
+
+- **Project-scoped statement pool** with status workflow (proposed, accepted, rejected) so the team can see what was considered and what was excluded.
+- **Per-item provenance**: source citation, multilingual translations, free-form tags, and an editable code.
+- **Version history** on each statement so revisions are traceable.
+- **Item-level comments** for team discussion of curatorial choices, alongside concourse-level memos that travel with exports for replication and pre-registration packages.
+- **Q-set sampling** into a study with one click; the link back to the concourse is preserved.
+
+### Analysis
+
+- **Built-in factor analysis** for initial exploration without exporting to external software.
+- **PCA or Centroid extraction** (Brown 1980) with Varimax or judgmental (manual) rotation and Kaiser normalization.
+- **Scree plot** with Kaiser criterion reference line for factor selection.
+- **Auto-flagging** using significance and dominance thresholds, or manual flagging for full researcher control.
+- **Distinguishing and consensus statements** classified via Standard Error of Differences at multiple significance levels (p < 0.05, 0.01, 0.001).
+- **Factor arrays, z-scores, composite reliability** (Spearman-Brown), and factor correlation matrix.
+
+### Data collection and monitoring
+
+- **Recruitment links** (public, single-use, or capacity-limited) with QR code generation and funnel tracking (started vs. completed).
+- **Monitoring dashboard** with submission timelines, device breakdowns, and completion rates.
+- **Session review** with grid reconstruction, survey responses, and audio playback.
+- **Discard with reason** to flag problematic responses while preserving the audit trail.
+
+### Export and interoperability
+
+| Format | Description |
+| :----- | :---------- |
+| **CSV** | Wide-format, one row per participant. Compatible with Excel, SPSS, Stata. |
+| **PQMethod** | `.dat` + `.sta` files ready for PQMethod and Ken-Q Analysis. |
+| **Ken-Q JSON** | Native format for Ken-Q web analysis. |
+| **R-Kit** | CSV + auto-generated R script using the `qmethod` package. |
+| **Research Package** | ZIP with all formats, codebook, and metadata for archiving. |
+
+### Privacy and security
+
+- **Self-hosted.** Data stays on your server with no third-party analytics or tracking.
+- **IP address hashing.** Participant IPs are SHA-256 hashed with a configurable salt before storage. Plaintext IPs are never persisted.
+- **Consent audit trail.** Each participant's consent is recorded with a hash of the consent version they agreed to.
+- **Security headers** (HSTS, CSP, X-Frame-Options) and bcrypt password hashing.
+- **Two-factor authentication** — TOTP (authenticator app), with a self-serve recovery flow to disable 2FA when the authenticator is lost.
+- **Email-driven account flows** — sign-up email verification and password reset via time-limited tokens; graceful degradation when SMTP is not configured (dev-friendly).
+- **Role-based access control.** Project-level roles (Owner, Member, Viewer) control who can edit, export, or manage team members.
+
+### Collaboration
+
+- **Projects** to isolate research groups, each with its own members and studies.
+- **Shared project access** for research teams, with role-based permissions for editing, exports, and member management.
+- **Invitation system** via email, or shareable link when SMTP is not configured.
+
+---

--- a/scripts/check_installation_docs.py
+++ b/scripts/check_installation_docs.py
@@ -68,12 +68,22 @@ def check_readme_demo_path() -> list[str]:
 def check_readme_demo_guidance() -> list[str]:
     readme = _read("README.md")
     errors: list[str] = []
-    start_link = readme.find("[Start Qualis locally with Docker](#quick-start-docker)")
+    # The Docker quick start must BE before the long overview, not merely be
+    # linked to from above it. The previous version of this check accepted a
+    # pointer at the top of the page while the section itself sat 137 lines
+    # down, behind the statement of need, the comparison table and the full
+    # feature catalogue — which is the arrangement it was written to prevent.
+    quick_start = readme.find("## Quick start (Docker)")
     statement_of_need = readme.find("## Statement of need")
 
-    if start_link == -1 or statement_of_need == -1 or start_link > statement_of_need:
+    if quick_start == -1:
+        errors.append("README.md has no '## Quick start (Docker)' section")
+    elif statement_of_need == -1:
+        errors.append("README.md has no '## Statement of need' section")
+    elif quick_start > statement_of_need:
         errors.append(
-            "README.md does not expose the Docker quick start before the long overview"
+            "README.md buries the Docker quick start below the long overview — "
+            "it must come first, since it is how Qualis is run"
         )
 
     for token in (


### PR DESCRIPTION
Docker was presented as the path for **evaluation and first-time use**. It is the main path — three commands, no configuration file to write first, and the basis of a self-hosted deployment. The README said otherwise and buried it **137 lines down**, behind the statement of need, the comparison table and a 71-line feature catalogue: a third of the page before the primary action.

## The guard already knew, and was guarding the workaround

`check_installation_docs.py` asserted that a **link** to the quick start appears before the statement of need. That is why a "First time here?" callout sat at the top of the page pointing 120 lines further down.

So someone had already noticed the problem and worked around it — and the check then froze the workaround in place. It stayed green while the section itself kept sinking, because it was never asked whether the section was there, only whether a pointer to it was.

It now requires the **section** to come first. Verified by moving it back below the overview and watching the check fail:

```
ERROR: README.md buries the Docker quick start below the long overview —
       it must come first, since it is how Qualis is run
```

The callout is gone, because the section is now where the callout used to point.

## What moved, and what deliberately did not

The bulk was never the academic framing. The feature catalogue was **71 lines** against **44** for the statement of need and the comparison table combined.

- **Moved:** the catalogue → `docs/reference/features.md`, verbatim, indexed under Reference in the docs tree. The README keeps a seven-row summary table.
- **Kept on the front page:** the statement of need and the comparison with existing tools. A **SoftwareX submission is coming**, and those are the two sections a reviewer looks for — moving them out would have been the wrong simplification.
- **Reframed:** the quick start now says plainly that this is how Qualis is run, and points people working *on* Qualis (rather than with it) at the local development setup.

## Result

| | before | after |
|---|---|---|
| README length | 427 lines | **377** |
| "how do I run this" | line 138 | **line 20** |

Heading hierarchy repaired along the way: `### Local development setup` was nested under `## Quick start` and is now its own section, with its `####` children promoted to `###`.

All internal anchors and every `docs/` link verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
