### PR TITLE
Audit the declared blind spots, and fix what it found

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -175,7 +175,7 @@ packaging==26.2
     #   requirements-parser
 pathspec==1.1.1
     # via mypy
-pip==26.1.2
+pip==26.2.1
     # via pip-api
 pip-api==0.0.34
     # via pip-audit

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1323,11 +1323,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]

--- a/docs/superpowers/plans/2026-07-30-participant-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-30-participant-ux-remediation.md
@@ -1445,9 +1445,12 @@ fact, not an oversight — but the row does look the same way at 1024 as it did 
 While verifying Task 6.1, the mobile a11y walk failed at
 `e2e/pages/RoughSortPage.ts:50` — `expect(nextBtn).toBeHidden()` timed out with
 the button still visible after 13 polls. It passed on an immediate rerun with no
-change, and again on every subsequent run. Unrelated to anything in Phase 6, and
-not investigated: recorded so the next intermittent red on this spec is not
-mistaken for a regression.
+change, and again on every subsequent run.
+
+**Closed 2026-08-21.** The completion screen animates out, so "hidden" was a property
+of an animation finishing rather than of the step being done. Every caller of
+`completeRoughSort` goes straight to the fine sort, so the method now waits for that
+navigation instead — the real post-condition, and a stabler one.
 
 
 ## Found while auditing the declared blind spots (2026-08-21)
@@ -1537,7 +1540,7 @@ Stated so the next audit does not assume it was checked.
 - **The admin space.** Nine raw emoji remain across four files there (Task 3.3, step 3). Untouched.
 - **The post-sort's second step's sticky bar, over content.** The step itself is walked by two specs and was captured at 375px, which confirmed the pill buttons and the absence of indigo. But both specs configure a study with no custom questions, so the page is short and the bar never actually sticks: the one thing Task 3.4 changed was not exercised on step 2. Step 1's opaque bar *was* verified over a scrolled page at 1280px.
 - **Landscape phones.** The audit ran portrait at 390×844 and desktop/tablet landscape. `isLandscapeMobile` (`GridSort.tsx:659`) selects a distinct fine-sort layout for landscape phones that was never walked with correct orientation reporting.
-- **The audio path.** Seven spoken comments are in the demo seed; none were played, recorded, or re-recorded.
+- **The audio path's upload, playback and re-record.** Walked as far as it can be walked 2026-08-21: without object storage `/api/config` reports `audio_storage: "unavailable"` and the affordance is hidden, so no E2E run reaches it. Forcing the flag shows the recorder is properly named and handles a denied microphone; everything past pressing record needs real storage.
 - **Resume by code, and the completion screen.** The flow was walked once, straight through.
 - **Dialogs and overlays.** The help overlay, the zoom/reading overlay behind the eye badge, and the mobile step menu were opened but not audited.
 - **The nine locales as rendered.** Every string finding is from the English UI. A French or Finnish run would put different pressure on every width finding in Phase 1 and Phase 6 — German especially, where compound nouns will test Task 1.1's truncation ceiling.

--- a/docs/superpowers/plans/2026-07-30-participant-ux-remediation.md
+++ b/docs/superpowers/plans/2026-07-30-participant-ux-remediation.md
@@ -1450,6 +1450,86 @@ not investigated: recorded so the next intermittent red on this spec is not
 mistaken for a regression.
 
 
+## Found while auditing the declared blind spots (2026-08-21)
+
+The `What this plan does not cover` list below was written so the next audit would not
+assume those things were checked. This is that audit, on six of them.
+
+### The fine-sort board has no scaling defect — the measurement did
+
+The first pass reported the board rendering at 0.20-0.59 scale on a seven-column pyramid,
+non-deterministically, leaving statements at 3 px. That was wrong, and the way it was
+wrong is worth keeping: the probe reached the filled board through `placeAllCards`, and
+that helper calls `tryZoomOut` — **two clicks on the zoom-out control**, -0.4 of scale.
+Every number was the probe's own zoom.
+
+Measured on arrival instead, before any interaction, on a 1-2-3-5-3-2-1 pyramid of 17
+statements: **0.791 at 1280x800, 0.715 at 1200, 0.549 at 1024, 0.479 on a 844x390
+landscape phone** — each one exactly what `computeAutoFitTransform` prescribes for its
+inputs, and stable across runs. There is no bug.
+
+A fix was written for the imagined bug (re-run the auto-fit when `cardDimensions`
+settle), it changed nothing, and that is what exposed the error: instrumenting
+`performAutoFit` showed all four of its calls already seeing settled values — wrapper
+908x695, content 1060x692, scale 0.79. The fix and its two unit tests were reverted.
+
+**This casts doubt on a Phase 4 finding.** "The mobile board's auto-fit is not
+deterministic" came from a probe built on the same helper. It was not re-measured here
+and should be treated as unconfirmed.
+
+### A German compound heading ran off the screen
+
+`consent.title` in German is "Informierte Einwilligung und
+Datenverarbeitungsvereinbarung". At 390 px it ran past the right edge and lost its last
+two letters, with no ellipsis to admit it — a compound offers no space to wrap at, and
+the heading declared neither hyphenation nor a break rule. Fixed on the four participant
+page headings. This is precisely the case the list below predicted: "German especially,
+where compound nouns will test Task 1.1's truncation ceiling."
+
+Finnish, the other locale walked, is clean at both 390 and 1024.
+
+### Phase 4's hyphenation earns its keep on the language that tests it
+
+The same German run renders a statement card as "Die Kreislauf-wirtschaft ist der
+wichtigste Hebel für Nachhaltig-keit." — correct break points, inside a 390 px card.
+Task 4.1's opt-in was the right call and this is the first evidence for it.
+
+### Task 6.3 put the stepper boundary at the wrong breakpoint
+
+`lg` was a guess. Measured with a five-step flow: at 1024 and 1152 only two labels render
+at all, and once several completed labels show they compete for one row and each
+truncates — a German run at 1024 gave "Welc…", "Let's …", "First impres…",
+"Your perspe…". At 1280 and 1440 all five render whole. The pill now serves everything
+below `xl`.
+
+### The resume toast covers text, and blocks nothing
+
+Phase 6 moved the toast off the header; the first reading of this audit was that it had
+merely relocated the collision, since it now lands on the sorting instruction and, in
+another case, on a section heading. Measuring what that costs says otherwise: at 390 and
+1280 the only control whose centre resolves to the toast is **its own close button**. It
+covers text a participant can read a second later, which is what a top-anchored toast
+does, and it reaches nothing they need to tap.
+
+No change made. The measurement became an assertion instead: the header-geometry test now
+fails if the toast ever covers a control.
+
+### The audio path cannot be walked without object storage
+
+`/api/config` reports `audio_storage: "unavailable"` when S3 credentials are absent, and
+the affordance is then hidden entirely — so no E2E run can reach it. Forcing the flag via
+route interception renders the recorder: it is properly named ("Record audio response if
+you prefer"), and a denied microphone produces a clear, actionable message. Upload,
+playback and re-record remain untested and need real storage.
+
+### Dialogs and overlays are sound
+
+The help dialog shows the canonical step name and reads cleanly at 390. The mobile step
+menu lists all five steps by name with the current one marked and the upcoming ones
+greyed — which is what makes the pill a real substitute for the stepper rather than a
+degradation.
+
+
 ## What this plan does not cover
 
 Stated so the next audit does not assume it was checked.
@@ -1466,7 +1546,7 @@ Stated so the next audit does not assume it was checked.
 - **Existing studies' step names.** The Phase 5 canon governs the i18n keys and the backend seed. Any study already in the database keeps whatever `process_steps[].title` it was created with, including "Why" and any researcher edit. No migration was written and none should be.
 - **The designer's editable-label list.** `welcome.consent.submit` is honoured as a `ui_labels` override but is not offered in `InterfaceEditor`, so no researcher can set it through the UI yet.
 - **The nine locales' step names as rendered.** Task 5.1 propagated by copying each locale's own `welcome.steps.*.title`, so the non-English names are as good as they already were. Only `en` and `fi` were read closely; the two new strings ("Why these choices", "First impressions recorded") were translated without a native reader.
-- **Landscape phones, still.** Task 6.4's note now says how to measure them. Nobody has.
-- **The stepper at 1024-1279.** See the Phase 6 finding above: labelled current and completed steps, anonymous upcoming ones. Left as is.
+- ~~**Landscape phones, still.**~~ Walked 2026-08-21 at 844x390: board fits, no overflow. The pyramid's top row sits slightly under the instruction pill.
+- ~~**The stepper at 1024-1279.**~~ Measured and closed 2026-08-21: the pill now serves below `xl`.
 - **Toast geometry anywhere but the participant header.** The gate runs on the participant flow. The admin header is also `h-16` and reads the same `--header-height`, but no admin test asserts it.
 - **`results.incomplete`.** Task 2.1's gate drops it, exactly as the admin gate does. Contrast over the fine-sort board's transform and over the rough sort's translucent tints is therefore unmeasured by a green run.

--- a/frontend/e2e/accessibility/participant-pages.spec.ts
+++ b/frontend/e2e/accessibility/participant-pages.spec.ts
@@ -44,7 +44,12 @@ import { PreSortPage } from '../pages/PreSortPage';
 import { RoughSortPage } from '../pages/RoughSortPage';
 import { WelcomePage } from '../pages/WelcomePage';
 import { placeAllCards } from '../helpers/rough-sort';
-import { expectContrastAtLeast, expectNoA11yViolations, waitForAnimationsToSettle } from './rules';
+import {
+    controlsCoveredByToast,
+    expectContrastAtLeast,
+    expectNoA11yViolations,
+    waitForAnimationsToSettle,
+} from './rules';
 
 test.setTimeout(120_000);
 
@@ -248,44 +253,10 @@ test.describe('Participant header geometry', () => {
                     Math.round(headerBox.width / 4),
                     Math.round(headerBox.height / 2)
                 );
-                /*
-                 * What the toast covers, and what that costs.
-                 *
-                 * A top-anchored toast covers something by definition; the
-                 * question is whether it is text the participant can read a
-                 * second later, or a control they cannot reach. Measured at
-                 * 390 and 1280 it covers the sorting instruction and the
-                 * progress counter — both transient, both harmless — and the
-                 * only control it lands on is its own close button, which is
-                 * excluded here. Anything else appearing in this list is a
-                 * regression.
-                 */
-                const blocked = new Set<string>();
-                for (const control of document.querySelectorAll(
-                    'button, a, input, select, textarea, [role="tab"], [role="button"]'
-                )) {
-                    const c = control as HTMLElement;
-                    const box = c.getBoundingClientRect();
-                    if (box.width === 0 || box.height === 0) continue;
-                    if (c.closest('[data-sonner-toast]')) continue;
-                    const over = document.elementFromPoint(
-                        Math.round(box.left + box.width / 2),
-                        Math.round(box.top + box.height / 2)
-                    );
-                    if (over?.closest('[data-sonner-toast]')) {
-                        blocked.add(
-                            (c.getAttribute('aria-label') ?? c.textContent ?? c.tagName)
-                                .trim()
-                                .slice(0, 30)
-                        );
-                    }
-                }
-
                 return {
                     toastTop: el.getBoundingClientRect().top,
                     headerBottom: headerBox.bottom,
                     hitIsToast: hit ? !!hit.closest('[data-sonner-toast]') : false,
-                    blockedControls: [...blocked],
                 };
             });
 
@@ -298,15 +269,18 @@ test.describe('Participant header geometry', () => {
                     )
                     .toBeGreaterThanOrEqual(geometry.headerBottom);
                 expect
-                    .soft(geometry.hitIsToast, 'the toast intercepts pointer events over the header')
-                    .toBe(false);
-                expect
                     .soft(
-                        geometry.blockedControls,
-                        'the toast covers a control the participant needs'
+                        geometry.hitIsToast,
+                        'the toast intercepts pointer events over the header'
                     )
-                    .toEqual([]);
+                    .toBe(false);
             }
+            expect
+                .soft(
+                    await controlsCoveredByToast(page),
+                    'the toast covers a control the participant needs'
+                )
+                .toEqual([]);
         });
     }
 });
@@ -421,7 +395,10 @@ for (const vp of A11Y_VIEWPORTS) {
              * the option label's own padding without admitting a real drift.
              */
             const lastOption = page.locator('[role="radiogroup"] label').last();
-            const rightAnchor = page.getByTestId('familiarity-scale-anchors').locator('span').last();
+            const rightAnchor = page
+                .getByTestId('familiarity-scale-anchors')
+                .locator('span')
+                .last();
             const optionBox = await lastOption.boundingBox();
             const anchorBox = await rightAnchor.boundingBox();
             expect(optionBox, 'rating scale: last option has no box').not.toBeNull();

--- a/frontend/e2e/accessibility/participant-pages.spec.ts
+++ b/frontend/e2e/accessibility/participant-pages.spec.ts
@@ -248,10 +248,44 @@ test.describe('Participant header geometry', () => {
                     Math.round(headerBox.width / 4),
                     Math.round(headerBox.height / 2)
                 );
+                /*
+                 * What the toast covers, and what that costs.
+                 *
+                 * A top-anchored toast covers something by definition; the
+                 * question is whether it is text the participant can read a
+                 * second later, or a control they cannot reach. Measured at
+                 * 390 and 1280 it covers the sorting instruction and the
+                 * progress counter — both transient, both harmless — and the
+                 * only control it lands on is its own close button, which is
+                 * excluded here. Anything else appearing in this list is a
+                 * regression.
+                 */
+                const blocked = new Set<string>();
+                for (const control of document.querySelectorAll(
+                    'button, a, input, select, textarea, [role="tab"], [role="button"]'
+                )) {
+                    const c = control as HTMLElement;
+                    const box = c.getBoundingClientRect();
+                    if (box.width === 0 || box.height === 0) continue;
+                    if (c.closest('[data-sonner-toast]')) continue;
+                    const over = document.elementFromPoint(
+                        Math.round(box.left + box.width / 2),
+                        Math.round(box.top + box.height / 2)
+                    );
+                    if (over?.closest('[data-sonner-toast]')) {
+                        blocked.add(
+                            (c.getAttribute('aria-label') ?? c.textContent ?? c.tagName)
+                                .trim()
+                                .slice(0, 30)
+                        );
+                    }
+                }
+
                 return {
                     toastTop: el.getBoundingClientRect().top,
                     headerBottom: headerBox.bottom,
                     hitIsToast: hit ? !!hit.closest('[data-sonner-toast]') : false,
+                    blockedControls: [...blocked],
                 };
             });
 
@@ -266,6 +300,12 @@ test.describe('Participant header geometry', () => {
                 expect
                     .soft(geometry.hitIsToast, 'the toast intercepts pointer events over the header')
                     .toBe(false);
+                expect
+                    .soft(
+                        geometry.blockedControls,
+                        'the toast covers a control the participant needs'
+                    )
+                    .toEqual([]);
             }
         });
     }

--- a/frontend/e2e/accessibility/rules.ts
+++ b/frontend/e2e/accessibility/rules.ts
@@ -246,3 +246,43 @@ export async function expectNoA11yViolations(page: Page, options: { soft?: boole
         : expect(summarise(results.violations));
     assertion.toEqual([]);
 }
+
+/**
+ * What a visible toast covers, and what that costs.
+ *
+ * A top-anchored toast covers something by definition; the question is whether it is
+ * text the participant can read a second later, or a control they cannot reach.
+ * Measured at 390 and 1280 on the resume toast: it lands on the sorting instruction
+ * and the progress counter — both transient, both harmless — and the only control it
+ * covers is its own close button, which is excluded here. Anything else in this list
+ * is a regression.
+ *
+ * Returns the accessible names of covered controls, empty when the toast blocks
+ * nothing.
+ */
+export async function controlsCoveredByToast(page: Page): Promise<string[]> {
+    return page.evaluate(() => {
+        const covered = new Set<string>();
+        const controls = document.querySelectorAll(
+            'button, a, input, select, textarea, [role="tab"], [role="button"]'
+        );
+        for (const control of controls) {
+            const element = control as HTMLElement;
+            const box = element.getBoundingClientRect();
+            if (box.width === 0 || box.height === 0) continue;
+            if (element.closest('[data-sonner-toast]')) continue;
+            const over = document.elementFromPoint(
+                Math.round(box.left + box.width / 2),
+                Math.round(box.top + box.height / 2)
+            );
+            if (over?.closest('[data-sonner-toast]')) {
+                covered.add(
+                    (element.getAttribute('aria-label') ?? element.textContent ?? element.tagName)
+                        .trim()
+                        .slice(0, 30)
+                );
+            }
+        }
+        return [...covered];
+    });
+}

--- a/frontend/e2e/pages/RoughSortPage.ts
+++ b/frontend/e2e/pages/RoughSortPage.ts
@@ -46,7 +46,18 @@ export class RoughSortPage extends BasePage {
         // Use JS click for robustness against dnd-kit sensors
         await nextBtn.evaluate((node: HTMLElement) => node.click());
 
-        // Ensure it's hidden before proceeding to prevent locator conflicts
-        await expect(nextBtn).toBeHidden({ timeout: 5000 });
+        /*
+         * Wait for the navigation the click causes, not for the button to
+         * disappear.
+         *
+         * `toBeHidden({timeout: 5000})` on this button flaked: observed once
+         * on the mobile accessibility walk, the button was still visible after
+         * 13 polls and the run failed, then passed on an immediate rerun and
+         * every run after. The completion screen animates out, so "hidden" is
+         * a property of an animation finishing rather than of the step being
+         * done — and every caller of this method goes straight to the fine
+         * sort, so the URL is both the real post-condition and a stabler one.
+         */
+        await this.page.waitForURL(/\/fine-sort(\?|$)/, { timeout: 15000 });
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1005,16 +1005,16 @@
             }
         },
         "node_modules/@ibm-cloud/openapi-ruleset/node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/@ibm-cloud/openapi-ruleset/node_modules/minimatch": {
@@ -4562,6 +4562,14 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@scarf/scarf": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+            "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/@sentry/browser": {
             "version": "10.59.0",
             "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.59.0.tgz",
@@ -4824,12 +4832,13 @@
             }
         },
         "node_modules/@stoplight/spectral-core": {
-            "version": "1.23.0",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.23.0.tgz",
-            "integrity": "sha512-WvdgmiiJrjiMrcw7ByxfcYtUvAXNp2MhAfcEIXP3Mn8ZOVwyAWIsFjLlsE5zRqj0LuN8+7OQM/L+BMcHj6x/BQ==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.23.1.tgz",
+            "integrity": "sha512-VLC8OhpO/pMJKb6IHhurxJjXO1qB56Ng1unIb8b+hNxdw0+SEcASvmR+RpjfHYX/jv/DfSaA1x8QhFBJBmqBOQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
+                "@scarf/scarf": "^1.4.0",
                 "@stoplight/better-ajv-errors": "1.0.3",
                 "@stoplight/json": "~3.21.0",
                 "@stoplight/path": "1.3.2",
@@ -5660,16 +5669,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -6670,9 +6679,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -7920,9 +7929,9 @@
             "license": "MIT"
         },
         "node_modules/dompurify": {
-            "version": "3.4.12",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+            "version": "3.4.14",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+            "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -8487,9 +8496,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -10137,9 +10146,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {
@@ -12032,9 +12041,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -13572,9 +13581,9 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.18.1",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-            "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+            "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -13594,12 +13603,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.18.1",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-            "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+            "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+            "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.18.1"
+                "react-router": "7.18.2"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -13684,9 +13693,9 @@
             }
         },
         "node_modules/readdir-glob/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -15524,16 +15533,16 @@
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/typedoc/node_modules/minimatch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -126,9 +126,9 @@
     },
     "overrides": {
         "@stoplight/spectral-functions": "1.10.2",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "minimatch@3.1.5": {
-            "brace-expansion": "1.1.16"
+            "brace-expansion": "1.1.18"
         },
         "exceljs": {
             "uuid": "11.1.1"

--- a/frontend/src/layouts/StudyLayout.tsx
+++ b/frontend/src/layouts/StudyLayout.tsx
@@ -391,11 +391,12 @@ const StudyLayoutContent: React.FC = () => {
 
                 {/*
                  * Compact progress (top edge), paired with the step pill below.
-                 * `lg:hidden` and not `md:hidden`: the pill now serves the
-                 * tablet too, and a progress indicator that vanished at 768
-                 * while its counterpart stayed would be the odd one out.
+                 * `xl:hidden` and not `md:hidden`: the pill now serves the
+                 * tablet and the small desktop too, and a progress indicator
+                 * that vanished at 768 while its counterpart stayed would be
+                 * the odd one out.
                  */}
-                <div className="lg:hidden absolute top-0 left-0 w-full h-1 bg-slate-100">
+                <div className="xl:hidden absolute top-0 left-0 w-full h-1 bg-slate-100">
                     <div
                         className="h-full bg-[var(--brand-accent)] transition-all duration-300 ease-in-out"
                         style={{
@@ -470,7 +471,7 @@ const StudyLayoutContent: React.FC = () => {
                     </div>
 
                     {/*
-                     * Step counter & menu — up to `lg`, not just up to `md`.
+                     * Step counter & menu — up to `xl`, not just up to `md`.
                      *
                      * Between 768 and 1023 the full stepper showed one label
                      * and four anonymous circles, the last of them a bare dot
@@ -480,7 +481,7 @@ const StudyLayoutContent: React.FC = () => {
                      * deliberate. This pill answers both — "Step 4/5" plus,
                      * on tap, every step by name — and it already existed.
                      */}
-                    <div className="lg:hidden relative shrink-0" ref={stepMenuRef}>
+                    <div className="xl:hidden relative shrink-0" ref={stepMenuRef}>
                         <button
                             type="button"
                             onClick={() => setIsStepMenuOpen(!isStepMenuOpen)}
@@ -556,8 +557,18 @@ const StudyLayoutContent: React.FC = () => {
                     </div>
                 </div>
 
-                {/* CENTER: Stepper — from `lg`, where every label has room. */}
-                <div className="hidden lg:flex flex-1 justify-center items-center min-w-0 mx-4">
+                {/*
+                 * CENTER: Stepper — from `xl`, which is where it first fits.
+                 *
+                 * `lg` was a guess and it was wrong. Measured with a five-step
+                 * flow: at 1024 and 1152 only two labels render at all (the
+                 * upcoming ones are `xl:block`), and once several completed
+                 * labels do show they compete for the same row and each one
+                 * truncates — a German run at 1024 rendered "Welc…",
+                 * "Let's …", "First impres…", "Your perspe…". At 1280 all five
+                 * render whole. So the pill serves everything below `xl`.
+                 */}
+                <div className="hidden xl:flex flex-1 justify-center items-center min-w-0 mx-4">
                     <div
                         data-testid="stepper-container"
                         className="flex items-center gap-1 lg:gap-2 min-w-0"

--- a/frontend/src/pages/ConsentPage.test.tsx
+++ b/frontend/src/pages/ConsentPage.test.tsx
@@ -91,6 +91,18 @@ describe('ConsentPage', () => {
         );
     });
 
+    it('lets a long compound heading break instead of running off the screen', () => {
+        // German: "Informierte Einwilligung und Datenverarbeitungsvereinbarung"
+        // has no space to wrap at inside the compound. Measured at 390 px it
+        // ran past the right edge and lost its last two letters, with no
+        // ellipsis to admit it. jsdom has no layout, so this asserts the rule
+        // that prevents it rather than the geometry.
+        renderWithProviders(<ConsentPage />);
+        const heading = screen.getByRole('heading', { level: 1 });
+        expect(heading.className).toContain('hyphens-auto');
+        expect(heading.className).toContain('[overflow-wrap:anywhere]');
+    });
+
     it('validates consent checkbox', async () => {
         renderWithProviders(<ConsentPage />);
 

--- a/frontend/src/pages/ConsentPage.tsx
+++ b/frontend/src/pages/ConsentPage.tsx
@@ -132,7 +132,18 @@ const ConsentPage: React.FC = () => {
     return (
         <div className="w-full max-w-2xl min-w-0 mx-auto py-6 sm:py-12 px-4 animate-in fade-in duration-500">
             <div className="mb-8 text-center">
-                <h1 className="text-2xl font-bold text-gray-900 mb-2">
+                {/*
+                 * `hyphens-auto` plus an anywhere-break: German has no
+                 * space to wrap at inside a compound, and this heading is
+                 * "Informierte Einwilligung und
+                 * Datenverarbeitungsvereinbarung" — measured at 390 px it
+                 * ran off the right edge and lost the last two letters
+                 * outright, with no ellipsis to admit it. Hyphenation
+                 * needs `<html lang>`, which `useStudyLocaleSync` sets;
+                 * the break is the fallback for a locale Chromium has no
+                 * dictionary for.
+                 */}
+                <h1 className="text-2xl font-bold text-gray-900 mb-2 hyphens-auto [overflow-wrap:anywhere]">
                     {t('consent.title', 'Informed consent and data processing agreement')}
                 </h1>
                 <p className="text-gray-600">

--- a/frontend/src/pages/PostSortPage.tsx
+++ b/frontend/src/pages/PostSortPage.tsx
@@ -184,7 +184,7 @@ const PostSortPage: React.FC<PostSortPageProps> = ({ highlightKey: _highlightKey
                     />
                 </div>
 
-                <h1 className="text-3xl font-bold text-slate-800 tracking-tight">
+                <h1 className="text-3xl font-bold text-slate-800 tracking-tight hyphens-auto [overflow-wrap:anywhere]">
                     {wizardStep === 1 ? t('post.title') : t('post.step2_title')}
                 </h1>
                 <p className="text-slate-600 max-w-lg mx-auto leading-relaxed">

--- a/frontend/src/pages/PreSortPage.tsx
+++ b/frontend/src/pages/PreSortPage.tsx
@@ -99,7 +99,7 @@ const PreSortPage: React.FC<PreSortPageProps> = ({ highlightKey }) => {
     return (
         <div className="max-w-3xl mx-auto py-6 sm:py-12 px-4 space-y-6 animate-in slide-in-from-right duration-500">
             <div>
-                <h1 className="text-2xl font-bold text-gray-900">{t('presort.title')}</h1>
+                <h1 className="text-2xl font-bold text-gray-900 hyphens-auto [overflow-wrap:anywhere]">{t('presort.title')}</h1>
                 <p className="text-gray-600">{t('presort.description')}</p>
             </div>
 

--- a/frontend/src/pages/PreSortPage.tsx
+++ b/frontend/src/pages/PreSortPage.tsx
@@ -99,7 +99,9 @@ const PreSortPage: React.FC<PreSortPageProps> = ({ highlightKey }) => {
     return (
         <div className="max-w-3xl mx-auto py-6 sm:py-12 px-4 space-y-6 animate-in slide-in-from-right duration-500">
             <div>
-                <h1 className="text-2xl font-bold text-gray-900 hyphens-auto [overflow-wrap:anywhere]">{t('presort.title')}</h1>
+                <h1 className="text-2xl font-bold text-gray-900 hyphens-auto [overflow-wrap:anywhere]">
+                    {t('presort.title')}
+                </h1>
                 <p className="text-gray-600">{t('presort.description')}</p>
             </div>
 

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -123,11 +123,11 @@ const WelcomePage: React.FC<WelcomePageProps> = ({ highlightKey }) => {
             {/* 1. Context Section (The "Why") */}
             <div className="text-center max-w-3xl mx-auto mb-8 space-y-6">
                 <div>
-                    <h1 className="text-2xl md:text-3xl font-bold text-gray-900 tracking-tight">
+                    <h1 className="text-2xl md:text-3xl font-bold text-gray-900 tracking-tight hyphens-auto [overflow-wrap:anywhere]">
                         {config.title}
                     </h1>
                     {config.subtitle && (
-                        <h2 className="text-lg sm:text-xl text-slate-600 font-normal mt-3">
+                        <h2 className="text-lg sm:text-xl text-slate-600 font-normal mt-3 hyphens-auto [overflow-wrap:anywhere]">
                             {config.subtitle}
                         </h2>
                     )}


### PR DESCRIPTION
The participant UX plan closed with a list headed *"Stated so the next audit does
not assume it was checked."* This is that audit, on six of those items, plus the
fixes it turned up. 7 commits.

## What was walked

| blind spot | outcome |
|---|---|
| Landscape phones | Clean. Board fits at 844×390, no overflow. |
| The audio path | Unreachable without object storage — see below. Affordance and error handling audited. |
| Dialogs and overlays | Clean. Help dialog and mobile step menu both correct. |
| The nine locales as rendered | **One defect, fixed.** |
| A pyramid grid at desktop | Clean — and the first report of a defect was my own measurement error. |
| The stepper at 1024–1279 | **Real, and worse than the plan said. Fixed.** |

## The correction that matters

The first pass of this audit reported the fine-sort board rendering at 0.20–0.59
scale on a seven-column pyramid, non-deterministically, leaving statements at 3 px.
**That was wrong.** The probe reached the filled board through `placeAllCards`, and
that helper calls `tryZoomOut` — two clicks on the zoom-out control, −0.4 of scale.
Every number was the probe's own zoom.

Measured on arrival instead: **0.791 at 1280, 0.715 at 1200, 0.549 at 1024, 0.479 on
a landscape phone** — each exactly what `computeAutoFitTransform` prescribes, stable
across runs. A fix was written for the imagined bug, changed nothing, and was
reverted; instrumenting `performAutoFit` showed all four of its calls already seeing
settled values.

This casts doubt on a Phase 4 finding — "the mobile board's auto-fit is not
deterministic" came from a probe built on the same helper. It is recorded as
unconfirmed rather than quietly dropped.

## The fixes

- **A German compound heading ran off the screen.** `consent.title` in German is
  "Informierte Einwilligung und Datenverarbeitungsvereinbarung"; at 390 px it lost its
  last two letters with no ellipsis to admit it. `hyphens-auto` now renders
  "Datenverarbeitungsverein-barung", with `[overflow-wrap:anywhere]` as the fallback
  for locales Chromium has no dictionary for. Applied to all four participant page
  headings, since welcome and post-sort render researcher-authored text of arbitrary
  length.
- **The stepper sat at the wrong breakpoint.** Phase 6 moved the pill up to `lg` on the
  assumption the stepper worked from 1024. Measured: at 1024 and 1152 only two labels
  render at all, and once several show they compete for one row and each truncates — a
  German run at 1024 gave "Welc…", "Let's …", "First impres…", "Your perspe…". All five
  render whole at 1280. The pill now serves everything below `xl`.
- **A flaky E2E wait.** `completeRoughSort` waited for the next button to become hidden;
  the completion screen animates out, so that is a property of an animation finishing.
  It now waits for the navigation every caller depends on.
- **`pip` 26.2.1.** `make ci` began failing on PYSEC-2026-3721. pip is in the lock only
  because `pip-audit` needs `pip-api` which needs pip — never executed by Qualis — so
  the existing `--ignore-vuln` pattern would have applied. Upgrading removes the finding
  instead of silencing it; the lock diff touches nothing else.

## The fix that wasn't needed

Phase 6 moved the resume toast off the header. This audit first read the result as the
collision having merely relocated — it now lands on the sorting instruction, and
elsewhere on a section heading. Measuring what that costs says otherwise: at 390 and
1280 the only control whose centre resolves to the toast is **its own close button**.
Nothing changed in the page; the measurement became an assertion instead, so the
header-geometry test now fails if a toast ever covers a control.

## Still not covered

- **Audio upload, playback, re-record.** Without object storage `/api/config` reports
  `audio_storage: "unavailable"` and the affordance is hidden, so no E2E run reaches it.
  Forcing the flag shows the recorder is properly named and handles a denied microphone.
- Three unrelated E2E specs fail `biome format`; `make lint` does not cover `e2e/`. Not a
  regression of this branch, and out of its scope.

## Verification

`make ci` exit 0, re-confirmed with `ci-fast` on the final tree. 1866 frontend tests.
E2E participant + accessibility run manually — **35 passed, 2 skipped, 0 failed** (the
skips are the tablet-only rotation test) — because `make ci` ends with "Skipped E2E".

🤖 Generated with [Claude Code](https://claude.com/claude-code)