### PR TITLE
fix(scalingo): stop the one-click deploy from shipping a known signing key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Inside a strict module: every function declares its return type, no implicit `An
 - Generate: `make migration-new` (auto-generates from model changes)
 - **Always review generated migrations** — auto-generation against a blank or out-of-sync DB will include unrelated tables. The migration must only contain the intended schema change.
 - Migrations run automatically on deploy via the `Procfile` `postdeploy` process (`python scripts/postdeploy.py`), which invokes `scripts/migrate.py` (alembic upgrade) then `init_db.py --skip-migrations`
-- Migration chain (33 migrations as of 2026-06-11, head `60af83267ba5`):
+- Migration chain (34 migrations as of 2026-07-28, head `f7c124e0ec1e`):
   `initial_schema` → `rename_randomize_statements_to_randomize_statement_order`
   → `remove_consent_buttons` → `add_pre_instruction`
   → `add_is_test_run_to_participants` → `add_audio_recordings_table`
@@ -146,6 +146,7 @@ Inside a strict module: every function declares its return type, no implicit `An
   → `add_auth_email_flows` → `fix_password_changed_at_default`
   → `rename_researcher_to_member_and_owner_uniqueness`
   → `add_pending_email_column` → `add_last_login_at`
+  → `remove_email_otp_2fa_channel`
 - Run `alembic history` (in `backend/`) for the canonical chain — this list will drift if not updated when new migrations are added.
 - PostgreSQL DDL is transactional: a failed migration rolls back entirely, leaving `alembic_version` unchanged
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,34 @@ Design studies, collect Q-sorts, and run factor analysis in the browser. Partici
 [![CI](https://github.com/jvastenaekels/qualis/actions/workflows/ci.yml/badge.svg)](https://github.com/jvastenaekels/qualis/actions/workflows/ci.yml)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19985835.svg)](https://doi.org/10.5281/zenodo.19985835)
 
-> **First time here?** [Start Qualis locally with Docker](#quick-start-docker).
-> The guided demo takes three commands and opens at `http://localhost:3000`.
+---
+
+## Where to start
+
+| What you want | Where to go |
+| :--- | :--- |
+| **See what Qualis does** | [Try the demo](#try-the-demo-docker) — three commands, a worked example study, nothing to configure. |
+| **Run studies with real participants** | [Deployment guide](docs/guides/deployment.md) — Scalingo or `docker-compose.production.yml`. Start here for anything that collects real data. |
+| **Work on Qualis itself** | [Local development setup](#local-development-setup) — hot reload, tests, contributing. |
 
 ---
 
-## Quick start (Docker)
+## Try the demo (Docker)
 
-**This is how you run Qualis.** Three commands bring up PostgreSQL, the backend, and the built frontend, with a worked example study already loaded — no configuration file to write first. Use it to evaluate Qualis, to run a pilot, or as the basis of a self-hosted deployment (see [Deployment](docs/guides/deployment.md) for production settings).
+Three commands bring up PostgreSQL, the backend and the built frontend, with the
+Bioeconomy Futures example study and 18 Q-sorts already loaded — no configuration
+file to write first.
 
-The [local development setup](#local-development-setup) below is for contributing to Qualis itself.
+> [!WARNING]
+> **The demo stack is for evaluation only. Never point real participants at it.**
+> It signs its sessions with a key published in this repository, ships a known
+> administrator account (`admin@example.com` / `admin123`) that its own sign-in
+> page advertises, runs PostgreSQL with `fsync=off` because the data is meant to
+> be thrown away, and — because it runs with `ENVIRONMENT=development` — exposes
+> an unauthenticated `/api/test/cleanup-all` endpoint that erases everything.
+>
+> For real studies, follow the [deployment guide](docs/guides/deployment.md).
+> It uses `docker-compose.production.yml`, which shares none of the above.
 
 > The first `make demo-up` **builds the backend and frontend images from source** (no pre-built image is pulled), so the initial run compiles the stack and may take a few minutes; subsequent runs reuse the cached layers. Qualis is self-hosted by design — there is no third-party-hosted instance, which is the point: participant data stays on infrastructure you control.
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ to regenerate the reference from R.
 
 ### Deploy
 
-Qualis deploys as a single application (FastAPI serves the built React frontend). See the [Deployment Guide](docs/guides/deployment.md) for Scalingo, Render, Heroku, and Docker instructions.
+Qualis deploys as a single application (FastAPI serves the built React frontend). See the [Deployment Guide](docs/guides/deployment.md) for the two documented paths: Scalingo, and Docker via `docker-compose.production.yml`.
 
 ---
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -8,14 +8,19 @@ For the canonical list of environment variables (with types and defaults), see [
 
 ## Supported platforms
 
-| Platform | Difficulty | Status |
-| -------- | ---------- | ------ |
-| **Scalingo** | Easy | Documented below; primary supported target. |
-| **Docker (self-host)** | Medium | `docker-compose.production.yml` in repo root; see [Docker](#docker). |
-| **Render** | Easy | Generic Python + Postgres app; same env vars as Scalingo. |
-| **Heroku** | Medium | Generic Python buildpack; same env vars and `Procfile` apply. |
+Two paths are documented, and both are exercised:
 
-The Scalingo path is the one used in production by the maintainer; the others are known to work with the standard Python buildpack but are not documented step-by-step.
+| Platform | Status |
+| -------- | ------ |
+| **Scalingo** | Documented [below](#scalingo). The instance the maintainer runs in production. |
+| **Docker (self-host)** | Documented [below](#docker). `docker-compose.production.yml` in the repo root, and the stack CI builds and health-checks on every pull request. |
+
+Qualis is an ordinary Python app with a `Procfile`, so any platform that speaks
+the standard Python buildpack — Heroku, Render, Clever Cloud — should run it with
+the same environment variables. Those are **not** tested and not documented
+step-by-step here, so treat them as plausible rather than supported: earlier
+versions of this page rated their difficulty, which implied a verification that
+had never happened.
 
 ---
 
@@ -38,6 +43,16 @@ graph LR
 
 - A Scalingo account and the [Scalingo CLI](https://doc.scalingo.com/cli).
 - The repository pushed to GitHub or GitLab.
+
+`scalingo.json` in the repo root declares the addon and every variable the app
+needs, generating `SECRET_KEY`, `IP_HASH_SALT` and `ADMIN_PASSWORD` rather than
+letting them fall back to defaults. A one-click deploy from that manifest asks
+only for `ADMIN_EMAIL`, `FRONTEND_URL` and `ALLOWED_ORIGINS`; the generated
+password is readable from the app's environment variables in the dashboard, and
+should be changed after the first login.
+
+The steps below do the same thing from the CLI, which is what you want when
+deploying into an existing app or an organisation account.
 
 ### Steps
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -187,7 +187,9 @@ when needed; audio also requires S3-compatible object storage.
 
 ## Required environment variables
 
-The minimum set for any production deployment:
+The minimum set for any production deployment. The two `QUALIS_*` rows apply to
+the Docker path only, where `docker-compose.production.yml` declares them with
+`${VAR:?}` — Compose refuses to start if either is unset.
 
 | Variable | Required | Notes |
 | -------- | :------: | ----- |
@@ -200,6 +202,8 @@ The minimum set for any production deployment:
 | `ADMIN_EMAIL` | first deploy | Email of the initial owner created when the database is empty. |
 | `ADMIN_PASSWORD` | first deploy | Unique initial password. Demo/template values are rejected in production. |
 | `TRUSTED_PROXIES` | behind a proxy | Set to `*` on Scalingo; use explicit proxy IPs on infrastructure you control. |
+| `QUALIS_DB_PASSWORD` | Docker only | Password for the bundled Postgres service. `docker-compose.production.yml` refuses to start without it. |
+| `QUALIS_ALLOWED_HOST_PATTERN` | Docker only | Regex of hosts the backend will answer for. Also mandatory — use `[.]` for literal dots. |
 
 For the full set (audio, S3, SMTP, Sentry, rate-limiting), see [`../reference/configuration.md#environment--app-settings`](../reference/configuration.md#environment--app-settings).
 

--- a/docs/tutorials/your-first-study.md
+++ b/docs/tutorials/your-first-study.md
@@ -17,7 +17,7 @@ We will build a study called **"Attitudes Toward Remote Work"** with 12 example 
 
 **Time required:** ~30 minutes
 
-**Prerequisites:** A running Qualis instance and an account with Owner or Member access to a project (the roles that can create studies). For the quickest local start, use the [Docker quick start](../../README.md#quick-start-docker). For a development environment with hot reload, use the [Development Workflow guide](../contributing/development.md).
+**Prerequisites:** A running Qualis instance and an account with Owner or Member access to a project (the roles that can create studies). For the quickest local start, use the [Docker demo](../../README.md#try-the-demo-docker). For a development environment with hot reload, use the [Development Workflow guide](../contributing/development.md).
 
 > **Following the English labels.** The administration interface initially follows your browser language. If it is not in English, use the language selector near the bottom of the left sidebar and select **EN — English**. The participant-facing language is configured separately for each study.
 

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,9 +1,42 @@
 {
   "name": "Qualis",
+  "description": "Open-source platform for Q-methodology research.",
+  "repository": "https://github.com/jvastenaekels/qualis",
+  "addons": [
+    "postgresql"
+  ],
   "env": {
     "ENVIRONMENT": {
       "description": "Application environment. Must be 'production' for any deployment with real users; 'development' enables test/seed routes used by E2E tests only.",
       "value": "production"
+    },
+    "SECRET_KEY": {
+      "description": "Signs the JWTs used for every authenticated request. Generated for you — never reuse a value from another deployment, and never leave the placeholder that ships in the repository.",
+      "generator": "secret"
+    },
+    "IP_HASH_SALT": {
+      "description": "Salt for the SHA-256 hashing of participant IP addresses. Unique per deployment, so hashes cannot be correlated across instances.",
+      "generator": "secret"
+    },
+    "ADMIN_PASSWORD": {
+      "description": "Password of the first owner account, created on the first deploy against an empty database. Generated for you — read it from the app's environment variables in the dashboard, then change it after your first login.",
+      "generator": "secret"
+    },
+    "ADMIN_EMAIL": {
+      "description": "Email address of the first owner account. Use your own; this is the login for the initial administrator.",
+      "value": ""
+    },
+    "FRONTEND_URL": {
+      "description": "Public HTTPS origin of this deployment, used to build account and invitation links. For example https://qualis.osc-fr1.scalingo.io",
+      "value": ""
+    },
+    "ALLOWED_ORIGINS": {
+      "description": "Comma-separated CORS allow-list. Normally the same value as FRONTEND_URL. No wildcards.",
+      "value": ""
+    },
+    "TRUSTED_PROXIES": {
+      "description": "Scalingo terminates TLS in front of the app, so rate limiting must read the client IP from the forwarded header.",
+      "value": "*"
     }
   }
 }

--- a/scripts/check_installation_docs.py
+++ b/scripts/check_installation_docs.py
@@ -73,11 +73,11 @@ def check_readme_demo_guidance() -> list[str]:
     # pointer at the top of the page while the section itself sat 137 lines
     # down, behind the statement of need, the comparison table and the full
     # feature catalogue — which is the arrangement it was written to prevent.
-    quick_start = readme.find("## Quick start (Docker)")
+    quick_start = readme.find("## Where to start")
     statement_of_need = readme.find("## Statement of need")
 
     if quick_start == -1:
-        errors.append("README.md has no '## Quick start (Docker)' section")
+        errors.append("README.md has no '## Where to start' section")
     elif statement_of_need == -1:
         errors.append("README.md has no '## Statement of need' section")
     elif quick_start > statement_of_need:
@@ -85,6 +85,22 @@ def check_readme_demo_guidance() -> list[str]:
             "README.md buries the Docker quick start below the long overview — "
             "it must come first, since it is how Qualis is run"
         )
+
+    # The demo stack ships a published signing key, a known admin account, an
+    # unauthenticated /api/test/cleanup-all, and fsync=off. A reader must not
+    # be able to mistake it for something to put participants in front of —
+    # an earlier revision of this page invited exactly that ("use it to run a
+    # pilot, or as the basis of a self-hosted deployment").
+    for token in (
+        "Never point real participants at it",
+        "cleanup-all",
+        "docs/guides/deployment.md",
+    ):
+        if token not in readme:
+            errors.append(
+                f"README.md no longer warns that the demo stack is evaluation-only "
+                f"(missing {token!r})"
+            )
 
     for token in (
         "**Expected result:**",


### PR DESCRIPTION
## The one-click deploy shipped a publicly known signing key

`scalingo.json` declared exactly one variable: `ENVIRONMENT`.

That manifest is what pre-fills a one-click deploy, so such a deploy never asked for `SECRET_KEY`, `IP_HASH_SALT` or `ADMIN_PASSWORD`. And `main.py` only logs `CRITICAL` for the insecure defaults — it does **not** refuse to start:

```python
if settings.SECRET_KEY == _INSECURE_DEFAULT_SENTINEL:
    logger.critical("SECRET_KEY is using the insecure default! …")
# …no exit, startup continues
```

The result was a live instance whose JWT signing key was `CHANGEME-insecure-dev-only` — a value published in this repository. Anyone could mint an administrator token for it.

Scalingo is the platform the maintainer runs in production, and **no CI job exercises that path** — not the `Procfile`, not `postdeploy.py`, not `scalingo.json` — which is how it drifted unnoticed.

### The fix

The manifest now declares every variable the app needs, with `"generator": "secret"` (confirmed against Scalingo's app-manifest documentation) for the three that must never have a default, plus the PostgreSQL addon that supplies `DATABASE_URL`:

| variable | how it is set |
|---|---|
| `SECRET_KEY`, `IP_HASH_SALT`, `ADMIN_PASSWORD` | **generated** |
| `ENVIRONMENT`, `TRUSTED_PROXIES` | fixed values |
| `ADMIN_EMAIL`, `FRONTEND_URL`, `ALLOWED_ORIGINS` | asked for — deployment-specific by nature |

The generated admin password is readable from the app's environment variables in the dashboard; the guide now says to change it after first login. The CLI steps already did the right thing and are unchanged — they are still what you want for an existing app or an organisation account.

## The platform table implied a verification that never happened

It rated **Render** as "Easy" and **Heroku** as "Medium" and asserted the same env vars apply. Nothing in CI or in the maintainer's own use exercises either. Scalingo and Docker are now presented as the two documented paths — Docker's stack is genuinely built and health-checked on every pull request — and buildpack-compatible platforms are described as plausible rather than supported.

## Also in this PR

**The "minimum set" was not the minimum set.** `docker-compose.production.yml` declares `QUALIS_DB_PASSWORD` and `QUALIS_ALLOWED_HOST_PATTERN` with `${VAR:?}`, so Compose refuses to start without either, yet neither was in the required-variables table. Added, marked `Docker only`.

**The migration chain was a version behind.** `CLAUDE.md` claimed 33 migrations, head `60af83267ba5`. `alembic heads` reports **34** and **`f7c124e0ec1e`** — the missing one is `remove_email_otp_2fa_channel`. Verified against `alembic heads` and the versions directory, not by reading the chain.

## Verified: none of today's Docker work touches the Scalingo runtime

Scalingo reads `Procfile` and `scalingo.json`; neither references Docker, and the compose files, Makefile and Playwright config are not read by the buildpack path. The one change that does cross into the shared backend is `DEMO_MODE`, checked against a simulated Scalingo environment (variable absent, `ENVIRONMENT=production`):

```
DEMO_MODE (default) : False
is_demo_mode        : False
```

Both gates closed. The demo card cannot appear on a production instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
